### PR TITLE
Weaken the requirements on fib unbounded

### DIFF
--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.rs
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.rs
@@ -71,7 +71,7 @@ fn fib_cell(v: FibCache) -> bool {
 #[requires(fib_cell(*mem))]
 #[requires(@i < (@mem).len())]
 #[ensures(@result === fib(@i))]
-#[requires(@i <= 63)]
+#[requires(0 <= @i)]
 fn fib_memo(mem: &FibCache, i: usize) -> usize {
     match mem[i].get() {
         Some(v) => v,

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -335,7 +335,7 @@ module C03FibUnbounded_FibMemo_Interface
   clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)),
   type ModelTy0.modelty = ModelTy0.modelty
   val fib_memo (mem : Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib))) (i : int) : int
-    requires {i <= 63}
+    requires {0 <= i}
     requires {i < Seq.length (Model0.model mem)}
     requires {FibCell0.fib_cell mem}
     ensures { result = Fib0.fib i }
@@ -365,7 +365,7 @@ module C03FibUnbounded_FibMemo
   clone C03FibUnbounded_Impl0_Get_Interface as Get0 with type t = Type.core_option_option int,
   type i = Type.c03fibunbounded_fib, predicate Inv0.inv = Inv0.inv
   let rec cfg fib_memo (mem : Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib))) (i : int) : int
-    requires {i <= 63}
+    requires {0 <= i}
     requires {i < Seq.length (Model0.model mem)}
     requires {FibCell0.fib_cell mem}
     ensures { result = Fib0.fib i }


### PR DESCRIPTION
I realized that I hadn't weakend the pre-conditions for the Fib unbounded example. Here we allow calculation for unbounded `i`. 
