### PR TITLE
Fix printing of adts

### DIFF
--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -11,10 +11,10 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type allzero_list  = 
-    | AllZero_List_Cons(uint32, allzero_list)
+    | AllZero_List_Cons uint32 (allzero_list)
     | AllZero_List_Nil
     
 end
@@ -44,7 +44,7 @@ module AllZero_Len
   use mach.int.Int32
   function len (l : Type.allzero_list) : int = 
     match (l) with
-      | Type.AllZero_List_Cons(_, ls) -> Int32.to_int (1 : int32) + len ls
+      | Type.AllZero_List_Cons _ ls -> Int32.to_int (1 : int32) + len ls
       | Type.AllZero_List_Nil -> Int32.to_int (0 : int32)
       end
 end
@@ -61,8 +61,8 @@ module AllZero_Get
   use mach.int.Int32
   function get (l : Type.allzero_list) (ix : int) : Type.core_option_option uint32 = 
     match (l) with
-      | Type.AllZero_List_Cons(x, ls) -> match (ix = Int32.to_int (0 : int32)) with
-        | True -> Type.Core_Option_Option_Some(x)
+      | Type.AllZero_List_Cons x ls -> match (ix = Int32.to_int (0 : int32)) with
+        | True -> Type.Core_Option_Option_Some x
         | False -> get ls (ix - Int32.to_int (1 : int32))
         end
       | Type.AllZero_List_Nil -> Type.Core_Option_Option_None
@@ -93,7 +93,7 @@ module AllZero_AllZero_Interface
   clone AllZero_Len_Interface as Len0
   val all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some((0 : uint32)) }
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
 end
 module AllZero_AllZero
@@ -112,7 +112,7 @@ module AllZero_AllZero
   clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = Type.allzero_list
   let rec cfg all_zero (l : borrowed (Type.allzero_list)) : ()
     ensures { Len0.len ( * l) = Len0.len ( ^ l) }
-    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some((0 : uint32)) }
+    ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) -> Get1.get ( ^ l) i = Type.Core_Option_Option_Some (0 : uint32) }
     
    = 
   var _0 : ();
@@ -136,13 +136,13 @@ module AllZero_AllZero
     goto BB1
   }
   BB1 {
-    invariant zeroed { (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * loop_l_2) -> Get1.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some((0 : uint32))) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l_1) -> Get1.get ( ^ l_1) i = Type.Core_Option_Option_Some((0 : uint32))) };
+    invariant zeroed { (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * loop_l_2) -> Get1.get ( ^ loop_l_2) i = Type.Core_Option_Option_Some (0 : uint32)) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l_1) -> Get1.get ( ^ l_1) i = Type.Core_Option_Option_Some (0 : uint32)) };
     invariant in_len { Len0.len ( ^ loop_l_2) = Len0.len ( * loop_l_2) -> Len0.len ( ^ l_1) = Len0.len ( * l_1) };
     goto BB2
   }
   BB2 {
     switch ( * loop_l_2)
-      | Type.AllZero_List_Cons(_, _) -> goto BB3
+      | Type.AllZero_List_Cons _ _ -> goto BB3
       | _ -> goto BB5
       end
   }
@@ -151,10 +151,10 @@ module AllZero_AllZero
     goto BB4
   }
   BB4 {
-    value_7 <- borrow_mut (let Type.AllZero_List_Cons(a, _) =  * loop_l_2 in a);
-    loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons(a, b) =  * loop_l_2 in Type.AllZero_List_Cons( ^ value_7, b)) };
-    next_8 <- borrow_mut (let Type.AllZero_List_Cons(_, a) =  * loop_l_2 in a);
-    loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons(a, b) =  * loop_l_2 in Type.AllZero_List_Cons(a,  ^ next_8)) };
+    value_7 <- borrow_mut (let Type.AllZero_List_Cons a _ =  * loop_l_2 in a);
+    loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons a b =  * loop_l_2 in Type.AllZero_List_Cons ( ^ value_7) b) };
+    next_8 <- borrow_mut (let Type.AllZero_List_Cons _ a =  * loop_l_2 in a);
+    loop_l_2 <- { loop_l_2 with current = (let Type.AllZero_List_Cons a b =  * loop_l_2 in Type.AllZero_List_Cons a ( ^ next_8)) };
     assume { Resolve2.resolve loop_l_2 };
     value_7 <- { value_7 with current = (0 : uint32) };
     assume { Resolve4.resolve value_7 };

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -10,15 +10,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type core_result_result 't 'e = 
-    | Core_Result_Result_Ok('t)
-    | Core_Result_Result_Err('e)
+    | Core_Result_Result_Ok 't
+    | Core_Result_Result_Err 'e
     
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type binarysearch_list 't = 
-    | BinarySearch_List_Cons('t, binarysearch_list 't)
+    | BinarySearch_List_Cons 't (binarysearch_list 't)
     | BinarySearch_List_Nil
     
 end
@@ -50,7 +50,7 @@ module BinarySearch_LenLogic
   use mach.int.Int32
   function len_logic (l : Type.binarysearch_list t) : int = 
     match (l) with
-      | Type.BinarySearch_List_Cons(_, ls) -> Int32.to_int (1 : int32) + len_logic ls
+      | Type.BinarySearch_List_Cons _ ls -> Int32.to_int (1 : int32) + len_logic ls
       | Type.BinarySearch_List_Nil -> Int32.to_int (0 : int32)
       end
 end
@@ -67,8 +67,8 @@ module BinarySearch_Get
   use mach.int.Int32
   function get (l : Type.binarysearch_list t) (ix : int) : Type.core_option_option t = 
     match (l) with
-      | Type.BinarySearch_List_Cons(t, ls) -> match (ix = Int32.to_int (0 : int32)) with
-        | True -> Type.Core_Option_Option_Some(t)
+      | Type.BinarySearch_List_Cons t ls -> match (ix = Int32.to_int (0 : int32)) with
+        | True -> Type.Core_Option_Option_Some t
         | False -> get ls (ix - Int32.to_int (1 : int32))
         end
       | Type.BinarySearch_List_Nil -> Type.Core_Option_Option_None
@@ -98,7 +98,7 @@ module BinarySearch_Impl0_Index_Interface
   clone BinarySearch_LenLogic_Interface as LenLogic0 with type t = t
   val index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some(result) = Get1.get self (UInt64.to_int ix) }
+    ensures { Type.Core_Option_Option_Some result = Get1.get self (UInt64.to_int ix) }
     
 end
 module BinarySearch_Impl0_Index
@@ -120,7 +120,7 @@ module BinarySearch_Impl0_Index
   clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = usize
   let rec cfg index (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
-    ensures { Type.Core_Option_Option_Some(result) = Get1.get self (UInt64.to_int ix) }
+    ensures { Type.Core_Option_Option_Some result = Get1.get self (UInt64.to_int ix) }
     
    = 
   var _0 : t;
@@ -163,7 +163,7 @@ module BinarySearch_Impl0_Index
   }
   BB2 {
     switch (l_4)
-      | Type.BinarySearch_List_Cons(_, _) -> goto BB3
+      | Type.BinarySearch_List_Cons _ _ -> goto BB3
       | _ -> goto BB7
       end
   }
@@ -172,8 +172,8 @@ module BinarySearch_Impl0_Index
     goto BB4
   }
   BB4 {
-    t_10 <- (let Type.BinarySearch_List_Cons(a, _) = l_4 in a);
-    ls_11 <- (let Type.BinarySearch_List_Cons(_, a) = l_4 in a);
+    t_10 <- (let Type.BinarySearch_List_Cons a _ = l_4 in a);
+    ls_11 <- (let Type.BinarySearch_List_Cons _ a = l_4 in a);
     assume { Resolve3.resolve l_4 };
     assume { Resolve2.resolve _13 };
     _13 <- ix_2;
@@ -279,7 +279,7 @@ module BinarySearch_Impl0_Len
   }
   BB2 {
     switch (l_3)
-      | Type.BinarySearch_List_Cons(_, _) -> goto BB3
+      | Type.BinarySearch_List_Cons _ _ -> goto BB3
       | _ -> goto BB5
       end
   }
@@ -288,7 +288,7 @@ module BinarySearch_Impl0_Len
     goto BB4
   }
   BB4 {
-    ls_8 <- (let Type.BinarySearch_List_Cons(_, a) = l_3 in a);
+    ls_8 <- (let Type.BinarySearch_List_Cons _ a = l_3 in a);
     assume { Resolve1.resolve l_3 };
     len_2 <- len_2 + (1 : usize);
     _9 <- ls_8;
@@ -324,7 +324,7 @@ module BinarySearch_IsSorted
   clone BinarySearch_Get_Interface as Get0 with type t = uint32
   function is_sorted (l : Type.binarysearch_list uint32) : bool = 
     forall x2 : (int) . forall x1 : (int) . x1 <= x2 -> match ((Get0.get l x1, Get0.get l x2)) with
-      | (Type.Core_Option_Option_Some(v1), Type.Core_Option_Option_Some(v2)) -> v1 <= v2
+      | (Type.Core_Option_Option_Some v1, Type.Core_Option_Option_Some v2) -> v1 <= v2
       | (Type.Core_Option_Option_None, Type.Core_Option_Option_None) -> true
       | _ -> false
       end
@@ -342,7 +342,7 @@ module BinarySearch_GetDefault
   clone BinarySearch_Get_Interface as Get0 with type t = t
   function get_default (l : Type.binarysearch_list t) (ix : int) (def : t) : t = 
     match (Get0.get l ix) with
-      | Type.Core_Option_Option_Some(v) -> v
+      | Type.Core_Option_Option_Some v -> v
       | Type.Core_Option_Option_None -> def
       end
 end
@@ -360,9 +360,9 @@ module BinarySearch_BinarySearch_Interface
   val binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted0.is_sorted arr}
     requires {LenLogic1.len_logic arr <= Int32.to_int (1000000 : int32)}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok(x) -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some(elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic1.len_logic arr -> elem < GetDefault2.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault2.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
     
 end
 module BinarySearch_BinarySearch
@@ -389,9 +389,9 @@ module BinarySearch_BinarySearch
   let rec cfg binary_search (arr : Type.binarysearch_list uint32) (elem : uint32) : Type.core_result_result usize usize
     requires {IsSorted2.is_sorted arr}
     requires {LenLogic0.len_logic arr <= Int32.to_int (1000000 : int32)}
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err(x) -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
-    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok(x) -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some(elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . UInt64.to_int x < i && i < LenLogic0.len_logic arr -> elem < GetDefault1.get_default arr i (0 : uint32)) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Err x -> (forall i : (int) . Int32.to_int (0 : int32) <= i && i < UInt64.to_int x -> GetDefault1.get_default arr i (0 : uint32) < elem) }
+    ensures { forall x : (usize) . result = Type.Core_Result_Result_Ok x -> Get3.get arr (UInt64.to_int x) = Type.Core_Option_Option_Some elem }
     
    = 
   var _0 : Type.core_result_result usize usize;
@@ -462,7 +462,7 @@ module BinarySearch_BinarySearch
     assume { Resolve5.resolve arr_1 };
     assume { Resolve6.resolve elem_2 };
     assume { Resolve7.resolve _4 };
-    _0 <- Type.Core_Result_Result_Err((0 : usize));
+    _0 <- Type.Core_Result_Result_Err (0 : usize);
     goto BB21
   }
   BB3 {
@@ -590,7 +590,7 @@ module BinarySearch_BinarySearch
     assume { Resolve9.resolve _42 };
     _42 <- base_10;
     assume { Resolve9.resolve base_10 };
-    _0 <- Type.Core_Result_Result_Ok(_42);
+    _0 <- Type.Core_Result_Result_Ok _42;
     goto BB20
   }
   BB16 {
@@ -614,7 +614,7 @@ module BinarySearch_BinarySearch
     _47 <- base_10;
     assume { Resolve9.resolve base_10 };
     _46 <- _47 + (1 : usize);
-    _0 <- Type.Core_Result_Result_Err(_46);
+    _0 <- Type.Core_Result_Result_Err _46;
     goto BB19
   }
   BB18 {
@@ -622,7 +622,7 @@ module BinarySearch_BinarySearch
     assume { Resolve9.resolve _48 };
     _48 <- base_10;
     assume { Resolve9.resolve base_10 };
-    _0 <- Type.Core_Result_Result_Err(_48);
+    _0 <- Type.Core_Result_Result_Err _48;
     goto BB19
   }
   BB19 {

--- a/creusot/tests/should_succeed/branch_borrow_3.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_3.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type branchborrow3_myint  = 
-    | BranchBorrow3_MyInt(usize)
+    | BranchBorrow3_MyInt usize
     
 end
 module BranchBorrow3_Main_Interface
@@ -36,8 +36,8 @@ module BranchBorrow3_Main
     goto BB0
   }
   BB0 {
-    _2 <- Type.BranchBorrow3_MyInt((10 : usize));
-    _3 <- Type.BranchBorrow3_MyInt((5 : usize));
+    _2 <- Type.BranchBorrow3_MyInt (10 : usize);
+    _3 <- Type.BranchBorrow3_MyInt (5 : usize);
     a_1 <- (_2, _3);
     b_4 <- borrow_mut a_1;
     a_1 <-  ^ b_4;
@@ -48,10 +48,10 @@ module BranchBorrow3_Main
     b_4 <- { b_4 with current = (let (a, b) =  * b_4 in ( ^ d_6, b)) };
     assume { (fun x -> true) b_4 };
     assume { (fun x -> true) _8 };
-    _8 <- (let Type.BranchBorrow3_MyInt(a) =  * c_5 in a);
+    _8 <- (let Type.BranchBorrow3_MyInt a =  * c_5 in a);
     assume { (fun x -> true) c_5 };
     assume { (fun x -> true) _9 };
-    _9 <- (let Type.BranchBorrow3_MyInt(a) =  * d_6 in a);
+    _9 <- (let Type.BranchBorrow3_MyInt a =  * d_6 in a);
     assume { (fun x -> true) d_6 };
     _7 <- _8 <> _9;
     assume { (fun x -> true) _7 };

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -13,16 +13,16 @@ module Type
     | Core_Marker_PhantomData
     
   type core_cell_unsafecell 't = 
-    | Core_Cell_UnsafeCell('t)
+    | Core_Cell_UnsafeCell 't
     
   type c01_even  = 
     | C01_Even
     
   type core_cell_cell 't = 
-    | Core_Cell_Cell(core_cell_unsafecell 't)
+    | Core_Cell_Cell (core_cell_unsafecell 't)
     
   type c01_cell 't 'i = 
-    | C01_Cell(core_cell_cell 't, core_marker_phantomdata 'i)
+    | C01_Cell (core_cell_cell 't) (core_marker_phantomdata 'i)
     
 end
 module Core_Marker_Sized

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -11,7 +11,7 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type core_cmp_ordering  = 
     | Core_Cmp_Ordering_Less

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type incsome2list_list  = 
-    | IncSome2List_List_Cons(uint32, incsome2list_list)
+    | IncSome2List_List_Cons uint32 (incsome2list_list)
     | IncSome2List_List_Nil
     
 end
@@ -25,7 +25,7 @@ module IncSome2List_SumList
   use mach.int.Int32
   function sum_list (l : Type.incsome2list_list) : int = 
     match (l) with
-      | Type.IncSome2List_List_Cons(a, l2) -> UInt32.to_int a + sum_list l2
+      | Type.IncSome2List_List_Cons a l2 -> UInt32.to_int a + sum_list l2
       | Type.IncSome2List_List_Nil -> Int32.to_int (0 : int32)
       end
 end
@@ -68,7 +68,7 @@ module IncSome2List_LemmaSumListNonneg
   }
   BB0 {
     switch (l_1)
-      | Type.IncSome2List_List_Cons(_, _) -> goto BB1
+      | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -89,7 +89,7 @@ module IncSome2List_LemmaSumListNonneg
     absurd
   }
   BB4 {
-    l_3 <- (let Type.IncSome2List_List_Cons(_, a) = l_1 in a);
+    l_3 <- (let Type.IncSome2List_List_Cons _ a = l_1 in a);
     assume { Resolve1.resolve l_1 };
     _4 <- l_3;
     assume { Resolve3.resolve l_3 };
@@ -148,7 +148,7 @@ module IncSome2List_SumListX
   }
   BB0 {
     switch (l_1)
-      | Type.IncSome2List_List_Cons(_, _) -> goto BB1
+      | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -169,8 +169,8 @@ module IncSome2List_SumListX
     absurd
   }
   BB4 {
-    a_3 <- (let Type.IncSome2List_List_Cons(a, _) = l_1 in a);
-    l2_4 <- (let Type.IncSome2List_List_Cons(_, a) = l_1 in a);
+    a_3 <- (let Type.IncSome2List_List_Cons a _ = l_1 in a);
+    l2_4 <- (let Type.IncSome2List_List_Cons _ a = l_1 in a);
     assume { Resolve1.resolve l_1 };
     assume { Resolve3.resolve _5 };
     _5 <- a_3;
@@ -261,7 +261,7 @@ module IncSome2List_TakeSomeRestList
   }
   BB0 {
     switch ( * ml_1)
-      | Type.IncSome2List_List_Cons(_, _) -> goto BB1
+      | Type.IncSome2List_List_Cons _ _ -> goto BB1
       | Type.IncSome2List_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -281,10 +281,10 @@ module IncSome2List_TakeSomeRestList
     absurd
   }
   BB4 {
-    ma_3 <- borrow_mut (let Type.IncSome2List_List_Cons(a, _) =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons(a, b) =  * ml_1 in Type.IncSome2List_List_Cons( ^ ma_3, b)) };
-    ml2_4 <- borrow_mut (let Type.IncSome2List_List_Cons(_, a) =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons(a, b) =  * ml_1 in Type.IncSome2List_List_Cons(a,  ^ ml2_4)) };
+    ma_3 <- borrow_mut (let Type.IncSome2List_List_Cons a _ =  * ml_1 in a);
+    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons a b =  * ml_1 in Type.IncSome2List_List_Cons ( ^ ma_3) b) };
+    ml2_4 <- borrow_mut (let Type.IncSome2List_List_Cons _ a =  * ml_1 in a);
+    ml_1 <- { ml_1 with current = (let Type.IncSome2List_List_Cons a b =  * ml_1 in Type.IncSome2List_List_Cons a ( ^ ml2_4)) };
     assume { Resolve1.resolve ml_1 };
     _6 <-  * ml2_4;
     _5 <- LemmaSumListNonneg4.lemma_sum_list_nonneg _6;

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type incsome2tree_tree  = 
-    | IncSome2Tree_Tree_Node(incsome2tree_tree, uint32, incsome2tree_tree)
+    | IncSome2Tree_Tree_Node (incsome2tree_tree) uint32 (incsome2tree_tree)
     | IncSome2Tree_Tree_Leaf
     
 end
@@ -25,7 +25,7 @@ module IncSome2Tree_SumTree
   use mach.int.Int32
   function sum_tree (t : Type.incsome2tree_tree) : int = 
     match (t) with
-      | Type.IncSome2Tree_Tree_Node(tl, a, tr) -> sum_tree tl + UInt32.to_int a + sum_tree tr
+      | Type.IncSome2Tree_Tree_Node tl a tr -> sum_tree tl + UInt32.to_int a + sum_tree tr
       | Type.IncSome2Tree_Tree_Leaf -> Int32.to_int (0 : int32)
       end
 end
@@ -72,7 +72,7 @@ module IncSome2Tree_LemmaSumTreeNonneg
   }
   BB0 {
     switch (t_1)
-      | Type.IncSome2Tree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -93,8 +93,8 @@ module IncSome2Tree_LemmaSumTreeNonneg
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSome2Tree_Tree_Node(a, _, _) = t_1 in a);
-    tr_4 <- (let Type.IncSome2Tree_Tree_Node(_, _, a) = t_1 in a);
+    tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = t_1 in a);
+    tr_4 <- (let Type.IncSome2Tree_Tree_Node _ _ a = t_1 in a);
     assume { Resolve1.resolve t_1 };
     _6 <- tl_3;
     assume { Resolve3.resolve tl_3 };
@@ -171,7 +171,7 @@ module IncSome2Tree_SumTreeX
   }
   BB0 {
     switch (t_1)
-      | Type.IncSome2Tree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -192,9 +192,9 @@ module IncSome2Tree_SumTreeX
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSome2Tree_Tree_Node(a, _, _) = t_1 in a);
-    a_4 <- (let Type.IncSome2Tree_Tree_Node(_, a, _) = t_1 in a);
-    tr_5 <- (let Type.IncSome2Tree_Tree_Node(_, _, a) = t_1 in a);
+    tl_3 <- (let Type.IncSome2Tree_Tree_Node a _ _ = t_1 in a);
+    a_4 <- (let Type.IncSome2Tree_Tree_Node _ a _ = t_1 in a);
+    tr_5 <- (let Type.IncSome2Tree_Tree_Node _ _ a = t_1 in a);
     assume { Resolve1.resolve t_1 };
     _7 <- tl_3;
     _6 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _7;
@@ -312,7 +312,7 @@ module IncSome2Tree_TakeSomeRestTree
   }
   BB0 {
     switch ( * mt_1)
-      | Type.IncSome2Tree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSome2Tree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSome2Tree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -332,12 +332,12 @@ module IncSome2Tree_TakeSomeRestTree
     absurd
   }
   BB4 {
-    mtl_3 <- borrow_mut (let Type.IncSome2Tree_Tree_Node(a, _, _) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSome2Tree_Tree_Node( ^ mtl_3, b, c)) };
-    ma_4 <- borrow_mut (let Type.IncSome2Tree_Tree_Node(_, a, _) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSome2Tree_Tree_Node(a,  ^ ma_4, c)) };
-    mtr_5 <- borrow_mut (let Type.IncSome2Tree_Tree_Node(_, _, a) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSome2Tree_Tree_Node(a, b,  ^ mtr_5)) };
+    mtl_3 <- borrow_mut (let Type.IncSome2Tree_Tree_Node a _ _ =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node ( ^ mtl_3) b c) };
+    ma_4 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ a _ =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node a ( ^ ma_4) c) };
+    mtr_5 <- borrow_mut (let Type.IncSome2Tree_Tree_Node _ _ a =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSome2Tree_Tree_Node a b c =  * mt_1 in Type.IncSome2Tree_Tree_Node a b ( ^ mtr_5)) };
     assume { Resolve1.resolve mt_1 };
     _7 <-  * mtl_3;
     _6 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _7;

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type incsomelist_list  = 
-    | IncSomeList_List_Cons(uint32, incsomelist_list)
+    | IncSomeList_List_Cons uint32 (incsomelist_list)
     | IncSomeList_List_Nil
     
 end
@@ -25,7 +25,7 @@ module IncSomeList_SumList
   use mach.int.Int32
   function sum_list (l : Type.incsomelist_list) : int = 
     match (l) with
-      | Type.IncSomeList_List_Cons(a, l2) -> UInt32.to_int a + sum_list l2
+      | Type.IncSomeList_List_Cons a l2 -> UInt32.to_int a + sum_list l2
       | Type.IncSomeList_List_Nil -> Int32.to_int (0 : int32)
       end
 end
@@ -68,7 +68,7 @@ module IncSomeList_LemmaSumListNonneg
   }
   BB0 {
     switch (l_1)
-      | Type.IncSomeList_List_Cons(_, _) -> goto BB1
+      | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -89,7 +89,7 @@ module IncSomeList_LemmaSumListNonneg
     absurd
   }
   BB4 {
-    l_3 <- (let Type.IncSomeList_List_Cons(_, a) = l_1 in a);
+    l_3 <- (let Type.IncSomeList_List_Cons _ a = l_1 in a);
     assume { Resolve1.resolve l_1 };
     _4 <- l_3;
     assume { Resolve3.resolve l_3 };
@@ -148,7 +148,7 @@ module IncSomeList_SumListX
   }
   BB0 {
     switch (l_1)
-      | Type.IncSomeList_List_Cons(_, _) -> goto BB1
+      | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -169,8 +169,8 @@ module IncSomeList_SumListX
     absurd
   }
   BB4 {
-    a_3 <- (let Type.IncSomeList_List_Cons(a, _) = l_1 in a);
-    l2_4 <- (let Type.IncSomeList_List_Cons(_, a) = l_1 in a);
+    a_3 <- (let Type.IncSomeList_List_Cons a _ = l_1 in a);
+    l2_4 <- (let Type.IncSomeList_List_Cons _ a = l_1 in a);
     assume { Resolve1.resolve l_1 };
     assume { Resolve3.resolve _5 };
     _5 <- a_3;
@@ -263,7 +263,7 @@ module IncSomeList_TakeSomeList
   }
   BB0 {
     switch ( * ml_1)
-      | Type.IncSomeList_List_Cons(_, _) -> goto BB1
+      | Type.IncSomeList_List_Cons _ _ -> goto BB1
       | Type.IncSomeList_List_Nil -> goto BB2
       | _ -> goto BB3
       end
@@ -283,10 +283,10 @@ module IncSomeList_TakeSomeList
     absurd
   }
   BB4 {
-    ma_5 <- borrow_mut (let Type.IncSomeList_List_Cons(a, _) =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons(a, b) =  * ml_1 in Type.IncSomeList_List_Cons( ^ ma_5, b)) };
-    ml2_6 <- borrow_mut (let Type.IncSomeList_List_Cons(_, a) =  * ml_1 in a);
-    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons(a, b) =  * ml_1 in Type.IncSomeList_List_Cons(a,  ^ ml2_6)) };
+    ma_5 <- borrow_mut (let Type.IncSomeList_List_Cons a _ =  * ml_1 in a);
+    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons a b =  * ml_1 in Type.IncSomeList_List_Cons ( ^ ma_5) b) };
+    ml2_6 <- borrow_mut (let Type.IncSomeList_List_Cons _ a =  * ml_1 in a);
+    ml_1 <- { ml_1 with current = (let Type.IncSomeList_List_Cons a b =  * ml_1 in Type.IncSomeList_List_Cons a ( ^ ml2_6)) };
     assume { Resolve1.resolve ml_1 };
     _9 <-  * ml2_6;
     _8 <- LemmaSumListNonneg4.lemma_sum_list_nonneg _9;

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type incsometree_tree  = 
-    | IncSomeTree_Tree_Node(incsometree_tree, uint32, incsometree_tree)
+    | IncSomeTree_Tree_Node (incsometree_tree) uint32 (incsometree_tree)
     | IncSomeTree_Tree_Leaf
     
 end
@@ -25,7 +25,7 @@ module IncSomeTree_SumTree
   use mach.int.Int32
   function sum_tree (t : Type.incsometree_tree) : int = 
     match (t) with
-      | Type.IncSomeTree_Tree_Node(tl, a, tr) -> sum_tree tl + UInt32.to_int a + sum_tree tr
+      | Type.IncSomeTree_Tree_Node tl a tr -> sum_tree tl + UInt32.to_int a + sum_tree tr
       | Type.IncSomeTree_Tree_Leaf -> Int32.to_int (0 : int32)
       end
 end
@@ -72,7 +72,7 @@ module IncSomeTree_LemmaSumTreeNonneg
   }
   BB0 {
     switch (t_1)
-      | Type.IncSomeTree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -93,8 +93,8 @@ module IncSomeTree_LemmaSumTreeNonneg
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSomeTree_Tree_Node(a, _, _) = t_1 in a);
-    tr_4 <- (let Type.IncSomeTree_Tree_Node(_, _, a) = t_1 in a);
+    tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = t_1 in a);
+    tr_4 <- (let Type.IncSomeTree_Tree_Node _ _ a = t_1 in a);
     assume { Resolve1.resolve t_1 };
     _6 <- tl_3;
     assume { Resolve3.resolve tl_3 };
@@ -171,7 +171,7 @@ module IncSomeTree_SumTreeX
   }
   BB0 {
     switch (t_1)
-      | Type.IncSomeTree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -192,9 +192,9 @@ module IncSomeTree_SumTreeX
     absurd
   }
   BB4 {
-    tl_3 <- (let Type.IncSomeTree_Tree_Node(a, _, _) = t_1 in a);
-    a_4 <- (let Type.IncSomeTree_Tree_Node(_, a, _) = t_1 in a);
-    tr_5 <- (let Type.IncSomeTree_Tree_Node(_, _, a) = t_1 in a);
+    tl_3 <- (let Type.IncSomeTree_Tree_Node a _ _ = t_1 in a);
+    a_4 <- (let Type.IncSomeTree_Tree_Node _ a _ = t_1 in a);
+    tr_5 <- (let Type.IncSomeTree_Tree_Node _ _ a = t_1 in a);
     assume { Resolve1.resolve t_1 };
     _7 <- tl_3;
     _6 <- LemmaSumTreeNonneg3.lemma_sum_tree_nonneg _7;
@@ -313,7 +313,7 @@ module IncSomeTree_TakeSomeTree
   }
   BB0 {
     switch ( * mt_1)
-      | Type.IncSomeTree_Tree_Node(_, _, _) -> goto BB1
+      | Type.IncSomeTree_Tree_Node _ _ _ -> goto BB1
       | Type.IncSomeTree_Tree_Leaf -> goto BB2
       | _ -> goto BB3
       end
@@ -333,12 +333,12 @@ module IncSomeTree_TakeSomeTree
     absurd
   }
   BB4 {
-    mtl_5 <- borrow_mut (let Type.IncSomeTree_Tree_Node(a, _, _) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSomeTree_Tree_Node( ^ mtl_5, b, c)) };
-    ma_6 <- borrow_mut (let Type.IncSomeTree_Tree_Node(_, a, _) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSomeTree_Tree_Node(a,  ^ ma_6, c)) };
-    mtr_7 <- borrow_mut (let Type.IncSomeTree_Tree_Node(_, _, a) =  * mt_1 in a);
-    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node(a, b, c) =  * mt_1 in Type.IncSomeTree_Tree_Node(a, b,  ^ mtr_7)) };
+    mtl_5 <- borrow_mut (let Type.IncSomeTree_Tree_Node a _ _ =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node ( ^ mtl_5) b c) };
+    ma_6 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ a _ =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node a ( ^ ma_6) c) };
+    mtr_7 <- borrow_mut (let Type.IncSomeTree_Tree_Node _ _ a =  * mt_1 in a);
+    mt_1 <- { mt_1 with current = (let Type.IncSomeTree_Tree_Node a b c =  * mt_1 in Type.IncSomeTree_Tree_Node a b ( ^ mtr_7)) };
     assume { Resolve1.resolve mt_1 };
     _10 <-  * mtl_5;
     _9 <- LemmaSumTreeNonneg4.lemma_sum_tree_nonneg _10;

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -11,7 +11,7 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type core_marker_phantomdata 't = 
     | Core_Marker_PhantomData
@@ -20,13 +20,13 @@ module Type
     | Alloc_Alloc_Global
     
   type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique(opaque_ptr, core_marker_phantomdata 't)
+    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
     
   type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec(core_ptr_unique_unique 't, usize, 'a)
+    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
     
   type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec(alloc_rawvec_rawvec 't 'a, usize)
+    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
     
 end
 module CreusotContracts_Builtins_Resolve
@@ -114,7 +114,7 @@ module InvariantMoves_TestInvariantMove
   }
   BB4 {
     switch (_4)
-      | Type.Core_Option_Option_Some(_) -> goto BB5
+      | Type.Core_Option_Option_Some _ -> goto BB5
       | _ -> goto BB7
       end
   }
@@ -124,7 +124,7 @@ module InvariantMoves_TestInvariantMove
   }
   BB6 {
     assume { Resolve5.resolve x_8 };
-    x_8 <- (let Type.Core_Option_Option_Some(a) = _4 in a);
+    x_8 <- (let Type.Core_Option_Option_Some a = _4 in a);
     assume { Resolve2.resolve _4 };
     assume { Resolve5.resolve x_8 };
     _3 <- ();

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -11,10 +11,10 @@ module Type
   use prelude.Prelude
   type listindexmut_option 't = 
     | ListIndexMut_Option_None
-    | ListIndexMut_Option_Some('t)
+    | ListIndexMut_Option_Some 't
     
   type listindexmut_list  = 
-    | ListIndexMut_List(uint32, listindexmut_option (listindexmut_list))
+    | ListIndexMut_List uint32 (listindexmut_option (listindexmut_list))
     
 end
 module CreusotContracts_Builtins_Resolve
@@ -42,8 +42,8 @@ module ListIndexMut_Len
   use Type
   use mach.int.Int32
   function len (l : Type.listindexmut_list) : int = 
-    let Type.ListIndexMut_List(_, ls) = l in Int32.to_int (1 : int32) + match (ls) with
-      | Type.ListIndexMut_Option_Some(ls) -> len ls
+    let Type.ListIndexMut_List _ ls = l in Int32.to_int (1 : int32) + match (ls) with
+      | Type.ListIndexMut_Option_Some ls -> len ls
       | Type.ListIndexMut_Option_None -> Int32.to_int (0 : int32)
       end
 end
@@ -59,10 +59,10 @@ module ListIndexMut_Get
   use mach.int.UInt32
   use mach.int.Int32
   function get (l : Type.listindexmut_list) (ix : int) : Type.listindexmut_option uint32 = 
-    let Type.ListIndexMut_List(i, ls) = l in match (ix > Int32.to_int (0 : int32)) with
-      | False -> Type.ListIndexMut_Option_Some(i)
+    let Type.ListIndexMut_List i ls = l in match (ix > Int32.to_int (0 : int32)) with
+      | False -> Type.ListIndexMut_Option_Some i
       | True -> match (ls) with
-        | Type.ListIndexMut_Option_Some(ls) -> get ls (ix - Int32.to_int (1 : int32))
+        | Type.ListIndexMut_Option_Some ls -> get ls (ix - Int32.to_int (1 : int32))
         | Type.ListIndexMut_Option_None -> Type.ListIndexMut_Option_None
         end
       end
@@ -90,8 +90,8 @@ module ListIndexMut_IndexMut_Interface
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
-    ensures { Type.ListIndexMut_Option_Some( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
     
 end
 module ListIndexMut_IndexMut
@@ -116,8 +116,8 @@ module ListIndexMut_IndexMut
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * param_l) && i <> UInt64.to_int param_ix -> Get1.get ( * param_l) i = Get1.get ( ^ param_l) i }
     ensures { Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { Type.ListIndexMut_Option_Some( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
-    ensures { Type.ListIndexMut_Option_Some( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( ^ result) = Get1.get ( ^ param_l) (UInt64.to_int param_ix) }
+    ensures { Type.ListIndexMut_Option_Some ( * result) = Get1.get ( * param_l) (UInt64.to_int param_ix) }
     
    = 
   var _0 : borrowed uint32;
@@ -172,9 +172,9 @@ module ListIndexMut_IndexMut
   }
   BB3 {
     assume { Resolve4.resolve _13 };
-    switch (let Type.ListIndexMut_List(_, a) =  * l_4 in a)
+    switch (let Type.ListIndexMut_List _ a =  * l_4 in a)
       | Type.ListIndexMut_Option_None -> goto BB4
-      | Type.ListIndexMut_Option_Some(_) -> goto BB5
+      | Type.ListIndexMut_Option_Some _ -> goto BB5
       | _ -> goto BB6
       end
   }
@@ -195,8 +195,8 @@ module ListIndexMut_IndexMut
     absurd
   }
   BB7 {
-    n_17 <- borrow_mut (let Type.ListIndexMut_Option_Some(a) = let Type.ListIndexMut_List(_, a) =  * l_4 in a in a);
-    l_4 <- { l_4 with current = (let Type.ListIndexMut_List(a, b) =  * l_4 in Type.ListIndexMut_List(a, let Type.ListIndexMut_Option_Some(a) = let Type.ListIndexMut_List(_, a) =  * l_4 in a in Type.ListIndexMut_Option_Some( ^ n_17))) };
+    n_17 <- borrow_mut (let Type.ListIndexMut_Option_Some a = let Type.ListIndexMut_List _ a =  * l_4 in a in a);
+    l_4 <- { l_4 with current = (let Type.ListIndexMut_List a b =  * l_4 in Type.ListIndexMut_List a (let Type.ListIndexMut_Option_Some a = let Type.ListIndexMut_List _ a =  * l_4 in a in Type.ListIndexMut_Option_Some ( ^ n_17))) };
     assume { Resolve2.resolve l_4 };
     _18 <- borrow_mut ( * n_17);
     n_17 <- { n_17 with current = ( ^ _18) };
@@ -215,8 +215,8 @@ module ListIndexMut_IndexMut
     assume { Resolve4.resolve _13 };
     _6 <- ();
     assume { Resolve7.resolve _6 };
-    _23 <- borrow_mut (let Type.ListIndexMut_List(a, _) =  * l_4 in a);
-    l_4 <- { l_4 with current = (let Type.ListIndexMut_List(a, b) =  * l_4 in Type.ListIndexMut_List( ^ _23, b)) };
+    _23 <- borrow_mut (let Type.ListIndexMut_List a _ =  * l_4 in a);
+    l_4 <- { l_4 with current = (let Type.ListIndexMut_List a b =  * l_4 in Type.ListIndexMut_List ( ^ _23) b) };
     assume { Resolve2.resolve l_4 };
     _3 <- borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _3) };
@@ -241,7 +241,7 @@ module ListIndexMut_Write_Interface
     requires {UInt64.to_int ix < Len0.len ( * l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some(v) = Get1.get ( ^ l) (UInt64.to_int ix) }
+    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) (UInt64.to_int ix) }
     
 end
 module ListIndexMut_Write
@@ -262,7 +262,7 @@ module ListIndexMut_Write
     requires {UInt64.to_int ix < Len0.len ( * l)}
     ensures { forall i : (int) . Int32.to_int (0 : int32) <= i && i < Len0.len ( * l) && i <> UInt64.to_int ix -> Get1.get ( * l) i = Get1.get ( ^ l) i }
     ensures { Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { Type.ListIndexMut_Option_Some(v) = Get1.get ( ^ l) (UInt64.to_int ix) }
+    ensures { Type.ListIndexMut_Option_Some v = Get1.get ( ^ l) (UInt64.to_int ix) }
     
    = 
   var _0 : ();
@@ -340,7 +340,7 @@ module ListIndexMut_Main
   }
   BB0 {
     _5 <- Type.ListIndexMut_Option_None;
-    _4 <- Type.ListIndexMut_List((10 : uint32), _5);
+    _4 <- Type.ListIndexMut_List (10 : uint32) _5;
     goto BB1
   }
   BB1 {
@@ -348,11 +348,11 @@ module ListIndexMut_Main
     goto BB2
   }
   BB2 {
-    _2 <- Type.ListIndexMut_Option_Some(_3);
+    _2 <- Type.ListIndexMut_Option_Some _3;
     goto BB3
   }
   BB3 {
-    l_1 <- Type.ListIndexMut_List((1 : uint32), _2);
+    l_1 <- Type.ListIndexMut_List (1 : uint32) _2;
     goto BB4
   }
   BB4 {

--- a/creusot/tests/should_succeed/logic_functions.stdout
+++ b/creusot/tests/should_succeed/logic_functions.stdout
@@ -11,7 +11,7 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
 end
 module LogicFunctions_Logical_Interface
@@ -75,7 +75,7 @@ module LogicFunctions_DerefPat
   use mach.int.Int32
   function deref_pat (o : Type.core_option_option int) : int = 
     match (o) with
-      | Type.Core_Option_Option_Some(a) -> a
+      | Type.Core_Option_Option_Some a -> a
       | Type.Core_Option_Option_None -> Int32.to_int (0 : int32)
       end
 end

--- a/creusot/tests/should_succeed/module_paths.stdout
+++ b/creusot/tests/should_succeed/module_paths.stdout
@@ -10,16 +10,16 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type modulepaths_a_t  = 
-    | ModulePaths_A_T(uint32)
+    | ModulePaths_A_T uint32
     
   type modulepaths_s  = 
-    | ModulePaths_S(modulepaths_a_t)
+    | ModulePaths_S (modulepaths_a_t)
     
   type modulepaths_b_o  = 
-    | ModulePaths_B_O(uint32)
+    | ModulePaths_B_O uint32
     
   type modulepaths_b_c_t  = 
-    | ModulePaths_B_C_T(modulepaths_a_t)
+    | ModulePaths_B_C_T (modulepaths_a_t)
     
 end
 module ModulePaths_Test_Interface

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type onesideupdate_myint  = 
-    | OneSideUpdate_MyInt(usize)
+    | OneSideUpdate_MyInt usize
     
 end
 module OneSideUpdate_Main_Interface
@@ -33,7 +33,7 @@ module OneSideUpdate_Main
     goto BB0
   }
   BB0 {
-    a_1 <- Type.OneSideUpdate_MyInt((10 : usize));
+    a_1 <- Type.OneSideUpdate_MyInt (10 : usize);
     b_2 <- borrow_mut a_1;
     a_1 <-  ^ b_2;
     _3 <- true;
@@ -47,7 +47,7 @@ module OneSideUpdate_Main
     assume { (fun x -> true) b_2 };
     assume { (fun x -> true) _3 };
     assume { (fun x -> true) _5 };
-    _5 <- (let Type.OneSideUpdate_MyInt(a) = a_1 in a);
+    _5 <- (let Type.OneSideUpdate_MyInt a = a_1 in a);
     assume { (fun x -> true) a_1 };
     _4 <- _5 = (10 : usize);
     assume { (fun x -> true) _4 };
@@ -57,7 +57,7 @@ module OneSideUpdate_Main
   BB2 {
     assume { (fun x -> true) a_1 };
     assume { (fun x -> true) _3 };
-    _6 <- Type.OneSideUpdate_MyInt((5 : usize));
+    _6 <- Type.OneSideUpdate_MyInt (5 : usize);
     assume { (fun x -> true) ( * b_2) };
     b_2 <- { b_2 with current = _6 };
     assume { (fun x -> true) b_2 };

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -11,11 +11,11 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type core_result_result 't 'e = 
-    | Core_Result_Result_Ok('t)
-    | Core_Result_Result_Err('e)
+    | Core_Result_Result_Ok 't
+    | Core_Result_Result_Err 'e
     
 end
 module Projections_CopyOutOfRef_Interface
@@ -68,8 +68,8 @@ module Projections_CopyOutOfSum
   }
   BB0 {
     switch (x_1)
-      | Type.Core_Result_Result_Ok(_) -> goto BB1
-      | Type.Core_Result_Result_Err(_) -> goto BB2
+      | Type.Core_Result_Result_Ok _ -> goto BB1
+      | Type.Core_Result_Result_Err _ -> goto BB2
       | _ -> goto BB3
       end
   }
@@ -80,7 +80,7 @@ module Projections_CopyOutOfSum
   BB2 {
     assume { (fun x -> true) _2 };
     assume { (fun x -> true) y_4 };
-    y_4 <- (let Type.Core_Result_Result_Err(a) = x_1 in a);
+    y_4 <- (let Type.Core_Result_Result_Err a = x_1 in a);
     assume { (fun x -> true) x_1 };
     assume { (fun x -> true) _0 };
     _0 <-  * y_4;
@@ -94,7 +94,7 @@ module Projections_CopyOutOfSum
   }
   BB4 {
     assume { (fun x -> true) x_3 };
-    x_3 <- (let Type.Core_Result_Result_Ok(a) = x_1 in a);
+    x_3 <- (let Type.Core_Result_Result_Ok a = x_1 in a);
     assume { (fun x -> true) x_1 };
     assume { (fun x -> true) _0 };
     _0 <-  * x_3;
@@ -131,7 +131,7 @@ module Projections_WriteIntoSum
   BB0 {
     switch ( * x_1)
       | Type.Core_Option_Option_None -> goto BB1
-      | Type.Core_Option_Option_Some(_) -> goto BB2
+      | Type.Core_Option_Option_Some _ -> goto BB2
       | _ -> goto BB3
       end
   }
@@ -151,8 +151,8 @@ module Projections_WriteIntoSum
     absurd
   }
   BB4 {
-    y_3 <- borrow_mut (let Type.Core_Option_Option_Some(a) =  * x_1 in a);
-    x_1 <- { x_1 with current = (let Type.Core_Option_Option_Some(a) =  * x_1 in Type.Core_Option_Option_Some( ^ y_3)) };
+    y_3 <- borrow_mut (let Type.Core_Option_Option_Some a =  * x_1 in a);
+    x_1 <- { x_1 with current = (let Type.Core_Option_Option_Some a =  * x_1 in Type.Core_Option_Option_Some ( ^ y_3)) };
     assume { (fun x -> true) x_1 };
     y_3 <- { y_3 with current = (10 : uint32) };
     assume { (fun x -> true) y_3 };
@@ -184,10 +184,10 @@ module Projections_Main
     goto BB0
   }
   BB0 {
-    _2 <- Type.Core_Option_Option_Some((10 : int32));
+    _2 <- Type.Core_Option_Option_Some (10 : int32);
     switch (_2)
       | Type.Core_Option_Option_None -> goto BB1
-      | Type.Core_Option_Option_Some(_) -> goto BB2
+      | Type.Core_Option_Option_Some _ -> goto BB2
       | _ -> goto BB3
       end
   }
@@ -209,7 +209,7 @@ module Projections_Main
   }
   BB4 {
     assume { (fun x -> true) x_4 };
-    x_4 <- (let Type.Core_Option_Option_Some(a) = _2 in a);
+    x_4 <- (let Type.Core_Option_Option_Some a = _2 in a);
     assume { (fun x -> true) _2 };
     assume { (fun x -> true) _5 };
     _5 <- x_4;

--- a/creusot/tests/should_succeed/replace.stdout
+++ b/creusot/tests/should_succeed/replace.stdout
@@ -11,10 +11,10 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type replace_something  = 
-    | Replace_Something(uint32, core_option_option (replace_something))
+    | Replace_Something uint32 (core_option_option (replace_something))
     
 end
 module Replace_Test_Interface

--- a/creusot/tests/should_succeed/spec_tests.stdout
+++ b/creusot/tests/should_succeed/spec_tests.stdout
@@ -14,7 +14,7 @@ module Type
     | SpecTests_T_B
     
   type spectests_s 'a 'b = 
-    | SpecTests_S('a, 'b)
+    | SpecTests_S 'a 'b
     
 end
 module SpecTests_Main_Interface
@@ -37,7 +37,7 @@ module SpecTests_TestSpecs_Interface
   use mach.int.Int
   use mach.int.UInt32
   val test_specs () : ()
-    ensures { Type.SpecTests_S((0 : uint32), true) = Type.SpecTests_S((1 : uint32), false) }
+    ensures { Type.SpecTests_S (0 : uint32) true = Type.SpecTests_S (1 : uint32) false }
     ensures { Type.SpecTests_T_A = Type.SpecTests_T_B }
     
 end
@@ -46,7 +46,7 @@ module SpecTests_TestSpecs
   use mach.int.Int
   use mach.int.UInt32
   let rec cfg test_specs () : ()
-    ensures { Type.SpecTests_S((0 : uint32), true) = Type.SpecTests_S((1 : uint32), false) }
+    ensures { Type.SpecTests_S (0 : uint32) true = Type.SpecTests_S (1 : uint32) false }
     ensures { Type.SpecTests_T_A = Type.SpecTests_T_B }
     
    = 

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type splitborrow_myint  = 
-    | SplitBorrow_MyInt(usize)
+    | SplitBorrow_MyInt usize
     
 end
 module SplitBorrow_Z_Interface
@@ -52,8 +52,8 @@ module SplitBorrow_Main
     goto BB0
   }
   BB0 {
-    _2 <- Type.SplitBorrow_MyInt((1 : usize));
-    _3 <- Type.SplitBorrow_MyInt((2 : usize));
+    _2 <- Type.SplitBorrow_MyInt (1 : usize);
+    _3 <- Type.SplitBorrow_MyInt (2 : usize);
     x_1 <- (_2, _3);
     y_4 <- borrow_mut x_1;
     x_1 <-  ^ y_4;
@@ -70,7 +70,7 @@ module SplitBorrow_Main
   }
   BB2 {
     assume { (fun x -> true) _6 };
-    _7 <- Type.SplitBorrow_MyInt((4 : usize));
+    _7 <- Type.SplitBorrow_MyInt (4 : usize);
     assume { (fun x -> true) (let (_, a) =  * y_4 in a) };
     y_4 <- { y_4 with current = (let (a, b) =  * y_4 in (a, _7)) };
     assume { (fun x -> true) _7 };
@@ -80,7 +80,7 @@ module SplitBorrow_Main
   }
   BB3 {
     assume { (fun x -> true) _6 };
-    _8 <- Type.SplitBorrow_MyInt((10 : usize));
+    _8 <- Type.SplitBorrow_MyInt (10 : usize);
     assume { (fun x -> true) (let (a, _) =  * y_4 in a) };
     y_4 <- { y_4 with current = (let (a, b) =  * y_4 in (_8, b)) };
     assume { (fun x -> true) _8 };
@@ -90,7 +90,7 @@ module SplitBorrow_Main
   }
   BB4 {
     assume { (fun x -> true) _9 };
-    _9 <- (let Type.SplitBorrow_MyInt(a) = let (a, _) =  * y_4 in a in a);
+    _9 <- (let Type.SplitBorrow_MyInt a = let (a, _) =  * y_4 in a in a);
     assume { (fun x -> true) y_4 };
     assume { (fun x -> true) _9 };
     _0 <- ();

--- a/creusot/tests/should_succeed/split_move.stdout
+++ b/creusot/tests/should_succeed/split_move.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type splitmove_myint  = 
-    | SplitMove_MyInt(usize)
+    | SplitMove_MyInt usize
     
 end
 module SplitMove_Main_Interface
@@ -35,21 +35,21 @@ module SplitMove_Main
     goto BB0
   }
   BB0 {
-    _2 <- Type.SplitMove_MyInt((1 : usize));
-    _3 <- Type.SplitMove_MyInt((2 : usize));
+    _2 <- Type.SplitMove_MyInt (1 : usize);
+    _3 <- Type.SplitMove_MyInt (2 : usize);
     a_1 <- (_2, _3);
     x_4 <- borrow_mut a_1;
     a_1 <-  ^ x_4;
     z_5 <- borrow_mut (let (_, a) =  * x_4 in a);
     x_4 <- { x_4 with current = (let (a, b) =  * x_4 in (a,  ^ z_5)) };
     assume { (fun x -> true) z_5 };
-    _6 <- Type.SplitMove_MyInt((3 : usize));
+    _6 <- Type.SplitMove_MyInt (3 : usize);
     assume { (fun x -> true) (let (a, _) =  * x_4 in a) };
     x_4 <- { x_4 with current = (let (a, b) =  * x_4 in (_6, b)) };
     assume { (fun x -> true) x_4 };
     assume { (fun x -> true) _6 };
     assume { (fun x -> true) _8 };
-    _8 <- (let Type.SplitMove_MyInt(a) = let (a, _) = a_1 in a in a);
+    _8 <- (let Type.SplitMove_MyInt a = let (a, _) = a_1 in a in a);
     assume { (fun x -> true) a_1 };
     _7 <- _8 = (3 : usize);
     assume { (fun x -> true) _7 };

--- a/creusot/tests/should_succeed/std_types.stdout
+++ b/creusot/tests/should_succeed/std_types.stdout
@@ -11,10 +11,10 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type stdtypes_mytype  = 
-    | StdTypes_MyType(core_option_option uint32)
+    | StdTypes_MyType (core_option_option uint32)
     
 end
 module StdTypes_X_Interface

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type switch_option 't = 
-    | Switch_Option_Some('t)
+    | Switch_Option_Some 't
     | Switch_Option_None
     
 end
@@ -38,7 +38,7 @@ module Switch_Test
   }
   BB0 {
     switch (o_1)
-      | Type.Switch_Option_Some(_) -> goto BB1
+      | Type.Switch_Option_Some _ -> goto BB1
       | Type.Switch_Option_None -> goto BB2
       | _ -> goto BB3
       end
@@ -60,7 +60,7 @@ module Switch_Test
   }
   BB4 {
     assume { (fun x -> true) x_3 };
-    x_3 <- (let Type.Switch_Option_Some(a) = o_1 in a);
+    x_3 <- (let Type.Switch_Option_Some a = o_1 in a);
     assume { (fun x -> true) o_1 };
     assume { (fun x -> true) _4 };
     _4 <- x_3;
@@ -96,7 +96,7 @@ module Switch_Test2
   }
   BB0 {
     switch (let (a, _) = o_1 in a)
-      | Type.Switch_Option_Some(_) -> goto BB1
+      | Type.Switch_Option_Some _ -> goto BB1
       | Type.Switch_Option_None -> goto BB2
       | _ -> goto BB3
       end
@@ -119,7 +119,7 @@ module Switch_Test2
   }
   BB4 {
     assume { (fun x -> true) x_3 };
-    x_3 <- (let Type.Switch_Option_Some(a) = let (a, _) = o_1 in a in a);
+    x_3 <- (let Type.Switch_Option_Some a = let (a, _) = o_1 in a in a);
     assume { (fun x -> true) o_1 };
     assume { (fun x -> true) _0 };
     _0 <- x_3;

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -10,8 +10,8 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type switchstruct_m 't = 
-    | SwitchStruct_M_F(uint32)
-    | SwitchStruct_M_G('t)
+    | SwitchStruct_M_F uint32
+    | SwitchStruct_M_G 't
     
 end
 module SwitchStruct_Test_Interface
@@ -40,8 +40,8 @@ module SwitchStruct_Test
   }
   BB0 {
     switch (o_1)
-      | Type.SwitchStruct_M_F(_) -> goto BB1
-      | Type.SwitchStruct_M_G(_) -> goto BB2
+      | Type.SwitchStruct_M_F _ -> goto BB1
+      | Type.SwitchStruct_M_G _ -> goto BB2
       | _ -> goto BB3
       end
   }
@@ -52,7 +52,7 @@ module SwitchStruct_Test
   BB2 {
     assume { (fun x -> true) _2 };
     assume { (fun x -> true) field2_5 };
-    field2_5 <- (let Type.SwitchStruct_M_G(a) = o_1 in a);
+    field2_5 <- (let Type.SwitchStruct_M_G a = o_1 in a);
     assume { (fun x -> true) o_1 };
     assume { (fun x -> true) _6 };
     _6 <- field2_5;
@@ -67,7 +67,7 @@ module SwitchStruct_Test
   }
   BB4 {
     assume { (fun x -> true) field1_3 };
-    field1_3 <- (let Type.SwitchStruct_M_F(a) = o_1 in a);
+    field1_3 <- (let Type.SwitchStruct_M_F a = o_1 in a);
     assume { (fun x -> true) o_1 };
     assume { (fun x -> true) _4 };
     _4 <- field1_3;

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -11,7 +11,7 @@ module Type
   use prelude.Prelude
   type core_option_option 't = 
     | Core_Option_Option_None
-    | Core_Option_Option_Some('t)
+    | Core_Option_Option_Some 't
     
   type core_cmp_ordering  = 
     | Core_Cmp_Ordering_Less

--- a/creusot/tests/should_succeed/type_constructors.stdout
+++ b/creusot/tests/should_succeed/type_constructors.stdout
@@ -15,7 +15,7 @@ module Type
     | TypeConstructors_B_X_C
     
   type typeconstructors_a_y  = 
-    | TypeConstructors_A_Y(typeconstructors_b_x)
+    | TypeConstructors_A_Y (typeconstructors_b_x)
     
 end
 module TypeConstructors_Main_Interface
@@ -35,7 +35,7 @@ module TypeConstructors_Main
     _1 <- Type.TypeConstructors_B_X_A;
     assume { (fun x -> true) _1 };
     _3 <- Type.TypeConstructors_B_X_B;
-    _2 <- Type.TypeConstructors_A_Y(_3);
+    _2 <- Type.TypeConstructors_A_Y _3;
     assume { (fun x -> true) _2 };
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -10,7 +10,7 @@ module Type
   use floating_point.Double
   use prelude.Prelude
   type whilelet_option 't = 
-    | WhileLet_Option_Some('t)
+    | WhileLet_Option_Some 't
     | WhileLet_Option_None
     
 end
@@ -56,7 +56,7 @@ module WhileLet_Main
     goto BB0
   }
   BB0 {
-    a_1 <- Type.WhileLet_Option_Some((10 : int32));
+    a_1 <- Type.WhileLet_Option_Some (10 : int32);
     b_2 <- borrow_mut a_1;
     a_1 <-  ^ b_2;
     assume { Resolve0.resolve a_1 };
@@ -68,7 +68,7 @@ module WhileLet_Main
   }
   BB2 {
     switch ( * b_2)
-      | Type.WhileLet_Option_Some(_) -> goto BB3
+      | Type.WhileLet_Option_Some _ -> goto BB3
       | _ -> goto BB5
       end
   }


### PR DESCRIPTION
Turns out I had set up the printing of ADTs incorrectly, assuming that why3's syntax was like Ocaml. 
This caused problems when trying to prove termination of functions as variant decrease would be hidden behind a tuple.
