### PR TITLE
Improve cloning of traits

### DIFF
--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -18,8 +18,8 @@ use rustc_middle::ty::{
 use heck::CamelCase;
 
 use crate::ctx::{self, *};
-use crate::translation::interface;
 use crate::translation::ty::translate_ty;
+use crate::translation::{interface, traits};
 use crate::util::{self, method_name};
 
 // Prelude modules
@@ -67,26 +67,47 @@ pub struct CloneMap<'tcx> {
     item_type: ItemType,
 
     // Graph which is used to calculate the full clone set
-    clone_graph: DiGraphMap<CloneNode<'tcx>, Option<SubstsRef<'tcx>>>,
+    clone_graph: DiGraphMap<CloneNode<'tcx>, Option<(DefId, SubstsRef<'tcx>)>>,
     // Index of the last cloned entry
     last_cloned: usize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Kind {
+    Named(Ident),
+    Hidden,
+    Export,
+    // Use,
+}
+
+#[derive(Clone, Debug)]
 pub struct CloneInfo<'tcx> {
-    name: Ident,
-    hidden: bool,
+    kind: Kind,
     projections: Vec<(DefId, Ty<'tcx>)>,
     cloned: bool,
 }
 
+impl Into<CloneKind> for Kind {
+    fn into(self) -> CloneKind {
+        match self {
+            Kind::Named(i) => CloneKind::Named(i),
+            Kind::Hidden => CloneKind::Bare,
+            Kind::Export => CloneKind::Export,
+        }
+    }
+}
+
 impl CloneInfo<'tcx> {
-    fn from_name(name: String) -> Self {
-        CloneInfo { name: name.into(), hidden: false, projections: Vec::new(), cloned: false }
+    fn from_name(name: Ident) -> Self {
+        CloneInfo { kind: Kind::Named(name), projections: Vec::new(), cloned: false }
     }
 
-    fn hidden(name: Ident) -> Self {
-        CloneInfo { name, hidden: true, projections: Vec::new(), cloned: false }
+    fn hidden() -> Self {
+        CloneInfo { kind: Kind::Hidden, projections: Vec::new(), cloned: false }
+    }
+
+    pub fn mk_export(&mut self) {
+        self.kind = Kind::Export;
     }
 
     pub fn add_projection(&mut self, proj: (DefId, Ty<'tcx>)) {
@@ -99,7 +120,11 @@ impl CloneInfo<'tcx> {
     }
 
     fn qname_raw(&self, method: Ident) -> QName {
-        QName { module: vec![self.name.clone()], name: method }
+        let module = match &self.kind {
+            Kind::Named(name) => vec![name.clone()],
+            _ => Vec::new(),
+        };
+        QName { module, name: method }
     }
 }
 
@@ -124,21 +149,23 @@ impl<'tcx> CloneMap<'tcx> {
             }
         };
 
-        let tcx = self.tcx;
-        let count = &mut self.count;
+        debug!("inserting {:?} {:?}", def_id, subst);
         self.names.entry((def_id, subst)).or_insert_with(|| {
-            let name_base = tcx.item_name(def_id).as_str().to_camel_case();
-            let info = CloneInfo::from_name(format!("{}{}", name_base, count));
-            *count += 1;
+            let base_sym = match util::item_type(self.tcx, def_id) {
+                ItemType::Impl => self.tcx.item_name(self.tcx.trait_id_of_impl(def_id).unwrap()),
+                _ => self.tcx.item_name(def_id),
+            };
+
+            let base: Ident = base_sym.as_str().to_camel_case().into();
+            let info = CloneInfo::from_name(format!("{}{}", &*base, self.count).into());
+            self.count += 1;
             info
         })
     }
 
     pub fn clone_self(&mut self, self_id: DefId) {
-        let mut modl = ctx::translate_value_id(self.tcx, self_id);
-        let clone_name = if modl.module.is_empty() { modl.name } else { modl.module.remove(0) };
         let subst = InternalSubsts::identity_for_item(self.tcx, self_id);
-        self.names.insert((self_id, subst), CloneInfo::hidden(clone_name));
+        self.names.insert((self_id, subst), CloneInfo::hidden());
     }
 
     pub fn import_prelude_module(&mut self, module: PreludeModule) {
@@ -166,7 +193,7 @@ impl<'tcx> CloneMap<'tcx> {
             let (&key, clone_info) = self.names.get_index(i).unwrap();
             i += 1;
 
-            if clone_info.hidden {
+            if clone_info.kind == Kind::Hidden {
                 continue;
             }
 
@@ -193,8 +220,15 @@ impl<'tcx> CloneMap<'tcx> {
             }
 
             for dep in ctx.dependencies(key.0).unwrap_or(&empty).keys() {
-                let orig = dep.1;
+                let orig = dep;
                 let dep = (dep.0, dep.1.subst(self.tcx, key.1));
+
+                let dep = match traits::resolve_opt(ctx.tcx, ctx.tcx.param_env(key.0), dep.0, dep.1)
+                {
+                    Some(dep) => (dep),
+                    None => (dep),
+                };
+
                 self.insert(dep.0, dep.1);
 
                 // Skip reflexive edges
@@ -203,7 +237,7 @@ impl<'tcx> CloneMap<'tcx> {
                 }
 
                 debug!("edge {:?} -> {:?}", dep, key);
-                self.clone_graph.add_edge(dep, key, Some(orig));
+                self.clone_graph.add_edge(dep, key, Some(*orig));
             }
         }
     }
@@ -241,7 +275,7 @@ impl<'tcx> CloneMap<'tcx> {
             }
             self.names[&node].cloned = true;
 
-            if self.names[&node].hidden {
+            if self.names[&node].kind == Kind::Hidden {
                 continue;
             }
 
@@ -258,28 +292,29 @@ impl<'tcx> CloneMap<'tcx> {
             let node_clones = ctx.dependencies(def_id).unwrap_or(&empty);
             for (dep, t, &orig_subst) in self.clone_graph.edges_directed(node, Incoming) {
                 debug!("s={:?} t={:?} e={:?}", dep, t, orig_subst);
-                let prov_info = match orig_subst {
-                    Some(subst) => &node_clones.names[&(dep.0, subst)],
+                let recv_info = match orig_subst {
+                    Some(recv_id) => &node_clones.names[&recv_id],
                     None => continue,
                 };
                 // Grab the symbols from all dependencies
-                let user_info = &self.names[&dep];
+                let caller_info = &self.names[&dep];
                 for sym in exported_symbols(ctx.tcx, dep.0) {
                     let elem = match sym {
-                        SymbolKind::Val(n) => {
-                            CloneSubst::Val(prov_info.qname_raw(n.clone()), user_info.qname_raw(n))
-                        }
+                        SymbolKind::Val(n) => CloneSubst::Val(
+                            recv_info.qname_raw(n.clone()),
+                            caller_info.qname_raw(n),
+                        ),
                         SymbolKind::Type(t) => CloneSubst::Type(
-                            prov_info.qname_raw(t.clone()),
-                            why3::mlcfg::Type::TConstructor(user_info.qname_raw(t)),
+                            recv_info.qname_raw(t.clone()),
+                            why3::mlcfg::Type::TConstructor(caller_info.qname_raw(t)),
                         ),
                         SymbolKind::Function(f) => CloneSubst::Function(
-                            prov_info.qname_raw(f.clone()),
-                            user_info.qname_raw(f),
+                            recv_info.qname_raw(f.clone()),
+                            caller_info.qname_raw(f),
                         ),
                         SymbolKind::Predicate(p) => CloneSubst::Predicate(
-                            prov_info.qname_raw(p.clone()),
-                            user_info.qname_raw(p),
+                            recv_info.qname_raw(p.clone()),
+                            caller_info.qname_raw(p),
                         ),
                     };
                     // If we are in an interface, then we should not attempt to share
@@ -295,7 +330,7 @@ impl<'tcx> CloneMap<'tcx> {
             decls.push(Decl::Clone(DeclClone {
                 name: cloneable_name(ctx.tcx, def_id, self.item_type.clone_interfaces()),
                 subst: clone_subst,
-                kind: CloneKind::Named(self.names[&node].name.clone()),
+                kind: self.names[&node].kind.clone().into(),
             }));
         }
 

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -352,7 +352,7 @@ fn cloneable_name(tcx: TyCtxt, def_id: DefId, interface: bool) -> QName {
                 // TODO: this should directly be a function...
                 QName { module: Vec::new(), name: interface::interface_name(tcx, def_id) }
             } else {
-                qname.module_name()
+                qname.module_name().unwrap().clone().into()
             }
         }
         Interface | Program => {

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -24,7 +24,7 @@ fn default_decl(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_span::Span
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
-    let name = translate_value_id(ctx.tcx, def_id).module_name().name();
+    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
 
     decls.extend(names.to_clones(ctx));
     decls.push(Decl::ValDecl(Val { sig }));

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -136,7 +136,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
 
         if util::is_trusted(self.tcx, self.def_id) {
             decls.push(Decl::ValDecl(ValKind::Val { sig }));
-            return Module { name: name.module_name().name, decls };
+            return Module { name: name.module_name().unwrap().clone(), decls };
         }
 
         self.translate_body();
@@ -164,7 +164,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             entry,
             blocks: self.past_blocks,
         }));
-        Module { name: name.module_name().name, decls }
+        Module { name: name.module_name().unwrap().clone(), decls }
     }
 
     fn translate_body(&mut self) {

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -256,7 +256,8 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
         let subst = self.tcx.mk_substs([GenericArg::from(ty)].iter());
 
         let param_env = self.tcx.param_env(self.def_id);
-        let resolve_impl = traits::impl_or_trait(self.tcx, param_env, trait_meth_id, subst);
+        let resolve_impl =
+            traits::resolve_assoc_item_opt(self.tcx, param_env, trait_meth_id, subst);
 
         match resolve_impl {
             Some((id, subst)) => {

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use why3::{
     declaration::{Decl, Module, ValKind},
     Ident,
@@ -41,5 +43,5 @@ pub fn interface_for(
 pub fn interface_name(tcx: TyCtxt, def_id: DefId) -> Ident {
     let name = translate_value_id(tcx, def_id);
 
-    format!("{}_Interface", &*name.module_name().name).into()
+    format!("{}_Interface", Cow::from(name.module_name().unwrap())).into()
 }

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -15,7 +15,7 @@ pub fn translate_logic(
     names.clone_self(def_id);
 
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
-    let name = translate_value_id(ctx.tcx, def_id).module_name().name();
+    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
@@ -45,7 +45,7 @@ pub fn translate_predicate(
 
     let mut sig = crate::util::signature_of(ctx, &mut names, def_id);
     sig.retty = None;
-    let name = translate_value_id(ctx.tcx, def_id).module_name().name();
+    let name = translate_value_id(ctx.tcx, def_id).module_name().unwrap().clone();
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -1,6 +1,6 @@
 use super::typing::{LogicalOp, Pattern, Term};
 use crate::ctx::*;
-use crate::translation::traits::impl_or_trait;
+use crate::translation::traits::{resolve_assoc_item_opt, resolve_opt};
 use crate::translation::{binop_to_binop, builtins, constant, ty::translate_ty, unop_to_unop};
 use why3::mlcfg::{BinOp, Exp, Pattern as Pat};
 
@@ -38,7 +38,7 @@ pub fn lower_term_to_why3<'tcx>(
             }
 
             let param_env = ctx.tcx.param_env(term_id);
-            let (target, subst) = impl_or_trait(ctx.tcx, param_env, id, subst).unwrap();
+            let (target, subst) = resolve_opt(ctx.tcx, param_env, id, subst).unwrap_or((id, subst));
 
             if is_identity_from(ctx.tcx, id, subst) {
                 return args.remove(0);

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -12,7 +12,7 @@ use why3::{
     QName,
 };
 
-use crate::{ctx, rustc_extensions};
+use crate::{ctx, resolve, rustc_extensions};
 
 use crate::ctx::*;
 use crate::translation::ty::{self, translate_ty};
@@ -149,6 +149,7 @@ pub fn translate_predicates(
     names: &mut CloneMap<'tcx>,
     preds: GenericPredicates<'tcx>,
 ) {
+    eprintln!("translate_predicates={:?}", preds);
     for (pred, _) in preds.predicates.iter() {
         use rustc_middle::ty::PredicateKind::*;
         match pred.kind().no_bound_vars().unwrap() {
@@ -201,7 +202,9 @@ fn translate_assoc_function(
     let trait_id = ctx.tcx.trait_id_of_impl(impl_id).unwrap();
 
     let assoc_subst = InternalSubsts::identity_for_item(ctx.tcx, impl_id);
-    let name = names.insert(assoc.def_id, assoc_subst).clone();
+    let name = names.insert(assoc.def_id, assoc_subst);
+    name.mk_export();
+    let name = name.clone();
 
     ctx.translate_function(assoc.def_id);
 
@@ -250,59 +253,107 @@ fn translate_trait_name(tcx: TyCtxt<'_>, def_id: DefId) -> QName {
     translate_value_id(tcx, def_id)
 }
 
-pub fn impl_or_trait(
+fn resolve_impl_source_opt(
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    def_id: DefId,
+    substs: SubstsRef<'tcx>,
+) -> Option<ImplSource<'tcx, ()>> {
+    let trait_ref = if let Some(assoc) = tcx.opt_associated_item(def_id) {
+        match assoc.container {
+            ImplContainer(def_id) => tcx.impl_trait_ref(def_id)?,
+            TraitContainer(def_id) => TraitRef { def_id, substs },
+        }
+    } else {
+        if tcx.is_trait(def_id) {
+            TraitRef { def_id, substs }
+        } else {
+            return None;
+        }
+    };
+
+    let trait_ref = trait_ref.to_poly_trait_ref();
+    let source = rustc_extensions::codegen::codegen_fulfill_obligation(tcx, (param_env, trait_ref));
+
+    match source {
+        Ok(src) => Some(src),
+        Err(mut err) => {
+            err.cancel();
+            return None;
+        }
+    }
+}
+
+pub fn resolve_opt(
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    def_id: DefId,
+    substs: SubstsRef<'tcx>,
+) -> Option<(DefId, SubstsRef<'tcx>)> {
+    if tcx.is_trait(def_id) {
+        resolve_trait_opt(tcx, param_env, def_id, substs)
+    } else {
+        resolve_assoc_item_opt(tcx, param_env, def_id, substs)
+    }
+}
+
+pub fn resolve_trait_opt(
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    def_id: DefId,
+    substs: SubstsRef<'tcx>,
+) -> Option<(DefId, SubstsRef<'tcx>)> {
+    if tcx.is_trait(def_id) {
+        match resolve_impl_source_opt(tcx, param_env, def_id, substs)? {
+            ImplSource::UserDefined(impl_data) => Some((impl_data.impl_def_id, impl_data.substs)),
+            ImplSource::Param(_, _) => Some((def_id, substs)),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+pub fn resolve_assoc_item_opt(
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
     def_id: DefId,
     subst: SubstsRef<'tcx>,
 ) -> Option<(DefId, SubstsRef<'tcx>)> {
-    if let Some(assoc) = tcx.opt_associated_item(def_id) {
-        let target = match assoc.container {
-            ImplContainer(_) => return Some((def_id, subst)),
-            TraitContainer(def_id) => def_id,
-        };
-        let trait_ref = TraitRef { def_id: target, substs: subst }.to_poly_trait_ref();
-        let source =
-            rustc_extensions::codegen::codegen_fulfill_obligation(tcx, (param_env, trait_ref));
+    let assoc = tcx.opt_associated_item(def_id)?;
+    let source = resolve_impl_source_opt(tcx, param_env, def_id, subst)?;
 
-        if let Err(mut err) = source {
-            err.cancel();
-            return None;
-        }
-        match source.unwrap() {
-            ImplSource::UserDefined(impl_data) => {
-                let trait_def_id = tcx.trait_id_of_impl(impl_data.impl_def_id).unwrap();
-                let trait_def = tcx.trait_def(trait_def_id);
-                // Find the id of the actual associated method we will be running
-                let leaf_def = trait_def
-                    .ancestors(tcx, impl_data.impl_def_id)
-                    .unwrap()
-                    .leaf_def(tcx, assoc.ident, assoc.kind)
-                    .unwrap_or_else(|| {
-                        panic!("{:?} not found in {:?}", assoc, impl_data.impl_def_id);
-                    });
-                use rustc_trait_selection::infer::TyCtxtInferExt;
-
-                // Translate the original substitution into one on the selected impl method
-                let leaf_substs = tcx.infer_ctxt().enter(|infcx| {
-                    let param_env = param_env.with_reveal_all_normalized(tcx);
-                    let substs = subst.rebase_onto(tcx, trait_def_id, impl_data.substs);
-                    let substs = rustc_trait_selection::traits::translate_substs(
-                        &infcx,
-                        param_env,
-                        impl_data.impl_def_id,
-                        substs,
-                        leaf_def.defining_node,
-                    );
-                    infcx.tcx.erase_regions(substs)
+    match source {
+        ImplSource::UserDefined(impl_data) => {
+            let trait_def_id = tcx.trait_id_of_impl(impl_data.impl_def_id).unwrap();
+            let trait_def = tcx.trait_def(trait_def_id);
+            // Find the id of the actual associated method we will be running
+            let leaf_def = trait_def
+                .ancestors(tcx, impl_data.impl_def_id)
+                .unwrap()
+                .leaf_def(tcx, assoc.ident, assoc.kind)
+                .unwrap_or_else(|| {
+                    panic!("{:?} not found in {:?}", assoc, impl_data.impl_def_id);
                 });
+            use rustc_trait_selection::infer::TyCtxtInferExt;
 
-                Some((leaf_def.item.def_id, leaf_substs))
-            }
-            ImplSource::Param(_, _) => Some((def_id, subst)),
-            _ => unimplemented!(),
+            // Translate the original substitution into one on the selected impl method
+            let leaf_substs = tcx.infer_ctxt().enter(|infcx| {
+                let param_env = param_env.with_reveal_all_normalized(tcx);
+                let substs = subst.rebase_onto(tcx, trait_def_id, impl_data.substs);
+                let substs = rustc_trait_selection::traits::translate_substs(
+                    &infcx,
+                    param_env,
+                    impl_data.impl_def_id,
+                    substs,
+                    leaf_def.defining_node,
+                );
+                infcx.tcx.erase_regions(substs)
+            });
+
+            Some((leaf_def.item.def_id, leaf_substs))
         }
-    } else {
-        Some((def_id, subst))
+        ImplSource::Param(_, _) => Some((def_id, subst)),
+        _ => unimplemented!(),
     }
 }

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -103,13 +103,13 @@ end
 module Core_Tuple_Impl7
   type a   
   type b   
-  clone Core_Tuple_Impl7_Gt_Interface as Gt4 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Ge_Interface as Ge3 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Le_Interface as Le2 with type a = a, type b = b
-  clone Core_Tuple_Impl7_Lt_Interface as Lt1 with type a = a, type b = b
-  clone Core_Tuple_Impl7_PartialCmp_Interface as PartialCmp0 with type a = a, type b = b
-  clone Core_Cmp_PartialOrd with type self = (a, b), type rhs = (a, b), val partial_cmp = PartialCmp0.partial_cmp,
-  val lt = Lt1.lt, val le = Le2.le, val ge = Ge3.ge, val gt = Gt4.gt
+  clone export Core_Tuple_Impl7_Gt_Interface with type a = a, type b = b
+  clone export Core_Tuple_Impl7_Ge_Interface with type a = a, type b = b
+  clone export Core_Tuple_Impl7_Le_Interface with type a = a, type b = b
+  clone export Core_Tuple_Impl7_Lt_Interface with type a = a, type b = b
+  clone export Core_Tuple_Impl7_PartialCmp_Interface with type a = a, type b = b
+  clone Core_Cmp_PartialOrd with type self = (a, b), type rhs = (a, b), val partial_cmp = partial_cmp, val lt = lt,
+  val le = le, val ge = ge, val gt = gt
 end
 module ConstrainedTypes_UsesConcreteInstance_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -377,6 +377,6 @@ module ListIndexMut_Main
 end
 module ListIndexMut_Impl0
   use Type
-  clone ListIndexMut_Impl0_Resolve as Resolve0
-  clone CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = Resolve0.resolve
+  clone export ListIndexMut_Impl0_Resolve
+  clone CreusotContracts_Builtins_Resolve with type self = Type.listindexmut_list, predicate resolve = resolve
 end

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -95,7 +95,6 @@ module CreusotContracts_Builtins_Resolve
 end
 module Modules_Nested_Impl0
   use Type
-  clone Modules_Nested_Impl0_Resolve as Resolve0
-  clone CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested,
-  predicate resolve = Resolve0.resolve
+  clone export Modules_Nested_Impl0_Resolve
+  clone CreusotContracts_Builtins_Resolve with type self = Type.modules_nested_nested, predicate resolve = resolve
 end

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -89,13 +89,13 @@ module TraitImpl_Impl0
   type b   
   type t2   
   type t1   
-  clone TraitImpl_Impl0_X_Interface as X0 with type b = b, type t2 = t2, type t1 = t1
-  clone TraitImpl_T with type self = (t1, t2), type b = b, val x = X0.x
+  clone export TraitImpl_Impl0_X_Interface with type b = b, type t2 = t2, type t1 = t1
+  clone TraitImpl_T with type self = (t1, t2), type b = b, val x = x
 end
 module TraitImpl_Impl1
   type b   
   use mach.int.Int
   use mach.int.UInt32
-  clone TraitImpl_Impl1_X_Interface as X0 with type b = b
-  clone TraitImpl_T with type self = uint32, type b = b, val x = X0.x
+  clone export TraitImpl_Impl1_X_Interface with type b = b
+  clone TraitImpl_T with type self = uint32, type b = b, val x = x
 end

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -100,8 +100,8 @@ end
 module C03_Impl0
   use mach.int.Int
   use mach.int.Int32
-  clone C03_Impl0_F_Interface as F0
-  clone C03_A with type self = int32, val f = F0.f
+  clone export C03_Impl0_F_Interface
+  clone C03_A with type self = int32, val f = f
 end
 module C03_B
   type self   
@@ -114,8 +114,8 @@ end
 module C03_Impl1
   use mach.int.Int
   use mach.int.UInt32
-  clone C03_Impl1_G_Interface as G0
-  clone C03_B with type self = uint32, val g = G0.g
+  clone export C03_Impl1_G_Interface
+  clone C03_B with type self = uint32, val g = g
 end
 module C03_C
   type self   
@@ -126,6 +126,6 @@ end
 module C03_Impl2
   use mach.int.Int
   use mach.int.UInt32
-  clone C03_Impl2_H_Interface as H0
-  clone C03_C with type self = uint32, type t = H0.g, val h = H0.h
+  clone export C03_Impl2_H_Interface
+  clone C03_C with type self = uint32, type t = g, val h = h
 end

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -83,10 +83,10 @@ end
 module C07_Impl0
   use mach.int.Int
   use mach.int.Int32
-  clone C07_Impl0_Ix_Interface as Ix0
+  clone export C07_Impl0_Ix_Interface
   type tgt  = 
     ()
-  clone C07_Ix with type self = int32, type tgt = tgt, val ix = Ix0.ix
+  clone C07_Ix with type self = int32, type tgt = tgt, val ix = ix
 end
 module C07_Test2_Interface
   use prelude.Prelude

--- a/creusot/tests/should_succeed/traits/10.stdout
+++ b/creusot/tests/should_succeed/traits/10.stdout
@@ -32,7 +32,7 @@ module C10_Impl0
   type t2   
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = t2
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = t1
-  clone C10_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2, predicate Resolve0.resolve = Resolve1.resolve,
+  clone export C10_Impl0_Resolve with type t1 = t1, type t2 = t2, predicate Resolve0.resolve = Resolve1.resolve,
   predicate Resolve1.resolve = Resolve2.resolve
-  clone CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = Resolve0.resolve
+  clone CreusotContracts_Builtins_Resolve with type self = (t1, t2), predicate resolve = resolve
 end

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -64,10 +64,8 @@ impl QName {
         self.name.clone()
     }
 
-    pub fn module_name(mut self) -> QName {
-        let name = self.module.pop().unwrap();
-
-        QName { module: self.module, name }
+    pub fn module_name(&self) -> Option<&Ident> {
+        self.module.last()
     }
 
     pub fn from_string(s: &str) -> Option<QName> {


### PR DESCRIPTION
This PR improves the cloning of traits by attempting to resolve instances during clone graph construction. 
A key aspect of the clone graph construction is that we apply substitutions on dependencies to obtain the a normalized version of all transitive dependencies. When dealing with traits this means that we can turn something like `Eq T` into `Eq Int`, and when that happens we want to be using the _implementation_ rather than the trait itself. 

This is particularily relevant for the `Cell` where we use a trait `Inv` to represent the invariants of cells. Without this change we end up having an opaque predicate for `Inv Even` in the context rather than the actual invariant which defines `Even`. 

This change also required ensuring that the module for an impl re-exports its symbols, and thus adding support for `clone export`. 
Of course, this will change when we address #30.

-------
Commits:

- Change module_name to return an &Ident
- Refactor trait resolution logic. Ensure that we normalize trait refs during module cloning
