### PR TITLE
Fix unsoundness in handling of 2-phase borrows

### DIFF
--- a/creusot-contracts/src/builtins/seq.rs
+++ b/creusot-contracts/src/builtins/seq.rs
@@ -48,6 +48,12 @@ impl<T> Seq<T> {
     pub fn push(self, _: T) -> Self {
         std::process::abort()
     }
+
+    #[logic]
+    pub fn last(self) -> Option<T> {
+        Some(*self.index(self.len() - 1))
+    }
+
     #[predicate]
     pub fn permutation_of(self, o: Self) -> bool {
         self.permut(o, 0, self.len())

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -68,4 +68,8 @@ impl<T> Vec<T> {
     pub fn swap(&mut self, i: usize, j: usize) {
         self.0.swap(i, j)
     }
+
+    pub fn last(&mut self) -> Option<&T> {
+        self.0.last()
+    }
 }

--- a/creusot/src/bimap.rs
+++ b/creusot/src/bimap.rs
@@ -1,0 +1,49 @@
+use indexmap::IndexMap;
+use std::hash::Hash;
+
+// A simple finite bijection between K and V
+pub struct BiMap<K, V> {
+    left: IndexMap<K, V>,
+    right: IndexMap<V, K>,
+}
+
+impl<K: Clone + Hash + Eq, V: Clone + Hash + Eq> BiMap<K, V> {
+    pub fn new() -> Self {
+        BiMap { left: Default::default(), right: Default::default() }
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> Option<(K, V)> {
+        let old_v = self.left.insert(k.clone(), v.clone());
+        let old_k = self.right.insert(v, k);
+
+        match (old_k, old_v) {
+            (Some(k), Some(v)) => Some((k, v)),
+            (None, None) => None,
+            _ => unreachable!(""),
+        }
+    }
+
+    pub fn remove_left(&mut self, k: &K) -> Option<(K, V)> {
+        let old_v = self.left.remove(k)?;
+        let old_k = self.right.remove(&old_v)?;
+
+        Some((old_k, old_v))
+    }
+
+    #[allow(dead_code)]
+    pub fn remove_right(&mut self, v: &V) -> Option<(K, V)> {
+        let old_k = self.right.remove(v)?;
+        let old_v = self.left.remove(&old_k)?;
+
+        Some((old_k, old_v))
+    }
+
+    #[allow(dead_code)]
+    pub fn lookup_left(&self, k: &K) -> Option<&V> {
+        self.left.get(k)
+    }
+
+    pub fn lookup_right(&self, v: &V) -> Option<&K> {
+        self.right.get(v)
+    }
+}

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -50,3 +50,5 @@ pub mod callbacks;
 pub mod options;
 
 use translation::*;
+
+pub(crate) mod bimap;

--- a/creusot/src/translation/function/place.rs
+++ b/creusot/src/translation/function/place.rs
@@ -25,6 +25,9 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
         proj: &[rustc_middle::mir::PlaceElem<'tcx>],
     ) -> Exp {
         let mut inner = self.translate_local(loc).ident().into();
+
+        self.two_phase_borrows.remove_left(&loc);
+
         use rustc_middle::mir::ProjectionElem::*;
         let mut place_ty = Place::ty_from(loc, &[], self.body, self.tcx);
 

--- a/creusot/tests/should_succeed/two_phase_borrow.rs
+++ b/creusot/tests/should_succeed/two_phase_borrow.rs
@@ -1,0 +1,15 @@
+// WHY3PROVE
+#![feature(register_tool, rustc_attrs)]
+#![register_tool(creusot)]
+#![feature(proc_macro_hygiene, stmt_expr_attributes)]
+#![feature(type_ascription)]
+
+extern crate creusot_contracts;
+
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+#[ensures(@(@^v)[(@v).len()] === (@v).len())]
+fn test(v: &mut Vec<usize>) {
+    v.push(v.len());
+}

--- a/creusot/tests/should_succeed/two_phase_borrow.stdout
+++ b/creusot/tests/should_succeed/two_phase_borrow.stdout
@@ -1,0 +1,288 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type alloc_alloc_global  = 
+    | Alloc_Alloc_Global
+    
+  type core_marker_phantomdata 't = 
+    | Core_Marker_PhantomData
+    
+  type core_ptr_unique_unique 't = 
+    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
+    
+  type alloc_rawvec_rawvec 't 'a = 
+    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
+    
+  type alloc_vec_vec 't 'a = 
+    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
+    
+  type creusotcontracts_std1_vec_vec 't = 
+    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
+    
+end
+module CreusotContracts_Builtins_Model_Model
+  type self   
+  type modelty   
+  function model (self : self) : modelty
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Interface
+  type t   
+  use Type
+  use seq.Seq
+  clone export CreusotContracts_Std1_Vec_Impl0_Model_Interface with type t = t
+  type modelty  = 
+    Seq.seq t
+  clone export CreusotContracts_Builtins_Model_Model with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelty = modelty, function model = model
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  use seq.Seq
+  clone export CreusotContracts_Std1_Vec_Impl0_Model with type t = t
+  type modelty  = 
+    Seq.seq t
+  clone export CreusotContracts_Builtins_Model_Model with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelty = modelty, function model = model
+end
+module CreusotContracts_Builtins_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = self
+  function model (self : self) : Model0.modelty
+end
+module CreusotContracts_Builtins_Model_Model_Model
+  type self   
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = self
+  function model (self : self) : Model0.modelty
+end
+module CreusotContracts_Builtins_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  function model (self : borrowed t) : Model0.modelty
+end
+module CreusotContracts_Builtins_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  function model (self : borrowed t) : Model0.modelty = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Builtins_Model_Impl1_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  clone export CreusotContracts_Builtins_Model_Impl1_Model_Interface with type t = t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export CreusotContracts_Builtins_Model_Model with type self = borrowed t, type modelty = modelty,
+  function model = model
+end
+module CreusotContracts_Builtins_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  clone export CreusotContracts_Builtins_Model_Impl1_Model with type t = t, type Model0.modelty = Model0.modelty,
+  function Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export CreusotContracts_Builtins_Model_Model with type self = borrowed t, type modelty = modelty,
+  function model = model
+end
+module CreusotContracts_Builtins_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Builtins_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Builtins_Resolve_Impl1_Interface
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Resolve_Impl1_Resolve_Interface with type t = t
+  clone export CreusotContracts_Builtins_Resolve_Resolve with type self = borrowed t, predicate resolve = resolve
+end
+module CreusotContracts_Builtins_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone export CreusotContracts_Builtins_Resolve_Impl1_Resolve with type t = t
+  clone export CreusotContracts_Builtins_Resolve_Resolve with type self = borrowed t, predicate resolve = resolve
+end
+module CreusotContracts_Builtins_Model_Impl0_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  function model (self : t) : Model0.modelty
+end
+module CreusotContracts_Builtins_Model_Impl0_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  function model (self : t) : Model0.modelty = 
+    Model0.model self
+end
+module CreusotContracts_Builtins_Model_Impl0_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  clone export CreusotContracts_Builtins_Model_Impl0_Model_Interface with type t = t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export CreusotContracts_Builtins_Model_Model with type self = t, type modelty = modelty, function model = model
+end
+module CreusotContracts_Builtins_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Builtins_Model_Model as Model0 with type self = t
+  clone export CreusotContracts_Builtins_Model_Impl0_Model with type t = t, type Model0.modelty = Model0.modelty,
+  function Model0.model = Model0.model
+  type modelty  = 
+    Model0.modelty
+  clone export CreusotContracts_Builtins_Model_Model with type self = t, type modelty = modelty, function model = model
+end
+module CreusotContracts_Std1_Vec_Impl1_Len_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { result = Seq.length (Model0.model self) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Len
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model1 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl0_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model1.modelty, function Model0.model = Model1.model
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { result = Seq.length (Model0.model self) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = t
+  clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module TwoPhaseBorrow_Test_Interface
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Interface as Model0 with type t = usize
+  clone CreusotContracts_Builtins_Model_Impl1_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  val test (v : borrowed (Type.creusotcontracts_std1_vec_vec usize)) : ()
+    ensures { Seq.get (Model0.model ( ^ v)) (Seq.length (Model1.model v)) = Seq.length (Model1.model v) }
+    
+end
+module TwoPhaseBorrow_Test
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0 as Model0 with type t = usize
+  clone CreusotContracts_Builtins_Model_Impl1 as Model1 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  clone CreusotContracts_Builtins_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Builtins_Resolve_Impl1 as Resolve0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Builtins_Model_Impl0 as Model2 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type Model0.modelty = Model0.modelty, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = usize, function Model0.model = Model2.model,
+  function Model1.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = usize,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  let rec cfg test (v : borrowed (Type.creusotcontracts_std1_vec_vec usize)) : ()
+    ensures { Seq.get (Model0.model ( ^ v)) (Seq.length (Model1.model v)) = Seq.length (Model1.model v) }
+    
+   = 
+  var _0 : ();
+  var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _2 : ();
+  var _3 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _4 : usize;
+  var _5 : Type.creusotcontracts_std1_vec_vec usize;
+  {
+    v_1 <- v;
+    goto BB0
+  }
+  BB0 {
+    _3 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _3) };
+    _5 <-  * _3;
+    assume { Resolve0.resolve v_1 };
+    _4 <- Len0.len _5;
+    goto BB1
+  }
+  BB1 {
+    _2 <- Push0.push _3 _4;
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _3 };
+    assume { Resolve1.resolve _4 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -47,9 +47,8 @@ fn knuth_shuffle<T>(v: &mut Vec<T>) {
     while n < v.len() {
         // We assign the length to a variable to work around a limitation with two-phase borrows
         // where we forget the value stored in the reference.
-        let l = v.len();
-        let i = rand_in_range(0, l - n);
-        v.swap(i, l - n - 1);
+        let i = rand_in_range(0, v.len() - n);
+        v.swap(i, v.len() - n - 1);
         n += 1;
     }
 }

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -374,18 +374,18 @@ module C03KnuthShuffle_KnuthShuffle
   var _10 : usize;
   var _11 : usize;
   var _12 : Type.creusotcontracts_std1_vec_vec t;
-  var l_13 : usize;
-  var _14 : Type.creusotcontracts_std1_vec_vec t;
-  var i_15 : usize;
-  var _16 : usize;
+  var i_13 : usize;
+  var _14 : usize;
+  var _15 : usize;
+  var _16 : Type.creusotcontracts_std1_vec_vec t;
   var _17 : usize;
-  var _18 : usize;
-  var _19 : ();
-  var _20 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _18 : ();
+  var _19 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _20 : usize;
   var _21 : usize;
   var _22 : usize;
   var _23 : usize;
-  var _24 : usize;
+  var _24 : Type.creusotcontracts_std1_vec_vec t;
   var _25 : usize;
   var _26 : ();
   var _27 : ();
@@ -421,52 +421,52 @@ module C03KnuthShuffle_KnuthShuffle
   BB4 {
     _9 <- _10 < _11;
     switch (_9)
-      | False -> goto BB9
+      | False -> goto BB10
       | True -> goto BB5
       | _ -> goto BB5
       end
   }
   BB5 {
     assume { Resolve3.resolve _9 };
-    _14 <-  * v_1;
-    l_13 <- Len0.len _14;
+    _16 <-  * v_1;
+    _15 <- Len0.len _16;
     goto BB6
   }
   BB6 {
     assume { Resolve2.resolve _17 };
-    _17 <- l_13;
-    assume { Resolve2.resolve _18 };
-    _18 <- n_5;
-    _16 <- _17 - _18;
-    i_15 <- RandInRange0.rand_in_range (0 : usize) _16;
+    _17 <- n_5;
+    _14 <- _15 - _17;
+    i_13 <- RandInRange0.rand_in_range (0 : usize) _14;
     goto BB7
   }
   BB7 {
-    _20 <- borrow_mut ( * v_1);
-    v_1 <- { v_1 with current = ( ^ _20) };
-    assume { Resolve2.resolve _21 };
-    _21 <- i_15;
-    assume { Resolve2.resolve i_15 };
-    assume { Resolve2.resolve _24 };
-    _24 <- l_13;
-    assume { Resolve2.resolve l_13 };
-    assume { Resolve2.resolve _25 };
-    _25 <- n_5;
-    _23 <- _24 - _25;
-    _22 <- _23 - (1 : usize);
-    _19 <- Swap0.swap _20 _21 _22;
+    _19 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _19) };
+    assume { Resolve2.resolve _20 };
+    _20 <- i_13;
+    assume { Resolve2.resolve i_13 };
+    _24 <-  * _19;
+    _23 <- Len0.len _24;
     goto BB8
   }
   BB8 {
-    assume { Resolve4.resolve _20 };
+    assume { Resolve2.resolve _25 };
+    _25 <- n_5;
+    _22 <- _23 - _25;
+    _21 <- _22 - (1 : usize);
+    _18 <- Swap0.swap _19 _20 _21;
+    goto BB9
+  }
+  BB9 {
+    assume { Resolve4.resolve _19 };
+    assume { Resolve2.resolve _20 };
     assume { Resolve2.resolve _21 };
-    assume { Resolve2.resolve _22 };
     n_5 <- n_5 + (1 : usize);
     _8 <- ();
     assume { Resolve5.resolve _8 };
     goto BB2
   }
-  BB9 {
+  BB10 {
     assume { Resolve4.resolve v_1 };
     assume { Resolve2.resolve n_5 };
     assume { Resolve3.resolve _9 };


### PR DESCRIPTION
It was previously possible to create a situation in which two phase borrows could cause unsoundness.
The issue was apparent in the following code:

```rust
v.push(v.len());

assert_eq!(v.last(), Some(v.len()));
```

This was translated to the following pseudo-mir:

```
let _t = &mut v;
let _t1 = & v;

let _t2 = len _t1 ;
let _t3 = push _t _t1;
```

which causes an issue as when we create `_t` we assign the prophecy of `_t` to `v`, thus the second borrow `_t1` will be the prophecy for `_t`.

The solution implemented in this PR is a little in-elegant but works well: track all possible two phase borrows and until they are 'activated' (rustc parlance), any futher borrows will use the *current* value of the unactivated borrow. In other words we act as if this was the written code:

```
let _t = &mut v;
let _t1 = & * _t;

let _t2 = len _t1 ;
let _t3 = push _t _t1;
```

An alternative implementation of a solution is to delay the creation of the 2-phased borrow `_t` until its activation. However, this introduces unsoundness because the interaction with how we insert resolutions. You can view that attempt here: https://github.com/xldenis/creusot/tree/tpb-2.

cc @jhjourdan, let me know what you think.
