### PR TITLE
Incrementally emit clones

### DIFF
--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -1,8 +1,11 @@
+# Enable 2021 edition for disjoint closure capture
+cargo-features = ["edition2021"]
+
 [package]
 name = "creusot"
 version = "0.1.0"
 authors = ["Xavier Denis <xldenis@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 itertools = "*"

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -87,10 +87,10 @@ module BinarySearch_Impl0_Index_Interface
 end
 module BinarySearch_Impl0_Index
   type t   
+  use Type
+  use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  use prelude.Prelude
-  use Type
   clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = Type.binarysearch_list t
   clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = bool
   clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = t
@@ -216,9 +216,9 @@ end
 module BinarySearch_Impl0_Len
   type t   
   use mach.int.Int
+  use mach.int.Int32
   use mach.int.UInt64
   use prelude.Prelude
-  use mach.int.Int32
   use Type
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.binarysearch_list t
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
@@ -353,26 +353,26 @@ module BinarySearch_BinarySearch
   use prelude.Prelude
   use mach.int.Int32
   use Type
-  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = usize
-  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = ()
-  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = Type.binarysearch_list uint32
-  clone BinarySearch_Get as Get11 with type t = uint32
-  clone BinarySearch_IsSorted as IsSorted10 with function Get0.get = Get11.get
-  clone BinarySearch_GetDefault as GetDefault1 with type t = uint32, function Get0.get = Get11.get
+  clone CreusotContracts_Builtins_Resolve as Resolve11 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve9 with type self = usize
+  clone CreusotContracts_Builtins_Resolve as Resolve8 with type self = ()
+  clone CreusotContracts_Builtins_Resolve as Resolve7 with type self = bool
+  clone CreusotContracts_Builtins_Resolve as Resolve6 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = Type.binarysearch_list uint32
+  clone BinarySearch_Get as Get3 with type t = uint32
+  clone BinarySearch_IsSorted as IsSorted2 with function Get0.get = Get3.get
+  clone BinarySearch_GetDefault as GetDefault1 with type t = uint32, function Get0.get = Get3.get
   clone BinarySearch_LenLogic as LenLogic0 with type t = uint32
-  clone BinarySearch_Impl0_Index_Interface as Index8 with type t = uint32,
-  function LenLogic0.len_logic = LenLogic0.len_logic, function Get1.get = Get11.get
-  clone BinarySearch_Impl0_Len_Interface as Len2 with type t = uint32,
+  clone BinarySearch_Impl0_Index_Interface as Index10 with type t = uint32,
+  function LenLogic0.len_logic = LenLogic0.len_logic, function Get1.get = Get3.get
+  clone BinarySearch_Impl0_Len_Interface as Len4 with type t = uint32,
   function LenLogic0.len_logic = LenLogic0.len_logic
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
-    requires {IsSorted10.is_sorted arr}
+    requires {IsSorted2.is_sorted arr}
     requires {LenLogic0.len_logic arr <= Int32.to_int (1000000 : int32)}
     ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
     ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok(x) -> Get11.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some(elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok(x) -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some(elem) }
     
    = 
   var _0 : Type.core_result_result usize usize;
@@ -428,7 +428,7 @@ module BinarySearch_BinarySearch
   }
   BB0 {
     _6 <- arr_1;
-    _5 <- Len2.len _6;
+    _5 <- Len4.len _6;
     goto BB1
   }
   BB1 {
@@ -440,18 +440,18 @@ module BinarySearch_BinarySearch
       end
   }
   BB2 {
-    assume { Resolve3.resolve arr_1 };
-    assume { Resolve4.resolve elem_2 };
-    assume { Resolve5.resolve _4 };
+    assume { Resolve5.resolve arr_1 };
+    assume { Resolve6.resolve elem_2 };
+    assume { Resolve7.resolve _4 };
     _0 <- Type.Core_Result_Result_Err((0 : usize));
     goto BB21
   }
   BB3 {
-    assume { Resolve5.resolve _4 };
+    assume { Resolve7.resolve _4 };
     _3 <- ();
-    assume { Resolve6.resolve _3 };
+    assume { Resolve8.resolve _3 };
     _9 <- arr_1;
-    size_8 <- Len2.len _9;
+    size_8 <- Len4.len _9;
     goto BB4
   }
   BB4 {
@@ -465,7 +465,7 @@ module BinarySearch_BinarySearch
     goto BB6
   }
   BB6 {
-    assume { Resolve7.resolve _17 };
+    assume { Resolve9.resolve _17 };
     _17 <- size_8;
     _16 <- _17 > (1 : usize);
     switch (_16)
@@ -475,44 +475,44 @@ module BinarySearch_BinarySearch
       end
   }
   BB7 {
-    assume { Resolve5.resolve _16 };
-    assume { Resolve7.resolve _19 };
+    assume { Resolve7.resolve _16 };
+    assume { Resolve9.resolve _19 };
     _19 <- size_8;
     _20 <- (2 : usize) = (0 : usize);
     assert { not _20 };
     goto BB9
   }
   BB8 {
-    assume { Resolve7.resolve size_8 };
-    assume { Resolve5.resolve _16 };
+    assume { Resolve9.resolve size_8 };
+    assume { Resolve7.resolve _16 };
     _11 <- ();
-    assume { Resolve6.resolve _11 };
+    assume { Resolve8.resolve _11 };
     _37 <- arr_1;
-    assume { Resolve3.resolve arr_1 };
-    assume { Resolve7.resolve _38 };
+    assume { Resolve5.resolve arr_1 };
+    assume { Resolve9.resolve _38 };
     _38 <- base_10;
-    _36 <- Index8.index _37 _38;
+    _36 <- Index10.index _37 _38;
     goto BB14
   }
   BB9 {
-    assume { Resolve5.resolve _20 };
+    assume { Resolve7.resolve _20 };
     half_18 <- _19 / (2 : usize);
-    assume { Resolve7.resolve _22 };
+    assume { Resolve9.resolve _22 };
     _22 <- base_10;
-    assume { Resolve7.resolve _23 };
+    assume { Resolve9.resolve _23 };
     _23 <- half_18;
     mid_21 <- _22 + _23;
     _28 <- arr_1;
-    assume { Resolve7.resolve _29 };
+    assume { Resolve9.resolve _29 };
     _29 <- mid_21;
-    _27 <- Index8.index _28 _29;
+    _27 <- Index10.index _28 _29;
     goto BB10
   }
   BB10 {
-    assume { Resolve4.resolve _26 };
+    assume { Resolve6.resolve _26 };
     _26 <- _27;
-    assume { Resolve9.resolve _27 };
-    assume { Resolve4.resolve _30 };
+    assume { Resolve11.resolve _27 };
+    assume { Resolve6.resolve _30 };
     _30 <- elem_2;
     _25 <- _26 > _30;
     switch (_25)
@@ -522,40 +522,40 @@ module BinarySearch_BinarySearch
       end
   }
   BB11 {
-    assume { Resolve7.resolve mid_21 };
-    assume { Resolve5.resolve _25 };
-    assume { Resolve7.resolve _24 };
+    assume { Resolve9.resolve mid_21 };
+    assume { Resolve7.resolve _25 };
+    assume { Resolve9.resolve _24 };
     _24 <- base_10;
-    assume { Resolve7.resolve base_10 };
+    assume { Resolve9.resolve base_10 };
     goto BB13
   }
   BB12 {
-    assume { Resolve7.resolve base_10 };
-    assume { Resolve5.resolve _25 };
-    assume { Resolve7.resolve _24 };
+    assume { Resolve9.resolve base_10 };
+    assume { Resolve7.resolve _25 };
+    assume { Resolve9.resolve _24 };
     _24 <- mid_21;
-    assume { Resolve7.resolve mid_21 };
+    assume { Resolve9.resolve mid_21 };
     goto BB13
   }
   BB13 {
-    assume { Resolve7.resolve base_10 };
+    assume { Resolve9.resolve base_10 };
     base_10 <- _24;
-    assume { Resolve7.resolve _31 };
+    assume { Resolve9.resolve _31 };
     _31 <- half_18;
-    assume { Resolve7.resolve half_18 };
+    assume { Resolve9.resolve half_18 };
     size_8 <- size_8 - _31;
-    assume { Resolve7.resolve _31 };
+    assume { Resolve9.resolve _31 };
     _15 <- ();
-    assume { Resolve6.resolve _15 };
+    assume { Resolve8.resolve _15 };
     goto BB5
   }
   BB14 {
-    assume { Resolve4.resolve cmp_35 };
+    assume { Resolve6.resolve cmp_35 };
     cmp_35 <- _36;
-    assume { Resolve9.resolve _36 };
-    assume { Resolve4.resolve _40 };
+    assume { Resolve11.resolve _36 };
+    assume { Resolve6.resolve _40 };
     _40 <- cmp_35;
-    assume { Resolve4.resolve _41 };
+    assume { Resolve6.resolve _41 };
     _41 <- elem_2;
     _39 <- _40 = _41;
     switch (_39)
@@ -565,23 +565,23 @@ module BinarySearch_BinarySearch
       end
   }
   BB15 {
-    assume { Resolve4.resolve elem_2 };
-    assume { Resolve4.resolve cmp_35 };
-    assume { Resolve5.resolve _39 };
-    assume { Resolve7.resolve _42 };
+    assume { Resolve6.resolve elem_2 };
+    assume { Resolve6.resolve cmp_35 };
+    assume { Resolve7.resolve _39 };
+    assume { Resolve9.resolve _42 };
     _42 <- base_10;
-    assume { Resolve7.resolve base_10 };
+    assume { Resolve9.resolve base_10 };
     _0 <- Type.Core_Result_Result_Ok(_42);
     goto BB20
   }
   BB16 {
-    assume { Resolve5.resolve _39 };
-    assume { Resolve4.resolve _44 };
+    assume { Resolve7.resolve _39 };
+    assume { Resolve6.resolve _44 };
     _44 <- cmp_35;
-    assume { Resolve4.resolve cmp_35 };
-    assume { Resolve4.resolve _45 };
+    assume { Resolve6.resolve cmp_35 };
+    assume { Resolve6.resolve _45 };
     _45 <- elem_2;
-    assume { Resolve4.resolve elem_2 };
+    assume { Resolve6.resolve elem_2 };
     _43 <- _44 < _45;
     switch (_43)
       | False -> goto BB18
@@ -590,19 +590,19 @@ module BinarySearch_BinarySearch
       end
   }
   BB17 {
-    assume { Resolve5.resolve _43 };
-    assume { Resolve7.resolve _47 };
+    assume { Resolve7.resolve _43 };
+    assume { Resolve9.resolve _47 };
     _47 <- base_10;
-    assume { Resolve7.resolve base_10 };
+    assume { Resolve9.resolve base_10 };
     _46 <- _47 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err(_46);
     goto BB19
   }
   BB18 {
-    assume { Resolve5.resolve _43 };
-    assume { Resolve7.resolve _48 };
+    assume { Resolve7.resolve _43 };
+    assume { Resolve9.resolve _48 };
     _48 <- base_10;
-    assume { Resolve7.resolve base_10 };
+    assume { Resolve9.resolve base_10 };
     _0 <- Type.Core_Result_Result_Err(_48);
     goto BB19
   }

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -19,12 +19,12 @@ module C03_Omg
   function omg (x : t) : bool = 
     true
 end
+module Core_Marker_Sized
+  type self   
+end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
-end
-module Core_Marker_Sized
-  type self   
 end
 module C03_Prog_Interface
   type t   
@@ -35,9 +35,9 @@ module C03_Prog_Interface
 end
 module C03_Prog
   type t   
-  clone Core_Marker_Sized as Sized2 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
   clone C03_Omg as Omg1 with type t = t
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg prog (x : t) : ()
     ensures { Omg1.omg x }
     
@@ -53,7 +53,7 @@ module C03_Prog
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve x_1 };
+    assume { Resolve2.resolve x_1 };
     return _0
   }
   
@@ -69,11 +69,11 @@ end
 module C03_Prog2
   use mach.int.Int
   use mach.int.Int32
-  clone C03_Omg as Omg1 with type t = int
   clone C03_Omg as Omg2 with type t = int32
-  clone C03_Prog_Interface as Prog0 with type t = int32, function Omg0.omg = Omg2.omg
+  clone C03_Prog_Interface as Prog1 with type t = int32, function Omg0.omg = Omg2.omg
+  clone C03_Omg as Omg0 with type t = int
   let rec cfg prog2 () : ()
-    ensures { Omg1.omg (Int32.to_int (0 : int32)) }
+    ensures { Omg0.omg (Int32.to_int (0 : int32)) }
     
    = 
   var _0 : ();
@@ -82,7 +82,7 @@ module C03_Prog2
     goto BB0
   }
   BB0 {
-    _1 <- Prog0.prog (0 : int32);
+    _1 <- Prog1.prog (0 : int32);
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -62,10 +62,10 @@ module C04_F
   use mach.int.UInt32
   clone C04_A as A3
   clone C04_B as B2 with function A0.a = A3.a
-  clone C04_C as C1 with function B0.b = B2.b
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone C04_C as C0 with function B0.b = B2.b
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = uint32
   let rec cfg f (x : uint32) : ()
-    requires {C1.c x}
+    requires {C0.c x}
     
    = 
   var _0 : ();
@@ -76,7 +76,7 @@ module C04_F
   }
   BB0 {
     _0 <- ();
-    assume { Resolve0.resolve x_1 };
+    assume { Resolve1.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -29,9 +29,9 @@ end
 module Core_Cmp_PartialOrd
   type self   
   type rhs   
+  clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = rhs
   use Type
   use prelude.Prelude
-  clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = rhs
   val partial_cmp (self : self) (other : rhs) : Type.core_option_option (Type.core_cmp_ordering)
   val lt (self : self) (other : rhs) : bool
   val le (self : self) (other : rhs) : bool

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -262,18 +262,18 @@ module ListIndexMut_Write
   use Type
   use prelude.Prelude
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve4 with type t = uint32
-  clone ListIndexMut_Get as Get6
-  clone ListIndexMut_Len as Len5
-  clone ListIndexMut_IndexMut_Interface as IndexMut3 with function Len0.len = Len5.len, function Get1.get = Get6.get
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = Type.listindexmut_list
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve6 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = usize
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve3 with type t = Type.listindexmut_list
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone ListIndexMut_Get as Get1
+  clone ListIndexMut_Len as Len0
+  clone ListIndexMut_IndexMut_Interface as IndexMut5 with function Len0.len = Len0.len, function Get1.get = Get1.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
-    requires {UInt64.to_int ix < Len5.len ( * l)}
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len5.len ( * l) && i <> UInt64.to_int ix -> Get6.get ( * l) i = Get6.get ( ^ l) i }
-    ensures { Len5.len ( ^ l) = Len5.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some(v) = Get6.get ( ^ l) (UInt64.to_int ix) }
+    requires {UInt64.to_int ix < Len0.len ( * l)}
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
+    ensures { Len0.len ( ^ l) = Len0.len ( * l) }
+    ensures { Type.ListIndexMut_Option_Some(v) = Get1.get ( ^ l) (UInt64.to_int ix) }
     
    = 
   var _0 : ();
@@ -291,23 +291,23 @@ module ListIndexMut_Write
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
+    assume { Resolve2.resolve _4 };
     _4 <- v_3;
-    assume { Resolve0.resolve v_3 };
+    assume { Resolve2.resolve v_3 };
     _6 <- borrow_mut ( * l_1);
     l_1 <- { l_1 with current = ( ^ _6) };
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _7 };
+    assume { Resolve3.resolve l_1 };
+    assume { Resolve4.resolve _7 };
     _7 <- ix_2;
-    assume { Resolve2.resolve ix_2 };
-    _5 <- IndexMut3.index_mut _6 _7;
+    assume { Resolve4.resolve ix_2 };
+    _5 <- IndexMut5.index_mut _6 _7;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve ( * _5) };
+    assume { Resolve2.resolve ( * _5) };
     _5 <- { _5 with current = _4 };
-    assume { Resolve0.resolve _4 };
-    assume { Resolve4.resolve _5 };
+    assume { Resolve2.resolve _4 };
+    assume { Resolve6.resolve _5 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -10,6 +10,16 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Marker_Sized
+  type self   
+end
+module Core_Cmp_PartialEq
+  type self   
+  type rhs   
+  use prelude.Prelude
+  val eq (self : self) (other : rhs) : bool
+  val ne (self : self) (other : rhs) : bool
+end
 module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
@@ -31,16 +41,6 @@ module CreusotContracts_Builtins_Impl11
   clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = Resolve0.resolve
 end
-module Core_Marker_Sized
-  type self   
-end
-module Core_Cmp_PartialEq
-  type self   
-  type rhs   
-  use prelude.Prelude
-  val eq (self : self) (other : rhs) : bool
-  val ne (self : self) (other : rhs) : bool
-end
 module ProjectionToggle_ProjToggle_Interface
   type t   
   use prelude.Prelude
@@ -52,10 +52,10 @@ end
 module ProjectionToggle_ProjToggle
   type t   
   use prelude.Prelude
-  clone Core_Cmp_PartialEq as PartialEq3 with type self = t, type rhs = t
-  clone Core_Marker_Sized as Sized2 with type self = t
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve1 with type t = t
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve3 with type t = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone Core_Cmp_PartialEq as PartialEq1 with type self = t, type rhs = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg proj_toggle (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { toggle = false -> result = b &&  ^ a =  * a }
     ensures { toggle = true -> result = a &&  ^ b =  * b }
@@ -77,9 +77,9 @@ module ProjectionToggle_ProjToggle
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
+    assume { Resolve2.resolve _6 };
     _6 <- toggle_1;
-    assume { Resolve0.resolve toggle_1 };
+    assume { Resolve2.resolve toggle_1 };
     switch (_6)
       | False -> goto BB2
       | True -> goto BB1
@@ -87,34 +87,34 @@ module ProjectionToggle_ProjToggle
       end
   }
   BB1 {
-    assume { Resolve1.resolve b_3 };
-    assume { Resolve0.resolve _6 };
+    assume { Resolve3.resolve b_3 };
+    assume { Resolve2.resolve _6 };
     _7 <- borrow_mut ( * a_2);
     a_2 <- { a_2 with current = ( ^ _7) };
-    assume { Resolve1.resolve a_2 };
+    assume { Resolve3.resolve a_2 };
     _5 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _5) };
-    assume { Resolve1.resolve _7 };
+    assume { Resolve3.resolve _7 };
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve a_2 };
-    assume { Resolve0.resolve _6 };
+    assume { Resolve3.resolve a_2 };
+    assume { Resolve2.resolve _6 };
     _8 <- borrow_mut ( * b_3);
     b_3 <- { b_3 with current = ( ^ _8) };
-    assume { Resolve1.resolve b_3 };
+    assume { Resolve3.resolve b_3 };
     _5 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _5) };
-    assume { Resolve1.resolve _8 };
+    assume { Resolve3.resolve _8 };
     goto BB3
   }
   BB3 {
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve1.resolve _5 };
+    assume { Resolve3.resolve _5 };
     _0 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _0) };
-    assume { Resolve1.resolve _4 };
+    assume { Resolve3.resolve _4 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -113,10 +113,10 @@ module Projections_WriteIntoSum_Interface
   val write_into_sum (x : borrowed (Type.core_option_option uint32)) : ()
 end
 module Projections_WriteIntoSum
-  use mach.int.Int
-  use mach.int.UInt32
   use prelude.Prelude
   use Type
+  use mach.int.Int
+  use mach.int.UInt32
   let rec cfg write_into_sum (x : borrowed (Type.core_option_option uint32)) : () = 
   var _0 : ();
   var x_1 : borrowed (Type.core_option_option uint32);

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -21,9 +21,9 @@ module Switch_Test_Interface
   val test (o : Type.switch_option uint32) : bool
 end
 module Switch_Test
+  use Type
   use mach.int.Int
   use mach.int.UInt32
-  use Type
   use prelude.Prelude
   let rec cfg test (o : Type.switch_option uint32) : bool = 
   var _0 : bool;

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -21,9 +21,9 @@ module SwitchStruct_Test_Interface
   val test (o : Type.switchstruct_m uint32) : bool
 end
 module SwitchStruct_Test
+  use Type
   use mach.int.Int
   use mach.int.UInt32
-  use Type
   use prelude.Prelude
   let rec cfg test (o : Type.switchstruct_m uint32) : bool = 
   var _0 : bool;

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -69,16 +69,16 @@ module Core_Cmp_PartialEq
 end
 module Core_Cmp_Eq
   type self   
-  use prelude.Prelude
   clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = self
+  use prelude.Prelude
   val assert_receiver_is_total_eq (self : self) : ()
 end
 module Core_Cmp_PartialOrd
   type self   
   type rhs   
+  clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = rhs
   use Type
   use prelude.Prelude
-  clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = rhs
   val partial_cmp (self : self) (other : rhs) : Type.core_option_option (Type.core_cmp_ordering)
   val lt (self : self) (other : rhs) : bool
   val le (self : self) (other : rhs) : bool
@@ -87,10 +87,10 @@ module Core_Cmp_PartialOrd
 end
 module Core_Cmp_Ord
   type self   
-  use Type
-  use prelude.Prelude
   clone Core_Cmp_PartialOrd as PartialOrd1 with type self = self, type rhs = self
   clone Core_Cmp_Eq as Eq0 with type self = self
+  use Type
+  use prelude.Prelude
   val cmp (self : self) (other : self) : Type.core_cmp_ordering
   val max (self : self) (other : self) : self
   val min (self : self) (other : self) : self

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -10,13 +10,13 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Marker_Sized
+  type self   
+end
 module C01_A
   type self   
   type b   
   val from_b (x : self) : b
-end
-module Core_Marker_Sized
-  type self   
 end
 module C01_UsesGeneric_Interface
   type t   
@@ -29,8 +29,8 @@ module C01_UsesGeneric
   use mach.int.Int
   use mach.int.UInt32
   clone C01_A as A2 with type self = t
-  clone Core_Marker_Sized as Sized1 with type self = t
-  clone C01_A as A0 with type self = t
+  clone C01_A as A1 with type self = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg uses_generic (b : t) : uint32 = 
   var _0 : uint32;
   var b_1 : t;
@@ -42,7 +42,7 @@ module C01_UsesGeneric
   BB0 {
     assume { (fun x -> true) _2 };
     _2 <- b_1;
-    _0 <- A0.from_b _2;
+    _0 <- A2.from_b _2;
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/traits/02.stdout
+++ b/creusot/tests/should_succeed/traits/02.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Marker_Sized
+  type self   
+end
 module C02_A
   type self   
   use prelude.Prelude
@@ -21,9 +24,6 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module Core_Marker_Sized
-  type self   
-end
 module C02_Omg_Interface
   type t   
   val omg (a : t) : bool
@@ -33,9 +33,9 @@ end
 module C02_Omg
   type t   
   use prelude.Prelude
-  clone Core_Marker_Sized as Sized2 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t
-  clone C02_A as A0 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone C02_A as A1 with type self = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg omg (a : t) : bool
     ensures { result = true }
     
@@ -49,14 +49,14 @@ module C02_Omg
   }
   BB0 {
     _2 <- a_1;
-    _0 <- A0.is_true _2;
+    _0 <- A1.is_true _2;
     goto BB1
   }
   BB1 {
     goto BB2
   }
   BB2 {
-    assume { Resolve1.resolve a_1 };
+    assume { Resolve2.resolve a_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -75,8 +75,8 @@ end
 module C03_Impl2_H
   type g   
   use prelude.Prelude
-  clone Core_Marker_Sized as Sized1 with type self = g
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = g
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = g
+  clone Core_Marker_Sized as Sized0 with type self = g
   let rec cfg h (y : g) : g = 
   var _0 : g;
   var y_1 : g;
@@ -85,9 +85,9 @@ module C03_Impl2_H
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _0 };
+    assume { Resolve1.resolve _0 };
     _0 <- y_1;
-    assume { Resolve0.resolve y_1 };
+    assume { Resolve1.resolve y_1 };
     return _0
   }
   
@@ -105,8 +105,8 @@ module C03_Impl0
 end
 module C03_B
   type self   
-  use prelude.Prelude
   clone Core_Marker_Sized as Sized0 with type self = self
+  use prelude.Prelude
   val g (self : self) : self
     ensures { result = result }
     
@@ -119,8 +119,8 @@ module C03_Impl1
 end
 module C03_C
   type self   
-  use prelude.Prelude
   type t   
+  use prelude.Prelude
   val h (x : t) : t
 end
 module C03_Impl2

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -10,6 +10,9 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module Core_Marker_Sized
+  type self   
+end
 module C04_A
   type self   
   use prelude.Prelude
@@ -21,9 +24,6 @@ module CreusotContracts_Builtins_Resolve
   type self   
   predicate resolve (self : self)
 end
-module Core_Marker_Sized
-  type self   
-end
 module C04_User_Interface
   type t   
   use prelude.Prelude
@@ -34,10 +34,10 @@ end
 module C04_User
   type t   
   use prelude.Prelude
-  clone Core_Marker_Sized as Sized3 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
-  clone C04_A as A0 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = bool
+  clone C04_A as A1 with type self = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg user (a : t) (b : t) : bool
     ensures { result = false }
     
@@ -63,38 +63,38 @@ module C04_User
   BB0 {
     _5 <- a_1;
     _6 <- b_2;
-    _4 <- A0.func1 _5 _6;
+    _4 <- A1.func1 _5 _6;
     goto BB7
   }
   BB1 {
-    assume { Resolve2.resolve a_1 };
-    assume { Resolve2.resolve b_2 };
-    assume { Resolve1.resolve _3 };
+    assume { Resolve3.resolve a_1 };
+    assume { Resolve3.resolve b_2 };
+    assume { Resolve2.resolve _3 };
     _0 <- false;
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve _3 };
+    assume { Resolve2.resolve _3 };
     _11 <- a_1;
-    assume { Resolve2.resolve a_1 };
+    assume { Resolve3.resolve a_1 };
     _12 <- b_2;
-    assume { Resolve2.resolve b_2 };
-    _10 <- A0.func3 _11 _12;
+    assume { Resolve3.resolve b_2 };
+    _10 <- A1.func3 _11 _12;
     goto BB9
   }
   BB3 {
     return _0
   }
   BB4 {
-    assume { Resolve1.resolve _4 };
+    assume { Resolve2.resolve _4 };
     _3 <- false;
     goto BB6
   }
   BB5 {
-    assume { Resolve1.resolve _4 };
+    assume { Resolve2.resolve _4 };
     _8 <- b_2;
     _9 <- a_1;
-    _7 <- A0.func2 _8 _9;
+    _7 <- A1.func2 _8 _9;
     goto BB8
   }
   BB6 {
@@ -112,12 +112,12 @@ module C04_User
       end
   }
   BB8 {
-    assume { Resolve1.resolve _3 };
+    assume { Resolve2.resolve _3 };
     _3 <- _7;
     goto BB6
   }
   BB9 {
-    assume { Resolve1.resolve _0 };
+    assume { Resolve2.resolve _0 };
     _0 <- _10;
     goto BB3
   }

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -12,9 +12,9 @@ module Type
 end
 module C06_Ix
   type self   
+  type tgt   
   use prelude.Prelude
   use mach.int.Int
-  type tgt   
   val ix (self : self) (ix : usize) : tgt
 end
 module Core_Marker_Sized
@@ -29,8 +29,8 @@ module Core_Cmp_PartialEq
 end
 module Core_Cmp_Eq
   type self   
-  use prelude.Prelude
   clone Core_Cmp_PartialEq as PartialEq0 with type self = self, type rhs = self
+  use prelude.Prelude
   val assert_receiver_is_total_eq (self : self) : ()
 end
 module C06_Test_Interface
@@ -41,14 +41,14 @@ module C06_Test_Interface
 end
 module C06_Test
   type t   
+  use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
-  use prelude.Prelude
-  clone Core_Marker_Sized as Sized1 with type self = t
-  clone C06_Ix as Ix0 with type self = t
-  clone Core_Cmp_Eq as Eq2 with type self = Ix0.tgt
-  let rec cfg test (a : t) : Ix0.tgt = 
-  var _0 : Ix0.tgt;
+  clone C06_Ix as Ix1 with type self = t
+  clone Core_Cmp_Eq as Eq2 with type self = Ix1.tgt
+  clone Core_Marker_Sized as Sized0 with type self = t
+  let rec cfg test (a : t) : Ix1.tgt = 
+  var _0 : Ix1.tgt;
   var a_1 : t;
   var _2 : t;
   {
@@ -58,7 +58,7 @@ module C06_Test
   BB0 {
     _2 <- a_1;
     assume { (fun x -> true) a_1 };
-    _0 <- Ix0.ix _2 (0 : usize);
+    _0 <- Ix1.ix _2 (0 : usize);
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -39,8 +39,8 @@ module Core_Marker_Sized
 end
 module C07_Ix
   type self   
-  use prelude.Prelude
   type tgt   
+  use prelude.Prelude
   val ix (self : self) : tgt
 end
 module C07_Test_Interface
@@ -55,10 +55,10 @@ end
 module C07_Test
   type g   
   type t   
-  use prelude.Prelude
   use mach.int.Int
-  use mach.int.UInt32
   use mach.int.UInt64
+  use mach.int.UInt32
+  use prelude.Prelude
   clone C07_Ix as Ix3 with type self = t, type tgt = uint32
   clone Core_Marker_Sized as Sized2 with type self = t
   clone C07_Ix as Ix1 with type self = g, type tgt = uint64

--- a/creusot/tests/should_succeed/traits/08.stdout
+++ b/creusot/tests/should_succeed/traits/08.stdout
@@ -10,10 +10,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Builtins_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module Core_Marker_Sized
   type self   
 end
@@ -25,15 +21,19 @@ module C08_Tr
   predicate predicate' (self : self)
   val program (self : self) : ()
 end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module C08_Test_Interface
   type t   
   val test (_1 : t) : ()
 end
 module C08_Test
   type t   
-  clone C08_Tr as Tr2 with type self = t
-  clone Core_Marker_Sized as Sized1 with type self = t
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = t
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t
+  clone C08_Tr as Tr1 with type self = t
+  clone Core_Marker_Sized as Sized0 with type self = t
   let rec cfg test (_1 : t) : () = 
   var _0 : ();
   var _1 : t;
@@ -46,7 +46,7 @@ module C08_Test
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _1 };
+    assume { Resolve2.resolve _1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -56,12 +56,12 @@ module C09_Test2
   type t   
   type u   
   clone Core_Marker_Sized as Sized2 with type self = u
-  clone Core_Marker_Sized as Sized1 with type self = t
-  clone C09_Tr as Tr0 with type self = t
-  clone C09_Tr as Tr3 with type self = u, type x = Tr0.x
-  let rec cfg test2 (t : Tr0.x) : Tr0.x = 
-  var _0 : Tr0.x;
-  var t_1 : Tr0.x;
+  clone C09_Tr as Tr1 with type self = t
+  clone C09_Tr as Tr3 with type self = u, type x = Tr1.x
+  clone Core_Marker_Sized as Sized0 with type self = t
+  let rec cfg test2 (t : Tr1.x) : Tr1.x = 
+  var _0 : Tr1.x;
+  var t_1 : Tr1.x;
   {
     t_1 <- t;
     goto BB0


### PR DESCRIPTION
Incrementally emit clones as we generate functions.

This addresses a particular use case of trait declarations that have contracts, which I cannot properly test for the moment due to a separate bug.

In short the issue is that if a contract mentions / uses an associated type declared in the trait, we need the related clones to come _after_ the associated type declaration, while at the moment they are emitted in a single block before any declarations. 

This PR changes `to_clones` to work on a `&mut` and each call emits the clones since the _last_ call. 