### PR TITLE
Properly translate associated types

### DIFF
--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -170,9 +170,11 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
         let mut decls: Vec<_> = Vec::new();
         decls.extend(all_generic_decls_for(self.tcx, self.def_id));
 
-        for tp in traits::traits_used_by(self.tcx, self.def_id) {
-            traits::translate_constraint(self.ctx, &mut self.clone_names, tp);
-        }
+        traits::translate_predicates(
+            self.ctx,
+            &mut self.clone_names,
+            self.tcx.predicates_of(self.def_id),
+        );
 
         let sig = signature_of(self.ctx, &mut self.clone_names, self.def_id);
         decls.extend(self.clone_names.to_clones(self.ctx));

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -59,9 +59,9 @@ module C07_Test
   use mach.int.Int
   use mach.int.UInt32
   use mach.int.UInt64
-  clone C07_Ix as Ix3 with type self = t
+  clone C07_Ix as Ix3 with type self = t, type tgt = uint32
   clone Core_Marker_Sized as Sized2 with type self = t
-  clone C07_Ix as Ix1 with type self = g
+  clone C07_Ix as Ix1 with type self = g, type tgt = uint64
   clone Core_Marker_Sized as Sized0 with type self = g
   let rec cfg test (a : uint32) (b : uint64) : bool = 
   var _0 : bool;

--- a/creusot/tests/should_succeed/traits/09.rs
+++ b/creusot/tests/should_succeed/traits/09.rs
@@ -1,0 +1,11 @@
+trait Tr {
+  type X;
+}
+
+fn test<T : Tr<X = u32>>(t: T::X) -> u32{
+  t + 0
+}
+
+fn test2<T : Tr, U : Tr< X = T::X>>(t : T::X) -> U::X {
+  t
+}

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -1,0 +1,78 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module Core_Marker_Sized
+  type self   
+end
+module C09_Tr
+  type self   
+  type x   
+end
+module C09_Test_Interface
+  type t   
+  use mach.int.Int
+  use mach.int.UInt32
+  val test (t : uint32) : uint32
+end
+module C09_Test
+  type t   
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C09_Tr as Tr1 with type self = t, type x = uint32
+  clone Core_Marker_Sized as Sized0 with type self = t
+  let rec cfg test (t : uint32) : uint32 = 
+  var _0 : uint32;
+  var t_1 : uint32;
+  var _2 : uint32;
+  {
+    t_1 <- t;
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) _2 };
+    _2 <- t_1;
+    assume { (fun x -> true) t_1 };
+    _0 <- _2 + (0 : uint32);
+    return _0
+  }
+  
+end
+module C09_Test2_Interface
+  type t   
+  type u   
+  clone C09_Tr as Tr0 with type self = t
+  val test2 (t : Tr0.x) : Tr0.x
+end
+module C09_Test2
+  type t   
+  type u   
+  clone Core_Marker_Sized as Sized2 with type self = u
+  clone Core_Marker_Sized as Sized1 with type self = t
+  clone C09_Tr as Tr0 with type self = t
+  clone C09_Tr as Tr3 with type self = u, type x = Tr0.x
+  let rec cfg test2 (t : Tr0.x) : Tr0.x = 
+  var _0 : Tr0.x;
+  var t_1 : Tr0.x;
+  {
+    t_1 <- t;
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) _0 };
+    _0 <- t_1;
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end


### PR DESCRIPTION
Ensures that we collect any projections that are performed on a given `(DefId, SubstsRef<'tcx>)` pair, and that they are taken into account when constructing the clone graph.


