### PR TITLE
Re-export the rand crate in creusot-contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ name = "creusot-contracts"
 version = "0.1.0"
 dependencies = [
  "creusot-contracts-proc",
+ "rand",
 ]
 
 [[package]]
@@ -313,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "predicates"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +371,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "*" }
+rand = "*"
 
 [features]
 default = []

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -11,3 +11,6 @@ pub mod builtins;
 
 #[cfg(feature = "contracts")]
 pub use builtins::*;
+
+// Re-export the rand crate
+pub use rand;

--- a/creusot/tests/should_succeed/rand.rs
+++ b/creusot/tests/should_succeed/rand.rs
@@ -6,5 +6,9 @@ use creusot_contracts::*;
 
 #[ensures(result >= 0u32)]
 fn try_rand() -> u32 {
-    rand::random()
+    if rand::random() {
+        7u32
+    } else {
+        rand::random()
+    }
 }

--- a/creusot/tests/should_succeed/rand.rs
+++ b/creusot/tests/should_succeed/rand.rs
@@ -1,0 +1,10 @@
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[ensures(result >= 0u32)]
+fn try_rand() -> u32 {
+    rand::random()
+}

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -18,6 +18,10 @@ module Rand_Random
   type t   
   val random () : t
 end
+module CreusotContracts_Builtins_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module Rand_TryRand_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -28,20 +32,40 @@ end
 module Rand_TryRand
   use mach.int.Int
   use mach.int.UInt32
-  clone Rand_Random_Interface as Random0 with type t = uint32
+  clone Rand_Random_Interface as Random2 with type t = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
+  clone Rand_Random_Interface as Random0 with type t = bool
   let rec cfg try_rand () : uint32
     ensures { result >= (0 : uint32) }
     
    = 
   var _0 : uint32;
+  var _1 : bool;
   {
     goto BB0
   }
   BB0 {
-    _0 <- Random0.random ();
+    _1 <- Random0.random ();
     goto BB1
   }
   BB1 {
+    switch (_1)
+      | False -> goto BB3
+      | True -> goto BB2
+      | _ -> goto BB2
+      end
+  }
+  BB2 {
+    assume { Resolve1.resolve _1 };
+    _0 <- (7 : uint32);
+    goto BB4
+  }
+  BB3 {
+    assume { Resolve1.resolve _1 };
+    _0 <- Random2.random ();
+    goto BB4
+  }
+  BB4 {
     return _0
   }
   

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -1,0 +1,48 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module Rand_Random_Interface
+  type t   
+  val random () : t
+end
+module Rand_Random
+  type t   
+  val random () : t
+end
+module Rand_TryRand_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  val try_rand () : uint32
+    ensures { result >= (0 : uint32) }
+    
+end
+module Rand_TryRand
+  use mach.int.Int
+  use mach.int.UInt32
+  clone Rand_Random_Interface as Random0 with type t = uint32
+  let rec cfg try_rand () : uint32
+    ensures { result >= (0 : uint32) }
+    
+   = 
+  var _0 : uint32;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- Random0.random ();
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end


### PR DESCRIPTION
Re-export the rand crate in the crate `creusot-contracts` for convenience.
This lets us naturally use `rand::random` in benchmarks.
Also add the test `rand` to check that.