### PR TITLE
Update toolchain

### DIFF
--- a/ci/rust-toolchain
+++ b/ci/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-07-30"
+channel = "nightly-2021-08-30"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -365,6 +365,10 @@ struct ProjectionTyVisitor<'a, 'tcx> {
 }
 
 impl TypeVisitor<'tcx> for ProjectionTyVisitor<'a, 'tcx> {
+    fn tcx_for_anon_const_substs(&self) -> Option<TyCtxt<'tcx>> {
+        None
+    }
+
     fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
         match t.kind() {
             TyKind::Projection(t) => (*self.f)(*t),

--- a/creusot/src/translation/specification/typing.rs
+++ b/creusot/src/translation/specification/typing.rs
@@ -214,6 +214,7 @@ fn lower_expr<'tcx>(
                 fields.iter().map(|f| lower_expr(tcx, thir, *f)).collect::<Result<_, _>>()?;
             Ok(Term::Tuple { fields })
         }
+        ExprKind::Use { source } => lower_expr(tcx, thir, source),
         ref ek => todo!("lower_expr: {:?}", ek),
     }
 }

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -137,7 +137,7 @@ pub fn check_not_mutally_recursive<'tcx>(
         // TODO: Look up a more efficient way of getting this info
         for variant in &def.variants {
             for field in &variant.fields {
-                for ty in field.ty(ctx.tcx, substs).walk() {
+                for ty in field.ty(ctx.tcx, substs).walk(ctx.tcx) {
                     let k = match ty.unpack() {
                         rustc_middle::ty::subst::GenericArgKind::Type(ty) => ty,
                         _ => continue,

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -114,6 +114,8 @@ module AllZero_AllZero
   var next_8 : borrowed (Type.allzero_list);
   var _9 : borrowed (Type.allzero_list);
   var _10 : ();
+  var _11 : ();
+  var _12 : ();
   {
     l_1 <- l;
     goto BB0

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -123,6 +123,8 @@ module BinarySearch_Impl0_Index
   var _16 : ();
   var _17 : ();
   var _18 : ();
+  var _19 : ();
+  var _20 : ();
   {
     self_1 <- self;
     ix_2 <- ix;
@@ -240,6 +242,8 @@ module BinarySearch_Impl0_Len
   var ls_8 : Type.binarysearch_list t;
   var _9 : Type.binarysearch_list t;
   var _10 : ();
+  var _11 : ();
+  var _12 : ();
   {
     self_1 <- self;
     goto BB0
@@ -401,20 +405,22 @@ module BinarySearch_BinarySearch
   var _30 : uint32;
   var _31 : usize;
   var _32 : ();
-  var cmp_33 : uint32;
-  var _34 : uint32;
-  var _35 : Type.binarysearch_list uint32;
-  var _36 : usize;
-  var _37 : bool;
-  var _38 : uint32;
-  var _39 : uint32;
-  var _40 : usize;
-  var _41 : bool;
-  var _42 : uint32;
-  var _43 : uint32;
-  var _44 : usize;
-  var _45 : usize;
+  var _33 : ();
+  var _34 : ();
+  var cmp_35 : uint32;
+  var _36 : uint32;
+  var _37 : Type.binarysearch_list uint32;
+  var _38 : usize;
+  var _39 : bool;
+  var _40 : uint32;
+  var _41 : uint32;
+  var _42 : usize;
+  var _43 : bool;
+  var _44 : uint32;
+  var _45 : uint32;
   var _46 : usize;
+  var _47 : usize;
+  var _48 : usize;
   {
     arr_1 <- arr;
     elem_2 <- elem;
@@ -438,7 +444,7 @@ module BinarySearch_BinarySearch
     assume { Resolve4.resolve elem_2 };
     assume { Resolve5.resolve _4 };
     _0 <- Type.Core_Result_Result_Err((0 : usize));
-    goto BB22
+    goto BB21
   }
   BB3 {
     assume { Resolve5.resolve _4 };
@@ -470,6 +476,10 @@ module BinarySearch_BinarySearch
   }
   BB7 {
     assume { Resolve5.resolve _16 };
+    assume { Resolve7.resolve _19 };
+    _19 <- size_8;
+    _20 <- (2 : usize) = (0 : usize);
+    assert { not _20 };
     goto BB9
   }
   BB8 {
@@ -477,21 +487,14 @@ module BinarySearch_BinarySearch
     assume { Resolve5.resolve _16 };
     _11 <- ();
     assume { Resolve6.resolve _11 };
-    _35 <- arr_1;
+    _37 <- arr_1;
     assume { Resolve3.resolve arr_1 };
-    assume { Resolve7.resolve _36 };
-    _36 <- base_10;
-    _34 <- Index8.index _35 _36;
-    goto BB15
+    assume { Resolve7.resolve _38 };
+    _38 <- base_10;
+    _36 <- Index8.index _37 _38;
+    goto BB14
   }
   BB9 {
-    assume { Resolve7.resolve _19 };
-    _19 <- size_8;
-    _20 <- (2 : usize) = (0 : usize);
-    assert { not _20 };
-    goto BB10
-  }
-  BB10 {
     assume { Resolve5.resolve _20 };
     half_18 <- _19 / (2 : usize);
     assume { Resolve7.resolve _22 };
@@ -503,9 +506,9 @@ module BinarySearch_BinarySearch
     assume { Resolve7.resolve _29 };
     _29 <- mid_21;
     _27 <- Index8.index _28 _29;
-    goto BB11
+    goto BB10
   }
-  BB11 {
+  BB10 {
     assume { Resolve4.resolve _26 };
     _26 <- _27;
     assume { Resolve9.resolve _27 };
@@ -513,28 +516,28 @@ module BinarySearch_BinarySearch
     _30 <- elem_2;
     _25 <- _26 > _30;
     switch (_25)
-      | False -> goto BB13
-      | True -> goto BB12
-      | _ -> goto BB12
+      | False -> goto BB12
+      | True -> goto BB11
+      | _ -> goto BB11
       end
   }
-  BB12 {
+  BB11 {
     assume { Resolve7.resolve mid_21 };
     assume { Resolve5.resolve _25 };
     assume { Resolve7.resolve _24 };
     _24 <- base_10;
     assume { Resolve7.resolve base_10 };
-    goto BB14
+    goto BB13
   }
-  BB13 {
+  BB12 {
     assume { Resolve7.resolve base_10 };
     assume { Resolve5.resolve _25 };
     assume { Resolve7.resolve _24 };
     _24 <- mid_21;
     assume { Resolve7.resolve mid_21 };
-    goto BB14
+    goto BB13
   }
-  BB14 {
+  BB13 {
     assume { Resolve7.resolve base_10 };
     base_10 <- _24;
     assume { Resolve7.resolve _31 };
@@ -546,70 +549,70 @@ module BinarySearch_BinarySearch
     assume { Resolve6.resolve _15 };
     goto BB5
   }
+  BB14 {
+    assume { Resolve4.resolve cmp_35 };
+    cmp_35 <- _36;
+    assume { Resolve9.resolve _36 };
+    assume { Resolve4.resolve _40 };
+    _40 <- cmp_35;
+    assume { Resolve4.resolve _41 };
+    _41 <- elem_2;
+    _39 <- _40 = _41;
+    switch (_39)
+      | False -> goto BB16
+      | True -> goto BB15
+      | _ -> goto BB15
+      end
+  }
   BB15 {
-    assume { Resolve4.resolve cmp_33 };
-    cmp_33 <- _34;
-    assume { Resolve9.resolve _34 };
-    assume { Resolve4.resolve _38 };
-    _38 <- cmp_33;
-    assume { Resolve4.resolve _39 };
-    _39 <- elem_2;
-    _37 <- _38 = _39;
-    switch (_37)
-      | False -> goto BB17
-      | True -> goto BB16
-      | _ -> goto BB16
-      end
-  }
-  BB16 {
     assume { Resolve4.resolve elem_2 };
-    assume { Resolve4.resolve cmp_33 };
-    assume { Resolve5.resolve _37 };
-    assume { Resolve7.resolve _40 };
-    _40 <- base_10;
+    assume { Resolve4.resolve cmp_35 };
+    assume { Resolve5.resolve _39 };
+    assume { Resolve7.resolve _42 };
+    _42 <- base_10;
     assume { Resolve7.resolve base_10 };
-    _0 <- Type.Core_Result_Result_Ok(_40);
-    goto BB21
-  }
-  BB17 {
-    assume { Resolve5.resolve _37 };
-    assume { Resolve4.resolve _42 };
-    _42 <- cmp_33;
-    assume { Resolve4.resolve cmp_33 };
-    assume { Resolve4.resolve _43 };
-    _43 <- elem_2;
-    assume { Resolve4.resolve elem_2 };
-    _41 <- _42 < _43;
-    switch (_41)
-      | False -> goto BB19
-      | True -> goto BB18
-      | _ -> goto BB18
-      end
-  }
-  BB18 {
-    assume { Resolve5.resolve _41 };
-    assume { Resolve7.resolve _45 };
-    _45 <- base_10;
-    assume { Resolve7.resolve base_10 };
-    _44 <- _45 + (1 : usize);
-    _0 <- Type.Core_Result_Result_Err(_44);
+    _0 <- Type.Core_Result_Result_Ok(_42);
     goto BB20
   }
-  BB19 {
-    assume { Resolve5.resolve _41 };
-    assume { Resolve7.resolve _46 };
-    _46 <- base_10;
+  BB16 {
+    assume { Resolve5.resolve _39 };
+    assume { Resolve4.resolve _44 };
+    _44 <- cmp_35;
+    assume { Resolve4.resolve cmp_35 };
+    assume { Resolve4.resolve _45 };
+    _45 <- elem_2;
+    assume { Resolve4.resolve elem_2 };
+    _43 <- _44 < _45;
+    switch (_43)
+      | False -> goto BB18
+      | True -> goto BB17
+      | _ -> goto BB17
+      end
+  }
+  BB17 {
+    assume { Resolve5.resolve _43 };
+    assume { Resolve7.resolve _47 };
+    _47 <- base_10;
     assume { Resolve7.resolve base_10 };
+    _46 <- _47 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err(_46);
+    goto BB19
+  }
+  BB18 {
+    assume { Resolve5.resolve _43 };
+    assume { Resolve7.resolve _48 };
+    _48 <- base_10;
+    assume { Resolve7.resolve base_10 };
+    _0 <- Type.Core_Result_Result_Err(_48);
+    goto BB19
+  }
+  BB19 {
     goto BB20
   }
   BB20 {
     goto BB21
   }
   BB21 {
-    goto BB22
-  }
-  BB22 {
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -166,19 +166,21 @@ module IncMaxRepeat_IncMaxRepeat
   var _17 : borrowed uint32;
   var _18 : ();
   var _19 : ();
-  var _20 : bool;
-  var _21 : bool;
+  var _20 : ();
+  var _21 : ();
   var _22 : bool;
-  var _23 : uint32;
-  var _24 : uint32;
+  var _23 : bool;
+  var _24 : bool;
   var _25 : uint32;
   var _26 : uint32;
-  var _27 : bool;
+  var _27 : uint32;
   var _28 : uint32;
-  var _29 : uint32;
+  var _29 : bool;
   var _30 : uint32;
   var _31 : uint32;
-  var _32 : ();
+  var _32 : uint32;
+  var _33 : uint32;
+  var _34 : ();
   {
     a_1 <- a;
     b_2 <- b;
@@ -209,28 +211,6 @@ module IncMaxRepeat_IncMaxRepeat
   }
   BB3 {
     assume { Resolve1.resolve _10 };
-    goto BB5
-  }
-  BB4 {
-    assume { Resolve0.resolve n_3 };
-    assume { Resolve1.resolve _10 };
-    _5 <- ();
-    assume { Resolve4.resolve _5 };
-    assume { Resolve0.resolve _23 };
-    _23 <- a_1;
-    assume { Resolve0.resolve _25 };
-    _25 <- b_2;
-    assume { Resolve0.resolve _26 };
-    _26 <- i_4;
-    _24 <- _25 + _26;
-    _22 <- _23 >= _24;
-    switch (_22)
-      | False -> goto BB8
-      | True -> goto BB7
-      | _ -> goto BB7
-      end
-  }
-  BB5 {
     _15 <- borrow_mut a_1;
     a_1 <-  ^ _15;
     _14 <- borrow_mut ( * _15);
@@ -242,9 +222,28 @@ module IncMaxRepeat_IncMaxRepeat
     _17 <- { _17 with current = ( ^ _16) };
     assume { Resolve2.resolve _17 };
     mc_13 <- TakeMax3.take_max _14 _16;
-    goto BB6
+    goto BB5
   }
-  BB6 {
+  BB4 {
+    assume { Resolve0.resolve n_3 };
+    assume { Resolve1.resolve _10 };
+    _5 <- ();
+    assume { Resolve4.resolve _5 };
+    assume { Resolve0.resolve _25 };
+    _25 <- a_1;
+    assume { Resolve0.resolve _27 };
+    _27 <- b_2;
+    assume { Resolve0.resolve _28 };
+    _28 <- i_4;
+    _26 <- _27 + _28;
+    _24 <- _25 >= _26;
+    switch (_24)
+      | False -> goto BB7
+      | True -> goto BB6
+      | _ -> goto BB6
+      end
+  }
+  BB5 {
     mc_13 <- { mc_13 with current = ( * mc_13 + (1 : uint32)) };
     assume { Resolve2.resolve mc_13 };
     i_4 <- i_4 + (1 : uint32);
@@ -252,47 +251,47 @@ module IncMaxRepeat_IncMaxRepeat
     assume { Resolve4.resolve _9 };
     goto BB1
   }
-  BB7 {
+  BB6 {
     assume { Resolve0.resolve a_1 };
     assume { Resolve0.resolve b_2 };
     assume { Resolve0.resolve i_4 };
-    assume { Resolve1.resolve _22 };
-    _21 <- true;
-    goto BB9
+    assume { Resolve1.resolve _24 };
+    _23 <- true;
+    goto BB8
+  }
+  BB7 {
+    assume { Resolve1.resolve _24 };
+    assume { Resolve0.resolve _30 };
+    _30 <- b_2;
+    assume { Resolve0.resolve b_2 };
+    assume { Resolve0.resolve _32 };
+    _32 <- a_1;
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve0.resolve _33 };
+    _33 <- i_4;
+    assume { Resolve0.resolve i_4 };
+    _31 <- _32 + _33;
+    _29 <- _30 >= _31;
+    assume { Resolve1.resolve _23 };
+    _23 <- _29;
+    goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _22 };
-    assume { Resolve0.resolve _28 };
-    _28 <- b_2;
-    assume { Resolve0.resolve b_2 };
-    assume { Resolve0.resolve _30 };
-    _30 <- a_1;
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve _31 };
-    _31 <- i_4;
-    assume { Resolve0.resolve i_4 };
-    _29 <- _30 + _31;
-    _27 <- _28 >= _29;
-    assume { Resolve1.resolve _21 };
-    _21 <- _27;
-    goto BB9
-  }
-  BB9 {
-    _20 <- not _21;
-    switch (_20)
-      | False -> goto BB11
-      | True -> goto BB10
-      | _ -> goto BB10
+    _22 <- not _23;
+    switch (_22)
+      | False -> goto BB10
+      | True -> goto BB9
+      | _ -> goto BB9
       end
   }
-  BB10 {
-    assume { Resolve1.resolve _20 };
+  BB9 {
+    assume { Resolve1.resolve _22 };
     absurd
   }
-  BB11 {
-    assume { Resolve1.resolve _20 };
-    _19 <- ();
-    assume { Resolve4.resolve _19 };
+  BB10 {
+    assume { Resolve1.resolve _22 };
+    _21 <- ();
+    assume { Resolve4.resolve _21 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -149,7 +149,9 @@ module ListIndexMut_IndexMut
   var _18 : borrowed (Type.listindexmut_list);
   var _19 : ();
   var _20 : ();
-  var _21 : borrowed uint32;
+  var _21 : ();
+  var _22 : ();
+  var _23 : borrowed uint32;
   {
     param_l_1 <- param_l;
     param_ix_2 <- param_ix;
@@ -183,48 +185,45 @@ module ListIndexMut_IndexMut
   }
   BB3 {
     assume { Resolve4.resolve _13 };
-    goto BB5
+    switch (let Type.ListIndexMut_List(_, a) =  * l_4 in a)
+      | Type.ListIndexMut_Option_None -> goto BB5
+      | Type.ListIndexMut_Option_Some(_) -> goto BB6
+      | _ -> goto BB7
+      end
   }
   BB4 {
     assume { Resolve3.resolve ix_5 };
     assume { Resolve4.resolve _13 };
     _6 <- ();
     assume { Resolve7.resolve _6 };
-    _21 <- borrow_mut (let Type.ListIndexMut_List(a, _) =  * l_4 in a);
-    l_4 <- { l_4 with current = (let Type.ListIndexMut_List(a, b) =  * l_4 in Type.ListIndexMut_List( ^ _21, b)) };
+    _23 <- borrow_mut (let Type.ListIndexMut_List(a, _) =  * l_4 in a);
+    l_4 <- { l_4 with current = (let Type.ListIndexMut_List(a, b) =  * l_4 in Type.ListIndexMut_List( ^ _23, b)) };
     assume { Resolve2.resolve l_4 };
-    _3 <- borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _3) };
-    assume { Resolve9.resolve _21 };
+    _3 <- borrow_mut ( * _23);
+    _23 <- { _23 with current = ( ^ _3) };
+    assume { Resolve9.resolve _23 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve9.resolve _3 };
     return _0
   }
   BB5 {
-    switch (let Type.ListIndexMut_List(_, a) =  * l_4 in a)
-      | Type.ListIndexMut_Option_None -> goto BB6
-      | Type.ListIndexMut_Option_Some(_) -> goto BB7
-      | _ -> goto BB8
-      end
+    assume { Resolve2.resolve l_4 };
+    assume { Resolve3.resolve ix_5 };
+    assume { Resolve5.resolve _16 };
+    absurd
   }
   BB6 {
-    assume { Resolve2.resolve l_4 };
-    assume { Resolve3.resolve ix_5 };
     assume { Resolve5.resolve _16 };
-    absurd
+    goto BB8
   }
   BB7 {
-    assume { Resolve5.resolve _16 };
-    goto BB9
-  }
-  BB8 {
     assume { Resolve2.resolve l_4 };
     assume { Resolve3.resolve ix_5 };
     assume { Resolve5.resolve _16 };
     absurd
   }
-  BB9 {
+  BB8 {
     n_17 <- borrow_mut (let Type.ListIndexMut_Option_Some(a) = let Type.ListIndexMut_List(_, a) =  * l_4 in a in a);
     l_4 <- { l_4 with current = (let Type.ListIndexMut_List(a, b) =  * l_4 in Type.ListIndexMut_List(a, let Type.ListIndexMut_Option_Some(a) = let Type.ListIndexMut_List(_, a) =  * l_4 in a in Type.ListIndexMut_Option_Some( ^ n_17))) };
     assume { Resolve2.resolve l_4 };

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -42,6 +42,8 @@ module Sum_SumFirstN
   var _10 : uint32;
   var _11 : uint32;
   var _12 : ();
+  var _13 : ();
+  var _14 : ();
   {
     n_1 <- n;
     goto BB0
@@ -70,7 +72,14 @@ module Sum_SumFirstN
   }
   BB3 {
     assume { Resolve1.resolve _8 };
-    goto BB5
+    assume { Resolve0.resolve _11 };
+    _11 <- i_3;
+    sum_2 <- sum_2 + _11;
+    assume { Resolve0.resolve _11 };
+    i_3 <- i_3 + (1 : uint32);
+    _7 <- ();
+    assume { Resolve2.resolve _7 };
+    goto BB1
   }
   BB4 {
     assume { Resolve0.resolve n_1 };
@@ -82,16 +91,6 @@ module Sum_SumFirstN
     _0 <- sum_2;
     assume { Resolve0.resolve sum_2 };
     return _0
-  }
-  BB5 {
-    assume { Resolve0.resolve _11 };
-    _11 <- i_3;
-    sum_2 <- sum_2 + _11;
-    assume { Resolve0.resolve _11 };
-    i_3 <- i_3 + (1 : uint32);
-    _7 <- ();
-    assume { Resolve2.resolve _7 };
-    goto BB1
   }
   
 end

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -55,6 +55,8 @@ module WhileLet_Main
   var _5 : isize;
   var _6 : Type.whilelet_option int32;
   var _7 : ();
+  var _8 : ();
+  var _9 : ();
   {
     goto BB0
   }


### PR DESCRIPTION
I had to update the toolchain so I can bump the edition to 2021. The patched version of `resolve_instance` is starting to bit-rot but it turns out this is not what we wanted anyways and I need to rip it out entirely.