### PR TITLE
Maximally share clones 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "getrandom"
@@ -206,9 +206,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -236,9 +236,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -304,9 +304,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 itertools = "*"
 env_logger = "*"
 log = "0.4"
-serde = "1.0.117"
+serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "*"
 unescape = "0.1"
 sequence_trie = "0.3.6"
 heck = "0.3"
-petgraph = "0.5.1"
+petgraph = "0.6"
 indexmap = { version = "1.6", features = ["serde"] }
 toml = "0.5.8"
 creusot-contracts = { path = "../creusot-contracts", features = ["typechecker"] }

--- a/creusot/src/cleanup_spec_closures.rs
+++ b/creusot/src/cleanup_spec_closures.rs
@@ -134,6 +134,6 @@ impl<'tcx> MutVisitor<'tcx> for LocalUpdater<'tcx> {
 
 fn no_mir(tcx: TyCtxt, def_id: DefId) -> bool {
     crate::util::is_no_translate(tcx, def_id)
-        || crate::is_logic(tcx, def_id)
-        || crate::is_predicate(tcx, def_id)
+        || crate::util::is_logic(tcx, def_id)
+        || crate::util::is_predicate(tcx, def_id)
 }

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -1,12 +1,12 @@
 mod builtins;
 pub mod constant;
+pub mod external;
 pub mod function;
+pub mod interface;
+mod logic;
 pub mod specification;
 pub mod traits;
 pub mod ty;
-
-pub mod external;
-mod logic;
 
 pub use external::translate_extern;
 pub use function::translate_function;
@@ -61,8 +61,8 @@ pub fn translate(mut ctx: TranslationCtx<'_, '_>) -> Result<()> {
         print_crate(
             &mut out,
             ctx.tcx.crate_name(LOCAL_CRATE).to_string().to_camel_case(),
-            ctx.types,
-            ctx.functions.values(),
+            &ctx.types,
+            ctx.modules(),
         )?;
     }
 
@@ -121,7 +121,7 @@ use self::external::load_exports;
 fn print_crate<'a, W, I: Iterator<Item = &'a Module>>(
     out: &mut W,
     _name: String,
-    types: Vec<TyDecl>,
+    types: &[TyDecl],
     functions: I,
 ) -> std::io::Result<()>
 where
@@ -133,7 +133,7 @@ where
         name: "Type".into(),
         decls: prelude_imports(false)
             .into_iter()
-            .chain(types.into_iter().flat_map(|ty| [Decl::TyDecl(ty)]))
+            .chain(types.into_iter().flat_map(|ty| [Decl::TyDecl(ty.clone())]))
             .collect(),
     };
 

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -33,7 +33,7 @@ pub fn translate_function<'tcx, 'sess>(
     ctx: &mut TranslationCtx<'sess, 'tcx>,
     def_id: DefId,
 ) -> Module {
-    let mut names = CloneMap::new(tcx);
+    let mut names = CloneMap::new(tcx, ItemType::Program);
     names.clone_self(def_id);
 
     let invariants = specification::gather_invariants(ctx, &mut names, def_id);
@@ -275,11 +275,15 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             Some(Some(inst)) => {
                 self.ctx.translate_impl(self.tcx.impl_of_method(inst.def_id()).unwrap());
 
-                QVar(self.clone_names.qname_for_mut(inst.def_id(), inst.substs))
+                QVar(
+                    self.clone_names
+                        .insert(inst.def_id(), inst.substs)
+                        .qname(self.tcx, inst.def_id()),
+                )
             }
             _ => {
                 self.ctx.translate_trait(trait_id);
-                QVar(self.clone_names.qname_for_mut(trait_meth_id, subst))
+                QVar(self.clone_names.insert(trait_meth_id, subst).qname(self.tcx, trait_meth_id))
             }
         }
     }

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -145,12 +145,15 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                     Some(i) => {
                         let impl_id = self.ctx.tcx.impl_of_method(i.def_id()).unwrap();
                         self.ctx.translate_impl(impl_id);
-                        return self.clone_names.qname_for_mut(i.def_id(), i.substs);
+                        return self
+                            .clone_names
+                            .insert(i.def_id(), i.substs)
+                            .qname(self.tcx, i.def_id());
                     }
                     None => {
                         // We are working on generics
                         self.ctx.translate_trait(it.container.id());
-                        return self.clone_names.qname_for_mut(def_id, subst);
+                        return self.clone_names.insert(def_id, subst).qname(self.tcx, def_id);
                     }
                 }
             }
@@ -159,7 +162,7 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
         // TODO: better spans during errors...
         self.ctx.translate_function(def_id);
 
-        self.clone_names.qname_for_mut(def_id, subst)
+        self.clone_names.insert(def_id, subst).qname(self.tcx, def_id)
     }
 }
 

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -1,12 +1,42 @@
-use why3::declaration::Module;
+use why3::declaration::{Decl, Module, ValKind};
 
-use crate::{clone_map::CloneMap, ctx::TranslationCtx, util};
+use crate::{clone_map::CloneMap, ctx::*, translation::function::all_generic_decls_for, util};
 
 use rustc_hir::def_id::DefId;
+use rustc_middle::ty::TyCtxt;
 
-fn interface_for(ctx: &mut TranslationCtx<'_, '_>, def_id: DefId) -> Module {
-	let mut names = CloneMap::new(ctx.tcx);
+pub struct Interface {
+    pub module: Module,
+}
 
-	let sig = util::signature_of(ctx, &mut names, def_id);
-	todo!()
+pub fn interface_for(
+    ctx: &mut TranslationCtx<'_, 'tcx>,
+    def_id: DefId,
+) -> (Interface, CloneMap<'tcx>) {
+    let mut names = CloneMap::new(ctx.tcx, ItemType::Interface);
+
+    let mut sig = util::signature_of(ctx, &mut names, def_id);
+
+    let mut decls: Vec<_> = all_generic_decls_for(ctx.tcx, def_id).collect();
+
+    decls.extend(names.clone().to_clones(ctx));
+
+    decls.push(Decl::ValDecl(match util::item_type(ctx.tcx, def_id) {
+        ItemType::Predicate => {
+            sig.retty = None;
+            ValKind::Predicate { sig }
+        }
+        ItemType::Logic => ValKind::Function { sig },
+        _ => ValKind::Val { sig },
+    }));
+
+    let name = interface_name(ctx.tcx, def_id);
+
+    (Interface { module: Module { name, decls } }, names)
+}
+
+pub fn interface_name(tcx: TyCtxt, def_id: DefId) -> String {
+    let name = translate_value_id(tcx, def_id);
+
+    format!("{}_Interface", name.module_name().name)
 }

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -1,5 +1,4 @@
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::TyCtxt;
 
 use why3::declaration::{Decl, Logic, Module, Predicate};
 
@@ -7,16 +6,12 @@ use crate::ctx::*;
 use crate::function::all_generic_decls_for;
 use crate::translation::specification;
 
-pub fn is_logic(tcx: TyCtxt, def_id: DefId) -> bool {
-    specification::get_attr(tcx.get_attrs(def_id), &["creusot", "spec", "logic"]).is_some()
-}
-
-pub fn is_predicate(tcx: TyCtxt, def_id: DefId) -> bool {
-    specification::get_attr(tcx.get_attrs(def_id), &["creusot", "spec", "predicate"]).is_some()
-}
-
-pub fn translate_logic(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_span::Span) -> Module {
-    let mut names = CloneMap::new(ctx.tcx);
+pub fn translate_logic(
+    ctx: &mut TranslationCtx<'_, 'tcx>,
+    def_id: DefId,
+    _span: rustc_span::Span,
+) -> (Module, CloneMap<'tcx>) {
+    let mut names = CloneMap::new(ctx.tcx, ItemType::Logic);
     names.clone_self(def_id);
 
     let term = specification::typing::typecheck(ctx.tcx, def_id.expect_local());
@@ -25,22 +20,22 @@ pub fn translate_logic(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_spa
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
-    decls.extend(names.to_clones(ctx));
+    decls.extend(names.clone().to_clones(ctx));
 
     let func = Decl::LogicDecl(Logic { sig, body });
 
     decls.push(func);
 
     let name = translate_value_id(ctx.tcx, def_id).module.join("");
-    Module { name, decls }
+    (Module { name, decls }, names)
 }
 
 pub fn translate_predicate(
-    ctx: &mut TranslationCtx,
+    ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
     _span: rustc_span::Span,
-) -> Module {
-    let mut names = CloneMap::new(ctx.tcx);
+) -> (Module, CloneMap<'tcx>) {
+    let mut names = CloneMap::new(ctx.tcx, ItemType::Predicate);
     names.clone_self(def_id);
 
     let term = specification::typing::typecheck(ctx.tcx, def_id.expect_local());
@@ -52,9 +47,9 @@ pub fn translate_predicate(
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
-    decls.extend(names.to_clones(ctx));
+    decls.extend(names.clone().to_clones(ctx));
     decls.push(func);
 
     let name = translate_value_id(ctx.tcx, def_id).module.join("");
-    Module { name, decls }
+    (Module { name, decls }, names)
 }

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -54,8 +54,8 @@ pub fn lower_term_to_why3<'tcx>(
             }
 
             builtins::lookup_builtin(ctx, target, &mut args).unwrap_or_else(|| {
-                let clone = names.qname_for_mut(target, subst);
-                Exp::Call(box Exp::QVar(clone), args)
+                let clone = names.insert(target, subst);
+                Exp::Call(box Exp::QVar(clone.qname(ctx.tcx, target)), args)
             })
         }
         Term::Forall { binder, box body } => {

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -153,7 +153,7 @@ pub fn translate_constraint<'tcx>(
     names: &mut CloneMap<'tcx>,
     tp: TraitPredicate<'tcx>,
 ) {
-    names.name_for_mut(tp.def_id(), tp.trait_ref.substs);
+    names.qname_for_mut(tp.def_id(), tp.trait_ref.substs);
 
     // If we haven't seen this trait, first translate it
     ctx.translate_trait(tp.def_id());
@@ -172,7 +172,7 @@ fn translate_assoc_function(
     let trait_id = ctx.tcx.trait_id_of_impl(impl_id).unwrap();
 
     let assoc_subst = InternalSubsts::identity_for_item(ctx.tcx, impl_id);
-    let name = names.name_for_mut(assoc.def_id, assoc_subst);
+    let name = names.insert(assoc.def_id, assoc_subst).clone();
 
     ctx.translate_function(assoc.def_id);
 
@@ -198,10 +198,7 @@ fn translate_assoc_function(
         .map(move |(tr_param, inst_param)| {
             CloneSubst::Type(
                 (&*tr_param.name.as_str().to_lowercase()).into(),
-                Type::TConstructor(QName {
-                    module: vec![name.clone()],
-                    name: inst_param.name.as_str().to_lowercase(),
-                }),
+                Type::TConstructor(name.qname(tcx, inst_param.def_id)),
             )
         });
 

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -35,7 +35,8 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
             return;
         }
 
-        let mut names = CloneMap::new(self.tcx);
+        let mut names = CloneMap::new(self.tcx, ItemType::Trait);
+        names.clone_self(def_id);
 
         // The first predicate is a trait reference so we skip it
         for super_trait in traits_used_by(self.tcx, def_id).filter(|t| t.def_id() != def_id) {
@@ -58,7 +59,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
                         item.def_id,
                     ));
 
-                    if crate::is_predicate(self.tcx, item.def_id) {
+                    if crate::util::is_predicate(self.tcx, item.def_id) {
                         sig.retty = None;
                         trait_decls.push(Decl::ValDecl(Predicate { sig }));
                     } else {
@@ -66,8 +67,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
                     }
                 }
                 AssocKind::Type => {
-                    let ty_name: why3::Ident =
-                        self.tcx.item_name(item.def_id).to_string().to_lowercase().into();
+                    let ty_name: why3::Ident = ty::ty_name(self.tcx, item.def_id).into();
 
                     trait_decls.push(Decl::TyDecl(TyDecl {
                         ty_name,
@@ -86,7 +86,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
 
         let trait_name = translate_trait_name(self.tcx, def_id);
 
-        self.functions.insert(def_id, Module { name: trait_name.name(), decls });
+        self.add_trait(def_id, Module { name: trait_name.name(), decls });
     }
 
     pub fn translate_impl(&mut self, impl_id: DefId) {
@@ -95,11 +95,11 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
         }
 
         let trait_ref = self.tcx.impl_trait_ref(impl_id).unwrap();
-        let mut names = CloneMap::new(self.tcx);
+        let mut names = CloneMap::new(self.tcx, ItemType::Impl);
 
         self.translate_trait(trait_ref.def_id);
 
-        let mut subst = ctx::type_param_subst(self, &mut names, trait_ref.def_id, trait_ref.substs);
+        let mut subst = ctx::base_subst(self, &mut names, trait_ref.def_id, trait_ref.substs);
 
         let mut assoc_types = Vec::new();
         for assoc in self.tcx.associated_items(impl_id).in_definition_order() {
@@ -144,7 +144,7 @@ impl<'tcx> TranslationCtx<'_, 'tcx> {
         }));
 
         let name = translate_value_id(self.tcx, impl_id);
-        self.functions.insert(impl_id, Module { name: name.name(), decls });
+        self.add_impl(impl_id, Module { name: name.name(), decls });
     }
 }
 
@@ -153,7 +153,7 @@ pub fn translate_constraint<'tcx>(
     names: &mut CloneMap<'tcx>,
     tp: TraitPredicate<'tcx>,
 ) {
-    names.qname_for_mut(tp.def_id(), tp.trait_ref.substs);
+    names.insert(tp.def_id(), tp.trait_ref.substs);
 
     // If we haven't seen this trait, first translate it
     ctx.translate_trait(tp.def_id());
@@ -202,15 +202,15 @@ fn translate_assoc_function(
             )
         });
 
-    let assoc_method = if crate::is_predicate(ctx.tcx, assoc.def_id) {
+    let assoc_method = if crate::util::is_predicate(ctx.tcx, assoc.def_id) {
         CloneSubst::Predicate(
             assoc.ident.to_string().into(),
-            names.qname_for_mut(assoc.def_id, assoc_subst),
+            names.insert(assoc.def_id, assoc_subst).qname(ctx.tcx, assoc.def_id),
         )
     } else {
         CloneSubst::Val(
             assoc.ident.to_string().into(),
-            names.qname_for_mut(assoc.def_id, assoc_subst),
+            names.insert(assoc.def_id, assoc_subst).qname(ctx.tcx, assoc.def_id),
         )
     };
 

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{self, subst::InternalSubsts, ProjectionTy, Ty, TyKind::*};
+use rustc_middle::ty::{self, subst::InternalSubsts, ProjectionTy, Ty, TyCtxt, TyKind::*};
 use rustc_span::Span;
 use rustc_span::Symbol;
 use std::collections::VecDeque;
@@ -110,7 +110,7 @@ pub fn translate_projection_ty(
     pty: &ProjectionTy<'tcx>,
 ) -> MlT {
     ctx.translate_trait(pty.trait_def_id(ctx.tcx));
-    let name = names.qname_for_mut(pty.item_def_id, pty.substs);
+    let name = names.insert(pty.item_def_id, pty.substs).qname(ctx.tcx, pty.item_def_id);
     MlT::TConstructor(name)
 }
 
@@ -174,6 +174,10 @@ fn translate_ty_param(p: Symbol) -> String {
     p.to_string().to_lowercase()
 }
 
+pub fn ty_name(tcx: TyCtxt, def_id: DefId) -> String {
+    tcx.item_name(def_id).to_string().to_lowercase()
+}
+
 // Translate a Rust type declation to an ML one
 // Rust tuple-like types are translated as one would expect, to product types in WhyML
 // However, Rust struct types are *not* translated to WhyML records, instead we 'forget' the field names
@@ -193,7 +197,7 @@ pub fn translate_tydecl(ctx: &mut TranslationCtx<'_, '_>, span: Span, did: DefId
     // TODO: allow mutually recursive types
     check_not_mutally_recursive(ctx, did, span);
 
-    let mut names = CloneMap::new(ctx.tcx);
+    let mut names = CloneMap::new(ctx.tcx, ItemType::Type);
 
     let adt = ctx.tcx.adt_def(did);
     let gens = ctx.tcx.generics_of(did);
@@ -282,7 +286,7 @@ fn uintty_to_ty(names: &mut CloneMap<'tcx>, ity: &rustc_middle::ty::UintTy) -> M
     }
 }
 
-fn floatty_to_ty(names: &mut CloneMap<'_>, fty: &rustc_middle::ty::FloatTy) -> MlT {
+fn floatty_to_ty(_: &mut CloneMap<'_>, fty: &rustc_middle::ty::FloatTy) -> MlT {
     use rustc_middle::ty::FloatTy::*;
 
     match fty {

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -110,9 +110,8 @@ pub fn translate_projection_ty(
     pty: &ProjectionTy<'tcx>,
 ) -> MlT {
     ctx.translate_trait(pty.trait_def_id(ctx.tcx));
-    let base = names.name_for_mut(pty.trait_def_id(ctx.tcx), pty.substs);
-    let name = ctx.tcx.item_name(pty.item_def_id).to_string().to_lowercase();
-    MlT::TConstructor(QName { module: vec![base], name })
+    let name = names.qname_for_mut(pty.item_def_id, pty.substs);
+    MlT::TConstructor(name)
 }
 
 use petgraph::algo::tarjan_scc;

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -18,6 +18,11 @@ module Type
     | AllZero_List_Nil
     
 end
+module AllZero_Len_Interface
+  use mach.int.Int
+  use Type
+  function len (l : Type.allzero_list) : int
+end
 module AllZero_Len
   use mach.int.Int
   use mach.int.Int32
@@ -27,6 +32,12 @@ module AllZero_Len
       | Type.AllZero_List_Cons(_, ls) -> Int32.to_int (1 : int32) + len ls
       | Type.AllZero_List_Nil -> Int32.to_int (0 : int32)
       end
+end
+module AllZero_Get_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  function get (l : Type.allzero_list) (ix : int) : Type.core_option_option uint32
 end
 module AllZero_Get
   use Type
@@ -46,6 +57,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -58,19 +74,32 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module AllZero_AllZero_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone AllZero_Get_Interface as Get1
+  clone AllZero_Len_Interface as Len0
+  val all_zero (l : borrowed (Type.allzero_list)) : ()
+    ensures { Len0.len ( * l) = Len0.len ( ^ l) }
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some((0 : uint32)) }
+    
+end
 module AllZero_AllZero
   use mach.int.Int
   use mach.int.Int32
   use Type
   use mach.int.UInt32
   use prelude.Prelude
-  clone AllZero_Len as Len0
-  clone AllZero_Get as Get1
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = Type.allzero_list
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t = Type.allzero_list
   clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t = Type.allzero_list
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = isize
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = Type.allzero_list
+  clone AllZero_Get as Get1
+  clone AllZero_Len as Len0
   let rec cfg all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some((0 : uint32)) }
@@ -133,6 +162,9 @@ module AllZero_AllZero
     goto BB1
   }
   
+end
+module AllZero_Main_Interface
+  val main () : ()
 end
 module AllZero_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -22,6 +22,12 @@ module Type
     | BinarySearch_List_Nil
     
 end
+module BinarySearch_LenLogic_Interface
+  type t   
+  use mach.int.Int
+  use Type
+  function len_logic (l : Type.binarysearch_list t) : int
+end
 module BinarySearch_LenLogic
   type t   
   use mach.int.Int
@@ -32,6 +38,12 @@ module BinarySearch_LenLogic
       | Type.BinarySearch_List_Cons(_, ls) -> Int32.to_int (1 : int32) + len_logic ls
       | Type.BinarySearch_List_Nil -> Int32.to_int (0 : int32)
       end
+end
+module BinarySearch_Get_Interface
+  type t   
+  use Type
+  use mach.int.Int
+  function get (l : Type.binarysearch_list t) (ix : int) : Type.core_option_option t
 end
 module BinarySearch_Get
   type t   
@@ -51,9 +63,26 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module Std_Process_Abort_Interface
+  val abort () : ()
+    ensures { false }
+    
+end
 module Std_Process_Abort
   val abort () : ()
     ensures { false }
+    
+end
+module BinarySearch_Impl0_Index_Interface
+  type t   
+  use Type
+  use prelude.Prelude
+  use mach.int.Int
+  clone BinarySearch_Get_Interface as Get1 with type t = t
+  clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
+  val index (self : Type.binarysearch_list t) (ix : usize) : t
+    requires {UInt64.to_int ix < LenLogic0.len_logic self}
+    ensures { Type.Core_Option_Option_Some(result) = Get1.get self (UInt64.to_int ix) }
     
 end
 module BinarySearch_Impl0_Index
@@ -62,16 +91,16 @@ module BinarySearch_Impl0_Index
   use mach.int.UInt64
   use prelude.Prelude
   use Type
-  clone BinarySearch_LenLogic as LenLogic0 with type t = t
-  clone BinarySearch_Get as Get1 with type t = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
-  clone Std_Process_Abort as Abort6
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = t
+  clone Std_Process_Abort_Interface as Abort6
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
+  clone BinarySearch_Get as Get1 with type t = t
+  clone BinarySearch_LenLogic as LenLogic0 with type t = t
   let rec cfg index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
     ensures { Type.Core_Option_Option_Some(result) = Get1.get self (UInt64.to_int ix) }
@@ -168,6 +197,20 @@ module BinarySearch_Impl0_Index
   }
   
 end
+module BinarySearch_Impl0_Len_Interface
+  type t   
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.UInt64
+  use prelude.Prelude
+  use Type
+  clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
+  val len (self : Type.binarysearch_list t) : usize
+    requires {LenLogic0.len_logic self <= Int32.to_int (1000000 : int32)}
+    ensures { UInt64.to_int result = LenLogic0.len_logic self }
+    ensures { result >= (0 : usize) }
+    
+end
 module BinarySearch_Impl0_Len
   type t   
   use mach.int.Int
@@ -175,12 +218,12 @@ module BinarySearch_Impl0_Len
   use prelude.Prelude
   use mach.int.Int32
   use Type
-  clone BinarySearch_LenLogic as LenLogic0 with type t = t
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = Type.binarysearch_list t
+  clone BinarySearch_LenLogic as LenLogic0 with type t = t
   let rec cfg len (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= Int32.to_int (1000000 : int32)}
     ensures { UInt64.to_int result = LenLogic0.len_logic self }
@@ -246,11 +289,17 @@ module BinarySearch_Impl0_Len
   }
   
 end
+module BinarySearch_IsSorted_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  function is_sorted (l : Type.binarysearch_list uint32) : bool
+end
 module BinarySearch_IsSorted
   use mach.int.Int
   use Type
   use mach.int.UInt32
-  clone BinarySearch_Get as Get0 with type t = uint32
+  clone BinarySearch_Get_Interface as Get0 with type t = uint32
   function is_sorted (l : Type.binarysearch_list uint32) : bool = 
     forall x2 : (int) . forall x1 : (int) . x1 <= x2 -> match ((Get0.get l x1, Get0.get l x2)) with
       | (Type.Core_Option_Option_Some(v1), Type.Core_Option_Option_Some(v2)) -> v1 <= v2
@@ -258,16 +307,40 @@ module BinarySearch_IsSorted
       | _ -> false
       end
 end
+module BinarySearch_GetDefault_Interface
+  type t   
+  use Type
+  use mach.int.Int
+  function get_default (l : Type.binarysearch_list t) (ix : int) (def : t) : t
+end
 module BinarySearch_GetDefault
   type t   
   use Type
   use mach.int.Int
-  clone BinarySearch_Get as Get0 with type t = t
+  clone BinarySearch_Get_Interface as Get0 with type t = t
   function get_default (l : Type.binarysearch_list t) (ix : int) (def : t) : t = 
     match (Get0.get l ix) with
       | Type.Core_Option_Option_Some(v) -> v
       | Type.Core_Option_Option_None -> def
       end
+end
+module BinarySearch_BinarySearch_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  use mach.int.UInt32
+  clone BinarySearch_Get_Interface as Get3 with type t = uint32
+  clone BinarySearch_GetDefault_Interface as GetDefault2 with type t = uint32
+  clone BinarySearch_LenLogic_Interface as LenLogic1 with type t = uint32
+  clone BinarySearch_IsSorted_Interface as IsSorted0
+  val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
+    requires {IsSorted0.is_sorted arr}
+    requires {LenLogic1.len_logic arr <= Int32.to_int (1000000 : int32)}
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok(x) -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some(elem) }
+    
 end
 module BinarySearch_BinarySearch
   use mach.int.Int
@@ -276,18 +349,20 @@ module BinarySearch_BinarySearch
   use prelude.Prelude
   use mach.int.Int32
   use Type
-  clone BinarySearch_LenLogic as LenLogic0 with type t = uint32
-  clone BinarySearch_GetDefault as GetDefault1 with type t = uint32
-  clone BinarySearch_Impl0_Len as Len2 with type t = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = usize
-  clone BinarySearch_Impl0_Index as Index8 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = uint32
-  clone BinarySearch_IsSorted as IsSorted10
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list uint32
   clone BinarySearch_Get as Get11 with type t = uint32
+  clone BinarySearch_IsSorted as IsSorted10 with function Get0.get = Get11.get
+  clone BinarySearch_GetDefault as GetDefault1 with type t = uint32, function Get0.get = Get11.get
+  clone BinarySearch_LenLogic as LenLogic0 with type t = uint32
+  clone BinarySearch_Impl0_Index_Interface as Index8 with type t = uint32,
+  function LenLogic0.len_logic = LenLogic0.len_logic, function Get1.get = Get11.get
+  clone BinarySearch_Impl0_Len_Interface as Len2 with type t = uint32,
+  function LenLogic0.len_logic = LenLogic0.len_logic
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted10.is_sorted arr}
     requires {LenLogic0.len_logic arr <= Int32.to_int (1000000 : int32)}
@@ -538,6 +613,9 @@ module BinarySearch_BinarySearch
     return _0
   }
   
+end
+module BinarySearch_Main_Interface
+  val main () : ()
 end
 module BinarySearch_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/branch_borrow_2.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_2.stdout
@@ -10,17 +10,26 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module BranchBorrow2_Main_Interface
+  val main () : ()
+end
 module BranchBorrow2_Main
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone Core_Panicking_Panic as Panic0
+  clone Core_Panicking_Panic_Interface as Panic0
   let rec cfg main () : () = 
   var _0 : ();
   var a_1 : int32;

--- a/creusot/tests/should_succeed/branch_borrow_3.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_3.stdout
@@ -13,6 +13,9 @@ module Type
     | BranchBorrow3_MyInt(usize)
     
 end
+module BranchBorrow3_Main_Interface
+  val main () : ()
+end
 module BranchBorrow3_Main
   use mach.int.Int
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/branch_borrow_4.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_4.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module BranchBorrow4_Main_Interface
+  val main () : ()
+end
 module BranchBorrow4_Main
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/clones/01.rs
+++ b/creusot/tests/should_succeed/clones/01.rs
@@ -1,0 +1,14 @@
+
+// The output should have `func2` cloning the interface of `func1`
+// but `func3` should only clone `func1` as its usage of `func1` is
+// internal.
+
+fn func1() {}
+
+fn func2() {
+  func1()
+}
+
+fn func3() {
+  func2()
+}

--- a/creusot/tests/should_succeed/clones/01.stdout
+++ b/creusot/tests/should_succeed/clones/01.stdout
@@ -1,0 +1,65 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C01_Func1_Interface
+  val func1 () : ()
+end
+module C01_Func1
+  let rec cfg func1 () : () = 
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C01_Func2_Interface
+  val func2 () : ()
+end
+module C01_Func2
+  clone C01_Func1_Interface as Func10
+  let rec cfg func2 () : () = 
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- Func10.func1 ();
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end
+module C01_Func3_Interface
+  val func3 () : ()
+end
+module C01_Func3
+  clone C01_Func2_Interface as Func20
+  let rec cfg func3 () : () = 
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- Func20.func2 ();
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/clones/02.rs
+++ b/creusot/tests/should_succeed/clones/02.rs
@@ -1,0 +1,27 @@
+// SHOULD_SUCCEED: parse-print
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+// Here we want to ensure that `program` properly shares
+// the implementation of simple between itself and `uses_simple`.
+
+logic! {
+  fn simple() -> bool {
+    true
+  }
+}
+
+logic! {
+  fn uses_simple() -> bool {
+    simple()
+  }
+}
+
+#[requires(uses_simple())]
+#[ensures(simple())]
+fn program() {}

--- a/creusot/tests/should_succeed/clones/02.stdout
+++ b/creusot/tests/should_succeed/clones/02.stdout
@@ -1,0 +1,53 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C02_Simple_Interface
+  function simple () : bool
+end
+module C02_Simple
+  function simple () : bool = 
+    true
+end
+module C02_UsesSimple_Interface
+  function uses_simple () : bool
+end
+module C02_UsesSimple
+  clone C02_Simple_Interface as Simple0
+  function uses_simple () : bool = 
+    Simple0.simple ()
+end
+module C02_Program_Interface
+  clone C02_Simple_Interface as Simple1
+  clone C02_UsesSimple_Interface as UsesSimple0
+  val program () : ()
+    requires {UsesSimple0.uses_simple ()}
+    ensures { Simple1.simple () }
+    
+end
+module C02_Program
+  clone C02_Simple as Simple1
+  clone C02_UsesSimple as UsesSimple0 with function Simple0.simple = Simple1.simple
+  let rec cfg program () : ()
+    requires {UsesSimple0.uses_simple ()}
+    ensures { Simple1.simple () }
+    
+   = 
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/clones/03.rs
+++ b/creusot/tests/should_succeed/clones/03.rs
@@ -1,0 +1,27 @@
+// SHOULD_SUCCEED: parse-print
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+logic! {
+  fn omg<T>(x: T) -> bool {
+    true
+  }
+}
+
+#[ensures(omg(x))]
+fn prog<T>(x: T) {}
+
+#[ensures(omg(0))]
+fn prog2() {
+  prog(0);
+}
+
+#[ensures(omg((0, 0)))]
+fn prog3() {
+
+}

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -1,0 +1,119 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C03_Omg_Interface
+  type t   
+  function omg (x : t) : bool
+end
+module C03_Omg
+  type t   
+  function omg (x : t) : bool = 
+    true
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module Core_Marker_Sized
+  type self   
+end
+module C03_Prog_Interface
+  type t   
+  clone C03_Omg_Interface as Omg0 with type t = t
+  val prog (x : t) : ()
+    ensures { Omg0.omg x }
+    
+end
+module C03_Prog
+  type t   
+  clone Core_Marker_Sized as Sized2 with type self = t
+  clone C03_Omg as Omg1 with type t = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
+  let rec cfg prog (x : t) : ()
+    ensures { Omg1.omg x }
+    
+   = 
+  var _0 : ();
+  var x_1 : t;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve0.resolve x_1 };
+    return _0
+  }
+  
+end
+module C03_Prog2_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  clone C03_Omg_Interface as Omg0 with type t = int
+  val prog2 () : ()
+    ensures { Omg0.omg (Int32.to_int (0 : int32)) }
+    
+end
+module C03_Prog2
+  use mach.int.Int
+  use mach.int.Int32
+  clone C03_Omg as Omg1 with type t = int
+  clone C03_Omg as Omg2 with type t = int32
+  clone C03_Prog_Interface as Prog0 with type t = int32, function Omg0.omg = Omg2.omg
+  let rec cfg prog2 () : ()
+    ensures { Omg1.omg (Int32.to_int (0 : int32)) }
+    
+   = 
+  var _0 : ();
+  var _1 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _1 <- Prog0.prog (0 : int32);
+    goto BB1
+  }
+  BB1 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C03_Prog3_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  clone C03_Omg_Interface as Omg0 with type t = (int, int)
+  val prog3 () : ()
+    ensures { Omg0.omg (Int32.to_int (0 : int32), Int32.to_int (0 : int32)) }
+    
+end
+module C03_Prog3
+  use mach.int.Int
+  use mach.int.Int32
+  clone C03_Omg as Omg0 with type t = (int, int)
+  let rec cfg prog3 () : ()
+    ensures { Omg0.omg (Int32.to_int (0 : int32), Int32.to_int (0 : int32)) }
+    
+   = 
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/clones/04.rs
+++ b/creusot/tests/should_succeed/clones/04.rs
@@ -1,0 +1,29 @@
+// SHOULD_SUCCEED: parse-print
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+logic! {
+  fn a(x: u32) -> bool {
+    x > 0u32
+  }
+}
+
+logic! {
+  fn b(x: u32) -> bool {
+    x > 10u32 && a(x)
+  }
+}
+
+logic! {
+  fn c(x: u32) -> bool {
+    x < 50u32 && b(x)
+  }
+}
+
+#[requires(c(x))]
+fn f(x: u32) {}

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -1,0 +1,83 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C04_A_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  function a (x : uint32) : bool
+end
+module C04_A
+  use mach.int.Int
+  use mach.int.UInt32
+  function a (x : uint32) : bool = 
+    x > (0 : uint32)
+end
+module C04_B_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  function b (x : uint32) : bool
+end
+module C04_B
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C04_A_Interface as A0
+  function b (x : uint32) : bool = 
+    x > (10 : uint32) && A0.a x
+end
+module C04_C_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  function c (x : uint32) : bool
+end
+module C04_C
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C04_B_Interface as B0
+  function c (x : uint32) : bool = 
+    x < (50 : uint32) && B0.b x
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C04_F_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C04_C_Interface as C0
+  val f (x : uint32) : ()
+    requires {C0.c x}
+    
+end
+module C04_F
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C04_A as A3
+  clone C04_B as B2 with function A0.a = A3.a
+  clone C04_C as C1 with function B0.b = B2.b
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  let rec cfg f (x : uint32) : ()
+    requires {C1.c x}
+    
+   = 
+  var _0 : ();
+  var x_1 : uint32;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    assume { Resolve0.resolve x_1 };
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -38,6 +38,13 @@ module Core_Cmp_PartialOrd
   val gt (self : self) (other : rhs) : bool
   val ge (self : self) (other : rhs) : bool
 end
+module Core_Tuple_Impl7_PartialCmp_Interface
+  type a   
+  type b   
+  use Type
+  use prelude.Prelude
+  val partial_cmp (self : (a, b)) (other : (a, b)) : Type.core_option_option (Type.core_cmp_ordering)
+end
 module Core_Tuple_Impl7_PartialCmp
   type a   
   type b   
@@ -45,11 +52,23 @@ module Core_Tuple_Impl7_PartialCmp
   use prelude.Prelude
   val partial_cmp (self : (a, b)) (other : (a, b)) : Type.core_option_option (Type.core_cmp_ordering)
 end
+module Core_Tuple_Impl7_Lt_Interface
+  type a   
+  type b   
+  use prelude.Prelude
+  val lt (self : (a, b)) (other : (a, b)) : bool
+end
 module Core_Tuple_Impl7_Lt
   type a   
   type b   
   use prelude.Prelude
   val lt (self : (a, b)) (other : (a, b)) : bool
+end
+module Core_Tuple_Impl7_Le_Interface
+  type a   
+  type b   
+  use prelude.Prelude
+  val le (self : (a, b)) (other : (a, b)) : bool
 end
 module Core_Tuple_Impl7_Le
   type a   
@@ -57,11 +76,23 @@ module Core_Tuple_Impl7_Le
   use prelude.Prelude
   val le (self : (a, b)) (other : (a, b)) : bool
 end
+module Core_Tuple_Impl7_Ge_Interface
+  type a   
+  type b   
+  use prelude.Prelude
+  val ge (self : (a, b)) (other : (a, b)) : bool
+end
 module Core_Tuple_Impl7_Ge
   type a   
   type b   
   use prelude.Prelude
   val ge (self : (a, b)) (other : (a, b)) : bool
+end
+module Core_Tuple_Impl7_Gt_Interface
+  type a   
+  type b   
+  use prelude.Prelude
+  val gt (self : (a, b)) (other : (a, b)) : bool
 end
 module Core_Tuple_Impl7_Gt
   type a   
@@ -72,19 +103,24 @@ end
 module Core_Tuple_Impl7
   type a   
   type b   
-  clone Core_Tuple_Impl7_PartialCmp as PartialCmp0 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Lt as Lt1 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Le as Le2 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Ge as Ge3 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Gt as Gt4 with type a = a, type b = b
+  clone Core_Tuple_Impl7_Gt_Interface as Gt4 with type a = a, type b = b
+  clone Core_Tuple_Impl7_Ge_Interface as Ge3 with type a = a, type b = b
+  clone Core_Tuple_Impl7_Le_Interface as Le2 with type a = a, type b = b
+  clone Core_Tuple_Impl7_Lt_Interface as Lt1 with type a = a, type b = b
+  clone Core_Tuple_Impl7_PartialCmp_Interface as PartialCmp0 with type a = a, type b = b
   clone Core_Cmp_PartialOrd with type self = (a, b), type rhs = (a, b), val partial_cmp = PartialCmp0.partial_cmp,
   val lt = Lt1.lt, val le = Le2.le, val ge = Ge3.ge, val gt = Gt4.gt
+end
+module ConstrainedTypes_UsesConcreteInstance_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val uses_concrete_instance (x : (uint32, uint32)) (y : (uint32, uint32)) : bool
 end
 module ConstrainedTypes_UsesConcreteInstance
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone Core_Tuple_Impl7_Lt as Lt0 with type a = uint32, type b = uint32
+  clone Core_Tuple_Impl7_Lt_Interface as Lt0 with type a = uint32, type b = uint32
   let rec cfg uses_concrete_instance (x : (uint32, uint32)) (y : (uint32, uint32)) : bool = 
   var _0 : bool;
   var x_1 : (uint32, uint32);
@@ -108,6 +144,9 @@ module ConstrainedTypes_UsesConcreteInstance
     return _0
   }
   
+end
+module ConstrainedTypes_Main_Interface
+  val main () : ()
 end
 module ConstrainedTypes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module DropPair_Main_Interface
+  val main () : ()
+end
 module DropPair_Main
   let rec cfg main () : () = 
   var _0 : ();
@@ -26,11 +29,16 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl10_Resolve_Interface
+  type t1   
+  type t2   
+  predicate resolve (self : (t1, t2))
+end
 module CreusotContracts_Builtins_Impl10_Resolve
   type t1   
   type t2   
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t1
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t2
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
@@ -39,6 +47,12 @@ module CreusotContracts_Builtins_Impl10
   type t2   
   clone CreusotContracts_Builtins_Impl10_Resolve as Resolve0 with type t1 = t1, type t2 = t2
   clone CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = Resolve0.resolve
+end
+module DropPair_DropPair_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val drop_pair (x : (borrowed uint32, borrowed uint32)) : ()
 end
 module DropPair_DropPair
   use prelude.Prelude
@@ -58,6 +72,12 @@ module DropPair_DropPair
     return _0
   }
   
+end
+module DropPair_DropPair2_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val drop_pair2 (x : (borrowed uint32, borrowed uint32)) : ()
 end
 module DropPair_DropPair2
   use prelude.Prelude
@@ -81,6 +101,11 @@ module DropPair_DropPair2
   }
   
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -92,6 +117,12 @@ module CreusotContracts_Builtins_Impl11
   use prelude.Prelude
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
+end
+module DropPair_Drop_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val drop (x : borrowed uint32) (y : borrowed uint32) : ()
 end
 module DropPair_Drop
   use prelude.Prelude

--- a/creusot/tests/should_succeed/empty.stdout
+++ b/creusot/tests/should_succeed/empty.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Empty_Main_Interface
+  val main () : ()
+end
 module Empty_Main
   let rec cfg main () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/forall.stdout
+++ b/creusot/tests/should_succeed/forall.stdout
@@ -10,6 +10,13 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Forall_Main_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val main () : ()
+    ensures { forall x : (uint32) . true && true && true && true && true && true && true && true && true }
+    
+end
 module Forall_Main
   use mach.int.Int
   use mach.int.UInt32

--- a/creusot/tests/should_succeed/immut.stdout
+++ b/creusot/tests/should_succeed/immut.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Immut_Main_Interface
+  val main () : ()
+end
 module Immut_Main
   use mach.int.Int
   use mach.int.UInt32

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -14,6 +14,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -26,13 +31,24 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module IncMax_TakeMax_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
+    ensures { match ( * ma >=  * mb) with
+      | True ->  * mb =  ^ mb && result = ma
+      | False ->  * ma =  ^ ma && result = mb
+      end }
+    
+end
 module IncMax_TakeMax
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
@@ -100,22 +116,35 @@ module IncMax_TakeMax
   }
   
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module IncMax_IncMax_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val inc_max (a : uint32) (b : uint32) : ()
+    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
+    
+end
 module IncMax_IncMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
-  clone IncMax_TakeMax as TakeMax1
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone Core_Panicking_Panic as Panic4
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic4
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone IncMax_TakeMax_Interface as TakeMax1
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max (a : uint32) (b : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -14,6 +14,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -26,12 +31,20 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module IncMax3_Swap_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val swap (mma : borrowed (borrowed uint32)) (mmb : borrowed (borrowed uint32)) : ()
+    ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
+    
+end
 module IncMax3_Swap
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = borrowed uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
   let rec cfg swap (mma : borrowed (borrowed uint32)) (mmb : borrowed (borrowed uint32)) : ()
     ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
     
@@ -68,16 +81,25 @@ module IncMax3_Swap
   }
   
 end
+module IncMax3_IncMax3_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  val inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
+    requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
+    ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
+    
+end
 module IncMax3_IncMax3
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = borrowed uint32
-  clone IncMax3_Swap as Swap3
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve5 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
+  clone IncMax3_Swap_Interface as Swap3
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = borrowed uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
@@ -252,22 +274,35 @@ module IncMax3_IncMax3
   }
   
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module IncMax3_TestIncMax3_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
+    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
+    
+end
 module IncMax3_TestIncMax3
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
-  clone IncMax3_IncMax3 as IncMax31
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone Core_Panicking_Panic as Panic4
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic4
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone IncMax3_IncMax3_Interface as IncMax31
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
   let rec cfg test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -14,6 +14,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -26,13 +31,24 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module IncMaxMany_TakeMax_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
+    ensures { match ( * ma >=  * mb) with
+      | True ->  * mb =  ^ mb && result = ma
+      | False ->  * ma =  ^ ma && result = mb
+      end }
+    
+end
 module IncMaxMany_TakeMax
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
@@ -100,22 +116,35 @@ module IncMaxMany_TakeMax
   }
   
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module IncMaxMany_IncMaxMany_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
+    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
+    
+end
 module IncMaxMany_IncMaxMany
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
-  clone IncMaxMany_TakeMax as TakeMax1
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone Core_Panicking_Panic as Panic4
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic4
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone IncMaxMany_TakeMax_Interface as TakeMax1
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -14,6 +14,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -26,13 +31,24 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module IncMaxRepeat_TakeMax_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
+    ensures { match ( * ma >=  * mb) with
+      | True ->  * mb =  ^ mb && result = ma
+      | False ->  * ma =  ^ ma && result = mb
+      end }
+    
+end
 module IncMaxRepeat_TakeMax
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg take_max (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { match ( * ma >=  * mb) with
       | True ->  * mb =  ^ mb && result = ma
@@ -100,22 +116,35 @@ module IncMaxRepeat_TakeMax
   }
   
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module IncMaxRepeat_IncMaxRepeat_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val inc_max_repeat (a : uint32) (b : uint32) (n : uint32) : ()
+    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
+    
+end
 module IncMaxRepeat_IncMaxRepeat
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = uint32
-  clone IncMaxRepeat_TakeMax as TakeMax3
+  clone Core_Panicking_Panic_Interface as Panic5
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
-  clone Core_Panicking_Panic as Panic5
+  clone IncMaxRepeat_TakeMax_Interface as TakeMax3
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg inc_max_repeat (a : uint32) (b : uint32) (n : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -17,10 +17,19 @@ module Type
     | ListIndexMut_List(uint32, listindexmut_option (listindexmut_list))
     
 end
+module ListIndexMut_Impl0_Resolve_Interface
+  use Type
+  predicate resolve (self : Type.listindexmut_list)
+end
 module ListIndexMut_Impl0_Resolve
   use Type
   predicate resolve (self : Type.listindexmut_list) = 
     true
+end
+module ListIndexMut_Len_Interface
+  use mach.int.Int
+  use Type
+  function len (l : Type.listindexmut_list) : int
 end
 module ListIndexMut_Len
   use mach.int.Int
@@ -31,6 +40,12 @@ module ListIndexMut_Len
       | Type.ListIndexMut_Option_Some(ls) -> len ls
       | Type.ListIndexMut_Option_None -> Int32.to_int (0 : int32)
       end
+end
+module ListIndexMut_Get_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  function get (l : Type.listindexmut_list) (ix : int) : Type.listindexmut_option uint32
 end
 module ListIndexMut_Get
   use Type
@@ -50,6 +65,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -62,9 +82,30 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module Std_Process_Abort_Interface
+  val abort () : ()
+    ensures { false }
+    
+end
 module Std_Process_Abort
   val abort () : ()
     ensures { false }
+    
+end
+module ListIndexMut_IndexMut_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  use prelude.Prelude
+  use mach.int.UInt32
+  clone ListIndexMut_Get_Interface as Get1
+  clone ListIndexMut_Len_Interface as Len0
+  val index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
+    requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
+    ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
+    ensures { Type.ListIndexMut_Option_Some( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
     
 end
 module ListIndexMut_IndexMut
@@ -74,16 +115,16 @@ module ListIndexMut_IndexMut
   use mach.int.Int32
   use Type
   use mach.int.UInt32
-  clone ListIndexMut_Len as Len0
-  clone ListIndexMut_Get as Get1
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = isize
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve6 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
-  clone Std_Process_Abort as Abort8
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve9 with type t = uint32
+  clone Std_Process_Abort_Interface as Abort8
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = ()
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve6 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = isize
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = usize
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve2 with type t = Type.listindexmut_list
+  clone ListIndexMut_Get as Get1
+  clone ListIndexMut_Len as Len0
   let rec cfg index_mut (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
@@ -201,19 +242,34 @@ module ListIndexMut_IndexMut
   }
   
 end
+module ListIndexMut_Write_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  use prelude.Prelude
+  use mach.int.UInt32
+  clone ListIndexMut_Get_Interface as Get1
+  clone ListIndexMut_Len_Interface as Len0
+  val write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
+    requires {UInt64.to_int ix < Len0.len ( * l)}
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    ensures { Len0.len ( ^ l) = Len0.len ( * l) }
+    ensures { Type.ListIndexMut_Option_Some(v) = Get1.get ( ^ l) (UInt64.to_int ix) }
+    
+end
 module ListIndexMut_Write
   use mach.int.Int
   use mach.int.Int32
   use Type
   use prelude.Prelude
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
-  clone ListIndexMut_IndexMut as IndexMut3
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve4 with type t = uint32
-  clone ListIndexMut_Len as Len5
   clone ListIndexMut_Get as Get6
+  clone ListIndexMut_Len as Len5
+  clone ListIndexMut_IndexMut_Interface as IndexMut3 with function Len0.len = Len5.len, function Get1.get = Get6.get
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {UInt64.to_int ix < Len5.len ( * l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len5.len ( * l) && i <> UInt64.to_int ix -> Get6.get ( * l) i = Get6.get ( ^ l) i }
@@ -263,15 +319,20 @@ module ListIndexMut_Impl0
   clone ListIndexMut_Impl0_Resolve as Resolve0
   clone CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = Resolve0.resolve
 end
+module ListIndexMut_Main_Interface
+  val main () : ()
+end
 module ListIndexMut_Main
   use mach.int.Int
   use mach.int.UInt32
   use mach.int.UInt64
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = Type.listindexmut_list
-  clone ListIndexMut_Write as Write1
   clone ListIndexMut_Impl0_Resolve as Resolve2
+  clone ListIndexMut_Get as Get4
+  clone ListIndexMut_Len as Len3
+  clone ListIndexMut_Write_Interface as Write1 with function Len0.len = Len3.len, function Get1.get = Get4.get
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg main () : () = 
   var _0 : ();
   var l_1 : Type.listindexmut_list;

--- a/creusot/tests/should_succeed/logic_functions.stdout
+++ b/creusot/tests/should_succeed/logic_functions.stdout
@@ -14,9 +14,18 @@ module Type
     | Core_Option_Option_Some('t)
     
 end
+module LogicFunctions_Logical_Interface
+  function logical () : bool
+end
 module LogicFunctions_Logical
   function logical () : bool = 
     true
+end
+module LogicFunctions_Main_Interface
+  clone LogicFunctions_Logical_Interface as Logical0
+  val main () : ()
+    ensures { Logical0.logical () }
+    
 end
 module LogicFunctions_Main
   clone LogicFunctions_Logical as Logical0
@@ -34,9 +43,16 @@ module LogicFunctions_Main
   }
   
 end
+module LogicFunctions_Nested_Nested_Interface
+  function nested () : bool
+end
 module LogicFunctions_Nested_Nested
   function nested () : bool = 
     true
+end
+module LogicFunctions_Arith_Interface
+  use mach.int.Int
+  function arith (n : int) (b : bool) : int
 end
 module LogicFunctions_Arith
   use mach.int.Int
@@ -45,6 +61,12 @@ module LogicFunctions_Arith
       | True -> - n + n - n * n
       | False -> n
       end
+end
+module LogicFunctions_DerefPat_Interface
+  use mach.int.Int
+  use prelude.Prelude
+  use Type
+  function deref_pat (o : Type.core_option_option int) : int
 end
 module LogicFunctions_DerefPat
   use mach.int.Int

--- a/creusot/tests/should_succeed/loop.stdout
+++ b/creusot/tests/should_succeed/loop.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Loop_Main_Interface
+  val main () : ()
+end
 module Loop_Main
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/match_int.stdout
+++ b/creusot/tests/should_succeed/match_int.stdout
@@ -10,16 +10,25 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module MatchInt_Main_Interface
+  val main () : ()
+end
 module MatchInt_Main
   use mach.int.Int
   use mach.int.Int32
-  clone Core_Panicking_Panic as Panic0
+  clone Core_Panicking_Panic_Interface as Panic0
   let rec cfg main () : () = 
   var _0 : ();
   var _1 : int32;

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -14,11 +14,18 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module Mc91_Mc91_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val mc91 (x : uint32) : uint32
+    ensures { x <= (100 : uint32) -> result = (91 : uint32) && x > (100 : uint32) -> result = x - (10 : uint32) }
+    
+end
 module Mc91_Mc91
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg mc91 (x : uint32) : uint32
     ensures { x <= (100 : uint32) -> result = (91 : uint32) && x > (100 : uint32) -> result = x - (10 : uint32) }
     
@@ -73,6 +80,9 @@ module Mc91_Mc91
     return _0
   }
   
+end
+module Mc91_Main_Interface
+  val main () : ()
 end
 module Mc91_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/module_paths.stdout
+++ b/creusot/tests/should_succeed/module_paths.stdout
@@ -22,6 +22,11 @@ module Type
     | ModulePaths_B_C_T(modulepaths_a_t)
     
 end
+module ModulePaths_Test_Interface
+  use Type
+  val test (a : Type.modulepaths_a_t) (b : Type.modulepaths_s) (c : Type.modulepaths_b_o) (d : Type.modulepaths_b_c_t) : ()
+    
+end
 module ModulePaths_Test
   use Type
   let rec cfg test (a : Type.modulepaths_a_t) (b : Type.modulepaths_s) (c : Type.modulepaths_b_o) (d : Type.modulepaths_b_c_t) : ()
@@ -48,6 +53,9 @@ module ModulePaths_Test
     return _0
   }
   
+end
+module ModulePaths_Main_Interface
+  val main () : ()
 end
 module ModulePaths_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -13,6 +13,10 @@ module Type
     | Modules_Nested_Nested_Test
     
 end
+module Modules_Nested_Impl0_Resolve_Interface
+  use Type
+  predicate resolve (self : Type.modules_nested_nested)
+end
 module Modules_Nested_Impl0_Resolve
   use Type
   predicate resolve (self : Type.modules_nested_nested) = 
@@ -27,6 +31,11 @@ module Modules_Nested_Impl0
   clone Modules_Nested_Impl0_Resolve as Resolve0
   clone CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested,
   predicate resolve = Resolve0.resolve
+end
+module Modules_Nested_InnerFunc_Interface
+  val inner_func () : bool
+    ensures { result = true }
+    
 end
 module Modules_Nested_InnerFunc
   use Type
@@ -48,6 +57,9 @@ module Modules_Nested_InnerFunc
   }
   
 end
+module Modules_Nested_Further_Another_Interface
+  val another () : bool
+end
 module Modules_Nested_Further_Another
   let rec cfg another () : bool = 
   var _0 : bool;
@@ -60,9 +72,12 @@ module Modules_Nested_Further_Another
   }
   
 end
+module Modules_Main_Interface
+  val main () : ()
+end
 module Modules_Main
-  clone Modules_Nested_InnerFunc as InnerFunc0
-  clone Modules_Nested_Further_Another as Another1
+  clone Modules_Nested_Further_Another_Interface as Another1
+  clone Modules_Nested_InnerFunc_Interface as InnerFunc0
   let rec cfg main () : () = 
   var _0 : ();
   var _1 : bool;

--- a/creusot/tests/should_succeed/move_path.stdout
+++ b/creusot/tests/should_succeed/move_path.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module MovePath_Main_Interface
+  val main () : ()
+end
 module MovePath_Main
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/multiple_scopes.stdout
+++ b/creusot/tests/should_succeed/multiple_scopes.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module MultipleScopes_MultipleScopes_Interface
+  val multiple_scopes () : ()
+end
 module MultipleScopes_MultipleScopes
   use mach.int.Int
   use mach.int.Int32
@@ -38,6 +41,9 @@ module MultipleScopes_MultipleScopes
     return _0
   }
   
+end
+module MultipleScopes_Main_Interface
+  val main () : ()
 end
 module MultipleScopes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/mut_call.stdout
+++ b/creusot/tests/should_succeed/mut_call.stdout
@@ -10,6 +10,12 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module MutCall_Kill_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val kill (_1 : borrowed uint32) : ()
+end
 module MutCall_Kill
   use prelude.Prelude
   use mach.int.Int
@@ -28,11 +34,14 @@ module MutCall_Kill
   }
   
 end
+module MutCall_Test_Interface
+  val test () : ()
+end
 module MutCall_Test
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone MutCall_Kill as Kill0
+  clone MutCall_Kill_Interface as Kill0
   let rec cfg test () : () = 
   var _0 : ();
   var a_1 : uint32;
@@ -59,6 +68,9 @@ module MutCall_Test
     return _0
   }
   
+end
+module MutCall_Main_Interface
+  val main () : ()
 end
 module MutCall_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -13,6 +13,9 @@ module Type
     | OneSideUpdate_MyInt(usize)
     
 end
+module OneSideUpdate_Main_Interface
+  val main () : ()
+end
 module OneSideUpdate_Main
   use mach.int.Int
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -14,6 +14,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -36,13 +41,21 @@ module Core_Cmp_PartialEq
   val eq (self : self) (other : rhs) : bool
   val ne (self : self) (other : rhs) : bool
 end
+module ProjectionToggle_ProjToggle_Interface
+  type t   
+  use prelude.Prelude
+  val proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
+    ensures { toggle = false -> result = b &&  ^ a =  * a }
+    ensures { toggle = true -> result = a &&  ^ b =  * b }
+    
+end
 module ProjectionToggle_ProjToggle
   type t   
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = t
-  clone Core_Marker_Sized as Sized2 with type self = t
   clone Core_Cmp_PartialEq as PartialEq3 with type self = t, type rhs = t
+  clone Core_Marker_Sized as Sized2 with type self = t
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = t
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   let rec cfg proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { toggle = false -> result = b &&  ^ a =  * a }
     ensures { toggle = true -> result = a &&  ^ b =  * b }
@@ -106,22 +119,31 @@ module ProjectionToggle_ProjToggle
   }
   
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module ProjectionToggle_Main_Interface
+  val main () : ()
+end
 module ProjectionToggle_Main
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = int32
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int32
-  clone ProjectionToggle_ProjToggle as ProjToggle2 with type t = int32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone Core_Panicking_Panic as Panic4
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
+  clone Core_Panicking_Panic_Interface as Panic4
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
+  clone ProjectionToggle_ProjToggle_Interface as ProjToggle2 with type t = int32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = int32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = int32
   let rec cfg main () : () = 
   var _0 : ();
   var a_1 : int32;

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -18,6 +18,12 @@ module Type
     | Core_Result_Result_Err('e)
     
 end
+module Projections_CopyOutOfRef_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  val copy_out_of_ref (x : uint32) : uint32
+end
 module Projections_CopyOutOfRef
   use mach.int.Int
   use mach.int.UInt32
@@ -36,6 +42,13 @@ module Projections_CopyOutOfRef
     return _0
   }
   
+end
+module Projections_CopyOutOfSum_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  use Type
+  use prelude.Prelude
+  val copy_out_of_sum (x : Type.core_result_result (borrowed uint32) (borrowed uint32)) : uint32
 end
 module Projections_CopyOutOfSum
   use mach.int.Int
@@ -92,6 +105,13 @@ module Projections_CopyOutOfSum
   }
   
 end
+module Projections_WriteIntoSum_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  val write_into_sum (x : borrowed (Type.core_option_option uint32)) : ()
+end
 module Projections_WriteIntoSum
   use mach.int.Int
   use mach.int.UInt32
@@ -141,6 +161,9 @@ module Projections_WriteIntoSum
     return _0
   }
   
+end
+module Projections_Main_Interface
+  val main () : ()
 end
 module Projections_Main
   use mach.int.Int

--- a/creusot/tests/should_succeed/prophecy.stdout
+++ b/creusot/tests/should_succeed/prophecy.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Prophecy_Main_Interface
+  val main () : ()
+end
 module Prophecy_Main
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/replace.stdout
+++ b/creusot/tests/should_succeed/replace.stdout
@@ -17,6 +17,10 @@ module Type
     | Replace_Something(uint32, core_option_option (replace_something))
     
 end
+module Replace_Test_Interface
+  use Type
+  val test (a : Type.replace_something) (b : Type.replace_something) : ()
+end
 module Replace_Test
   use Type
   let rec cfg test (a : Type.replace_something) (b : Type.replace_something) : () = 
@@ -51,6 +55,9 @@ module Replace_Test
     return _0
   }
   
+end
+module Replace_Main_Interface
+  val main () : ()
 end
 module Replace_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/spec_tests.stdout
+++ b/creusot/tests/should_succeed/spec_tests.stdout
@@ -17,6 +17,15 @@ module Type
     | SpecTests_S('a, 'b)
     
 end
+module SpecTests_TestSpecs_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  val test_specs () : ()
+    ensures { Type.SpecTests_S((0 : uint32), true) = Type.SpecTests_S((1 : uint32), false) }
+    ensures { Type.SpecTests_T_A = Type.SpecTests_T_B }
+    
+end
 module SpecTests_TestSpecs
   use Type
   use mach.int.Int
@@ -35,6 +44,9 @@ module SpecTests_TestSpecs
     return _0
   }
   
+end
+module SpecTests_Main_Interface
+  val main () : ()
 end
 module SpecTests_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/specification/division.stdout
+++ b/creusot/tests/should_succeed/specification/division.stdout
@@ -14,11 +14,18 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module Division_Divide_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val divide (y : uint32) (x : uint32) : uint32
+    requires {x <> (0 : uint32)}
+    
+end
 module Division_Divide
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg divide (y : uint32) (x : uint32) : uint32
     requires {x <> (0 : uint32)}
     

--- a/creusot/tests/should_succeed/specification/logic_call.stdout
+++ b/creusot/tests/should_succeed/specification/logic_call.stdout
@@ -10,10 +10,22 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module LogicCall_Reflexive_Interface
+  type t   
+  function reflexive (x : t) : bool
+end
 module LogicCall_Reflexive
   type t   
   function reflexive (x : t) : bool = 
     true = true
+end
+module LogicCall_Dummy_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  clone LogicCall_Reflexive_Interface as Reflexive0 with type t = uint32
+  val dummy () : uint32
+    ensures { Reflexive0.reflexive result }
+    
 end
 module LogicCall_Dummy
   use mach.int.Int

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -13,6 +13,9 @@ module Type
     | SplitBorrow_MyInt(usize)
     
 end
+module SplitBorrow_Z_Interface
+  val z () : bool
+end
 module SplitBorrow_Z
   let rec cfg z () : bool = 
   var _0 : bool;
@@ -25,12 +28,15 @@ module SplitBorrow_Z
   }
   
 end
+module SplitBorrow_Main_Interface
+  val main () : ()
+end
 module SplitBorrow_Main
   use mach.int.Int
   use mach.int.UInt64
   use prelude.Prelude
   use Type
-  clone SplitBorrow_Z as Z0
+  clone SplitBorrow_Z_Interface as Z0
   let rec cfg main () : () = 
   var _0 : ();
   var x_1 : (Type.splitborrow_myint, Type.splitborrow_myint);

--- a/creusot/tests/should_succeed/split_move.stdout
+++ b/creusot/tests/should_succeed/split_move.stdout
@@ -13,6 +13,9 @@ module Type
     | SplitMove_MyInt(usize)
     
 end
+module SplitMove_Main_Interface
+  val main () : ()
+end
 module SplitMove_Main
   use mach.int.Int
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/std_types.stdout
+++ b/creusot/tests/should_succeed/std_types.stdout
@@ -17,6 +17,10 @@ module Type
     | StdTypes_MyType(core_option_option uint32)
     
 end
+module StdTypes_X_Interface
+  use Type
+  val x (x : Type.stdtypes_mytype) : ()
+end
 module StdTypes_X
   use Type
   let rec cfg x (x : Type.stdtypes_mytype) : () = 
@@ -32,6 +36,9 @@ module StdTypes_X
     return _0
   }
   
+end
+module StdTypes_Main_Interface
+  val main () : ()
 end
 module StdTypes_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -14,12 +14,19 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module Sum_SumFirstN_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val sum_first_n (n : uint32) : uint32
+    ensures { result = div (n * n + (1 : uint32)) (2 : uint32) }
+    
+end
 module Sum_SumFirstN
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
   let rec cfg sum_first_n (n : uint32) : uint32
     ensures { result = div (n * n + (1 : uint32)) (2 : uint32) }
     
@@ -87,6 +94,9 @@ module Sum_SumFirstN
     goto BB1
   }
   
+end
+module Sum_Main_Interface
+  val main () : ()
 end
 module Sum_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -14,6 +14,12 @@ module Type
     | Switch_Option_None
     
 end
+module Switch_Test_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  val test (o : Type.switch_option uint32) : bool
+end
 module Switch_Test
   use mach.int.Int
   use mach.int.UInt32
@@ -66,6 +72,12 @@ module Switch_Test
   }
   
 end
+module Switch_Test2_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  use Type
+  val test2 (o : (Type.switch_option uint32, uint32)) : uint32
+end
 module Switch_Test2
   use mach.int.Int
   use mach.int.UInt32
@@ -116,6 +128,9 @@ module Switch_Test2
     return _0
   }
   
+end
+module Switch_Main_Interface
+  val main () : ()
 end
 module Switch_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -14,6 +14,12 @@ module Type
     | SwitchStruct_M_G('t)
     
 end
+module SwitchStruct_Test_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt32
+  val test (o : Type.switchstruct_m uint32) : bool
+end
 module SwitchStruct_Test
   use mach.int.Int
   use mach.int.UInt32
@@ -72,6 +78,9 @@ module SwitchStruct_Test
     return _0
   }
   
+end
+module SwitchStruct_Main_Interface
+  val main () : ()
 end
 module SwitchStruct_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -26,17 +26,23 @@ module Trait_TraitWParams
   type self   
   type d   
   type c   
-  clone Core_Marker_Sized as Sized0 with type self = d
   clone Core_Marker_Sized as Sized1 with type self = c
+  clone Core_Marker_Sized as Sized0 with type self = d
+end
+module Trait_UsesCustom_Interface
+  type a   
+  type b   
+  type t   
+  val uses_custom (t : t) : ()
 end
 module Trait_UsesCustom
   type a   
   type b   
   type t   
-  clone Core_Marker_Sized as Sized0 with type self = a
-  clone Core_Marker_Sized as Sized1 with type self = b
-  clone Core_Marker_Sized as Sized2 with type self = t
   clone Trait_TraitWParams as TraitWParams3 with type self = t, type d = a, type c = b
+  clone Core_Marker_Sized as Sized2 with type self = t
+  clone Core_Marker_Sized as Sized1 with type self = b
+  clone Core_Marker_Sized as Sized0 with type self = a
   let rec cfg uses_custom (t : t) : () = 
   var _0 : ();
   var t_1 : t;
@@ -83,8 +89,8 @@ module Core_Cmp_Ord
   type self   
   use Type
   use prelude.Prelude
-  clone Core_Cmp_Eq as Eq0 with type self = self
   clone Core_Cmp_PartialOrd as PartialOrd1 with type self = self, type rhs = self
+  clone Core_Cmp_Eq as Eq0 with type self = self
   val cmp (self : self) (other : self) : Type.core_cmp_ordering
   val max (self : self) (other : self) : self
   val min (self : self) (other : self) : self
@@ -94,20 +100,26 @@ module Trait_TraitWParams2
   type self   
   type d   
   type c   
-  clone Trait_TraitWParams as TraitWParams0 with type self = self, type d = d, type c = c
-  clone Core_Marker_Sized as Sized1 with type self = d
-  clone Core_Cmp_Ord as Ord2 with type self = d
   clone Core_Marker_Sized as Sized3 with type self = c
+  clone Core_Cmp_Ord as Ord2 with type self = d
+  clone Core_Marker_Sized as Sized1 with type self = d
+  clone Trait_TraitWParams as TraitWParams0 with type self = self, type d = d, type c = c
+end
+module Trait_UsesCustom2_Interface
+  type a   
+  type b   
+  type t   
+  val uses_custom2 (t : t) : ()
 end
 module Trait_UsesCustom2
   type a   
   type b   
   type t   
-  clone Core_Marker_Sized as Sized0 with type self = a
-  clone Core_Cmp_Ord as Ord1 with type self = a
-  clone Core_Marker_Sized as Sized2 with type self = b
-  clone Core_Marker_Sized as Sized3 with type self = t
   clone Trait_TraitWParams2 as TraitWParams24 with type self = t, type d = a, type c = b
+  clone Core_Marker_Sized as Sized3 with type self = t
+  clone Core_Marker_Sized as Sized2 with type self = b
+  clone Core_Cmp_Ord as Ord1 with type self = a
+  clone Core_Marker_Sized as Sized0 with type self = a
   let rec cfg uses_custom2 (t : t) : () = 
   var _0 : ();
   var t_1 : t;
@@ -124,6 +136,9 @@ module Trait_UsesCustom2
     return _0
   }
   
+end
+module Trait_Main_Interface
+  val main () : ()
 end
 module Trait_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module TraitImpl_Main_Interface
+  val main () : ()
+end
 module TraitImpl_Main
   let rec cfg main () : () = 
   var _0 : ();
@@ -21,6 +24,12 @@ module TraitImpl_Main
     return _0
   }
   
+end
+module TraitImpl_Impl0_X_Interface
+  type b   
+  type t2   
+  type t1   
+  val x (self : (t1, t2)) : ()
 end
 module TraitImpl_Impl0_X
   type b   
@@ -42,6 +51,12 @@ module TraitImpl_Impl0_X
     return _0
   }
   
+end
+module TraitImpl_Impl1_X_Interface
+  type b   
+  use mach.int.Int
+  use mach.int.UInt32
+  val x (self : uint32) : ()
 end
 module TraitImpl_Impl1_X
   type b   
@@ -74,13 +89,13 @@ module TraitImpl_Impl0
   type b   
   type t2   
   type t1   
-  clone TraitImpl_Impl0_X as X0 with type b = b, type t2 = t2, type t1 = t1
+  clone TraitImpl_Impl0_X_Interface as X0 with type b = b, type t2 = t2, type t1 = t1
   clone TraitImpl_T with type self = (t1, t2), type b = b, val x = X0.x
 end
 module TraitImpl_Impl1
   type b   
   use mach.int.Int
   use mach.int.UInt32
-  clone TraitImpl_Impl1_X as X0 with type b = b
+  clone TraitImpl_Impl1_X_Interface as X0 with type b = b
   clone TraitImpl_T with type self = uint32, type b = b, val x = X0.x
 end

--- a/creusot/tests/should_succeed/traits/01.rs
+++ b/creusot/tests/should_succeed/traits/01.rs
@@ -1,4 +1,5 @@
 // WHY3SKIP
+// Broken because of trait generics
 trait A {
 	fn from_b<B>(x: Self) -> B;
 }

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -18,13 +18,19 @@ end
 module Core_Marker_Sized
   type self   
 end
+module C01_UsesGeneric_Interface
+  type t   
+  use mach.int.Int
+  use mach.int.UInt32
+  val uses_generic (b : t) : uint32
+end
 module C01_UsesGeneric
   type t   
   use mach.int.Int
   use mach.int.UInt32
-  clone C01_A as A0 with type self = t
-  clone Core_Marker_Sized as Sized1 with type self = t
   clone C01_A as A2 with type self = t
+  clone Core_Marker_Sized as Sized1 with type self = t
+  clone C01_A as A0 with type self = t
   let rec cfg uses_generic (b : t) : uint32 = 
   var _0 : uint32;
   var b_1 : t;
@@ -46,6 +52,9 @@ module C01_UsesGeneric
     return _0
   }
   
+end
+module C01_Main_Interface
+  val main () : ()
 end
 module C01_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/traits/02.stdout
+++ b/creusot/tests/should_succeed/traits/02.stdout
@@ -24,12 +24,18 @@ end
 module Core_Marker_Sized
   type self   
 end
+module C02_Omg_Interface
+  type t   
+  val omg (a : t) : bool
+    ensures { result = true }
+    
+end
 module C02_Omg
   type t   
   use prelude.Prelude
-  clone C02_A as A0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t
   clone Core_Marker_Sized as Sized2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t
+  clone C02_A as A0 with type self = t
   let rec cfg omg (a : t) : bool
     ensures { result = true }
     

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -14,6 +14,12 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module C03_Impl0_F_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  val f (self : int32) : int32
+end
 module C03_Impl0_F
   use mach.int.Int
   use mach.int.Int32
@@ -32,6 +38,12 @@ module C03_Impl0_F
     return _0
   }
   
+end
+module C03_Impl1_G_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  val g (self : uint32) : uint32
 end
 module C03_Impl1_G
   use mach.int.Int
@@ -55,11 +67,16 @@ end
 module Core_Marker_Sized
   type self   
 end
+module C03_Impl2_H_Interface
+  type g   
+  use prelude.Prelude
+  val h (y : g) : g
+end
 module C03_Impl2_H
   type g   
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = g
   clone Core_Marker_Sized as Sized1 with type self = g
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = g
   let rec cfg h (y : g) : g = 
   var _0 : g;
   var y_1 : g;
@@ -83,7 +100,7 @@ end
 module C03_Impl0
   use mach.int.Int
   use mach.int.Int32
-  clone C03_Impl0_F as F0
+  clone C03_Impl0_F_Interface as F0
   clone C03_A with type self = int32, val f = F0.f
 end
 module C03_B
@@ -97,7 +114,7 @@ end
 module C03_Impl1
   use mach.int.Int
   use mach.int.UInt32
-  clone C03_Impl1_G as G0
+  clone C03_Impl1_G_Interface as G0
   clone C03_B with type self = uint32, val g = G0.g
 end
 module C03_C
@@ -109,6 +126,6 @@ end
 module C03_Impl2
   use mach.int.Int
   use mach.int.UInt32
-  clone C03_Impl2_H as H0
+  clone C03_Impl2_H_Interface as H0
   clone C03_C with type self = uint32, type t = H0.g, val h = H0.h
 end

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -24,13 +24,20 @@ end
 module Core_Marker_Sized
   type self   
 end
+module C04_User_Interface
+  type t   
+  use prelude.Prelude
+  val user (a : t) (b : t) : bool
+    ensures { result = false }
+    
+end
 module C04_User
   type t   
   use prelude.Prelude
-  clone C04_A as A0 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
   clone Core_Marker_Sized as Sized3 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone C04_A as A0 with type self = t
   let rec cfg user (a : t) (b : t) : bool
     ensures { result = false }
     

--- a/creusot/tests/should_succeed/traits/06.rs
+++ b/creusot/tests/should_succeed/traits/06.rs
@@ -1,4 +1,3 @@
-// WHY3SKIP
 trait Ix {
 	type Tgt;
 

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -14,9 +14,8 @@ module C06_Ix
   type self   
   use prelude.Prelude
   use mach.int.Int
-  clone C06_Ix as Ix0 with type self = self
   type tgt   
-  val ix (self : self) (ix : usize) : Ix0.tgt
+  val ix (self : self) (ix : usize) : tgt
 end
 module Core_Marker_Sized
   type self   
@@ -34,13 +33,19 @@ module Core_Cmp_Eq
   clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = self
   val assert_receiver_is_total_eq (self : self) : ()
 end
+module C06_Test_Interface
+  type t   
+  use prelude.Prelude
+  clone C06_Ix as Ix0 with type self = t
+  val test (a : t) : Ix0.tgt
+end
 module C06_Test
   type t   
   use mach.int.Int
   use mach.int.UInt64
   use prelude.Prelude
-  clone C06_Ix as Ix0 with type self = t
   clone Core_Marker_Sized as Sized1 with type self = t
+  clone C06_Ix as Ix0 with type self = t
   clone Core_Cmp_Eq as Eq2 with type self = Ix0.tgt
   let rec cfg test (a : t) : Ix0.tgt = 
   var _0 : Ix0.tgt;

--- a/creusot/tests/should_succeed/traits/07.rs
+++ b/creusot/tests/should_succeed/traits/07.rs
@@ -1,4 +1,3 @@
-// WHY3SKIP
 trait Ix {
 	type Tgt;
 	fn ix(&self) -> Self::Tgt;

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -10,6 +10,12 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module C07_Impl0_Ix_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.Int32
+  val ix (self : int32) : ()
+end
 module C07_Impl0_Ix
   use prelude.Prelude
   use mach.int.Int
@@ -34,9 +40,17 @@ end
 module C07_Ix
   type self   
   use prelude.Prelude
-  clone C07_Ix as Ix0 with type self = self
   type tgt   
-  val ix (self : self) : Ix0.tgt
+  val ix (self : self) : tgt
+end
+module C07_Test_Interface
+  type g   
+  type t   
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  use mach.int.UInt64
+  val test (a : uint32) (b : uint64) : bool
 end
 module C07_Test
   type g   
@@ -45,10 +59,10 @@ module C07_Test
   use mach.int.Int
   use mach.int.UInt32
   use mach.int.UInt64
-  clone Core_Marker_Sized as Sized0 with type self = g
-  clone C07_Ix as Ix1 with type self = g
-  clone Core_Marker_Sized as Sized2 with type self = t
   clone C07_Ix as Ix3 with type self = t
+  clone Core_Marker_Sized as Sized2 with type self = t
+  clone C07_Ix as Ix1 with type self = g
+  clone Core_Marker_Sized as Sized0 with type self = g
   let rec cfg test (a : uint32) (b : uint64) : bool = 
   var _0 : bool;
   var a_1 : uint32;
@@ -69,16 +83,22 @@ end
 module C07_Impl0
   use mach.int.Int
   use mach.int.Int32
-  clone C07_Impl0_Ix as Ix0
+  clone C07_Impl0_Ix_Interface as Ix0
   type tgt  = 
     ()
   clone C07_Ix with type self = int32, type tgt = tgt, val ix = Ix0.ix
+end
+module C07_Test2_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.Int32
+  val test2 (a : int32) : ()
 end
 module C07_Test2
   use prelude.Prelude
   use mach.int.Int
   use mach.int.Int32
-  clone C07_Impl0_Ix as Ix0
+  clone C07_Impl0_Ix_Interface as Ix0
   let rec cfg test2 (a : int32) : () = 
   var _0 : ();
   var a_1 : int32;

--- a/creusot/tests/should_succeed/two_modules.stdout
+++ b/creusot/tests/should_succeed/two_modules.stdout
@@ -15,6 +15,10 @@ module Type
     | TwoModules_Mod1_T_C
     
 end
+module TwoModules_Mod2_X_Interface
+  use Type
+  val x (t : Type.twomodules_mod1_t) : bool
+end
 module TwoModules_Mod2_X
   use Type
   let rec cfg x (t : Type.twomodules_mod1_t) : bool = 
@@ -31,9 +35,12 @@ module TwoModules_Mod2_X
   }
   
 end
+module TwoModules_Main_Interface
+  val main () : ()
+end
 module TwoModules_Main
   use Type
-  clone TwoModules_Mod2_X as X0
+  clone TwoModules_Mod2_X_Interface as X0
   let rec cfg main () : () = 
   var _0 : ();
   var _1 : bool;

--- a/creusot/tests/should_succeed/type_constructors.stdout
+++ b/creusot/tests/should_succeed/type_constructors.stdout
@@ -18,6 +18,9 @@ module Type
     | TypeConstructors_A_Y(typeconstructors_b_x)
     
 end
+module TypeConstructors_Main_Interface
+  val main () : ()
+end
 module TypeConstructors_Main
   use Type
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/unary_op.stdout
+++ b/creusot/tests/should_succeed/unary_op.stdout
@@ -10,14 +10,23 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Panicking_Panic_Interface
+  use prelude.Prelude
+  val panic (expr : string) : ()
+    ensures { false }
+    
+end
 module Core_Panicking_Panic
   use prelude.Prelude
   val panic (expr : string) : ()
     ensures { false }
     
 end
+module UnaryOp_Main_Interface
+  val main () : ()
+end
 module UnaryOp_Main
-  clone Core_Panicking_Panic as Panic0
+  clone Core_Panicking_Panic_Interface as Panic0
   let rec cfg main () : () = 
   var _0 : ();
   var _1 : ();

--- a/creusot/tests/should_succeed/unnest.stdout
+++ b/creusot/tests/should_succeed/unnest.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Unnest_Main_Interface
+  val main () : ()
+end
 module Unnest_Main
   let rec cfg main () : () = 
   var _0 : ();
@@ -26,6 +29,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -38,12 +46,22 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module Unnest_Unnest_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  val unnest (x : borrowed (borrowed uint32)) : borrowed uint32
+    ensures {  ^  * x =  ^  ^ x }
+    ensures {  ^ result =  *  ^ x }
+    ensures {  * result =  *  * x }
+    
+end
 module Unnest_Unnest
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = borrowed uint32
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = borrowed uint32
   let rec cfg unnest (x : borrowed (borrowed uint32)) : borrowed uint32
     ensures {  ^  * x =  ^  ^ x }
     ensures {  ^ result =  *  ^ x }

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -14,12 +14,19 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module UnusedInLoop_UnusedInLoop_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val unused_in_loop (b : bool) : uint32
+    ensures { result = (10 : uint32) }
+    
+end
 module UnusedInLoop_UnusedInLoop
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = ()
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
   let rec cfg unused_in_loop (b : bool) : uint32
     ensures { result = (10 : uint32) }
     
@@ -69,6 +76,9 @@ module UnusedInLoop_UnusedInLoop
     goto BB1
   }
   
+end
+module UnusedInLoop_Main_Interface
+  val main () : ()
 end
 module UnusedInLoop_Main
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -18,6 +18,11 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Builtins_Impl11_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
 module CreusotContracts_Builtins_Impl11_Resolve
   type t   
   use prelude.Prelude
@@ -30,15 +35,18 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
+module WhileLet_Main_Interface
+  val main () : ()
+end
 module WhileLet_Main
   use mach.int.Int
   use mach.int.Int32
   use Type
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.whilelet_option int32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = Type.whilelet_option int32
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = Type.whilelet_option int32
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = Type.whilelet_option int32
   let rec cfg main () : () = 
   var _0 : ();
   var a_1 : Type.whilelet_option int32;


### PR DESCRIPTION
This PR closes #26.

In Why3, clones are _generative_, they create a fully fresh definition each time they are evaluated. Additionally, in Why3, terms do not respect alpha equivalence. If two definitions differ only by name, they are _different_ no matter what. 
The solution this PR implements is a mechanism to avoid cloning the same module multiple times at all, and instead _maximally_ share clones. 

# Context

As a quick reminder, in Creusot, each function is translated to a why3 module which clones all of its dependencies, _substituting_ type parameters in the clone.
This means that we will clone a function for each unique substitution it is applied to, and this PR does not attempt to change this. 
However, this PR solves the following issue, imagine we have:

```rust

logic! {
  fn my_precond(x: u32) -> bool {
   something_here
  }
}

#[requires(my_precond(x))]
fn a(x: u32)  { .. }

#[requires(my_precond(x))]
fn b(x : u32) { a(x) }
```

In the module for `b`, we will clone `my_precond`, a dependency from the contract, and `a` a dependency from the definition of `b`. However, by cloning `a`, we will also trigger a _second_ clone of `my_precond` from within the module of `a`. 
This leads to an issue when we attempt to prove the precondition of `a`. In our context we will have `my_precond0(x)` but we are asked to prove `my_precond1(x)`!

# Solution

The solution to this problem is in two parts. 

1. Introduce interfaces 
2. Maximal sharing of clones through said interfaces

Each function, logical or program, is given an _interface_. The interface describes what is visible from a caller: the function's signature and contract, nothing else. If a contract depends on other functions (ie: `my_precond`) then those interfaces are cloned. However, the interface is _abstract_, the actual symbols contained within are `val` in Why3, they have no body and can be _refined_. 

Additionally, each function is given an _implementation_, which defines the actual _body_ of the function. Here is where things get a little subtle as we behave differently for logic and program functions. 

- For logic functions, the body clones the interfaces of all dependencies. This leaves all dependencies in the body abstract. 
- For program functions, we clone the _interface_ of program functions but the _body_ of logic functions. This distinction occurs because we want logic functions to be transparent in proofs, we need to be able to reason on their definitions for them to be useful. 

So far, we have basically reproduced the previous situation but with extra complications, however, by introducing interfaces, we have opened a door to _sharing_. When performing a clone, why3 allows us to refine the definitions of abstract symbols by providing a concrete instantiation for them.

As we've always left dependencies abstract in interfaces and in the definitions of logic function bodies, that means that we can carefully construct a substitution which will share a single definition as widely as possible. 

To do this we construct a sharing graph in which nodes are function instantiations (DefId + Subst pairs), and edges represent dependencies. 
Then we traverse this graph in topological order, at each node, we look at all edges we depend on and add them to the substitution for the current node. 
This ensures that we fully share instantiations throughout the entire call graph. 

--- 

Because of how this is currently implemented we do not support calculating dependencies of functions that come from other crates, but I would rather address this in a follow up PR as this currently fixes a large amount of issues in current proofs. 
I have a relatively clear plan on how to restore support for multi-crate projects. 

