### PR TITLE
Flag to enable unbounded arithmetic

### DIFF
--- a/creusot/src/bin/cargo-creusot.rs
+++ b/creusot/src/bin/cargo-creusot.rs
@@ -17,6 +17,7 @@ fn main() {
         (@setting TrailingVarArg)
         (@setting AllowLeadingHyphen)
         (@arg PACKAGE: -p --package [PKG] "package to verify")
+        (@arg unbounded: --unbounded "disable arithmetic bounds checking")
         (@arg flags: ... "cargo flags")
     )
     .get_matches_from(std::env::args().skip(2));
@@ -28,6 +29,10 @@ fn main() {
         .arg("-q")
         .args(std::env::args().skip(2))
         .env("RUSTC_WRAPPER", creusot_rustc_path);
+
+    if matches.is_present("unbounded") {
+        cmd.env("CREUSOT_UNBOUNDED", "1");
+    };
 
     if let Some(tgt) = matches.value_of("pkg") {
         cmd.env("CREUSOT_TARGET", tgt);

--- a/creusot/src/options.rs
+++ b/creusot/src/options.rs
@@ -11,6 +11,7 @@ pub struct Options {
     pub export_metadata: bool,
     pub dependency: bool,
     pub output_file: Option<String>,
+    pub bounds_check: bool,
 }
 
 impl Options {
@@ -33,6 +34,8 @@ impl Options {
             None => HashMap::new(),
         };
 
+        let bounds_check = !creusot_unbounded();
+
         Options {
             has_contracts,
             be_rustc,
@@ -42,6 +45,7 @@ impl Options {
             continue_compilation: continue_compiler(),
             metadata_path: creusot_metadata_path(),
             extern_paths,
+            bounds_check,
         }
     }
 }
@@ -59,4 +63,8 @@ fn creusot_metadata_path() -> Option<String> {
 
 fn export_metadata() -> bool {
     std::env::var_os("CREUSOT_EXPORT_METADATA").map(|f| f != "false").unwrap_or(true)
+}
+
+fn creusot_unbounded() -> bool {
+    std::env::var_os("CREUSOT_UNBOUNDED").is_some()
 }

--- a/creusot/src/translation/constant.rs
+++ b/creusot/src/translation/constant.rs
@@ -1,22 +1,18 @@
-use rustc_middle::ty::TyCtxt;
 use rustc_resolve::Namespace;
 use why3::mlcfg::{self, Constant};
 
-use crate::{
-    clone_map::{CloneMap, PreludeModule},
-    translation::ty,
-};
+use crate::{clone_map::CloneMap, ctx::TranslationCtx, translation::ty};
 
 pub fn from_mir_constant<'tcx>(
-    tcx: TyCtxt<'tcx>,
+    ctx: &mut TranslationCtx<'_, 'tcx>,
     names: &mut CloneMap<'tcx>,
     c: &rustc_middle::mir::Constant<'tcx>,
 ) -> mlcfg::Constant {
-    from_mir_constant_kind(tcx, names, c.literal)
+    from_mir_constant_kind(ctx, names, c.literal)
 }
 
 pub fn from_mir_constant_kind<'tcx>(
-    tcx: TyCtxt<'tcx>,
+    ctx: &mut TranslationCtx<'_, 'tcx>,
     names: &mut CloneMap<'tcx>,
     ck: rustc_middle::mir::ConstantKind<'tcx>,
 ) -> mlcfg::Constant {
@@ -24,52 +20,26 @@ pub fn from_mir_constant_kind<'tcx>(
     use rustc_middle::ty::{IntTy::*, UintTy::*};
     use rustc_target::abi::Size;
 
+    let ty = ty::translate_ty(ctx, names, rustc_span::DUMMY_SP, ck.ty());
     match ck.ty().kind() {
-        Int(I8) => {
-            Constant::Int(ck.try_to_bits(Size::from_bytes(1)).unwrap() as i128, Some(ty::i8_ty()))
-        }
-        Int(I16) => {
-            Constant::Int(ck.try_to_bits(Size::from_bytes(2)).unwrap() as i128, Some(ty::i16_ty()))
-        }
-        Int(I32) => {
-            names.import_prelude_module(PreludeModule::Int);
-            names.import_prelude_module(PreludeModule::Int32);
-            Constant::Int(ck.try_to_bits(Size::from_bytes(4)).unwrap() as i128, Some(ty::i32_ty()))
-        }
-        Int(I64) => {
-            names.import_prelude_module(PreludeModule::Int);
-            names.import_prelude_module(PreludeModule::Int64);
-            Constant::Int(ck.try_to_bits(Size::from_bytes(8)).unwrap() as i128, Some(ty::i64_ty()))
-        }
+        Int(I8) => Constant::Int(ck.try_to_bits(Size::from_bytes(1)).unwrap() as i128, Some(ty)),
+        Int(I16) => Constant::Int(ck.try_to_bits(Size::from_bytes(2)).unwrap() as i128, Some(ty)),
+        Int(I32) => Constant::Int(ck.try_to_bits(Size::from_bytes(4)).unwrap() as i128, Some(ty)),
+        Int(I64) => Constant::Int(ck.try_to_bits(Size::from_bytes(8)).unwrap() as i128, Some(ty)),
         Int(I128) => unimplemented!("128-bit integers are not supported"),
 
-        Uint(U8) => Constant::Uint(ck.try_to_bits(Size::from_bytes(1)).unwrap(), Some(ty::u8_ty())),
-        Uint(U16) => {
-            Constant::Uint(ck.try_to_bits(Size::from_bytes(2)).unwrap(), Some(ty::u16_ty()))
-        }
-        Uint(U32) => {
-            names.import_prelude_module(PreludeModule::Int);
-            names.import_prelude_module(PreludeModule::UInt32);
-            Constant::Uint(ck.try_to_bits(Size::from_bytes(4)).unwrap(), Some(ty::u32_ty()))
-        }
-        Uint(U64) => {
-            names.import_prelude_module(PreludeModule::Int);
-            names.import_prelude_module(PreludeModule::UInt32);
-            Constant::Uint(ck.try_to_bits(Size::from_bytes(8)).unwrap(), Some(ty::u64_ty()))
-        }
+        Uint(U8) => Constant::Uint(ck.try_to_bits(Size::from_bytes(1)).unwrap(), Some(ty)),
+        Uint(U16) => Constant::Uint(ck.try_to_bits(Size::from_bytes(2)).unwrap(), Some(ty)),
+        Uint(U32) => Constant::Uint(ck.try_to_bits(Size::from_bytes(4)).unwrap(), Some(ty)),
+        Uint(U64) => Constant::Uint(ck.try_to_bits(Size::from_bytes(8)).unwrap(), Some(ty)),
         Uint(U128) => {
             unimplemented!("128-bit integers are not supported")
         }
-        Uint(Usize) => {
-            names.import_prelude_module(PreludeModule::Int);
-            names.import_prelude_module(PreludeModule::UInt64);
-            names.import_prelude_module(PreludeModule::Prelude);
-            Constant::Uint(ck.try_to_bits(Size::from_bytes(8)).unwrap(), Some(ty::usize_ty()))
-        }
+        Uint(Usize) => Constant::Uint(ck.try_to_bits(Size::from_bytes(8)).unwrap(), Some(ty)),
         _ => {
             use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter};
             let mut fmt = String::new();
-            let cx = FmtPrinter::new(tcx, &mut fmt, Namespace::ValueNS);
+            let cx = FmtPrinter::new(ctx.tcx, &mut fmt, Namespace::ValueNS);
             // cx.pretty_print_const(ck, false).unwrap();
             use rustc_middle::mir::ConstantKind;
             match ck {

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -356,7 +356,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
         match operand {
             Operand::Copy(pl) | Operand::Move(pl) => self.translate_rplace(pl),
             Operand::Constant(c) => {
-                Const(crate::constant::from_mir_constant(self.tcx, &mut self.clone_names, c))
+                Const(crate::constant::from_mir_constant(&mut self.ctx, &mut self.clone_names, c))
             }
         }
     }

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -55,9 +55,11 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                     self.emit_statement(Assume(assumption));
                     self.translate_rplace(pl)
                 }
-                Constant(box c) => {
-                    Const(crate::constant::from_mir_constant(self.tcx, &mut self.clone_names, c))
-                }
+                Constant(box c) => Const(crate::constant::from_mir_constant(
+                    &mut self.ctx,
+                    &mut self.clone_names,
+                    c,
+                )),
             },
             Rvalue::Ref(_, ss, pl) => match ss {
                 Shared | Shallow | Unique => self.translate_rplace(pl),

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -106,7 +106,7 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                 let rhs = match value {
                     Operand::Move(pl) | Operand::Copy(pl) => self.translate_rplace(pl),
                     Operand::Constant(box c) => Exp::Const(crate::constant::from_mir_constant(
-                        self.tcx,
+                        &mut self.ctx,
                         &mut self.clone_names,
                         c,
                     )),

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -11,7 +11,7 @@ pub fn lower_term_to_why3<'tcx>(
     term: Term<'tcx>,
 ) -> Exp {
     match term {
-        Term::Const(c) => Exp::Const(constant::from_mir_constant_kind(ctx.tcx, names, c.into())),
+        Term::Const(c) => Exp::Const(constant::from_mir_constant_kind(ctx, names, c.into())),
         Term::Var(v) => Exp::Var(v.into()),
         Term::Binary { op, box lhs, box rhs } => Exp::BinaryOp(
             binop_to_binop(op),

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -205,8 +205,8 @@ module BinarySearch_Impl0_Len_Interface
   type t   
   use mach.int.Int
   use mach.int.Int32
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val len (self : Type.binarysearch_list t) : usize
@@ -219,8 +219,8 @@ module BinarySearch_Impl0_Len
   type t   
   use mach.int.Int
   use mach.int.Int32
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   clone BinarySearch_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
@@ -353,8 +353,8 @@ end
 module BinarySearch_BinarySearch
   use mach.int.Int
   use mach.int.UInt32
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use mach.int.Int32
   use Type
   clone BinarySearch_Get as Get3 with type t = uint32

--- a/creusot/tests/should_succeed/branch_borrow_3.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_3.stdout
@@ -18,8 +18,8 @@ module BranchBorrow3_Main_Interface
 end
 module BranchBorrow3_Main
   use mach.int.Int
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   let rec cfg main () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -105,8 +105,8 @@ module ListIndexMut_IndexMut_Interface
 end
 module ListIndexMut_IndexMut
   use mach.int.Int
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use mach.int.Int32
   use Type
   use mach.int.UInt32
@@ -317,8 +317,8 @@ end
 module ListIndexMut_Main
   use mach.int.Int
   use mach.int.UInt32
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   clone ListIndexMut_Impl0_Resolve as Resolve2
   clone ListIndexMut_Get as Get4

--- a/creusot/tests/should_succeed/match_int.stdout
+++ b/creusot/tests/should_succeed/match_int.stdout
@@ -28,6 +28,7 @@ end
 module MatchInt_Main
   use mach.int.Int
   use mach.int.Int32
+  use prelude.Prelude
   clone Core_Panicking_Panic_Interface as Panic0
   let rec cfg main () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -18,8 +18,8 @@ module OneSideUpdate_Main_Interface
 end
 module OneSideUpdate_Main
   use mach.int.Int
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   let rec cfg main () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -33,8 +33,8 @@ module SplitBorrow_Main_Interface
 end
 module SplitBorrow_Main
   use mach.int.Int
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   clone SplitBorrow_Z_Interface as Z0
   let rec cfg main () : () = 

--- a/creusot/tests/should_succeed/split_move.stdout
+++ b/creusot/tests/should_succeed/split_move.stdout
@@ -18,8 +18,8 @@ module SplitMove_Main_Interface
 end
 module SplitMove_Main
   use mach.int.Int
-  use mach.int.UInt64
   use prelude.Prelude
+  use mach.int.UInt64
   use Type
   let rec cfg main () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/syntax/03_unbounded.rs
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.rs
@@ -1,0 +1,13 @@
+// UNBOUNDED
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+#[ensures(result == 4294967294u32)]
+fn no_bounds_check(x: u32, y: u32) -> u32 {
+  2_147_483_647 + 2_147_483_647
+}

--- a/creusot/tests/should_succeed/syntax/03_unbounded.stdout
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.stdout
@@ -1,0 +1,45 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C03Unbounded_NoBoundsCheck_Interface
+  use mach.int.Int
+  val no_bounds_check (x : int) (y : int) : int
+    ensures { result = (4294967294 : int) }
+    
+end
+module C03Unbounded_NoBoundsCheck
+  use mach.int.Int
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = int
+  let rec cfg no_bounds_check (x : int) (y : int) : int
+    ensures { result = (4294967294 : int) }
+    
+   = 
+  var _0 : int;
+  var x_1 : int;
+  var y_2 : int;
+  {
+    x_1 <- x;
+    y_2 <- y;
+    goto BB0
+  }
+  BB0 {
+    _0 <- (2147483647 : int) + (2147483647 : int);
+    assume { Resolve0.resolve x_1 };
+    assume { Resolve0.resolve y_2 };
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/unary_op.stdout
+++ b/creusot/tests/should_succeed/unary_op.stdout
@@ -26,6 +26,7 @@ module UnaryOp_Main_Interface
   val main () : ()
 end
 module UnaryOp_Main
+  use prelude.Prelude
   clone Core_Panicking_Panic_Interface as Panic0
   let rec cfg main () : () = 
   var _0 : ();


### PR DESCRIPTION
Adds a config flag which disables bounds checking by translating all integer types to `Int`. 
This flag can be enabled in tests by putting a magic comment on the first line containing `UNBOUNDED`

Closes #70.

cc @shiatsumat
