### PR TITLE
Fix commands build and mlcfg to temporarily move into the base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ More examples are found in [creusot/tests/should_succeed](creusot/tests/should_s
 
 Creusot can translate the Rust programs into a language supported by Why3, called MLCFG (a call flow graph for ML, more specifically WhyML).
 
-By running the following, you can have Creusot turn a Rust program to a MLCFG.
+By running the following, you can have Creusot turn a Rust program to an MLCFG.
 ```
-REPO/mlcfg PATH/TO/PROGRAM.rs -o PATH/TO/OUTPUT.mlcfg
+REPO/mlcfg PATH/TO/PROGRAM.rs > PATH/TO/OUTPUT.mlcfg
 ```
-If you omit the `-o ...` part, it outputs MLCFG to stdout.
+The `REPO/mlcfg` command outputs an MLCFG to stdout.
 (The file extension of MLCFG is not relevant to Why3.)
 
 You can play with examples in [creusot/tests/should_succeed](creusot/tests/should_succeed).

--- a/build
+++ b/build
@@ -4,4 +4,7 @@
 # if not installed (by reading ./rust-toolchain).
 # Then cargo (re)builds creusot and creusot-contracts.
 # TODO: Better way, without executing all the tests.
+SCRIPTPATH=$(dirname "$BASH_SOURCE")
+pushd $SCRIPTPATH > /dev/null
 cargo test
+popd > /dev/null

--- a/mlcfg
+++ b/mlcfg
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+pushd $(dirname $1) > /dev/null
+INPUTPATH=$(pwd)/$(basename $1)
+popd > /dev/null
 SCRIPTPATH=$(dirname "$BASH_SOURCE")
+pushd $SCRIPTPATH > /dev/null
 cargo run --bin creusot-rustc -- -Zno-codegen \
-  --extern creusot_contracts=$SCRIPTPATH/target/debug/libcreusot_contracts.rlib \
-  -Ldependency=$SCRIPTPATH/target/debug/deps/ \
-  $@
+  --extern creusot_contracts=./target/debug/libcreusot_contracts.rlib \
+  -Ldependency=./target/debug/deps/ \
+  $INPUTPATH
+popd > /dev/null


### PR DESCRIPTION
In order to make `cargo` properly work for the commands `build` and `mlcfg`, we modified the scripts using `pushd`/`popd`.