### PR TITLE
Fix unsoundness: actually run the borrow checker on program functions

### DIFF
--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -40,6 +40,7 @@ pub fn translate_function<'tcx, 'sess>(
     names.clone_self(def_id);
 
     let gather = GatherInvariants::gather(ctx, &mut names, def_id);
+    tcx.ensure().mir_borrowck(def_id.expect_local());
     let (body, _) = tcx.mir_promoted(WithOptConstParam::unknown(def_id.expect_local()));
     let mut body = body.borrow().clone();
     // Basic clean up, replace FalseEdges with Gotos. Could potentially also replace other statement with Nops.

--- a/creusot/tests/should_succeed/inc_max_3.rs
+++ b/creusot/tests/should_succeed/inc_max_3.rs
@@ -1,19 +1,18 @@
+// UNBOUNDED
 #![feature(register_tool, rustc_attrs)]
 #![register_tool(creusot)]
 
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
+#[trusted]
 #[ensures(^mma === *mmb && ^mmb === *mma)]
-fn swap<'a>(mma: &'a mut &'a mut u32, mmb: &'a mut &'a mut u32) {
-    let tmp = *mma;
-    *mma = *mmb;
-    *mmb = tmp;
+fn swap<'a, 'b>(mma: &'a mut &'b mut u32, mmb: &'a mut &'b mut u32) {
+    std::mem::swap(mma, mmb);
 }
 
-#[requires(*ma <= 1_000_000u32 && *mb <= 1_000_000u32 && *mc <= 1_000_000u32)]
 #[ensures(^ma != ^mb && ^mb != ^mc && ^mc != ^ma)]
-fn inc_max_3<'a>(ma: &'a mut u32, mb: &'a mut u32, mc: &'a mut u32) {
+fn inc_max_3<'a>(mut ma: &'a mut u32, mut mb: &'a mut u32, mut mc: &'a mut u32) {
     if *ma < *mb {
         swap(&mut ma, &mut mb);
     }
@@ -27,7 +26,6 @@ fn inc_max_3<'a>(ma: &'a mut u32, mb: &'a mut u32, mc: &'a mut u32) {
     *mb += 1;
 }
 
-#[requires(a <= 1_000_000u32 && b <= 1_000_000u32 && c <= 1_000_000u32)]
 fn test_inc_max_3(mut a: u32, mut b: u32, mut c: u32) {
     inc_max_3(&mut a, &mut b, &mut c);
     assert!(a != b && b != c && c != a);

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -28,108 +28,68 @@ end
 module IncMax3_Swap_Interface
   use prelude.Prelude
   use mach.int.Int
-  use mach.int.UInt32
-  val swap (mma : borrowed (borrowed uint32)) (mmb : borrowed (borrowed uint32)) : ()
+  val swap (mma : borrowed (borrowed int)) (mmb : borrowed (borrowed int)) : ()
     ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
     
 end
 module IncMax3_Swap
   use prelude.Prelude
   use mach.int.Int
-  use mach.int.UInt32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve1 with type t = borrowed uint32
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
-  let rec cfg swap (mma : borrowed (borrowed uint32)) (mmb : borrowed (borrowed uint32)) : ()
+  val swap (mma : borrowed (borrowed int)) (mmb : borrowed (borrowed int)) : ()
     ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
     
-   = 
-  var _0 : ();
-  var mma_1 : borrowed (borrowed uint32);
-  var mmb_2 : borrowed (borrowed uint32);
-  var tmp_3 : borrowed uint32;
-  var _4 : borrowed uint32;
-  var _5 : borrowed uint32;
-  {
-    mma_1 <- mma;
-    mmb_2 <- mmb;
-    goto BB0
-  }
-  BB0 {
-    assume { Resolve0.resolve tmp_3 };
-    tmp_3 <-  * mma_1;
-    _4 <- borrow_mut ( *  * mmb_2);
-    mmb_2 <- { mmb_2 with current = { ( * mmb_2) with current = ( ^ _4) } };
-    assume { Resolve0.resolve ( * mma_1) };
-    mma_1 <- { mma_1 with current = _4 };
-    assume { Resolve1.resolve mma_1 };
-    assume { Resolve0.resolve _4 };
-    _5 <- borrow_mut ( * tmp_3);
-    tmp_3 <- { tmp_3 with current = ( ^ _5) };
-    assume { Resolve0.resolve tmp_3 };
-    assume { Resolve0.resolve ( * mmb_2) };
-    mmb_2 <- { mmb_2 with current = _5 };
-    assume { Resolve1.resolve mmb_2 };
-    assume { Resolve0.resolve _5 };
-    _0 <- ();
-    return _0
-  }
-  
 end
 module IncMax3_IncMax3_Interface
-  use mach.int.Int
-  use mach.int.UInt32
   use prelude.Prelude
-  val inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
-    requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
+  use mach.int.Int
+  val inc_max_3 (ma : borrowed int) (mb : borrowed int) (mc : borrowed int) : ()
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
     
 end
 module IncMax3_IncMax3
-  use mach.int.Int
-  use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = uint32
+  use mach.int.Int
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve5 with type t = int
   clone CreusotContracts_Builtins_Resolve as Resolve4 with type self = ()
   clone IncMax3_Swap_Interface as Swap3
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = borrowed uint32
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve2 with type t = borrowed int
   clone CreusotContracts_Builtins_Resolve as Resolve1 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = uint32
-  let rec cfg inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
-    requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
+  clone CreusotContracts_Builtins_Resolve as Resolve0 with type self = int
+  let rec cfg inc_max_3 (ma : borrowed int) (mb : borrowed int) (mc : borrowed int) : ()
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
     
    = 
   var _0 : ();
-  var ma_1 : borrowed uint32;
-  var mb_2 : borrowed uint32;
-  var mc_3 : borrowed uint32;
+  var ma_1 : borrowed int;
+  var mb_2 : borrowed int;
+  var mc_3 : borrowed int;
   var _4 : ();
   var _5 : bool;
-  var _6 : uint32;
-  var _7 : uint32;
+  var _6 : int;
+  var _7 : int;
   var _8 : ();
-  var _9 : borrowed (borrowed uint32);
-  var _10 : borrowed (borrowed uint32);
-  var _11 : borrowed (borrowed uint32);
-  var _12 : borrowed (borrowed uint32);
+  var _9 : borrowed (borrowed int);
+  var _10 : borrowed (borrowed int);
+  var _11 : borrowed (borrowed int);
+  var _12 : borrowed (borrowed int);
   var _13 : ();
   var _14 : bool;
-  var _15 : uint32;
-  var _16 : uint32;
+  var _15 : int;
+  var _16 : int;
   var _17 : ();
-  var _18 : borrowed (borrowed uint32);
-  var _19 : borrowed (borrowed uint32);
-  var _20 : borrowed (borrowed uint32);
-  var _21 : borrowed (borrowed uint32);
+  var _18 : borrowed (borrowed int);
+  var _19 : borrowed (borrowed int);
+  var _20 : borrowed (borrowed int);
+  var _21 : borrowed (borrowed int);
   var _22 : ();
   var _23 : bool;
-  var _24 : uint32;
-  var _25 : uint32;
+  var _24 : int;
+  var _25 : int;
   var _26 : ();
-  var _27 : borrowed (borrowed uint32);
-  var _28 : borrowed (borrowed uint32);
-  var _29 : borrowed (borrowed uint32);
-  var _30 : borrowed (borrowed uint32);
+  var _27 : borrowed (borrowed int);
+  var _28 : borrowed (borrowed int);
+  var _29 : borrowed (borrowed int);
+  var _30 : borrowed (borrowed int);
   {
     ma_1 <- ma;
     mb_2 <- mb;
@@ -259,9 +219,9 @@ module IncMax3_IncMax3
     goto BB12
   }
   BB12 {
-    ma_1 <- { ma_1 with current = ( * ma_1 + (2 : uint32)) };
+    ma_1 <- { ma_1 with current = ( * ma_1 + (2 : int)) };
     assume { Resolve5.resolve ma_1 };
-    mb_2 <- { mb_2 with current = ( * mb_2 + (1 : uint32)) };
+    mb_2 <- { mb_2 with current = ( * mb_2 + (1 : int)) };
     assume { Resolve5.resolve mb_2 };
     _0 <- ();
     return _0
@@ -282,49 +242,42 @@ module Core_Panicking_Panic
 end
 module IncMax3_TestIncMax3_Interface
   use mach.int.Int
-  use mach.int.UInt32
-  val test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
-    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
-    
+  val test_inc_max_3 (a : int) (b : int) (c : int) : ()
 end
 module IncMax3_TestIncMax3
   use mach.int.Int
-  use mach.int.UInt32
   use prelude.Prelude
   clone CreusotContracts_Builtins_Resolve as Resolve5 with type self = ()
   clone Core_Panicking_Panic_Interface as Panic4
   clone CreusotContracts_Builtins_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = uint32
+  clone CreusotContracts_Builtins_Resolve as Resolve2 with type self = int
   clone IncMax3_IncMax3_Interface as IncMax31
-  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = uint32
-  let rec cfg test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
-    requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
-    
-   = 
+  clone CreusotContracts_Builtins_Impl12_Resolve as Resolve0 with type t = int
+  let rec cfg test_inc_max_3 (a : int) (b : int) (c : int) : () = 
   var _0 : ();
-  var a_1 : uint32;
-  var b_2 : uint32;
-  var c_3 : uint32;
+  var a_1 : int;
+  var b_2 : int;
+  var c_3 : int;
   var _4 : ();
-  var _5 : borrowed uint32;
-  var _6 : borrowed uint32;
-  var _7 : borrowed uint32;
-  var _8 : borrowed uint32;
-  var _9 : borrowed uint32;
-  var _10 : borrowed uint32;
+  var _5 : borrowed int;
+  var _6 : borrowed int;
+  var _7 : borrowed int;
+  var _8 : borrowed int;
+  var _9 : borrowed int;
+  var _10 : borrowed int;
   var _11 : ();
   var _12 : bool;
   var _13 : bool;
   var _14 : bool;
   var _15 : bool;
-  var _16 : uint32;
-  var _17 : uint32;
+  var _16 : int;
+  var _17 : int;
   var _18 : bool;
-  var _19 : uint32;
-  var _20 : uint32;
+  var _19 : int;
+  var _20 : int;
   var _21 : bool;
-  var _22 : uint32;
-  var _23 : uint32;
+  var _22 : int;
+  var _23 : int;
   var _24 : ();
   {
     a_1 <- a;


### PR DESCRIPTION
Turns out `mir_promoted` doesn't actually run the borrow checker (it might have before?). 
This meant that creusot would happily attempt to translate programs which do not satisfy borrow checking.

cc: @shiatsumat
