### PR TITLE
Metadata Encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ mir_dump/
 
 # Creusot files
 *.creusot
+*.cmeta
 
 # Why3 Files
 /*.mlcfg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "creusot-contracts",
+ "creusot-metadata",
  "env_logger",
  "glob",
  "heck",
@@ -143,6 +144,13 @@ dependencies = [
  "quote",
  "syn 1.0.76",
  "uuid",
+]
+
+[[package]]
+name = "creusot-metadata"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "creusot",
   "creusot-contracts",
   "creusot-contracts-proc",
+  "creusot-metadata",
   "why3",
   "why3tests",
 ]

--- a/creusot-metadata/Cargo.toml
+++ b/creusot-metadata/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "creusot-metadata"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+indexmap = "1.7.0"

--- a/creusot-metadata/src/decoder.rs
+++ b/creusot-metadata/src/decoder.rs
@@ -1,18 +1,18 @@
+use rustc_data_structures::owning_ref::OwningRef;
+use rustc_data_structures::rustc_erase_owner;
 use rustc_data_structures::sync::{Lrc, MetadataRef};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex, DefPathHash, StableCrateId};
 use rustc_metadata::creader::CStore;
 use rustc_middle::implement_ty_decoder;
 use rustc_middle::middle::cstore::CrateStore;
+use rustc_middle::ty;
 use rustc_middle::ty::codec::TyDecoder;
+use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_serialize::opaque;
 pub use rustc_serialize::{Decodable, Decoder};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use rustc_data_structures::owning_ref::OwningRef;
-use rustc_data_structures::rustc_erase_owner;
-use rustc_middle::ty;
-use rustc_middle::ty::{Ty, TyCtxt};
 
 // copied from rustc
 #[derive(Clone)]

--- a/creusot-metadata/src/decoder.rs
+++ b/creusot-metadata/src/decoder.rs
@@ -1,0 +1,144 @@
+use rustc_data_structures::sync::{Lrc, MetadataRef};
+use rustc_hir::def_id::{CrateNum, DefId, DefIndex, DefPathHash, StableCrateId};
+use rustc_metadata::creader::CStore;
+use rustc_middle::implement_ty_decoder;
+use rustc_middle::middle::cstore::CrateStore;
+use rustc_middle::ty::codec::TyDecoder;
+use rustc_serialize::opaque;
+pub use rustc_serialize::{Decodable, Decoder};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use rustc_data_structures::owning_ref::OwningRef;
+use rustc_data_structures::rustc_erase_owner;
+use rustc_middle::ty;
+use rustc_middle::ty::{Ty, TyCtxt};
+
+// copied from rustc
+#[derive(Clone)]
+pub struct MetadataBlob(pub Lrc<MetadataRef>);
+
+impl MetadataBlob {
+    pub fn from_file(path: &Path) -> Result<Self, std::io::Error> {
+        let mut encoded = Vec::new();
+        let mut file = File::open(path)?;
+        file.read_to_end(&mut encoded)?;
+
+        let encoded_owned = OwningRef::new(encoded);
+        let metadat_ref: OwningRef<Box<_>, [u8]> = encoded_owned.map_owner_box();
+        Ok(MetadataBlob(Lrc::new(rustc_erase_owner!(metadat_ref))))
+    }
+}
+
+pub struct MetadataDecoder<'a, 'tcx> {
+    opaque: opaque::Decoder<'a>,
+    cnum: CrateNum,
+    tcx: TyCtxt<'tcx>,
+}
+
+impl MetadataDecoder<'a, 'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, cnum: CrateNum, blob: &'a MetadataBlob) -> Self {
+        MetadataDecoder { opaque: opaque::Decoder::new(&blob.0, 0), cnum, tcx }
+    }
+
+    // From rustc
+    fn def_path_hash_to_def_id(&self, hash: DefPathHash) -> DefId {
+        let stable_crate_id = hash.stable_crate_id();
+
+        // If this is a DefPathHash from the local crate, we can look up the
+        // DefId in the tcx's `Definitions`.
+        if stable_crate_id == self.tcx.sess.local_stable_crate_id() {
+            self.tcx.definitions_untracked().local_def_path_hash_to_def_id(hash).to_def_id()
+        } else {
+            // If this is a DefPathHash from an upstream crate, let the CrateStore map
+            // it to a DefId.
+            let cnum = self.tcx.stable_crate_id_to_crate_num(stable_crate_id);
+            CStore::from_tcx(self.tcx).def_path_hash_to_def_id(cnum, hash)
+        }
+    }
+}
+
+// the following two instances are from rustc
+// This impl makes sure that we get a runtime error when we try decode a
+// `DefIndex` that is not contained in a `DefId`. Such a case would be problematic
+// because we would not know how to transform the `DefIndex` to the current
+// context.
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefIndex {
+    fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Result<DefIndex, String> {
+        Err(d.error("trying to decode `DefIndex` outside the context of a `DefId`"))
+    }
+}
+
+// Both the `CrateNum` and the `DefIndex` of a `DefId` can change in between two
+// compilation sessions. We use the `DefPathHash`, which is stable across
+// sessions, to map the old `DefId` to the new one.
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefId {
+    fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Result<Self, String> {
+        let def_path_hash = DefPathHash::decode(d)?;
+        Ok(d.def_path_hash_to_def_id(def_path_hash))
+    }
+}
+
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for CrateNum {
+    fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Result<CrateNum, String> {
+        let stable_id = StableCrateId::decode(d)?;
+        Ok(d.tcx.stable_crate_id_to_crate_num(stable_id))
+    }
+}
+
+implement_ty_decoder!(MetadataDecoder<'a, 'tcx>);
+
+impl<'a, 'tcx> TyDecoder<'tcx> for MetadataDecoder<'a, 'tcx> {
+    const CLEAR_CROSS_CRATE: bool = true;
+
+    #[inline]
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    #[inline]
+    fn peek_byte(&self) -> u8 {
+        self.opaque.data[self.opaque.position()]
+    }
+
+    #[inline]
+    fn position(&self) -> usize {
+        self.opaque.position()
+    }
+
+    fn cached_ty_for_shorthand<F>(
+        &mut self,
+        shorthand: usize,
+        or_insert_with: F,
+    ) -> Result<Ty<'tcx>, Self::Error>
+    where
+        F: FnOnce(&mut Self) -> Result<Ty<'tcx>, Self::Error>,
+    {
+        let tcx = self.tcx();
+
+        let key = ty::CReaderCacheKey { cnum: Some(self.cnum), pos: shorthand };
+
+        if let Some(&ty) = tcx.ty_rcache.borrow().get(&key) {
+            return Ok(ty);
+        }
+
+        let ty = or_insert_with(self)?;
+        tcx.ty_rcache.borrow_mut().insert(key, ty);
+        Ok(ty)
+    }
+
+    fn with_position<F, R>(&mut self, pos: usize, f: F) -> R
+    where
+        F: FnOnce(&mut Self) -> R,
+    {
+        let new_opaque = opaque::Decoder::new(self.opaque.data, pos);
+        let old_opaque = std::mem::replace(&mut self.opaque, new_opaque);
+        let r = f(self);
+        self.opaque = old_opaque;
+        r
+    }
+
+    fn decode_alloc_id(&mut self) -> Result<rustc_middle::mir::interpret::AllocId, Self::Error> {
+        unimplemented!("decode_alloc_id")
+    }
+}

--- a/creusot-metadata/src/encoder.rs
+++ b/creusot-metadata/src/encoder.rs
@@ -1,0 +1,116 @@
+use rustc_middle::mir::interpret::AllocId;
+use rustc_middle::ty::codec::TyEncoder;
+use rustc_middle::ty::{self, PredicateKind, Ty};
+use rustc_serialize::opaque;
+pub use rustc_serialize::{Encodable, Encoder};
+
+use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
+use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
+use rustc_middle::ty::TyCtxt;
+
+pub struct MetadataEncoder<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    opaque: opaque::Encoder,
+    type_shorthands: FxHashMap<Ty<'tcx>, usize>,
+    predicate_shorthands: FxHashMap<PredicateKind<'tcx>, usize>,
+    interpret_allocs: FxIndexSet<AllocId>,
+}
+
+impl MetadataEncoder<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        MetadataEncoder {
+            tcx,
+            opaque: opaque::Encoder::new(vec![]),
+            type_shorthands: Default::default(),
+            predicate_shorthands: Default::default(),
+            interpret_allocs: Default::default(),
+        }
+    }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.opaque.into_inner()
+    }
+}
+
+macro_rules! encoder_methods {
+    ($($name:ident($ty:ty);)*) => {
+        $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
+            self.opaque.$name(value)
+        })*
+    }
+}
+impl Encoder for MetadataEncoder<'tcx> {
+    type Error = <opaque::Encoder as Encoder>::Error;
+
+    #[inline]
+    fn emit_unit(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    encoder_methods! {
+        emit_usize(usize);
+        emit_u128(u128);
+        emit_u64(u64);
+        emit_u32(u32);
+        emit_u16(u16);
+        emit_u8(u8);
+
+        emit_isize(isize);
+        emit_i128(i128);
+        emit_i64(i64);
+        emit_i32(i32);
+        emit_i16(i16);
+        emit_i8(i8);
+
+        emit_bool(bool);
+        emit_f64(f64);
+        emit_f32(f32);
+        emit_char(char);
+        emit_str(&str);
+        emit_raw_bytes(&[u8]);
+    }
+}
+
+impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for DefId {
+    fn encode(&self, s: &mut MetadataEncoder<'tcx>) -> opaque::EncodeResult {
+        s.tcx.def_path_hash(*self).encode(s)
+    }
+}
+
+impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for DefIndex {
+    fn encode(&self, _: &mut MetadataEncoder<'tcx>) -> opaque::EncodeResult {
+        panic!("encoding `DefIndex` without context");
+    }
+}
+
+impl<'tcx> Encodable<MetadataEncoder<'tcx>> for CrateNum {
+    fn encode(&self, s: &mut MetadataEncoder<'tcx>) -> opaque::EncodeResult {
+        s.tcx.stable_crate_id(*self).encode(s)
+    }
+}
+
+impl TyEncoder<'tcx> for MetadataEncoder<'tcx> {
+    // What the fuck does this mean?
+    const CLEAR_CROSS_CRATE: bool = true;
+
+    fn position(&self) -> usize {
+        self.opaque.position()
+    }
+
+    fn type_shorthands(&mut self) -> &mut FxHashMap<Ty<'tcx>, usize> {
+        &mut self.type_shorthands
+    }
+
+    fn predicate_shorthands(&mut self) -> &mut FxHashMap<ty::PredicateKind<'tcx>, usize> {
+        &mut self.predicate_shorthands
+    }
+
+    fn encode_alloc_id(
+        &mut self,
+        alloc_id: &rustc_middle::mir::interpret::AllocId,
+    ) -> Result<(), Self::Error> {
+        let (index, _) = self.interpret_allocs.insert_full(*alloc_id);
+
+        index.encode(self)
+    }
+}

--- a/creusot-metadata/src/lib.rs
+++ b/creusot-metadata/src/lib.rs
@@ -1,0 +1,13 @@
+#![feature(rustc_private)]
+#![feature(in_band_lifetimes)]
+#![feature(min_specialization)]
+
+extern crate rustc_data_structures;
+extern crate rustc_hir;
+extern crate rustc_metadata;
+extern crate rustc_middle;
+extern crate rustc_serialize;
+extern crate rustc_span;
+
+pub mod decoder;
+pub mod encoder;

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -14,12 +14,12 @@ unescape = "0.1"
 sequence_trie = "0.3.6"
 heck = "0.3"
 petgraph = "0.6"
-indexmap = { version = "1.6", features = ["serde"] }
+indexmap = { version = "1.7.0", features = ["serde"] }
 toml = "0.5.8"
 creusot-contracts = { path = "../creusot-contracts", features = ["typechecker"] }
 why3 = { path = "../why3", features = ["serialize"] }
-
 clap = "2.33"
+creusot-metadata = { path = "../creusot-metadata" }
 
 [dev-dependencies]
 glob = "*"

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -24,10 +24,11 @@ use why3::{
 use std::io::Result;
 
 use crate::ctx::TranslationCtx;
+use std::io::Write;
 use why3::mlcfg;
 
 pub fn translate(mut ctx: TranslationCtx<'_, '_>) -> Result<()> {
-    load_exports(&mut ctx);
+    ctx.load_metadata();
 
     for def_id in ctx.tcx.body_owners() {
         let def_id = def_id.to_def_id();
@@ -114,10 +115,6 @@ pub fn prelude_imports(type_import: bool) -> Vec<Decl> {
     }
     imports
 }
-
-use std::io::Write;
-
-use self::external::load_exports;
 
 fn print_crate<'a, W, I: Iterator<Item = &'a Module>>(
     out: &mut W,

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -1,16 +1,24 @@
-use indexmap::IndexMap;
-use rustc_hir::def_id::{CrateNum, DefId};
-use rustc_middle::ty::Visibility;
-
-use why3::declaration::{Decl, Module, ValKind::Val};
-
 use crate::function::all_generic_decls_for;
 use crate::{ctx::*, util};
+use creusot_metadata::decoder::{Decodable, MetadataBlob, MetadataDecoder};
+use creusot_metadata::encoder::{Encodable, MetadataEncoder};
+use indexmap::IndexMap;
+use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
+use rustc_index::vec::Idx;
+use rustc_metadata::creader::CStore;
+use rustc_middle::middle::cstore::CrateStore;
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::{TyCtxt, Visibility};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use why3::declaration::{Decl, Module, ValKind::Val};
 
 // Translate functions that are external to the crate as opaque values
 pub fn translate_extern(ctx: &mut TranslationCtx, def_id: DefId, span: rustc_span::Span) -> Module {
     debug!("using external info for def_id={:?}", def_id);
-    match ctx.externs.get(&def_id) {
+    match ctx.externs.body(def_id) {
         Some(modl) => modl.clone(),
         None => default_decl(ctx, def_id, span),
     }
@@ -32,8 +40,59 @@ fn default_decl(ctx: &mut TranslationCtx, def_id: DefId, _span: rustc_span::Span
     Module { name, decls }
 }
 
-use rustc_hir::def_id::LOCAL_CRATE;
-use rustc_index::vec::Idx;
+type CloneMetadata<'tcx> = HashMap<DefId, CloneSummary<'tcx>>;
+
+// TODO: this should lazily load the metadata.
+pub struct CrateMetadata<'tcx> {
+    tcx: TyCtxt<'tcx>,
+
+    modules: IndexMap<DefId, Module>,
+    dependencies: CloneMetadata<'tcx>,
+}
+
+impl CrateMetadata<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self { tcx, modules: Default::default(), dependencies: Default::default() }
+    }
+
+    pub fn dependencies(&self, def_id: DefId) -> Option<&CloneSummary<'tcx>> {
+        assert!(!def_id.is_local());
+        self.dependencies.get(&def_id)
+    }
+
+    pub fn body(&self, def_id: DefId) -> Option<&Module> {
+        assert!(!def_id.is_local());
+        self.modules.get(&def_id)
+    }
+
+    pub fn load(&mut self, overrides: &HashMap<String, String>) {
+        let cstore = CStore::from_tcx(self.tcx);
+        for cnum in external_crates(self.tcx) {
+            self.load_crate(cstore, overrides, cnum);
+        }
+    }
+
+    fn load_crate(&mut self, cstore: &CStore, overrides: &HashMap<String, String>, cnum: CrateNum) {
+        let base_path = creusot_metadata_base_path(cstore, overrides, cnum);
+
+        let binary_path = creusot_metadata_binary_path(base_path.clone());
+
+        if let Some(dep_info) = load_binary_metadata(self.tcx, cstore, cnum, &binary_path) {
+            for (def_id, summary) in dep_info.into_iter() {
+                self.dependencies.insert(def_id, summary.into_iter().collect());
+            }
+        }
+
+        let binary_path = creusot_metadata_logic_path(base_path);
+
+        if let Some(functions) = load_logic_metadata(cstore, cnum, &binary_path) {
+            self.modules.extend(functions)
+        }
+    }
+}
+
+type LogicMetadata<'a> = IndexMap<usize, &'a Module>;
+type CloneMetaSerialize<'tcx> = HashMap<DefId, Vec<((DefId, SubstsRef<'tcx>), String)>>;
 
 fn export_file(ctx: &TranslationCtx, out: &Option<String>) -> PathBuf {
     out.as_ref().map(|s| s.clone().into()).unwrap_or_else(|| {
@@ -46,87 +105,145 @@ fn export_file(ctx: &TranslationCtx, out: &Option<String>) -> PathBuf {
     })
 }
 
+#[deprecated = "use MetadataDecoder instead"]
 pub fn dump_exports(ctx: &TranslationCtx, out: &Option<String>) {
-    let out_filename = export_file(ctx, out);
+    let mut out_filename = export_file(ctx, out);
 
     debug!("dump_exports={:?}", out_filename);
 
-    let exports: IndexMap<_, _> = ctx
-        .functions
-        .iter()
-        .filter(|(def_id, _)| {
-            ctx.tcx.visibility(**def_id) == Visibility::Public && def_id.is_local()
-        })
-        .map(|(def_id, func)| (def_id.expect_local().index(), func.body()))
-        .collect();
-
-    let res = std::fs::File::create(out_filename)
+    let exports = logic_declaration_metadata(ctx);
+    let res = std::fs::File::create(out_filename.clone())
         .and_then(|mut file| serde_json::to_writer(&mut file, &exports).map_err(|e| e.into()));
 
     if let Err(err) = res {
         warn!("failed to dump creusot metadata err={:?}", err);
     };
+
+    out_filename.set_extension("cmeta");
+
+    let clone_metadata = clone_metadata(ctx);
+
+    dump_binary_metadata(ctx.tcx, &out_filename, clone_metadata).unwrap();
 }
 
-pub fn load_exports(ctx: &mut TranslationCtx) {
-    let cstore = CStore::from_tcx(ctx.tcx);
-    for cr in external_crates(ctx) {
-        ctx.externs.extend(load_crate_creusot_metadata(cstore, &ctx.opts.extern_paths, cr))
-    }
+fn logic_declaration_metadata<'a>(ctx: &'a TranslationCtx<'_, '_>) -> LogicMetadata<'a> {
+    ctx.functions
+        .iter()
+        .filter(|(def_id, _)| {
+            ctx.tcx.visibility(**def_id) == Visibility::Public && def_id.is_local()
+        })
+        .map(|(def_id, func)| (def_id.expect_local().index(), func.body()))
+        .collect()
 }
 
-use rustc_metadata::creader::CStore;
-use rustc_middle::middle::cstore::CrateStore;
-use std::collections::HashMap;
-fn load_crate_creusot_metadata(
+fn clone_metadata(ctx: &TranslationCtx<'_, 'tcx>) -> CloneMetaSerialize<'tcx> {
+    ctx.functions
+        .iter()
+        .filter(|(def_id, _)| {
+            ctx.tcx.visibility(**def_id) == Visibility::Public && def_id.is_local()
+        })
+        .map(|(def_id, v)| (*def_id, v.dependencies().clone().into_iter().collect()))
+        .collect()
+}
+
+fn dump_binary_metadata(
+    tcx: TyCtxt<'tcx>,
+    path: &Path,
+    dep_info: CloneMetaSerialize<'tcx>,
+) -> Result<(), std::io::Error> {
+    let mut encoder = MetadataEncoder::new(tcx);
+    dep_info.encode(&mut encoder).unwrap();
+    // encode_index_map(&dep_info, &mut encoder).unwrap();
+
+    File::create(path).and_then(|mut file| file.write(&encoder.into_inner())).map_err(|err| {
+        warn!("could not encode metadata for crate `{:?}`, error: {:?}", "LOCAL_CRATE", err);
+        err
+    })?;
+    Ok(())
+}
+
+fn load_binary_metadata(
+    tcx: TyCtxt<'tcx>,
     cstore: &CStore,
-    externs: &HashMap<String, String>,
-    cr: CrateNum,
-) -> IndexMap<DefId, Module> {
-    let creusot_path = if let Some(path) = externs.get(&cstore.crate_name(cr).to_string()) {
-        debug!("loading crate {:?} from extern path", cr);
-        path.into()
-    } else {
-        let cs = cstore.crate_source_untracked(cr);
-        crate_creusot_data_path(&cs)
+    cnum: CrateNum,
+    path: &Path,
+) -> Option<CloneMetadata<'tcx>> {
+    let blob = match MetadataBlob::from_file(&path) {
+        Ok(b) => b,
+        Err(_) => {
+            warn!("could not read dependency metadata for crate `{:?}`", cstore.crate_name(cnum));
+            return None;
+        }
     };
 
-    debug!("loading metadata from path={:?}", creusot_path);
+    let mut decoder = MetadataDecoder::new(tcx, cnum, &blob);
+    let map = match CloneMetaSerialize::decode(&mut decoder) {
+        Ok(b) => b,
+        Err(_) => {
+            warn!("could not read dependency metadata for crate `{:?}`", cstore.crate_name(cnum));
+            return None;
+        }
+    };
 
-    let rdr = std::fs::File::open(creusot_path);
+    Some(map.into_iter().map(|(id, vec)| (id, vec.into_iter().collect())).collect())
+    // Some(map)
+}
+
+fn load_logic_metadata(
+    cstore: &CStore,
+    cr: CrateNum,
+    path: &Path,
+) -> Option<impl Iterator<Item = (DefId, Module)>> {
+    let rdr = File::open(path);
 
     if let Err(err) = rdr {
         warn!("could not load metadata for crate={:?} err={:?}", cstore.crate_name(cr), err);
-        return IndexMap::new();
+        return None;
     }
     let map_res: Result<IndexMap<u32, _>, _> = serde_json::from_reader(rdr.unwrap());
 
     if let Err(err) = map_res {
         warn!("error reading metadata for crate={:?} err={:?}", cr, err);
-        return IndexMap::new();
+        return None;
     }
 
-    map_res
-        .unwrap()
-        .into_iter()
-        .map(|(ix, val)| (DefId { krate: cr, index: ix.into() }, val))
-        .collect()
+    Some(
+        map_res
+            .unwrap()
+            .into_iter()
+            .map(move |(ix, val)| (DefId { krate: cr, index: ix.into() }, val)),
+    )
 }
 
-use rustc_middle::middle::cstore::CrateSource;
-use std::path::PathBuf;
-/// Constructs a path to creusot metadata (if present) using the crate source
-/// We store the metadata in a `.creusot` json file alongside the rest of the build artifacts
-fn crate_creusot_data_path(src: &CrateSource) -> PathBuf {
-    let mut path = src.paths().next().unwrap().clone();
+fn creusot_metadata_base_path(
+    cstore: &CStore,
+    overrides: &HashMap<String, String>,
+    cnum: CrateNum,
+) -> PathBuf {
+    if let Some(path) = overrides.get(&cstore.crate_name(cnum).to_string()) {
+        debug!("loading crate {:?} from override path", cnum);
+        path.into()
+    } else {
+        let cs = cstore.crate_source_untracked(cnum);
+        let x = cs.paths().next().unwrap().clone();
+        x
+    }
+}
+
+fn creusot_metadata_binary_path(mut path: PathBuf) -> PathBuf {
+    path.set_extension("cmeta");
+    path
+}
+
+fn creusot_metadata_logic_path(mut path: PathBuf) -> PathBuf {
     path.set_extension("creusot");
     path
 }
 
-fn external_crates<'tcx>(ctx: &TranslationCtx<'_, 'tcx>) -> Vec<CrateNum> {
+fn external_crates(tcx: TyCtxt<'tcx>) -> Vec<CrateNum> {
     let mut deps = Vec::new();
-    for cr in ctx.tcx.crates(()) {
-        if let Some(extern_crate) = ctx.tcx.extern_crate(cr.as_def_id()) {
+    for cr in tcx.crates(()) {
+        if let Some(extern_crate) = tcx.extern_crate(cr.as_def_id()) {
             if extern_crate.is_direct() {
                 deps.push(*cr);
             }

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -42,6 +42,23 @@ module CreusotContracts_Builtins_Impl11_Resolve
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
+module CreusotContracts_Builtins_Impl12_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Builtins_Impl12_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Builtins_Impl12
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Impl12_Resolve with type t = t
+  clone CreusotContracts_Builtins_Resolve with type self = borrowed t, predicate resolve = resolve
+end
 module DropPair_DropPair2_Interface
   use prelude.Prelude
   use mach.int.Int
@@ -52,7 +69,9 @@ module DropPair_DropPair2
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
+  predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair2 (x : (borrowed uint32, borrowed uint32)) : () = 
   var _0 : ();
   var x_1 : (borrowed uint32, borrowed uint32);
@@ -69,17 +88,6 @@ module DropPair_DropPair2
     return _0
   }
   
-end
-module CreusotContracts_Builtins_Impl12_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Builtins_Impl12_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
 end
 module DropPair_Drop_Interface
   use prelude.Prelude
@@ -130,7 +138,9 @@ module DropPair_DropPair
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32
+  clone CreusotContracts_Builtins_Impl12 as Resolve1 with type t = uint32
+  clone CreusotContracts_Builtins_Impl11_Resolve as Resolve0 with type t1 = borrowed uint32, type t2 = borrowed uint32,
+  predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair (x : (borrowed uint32, borrowed uint32)) : ()
     ensures {  ^ (let (a, _) = x in a) =  * (let (a, _) = x in a) }
     ensures { Resolve0.resolve x }

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -24,8 +24,7 @@ fn main() {
     metadata_file
         .args(&["creusot", "--package", "creusot-contracts", "--features=contracts"])
         .env("CREUSOT_METADATA_PATH", &temp_file)
-        .env("CREUSOT_CONTINUE", "true")
-        .env("RUST_BACKTRACE", "1");
+        .env("CREUSOT_CONTINUE", "true");
 
     if !metadata_file.status().expect("could not dump metadata for `creusot_contracts`").success() {
         eprintln!("{}", String::from_utf8_lossy(&metadata_file.output().unwrap().stderr));

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -17,6 +17,10 @@ impl Ident {
         // TODO: ensure that all characters are valid
         Ident(name.into())
     }
+
+    pub fn to_string(self) -> String {
+        self.0
+    }
 }
 
 // TODO: Make this try_from and test for validity


### PR DESCRIPTION
This PR implements a full solution to the issues outlined in #94. 

I add a new crate `creusot_metadata` which provides an instance of `rustc`'s `TyEncoder` & `TyDecoder`, capable of serializing and deserializing rustc datastructures! 
This means that we will be able to serialize abitrary metadata about compilation to be shared across crates.
For the moment, I will only serialize a 'clone summary' which maps `(DefId, SubstsRef)` pairs to their clone name. 
This will be used to fix the issues presented in #94 by providing us with sufficient information to build the full sharing graph.

A follow up PR should ensure that we also serialize logic functions in this manner, rather than as a json blob. 
