### PR TITLE
Knight's Tour

### DIFF
--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -103,11 +103,4 @@ impl<T: Clone> Clone for Vec<T> {
 #[ensures(forall<i : Int> 0 <= i && i < @n ==> (@result)[i] === elem)]
 pub fn from_elem<T: Clone>(elem: T, n: usize) -> Vec<T> {
     panic!()
-    // if n = 0 { return Vec::new() }
-    // else {
-    //     let mut v = std::vec::Vec::with_capacity(n);
-    //     v.extend(std::iter::repeat_with(|| elem.clone()).take(n-1));
-    //     v.push(elem);
-    //     return Vec(v)
-    // }
 }

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -385,7 +385,6 @@ impl<'tcx> CloneMap<'tcx> {
 
             // Add any 'additional dependencies'
             for (sym, dep) in &self.names[&node].additional_deps {
-                let target_sym = ident_of(*sym);
                 let mut syms = refinable_symbols(ctx.tcx, def_id).filter(|sk| sk.sym() == *sym);
                 let sym = syms.next().unwrap();
                 assert!(syms.next().is_none());

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -11,7 +11,7 @@ use crate::{rustc_extensions, util};
 
 use crate::ctx::*;
 use crate::translation::ty;
-use crate::util::{ident_of, ident_of_ty, is_spec};
+use crate::util::{ident_of_ty, is_spec};
 
 impl<'tcx> TranslationCtx<'_, 'tcx> {
     // Translate a trait declaration

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -188,10 +188,6 @@ fn translate_ty_param(p: Symbol) -> Ident {
     Ident::build(&p.to_string().to_lowercase())
 }
 
-pub fn ty_name(tcx: TyCtxt, def_id: DefId) -> String {
-    tcx.item_name(def_id).to_string().to_lowercase()
-}
-
 // Translate a Rust type declation to an ML one
 // Rust tuple-like types are translated as one would expect, to product types in WhyML
 // However, Rust struct types are *not* translated to WhyML records, instead we 'forget' the field names

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -1,0 +1,188 @@
+// WHY3PROVE NO_SPLIT CVC4
+extern crate creusot_contracts;
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+#[derive(Copy)]
+struct Point {
+    x: isize,
+    y: isize,
+}
+
+// ISSUE: patterns in function binders are unsupported!
+impl Point {
+    #[requires(-10000 <= @(self.x) && @(self.x) <= 10000)]
+    #[requires(-10000 <= @(self.y) && @(self.y) <= 10000)]
+    #[requires(-10000 <= @(p.0) && @(p.0) <= 10000)]
+    #[requires(-10000 <= @(p.1) && @(p.1) <= 10000)]
+    #[ensures(@(result.x) === @(self.x) + @(p.0))]
+    #[ensures(@(result.y) === @(self.y) + @(p.1))]
+    fn mov(&self, p: &(isize, isize)) -> Self {
+        Self { x: (self.x + p.0), y: (self.y + p.1) }
+    }
+}
+
+struct Board {
+    size: usize,
+    field: Vec<Vec<usize>>,
+}
+
+impl Board {
+    #[predicate]
+    fn wf(self) -> bool {
+        pearlite! {
+            @(self.size) <= 1_000 &&
+            (@(self.field)).len() === @self.size &&
+            forall<i : Int> 0 <= i && i < @self.size ==> (@(@(self.field))[i]).len() === @self.size
+        }
+    }
+    #[requires(@size <= 1000)]
+    #[ensures(result.size === size)]
+    #[ensures(result.wf())]
+    fn new(size: usize) -> Self {
+        let mut rows: Vec<Vec<_>> = Vec::with_capacity(size);
+
+        let mut i = 0;
+        #[invariant(i_size, i <= size)]
+        #[invariant(rows,
+            forall<j : Int> 0 <= j && j < @i ==> (@((@rows)[j])).len() === @size)]
+        #[invariant(row_len, (@rows).len() === @i )]
+        while i < size {
+            rows.push(vec::from_elem(0, size));
+            i += 1;
+        }
+
+        Self { size, field: rows }
+    }
+
+    #[requires(self.wf())]
+    #[ensures(result ==> self.in_bounds(p))]
+    fn available(&self, p: Point) -> bool {
+        0 <= p.x
+            && (p.x as usize) < self.size
+            && 0 <= p.y
+            && (p.y as usize) < self.size
+            && self.field[p.x as usize][p.y as usize] == 0
+    }
+
+    #[predicate]
+    fn in_bounds(self, p: Point) -> bool {
+        pearlite! {
+            0 <= @(p.x) && @(p.x)< @(self.size) && 0 <= @(p.y) && @(p.y) < @(self.size)
+        }
+    }
+
+    // calculate the number of possible moves
+    #[requires(self.wf())]
+    #[requires(self.in_bounds(p))]
+    fn count_degree(&self, p: Point) -> usize {
+        let mut count = 0;
+
+        let mut i = 0;
+        #[invariant(count, count <= i)]
+        while i < moves().len() {
+            let next = p.mov(&moves()[i]);
+            if self.available(next) {
+                count += 1;
+            }
+            i += 1;
+        }
+        count
+    }
+
+    #[requires(self.wf())]
+    #[requires(self.in_bounds(p))]
+    #[ensures((^self).wf())]
+    #[ensures((^self).size === (*self).size)]
+    fn set(&mut self, p: Point, v: usize) {
+        self.field[p.x as usize][p.y as usize] = v
+    }
+}
+
+#[trusted]
+#[ensures((@result).len() === 8)]
+#[ensures(forall<i : Int> 0 <= i && i < 8 ==> -2 <= @((@result)[i].0) && @((@result)[i].0) <= 2 && -2 <= @((@result)[i].1) &&@((@result)[i].1) <= 2)]
+fn moves() -> Vec<(isize, isize)> {
+    let mut v = Vec::new();
+    v.push((2, 1));
+    v.push((1, 2));
+    v.push((-1, 2));
+    v.push((-2, 1));
+    v.push((-2, -1));
+    v.push((-1, -2));
+    v.push((1, -2));
+    v.push((2, -1));
+
+    v
+}
+
+fn min(v: &Vec<(usize, Point)>) -> Option<&(usize, Point)> {
+    let mut i = 0;
+    let mut min = None;
+    while i < v.len() {
+        match min {
+            None => min = Some(&v[i]),
+            Some(m) => {
+                if v[i].0 < m.0 {
+                    min = Some(&v[i])
+                }
+            }
+        };
+        i += 1;
+    }
+    min
+}
+
+#[logic]
+#[requires(@a <= 1_000)]
+#[ensures(@a * @a <= 1_000_000)]
+fn dumb_nonlinear_arith(a: usize) {}
+
+#[requires(0 < @size && @size <= 1000)]
+#[requires(x < size)]
+#[requires(y < size)]
+fn knights_tour(size: usize, x: usize, y: usize) -> Option<Board> {
+    let mut board = Board::new(size);
+    let mut p = Point { x: x as isize, y: y as isize };
+    let mut step = 1;
+
+    board.set(p, step);
+    step += 1;
+
+    proof_assert! {{ dumb_nonlinear_arith(size); true }}
+    #[invariant(b, board.size === size)]
+    #[invariant(b, board.wf())]
+    #[invariant(p, board.in_bounds(p))]
+    // rather annoyingly z3 gets stuck proving size * size is inbounds, seemingly
+    // due to a why3 bug / limitation in mlcfg
+    while step <= (size * size) {
+        // choose next square by Warnsdorf's rule
+        let mut candidates = Vec::new();
+        let mut i = 0;
+        while i < moves().len() {
+            proof_assert! { board.in_bounds(p) };
+            let adj = p.mov(&moves()[i]);
+            if board.available(adj) {
+                let degree = board.count_degree(adj);
+                candidates.push((degree, adj));
+            }
+        }
+        match min(&candidates) {
+            Some(&(_, adj)) => p = adj,
+            None => return None,
+        };
+        board.set(p, step);
+        step += 1;
+    }
+    Some(board)
+}
+
+// fn main() {
+//     let (x, y) = (3, 1);
+//     // println!("Board size: {}", SIZE);
+//     // println!("Starting position: ({}, {})", x, y);
+//     // match knights_tour(x, y) {
+//     //     Some(b) => print!("{}", b),
+//     //     None => println!("Fail!"),
+//     // }
+// }

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -1,0 +1,1820 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type core_marker_phantomdata 't = 
+    | Core_Marker_PhantomData
+    
+  type core_ptr_unique_unique 't = 
+    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
+    
+  type alloc_rawvec_rawvec 't 'a = 
+    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
+    
+  type alloc_vec_vec 't 'a = 
+    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
+    
+  type alloc_alloc_global  = 
+    | Alloc_Alloc_Global
+    
+  type creusotcontracts_std1_vec_vec 't = 
+    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
+    
+  type c06knightstour_point  = 
+    | C06KnightsTour_Point isize isize
+    
+  function c06knightstour_point_Point_y (self : c06knightstour_point) : isize
+  val c06knightstour_point_Point_y (self : c06knightstour_point) : isize
+    ensures { result = c06knightstour_point_Point_y self }
+    
+  axiom c06knightstour_point_Point_y_acc : forall a : isize, b : isize . c06knightstour_point_Point_y (C06KnightsTour_Point a b : c06knightstour_point) = b
+  function c06knightstour_point_Point_x (self : c06knightstour_point) : isize
+  val c06knightstour_point_Point_x (self : c06knightstour_point) : isize
+    ensures { result = c06knightstour_point_Point_x self }
+    
+  axiom c06knightstour_point_Point_x_acc : forall a : isize, b : isize . c06knightstour_point_Point_x (C06KnightsTour_Point a b : c06knightstour_point) = a
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
+    
+  function core_option_option_Some_0 (self : core_option_option 't) : 't
+  val core_option_option_Some_0 (self : core_option_option 't) : 't
+    ensures { result = core_option_option_Some_0 self }
+    
+  axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
+  type c06knightstour_board  = 
+    | C06KnightsTour_Board usize (creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize))
+    
+  function c06knightstour_board_Board_size (self : c06knightstour_board) : usize
+  val c06knightstour_board_Board_size (self : c06knightstour_board) : usize
+    ensures { result = c06knightstour_board_Board_size self }
+    
+  axiom c06knightstour_board_Board_size_acc : forall a : usize, b : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize) . c06knightstour_board_Board_size (C06KnightsTour_Board a b : c06knightstour_board) = a
+  function c06knightstour_board_Board_field (self : c06knightstour_board) : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize)
+    
+  val c06knightstour_board_Board_field (self : c06knightstour_board) : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize)
+    ensures { result = c06knightstour_board_Board_field self }
+    
+  axiom c06knightstour_board_Board_field_acc : forall a : usize, b : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize) . c06knightstour_board_Board_field (C06KnightsTour_Board a b : c06knightstour_board) = b
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : t) : ModelTy0.modelTy = 
+    Model0.model self
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
+  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl1_Len_Interface
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Len
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
+    
+end
+module Core_Ops_Index_Index_Output
+  type self   
+  type idx   
+  type output   
+end
+module Core_Ops_Index_Index_Index_Interface
+  type self   
+  type idx   
+  use prelude.Prelude
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index (self : self) (index : idx) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Index_Index_Index
+  type self   
+  type idx   
+  use prelude.Prelude
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index (self : self) (index : idx) : Output0.output
+    requires {false}
+    
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3_Index_Interface
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl3_Index
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
+    requires {UInt64.to_int ix < Seq.length (Model0.model self)}
+    ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
+module C06KnightsTour_Min_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  val min (v : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)) : Type.core_option_option (usize, Type.c06knightstour_point)
+    
+end
+module C06KnightsTour_Min
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  use mach.int.Int64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.core_option_option (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model0.model
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  let rec cfg min (v : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)) : Type.core_option_option (usize, Type.c06knightstour_point)
+    
+   = 
+  var _0 : Type.core_option_option (usize, Type.c06knightstour_point);
+  var v_1 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var i_2 : usize;
+  var min_3 : Type.core_option_option (usize, Type.c06knightstour_point);
+  var _4 : ();
+  var _5 : ();
+  var _6 : bool;
+  var _7 : usize;
+  var _8 : usize;
+  var _9 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _10 : ();
+  var _11 : isize;
+  var _12 : Type.core_option_option (usize, Type.c06knightstour_point);
+  var _13 : (usize, Type.c06knightstour_point);
+  var _14 : (usize, Type.c06knightstour_point);
+  var _15 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _16 : usize;
+  var m_17 : (usize, Type.c06knightstour_point);
+  var _18 : bool;
+  var _19 : usize;
+  var _20 : (usize, Type.c06knightstour_point);
+  var _21 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _22 : usize;
+  var _23 : usize;
+  var _24 : Type.core_option_option (usize, Type.c06knightstour_point);
+  var _25 : (usize, Type.c06knightstour_point);
+  var _26 : (usize, Type.c06knightstour_point);
+  var _27 : (usize, Type.c06knightstour_point);
+  var _28 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _29 : usize;
+  var _30 : ();
+  var _31 : ();
+  var _32 : ();
+  {
+    v_1 <- v;
+    goto BB0
+  }
+  BB0 {
+    i_2 <- (0 : usize);
+    min_3 <- Type.Core_Option_Option_None;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _7 };
+    _7 <- i_2;
+    _9 <- v_1;
+    _8 <- Len0.len _9;
+    goto BB3
+  }
+  BB3 {
+    _6 <- _7 < _8;
+    switch (_6)
+      | False -> goto BB16
+      | _ -> goto BB4
+      end
+  }
+  BB4 {
+    switch (min_3)
+      | Type.Core_Option_Option_None -> goto BB5
+      | Type.Core_Option_Option_Some _ -> goto BB6
+      end
+  }
+  BB5 {
+    assume { Resolve2.resolve min_3 };
+    goto BB8
+  }
+  BB6 {
+    assume { Resolve3.resolve m_17 };
+    m_17 <- Type.core_option_option_Some_0 min_3;
+    _21 <- v_1;
+    assume { Resolve0.resolve _22 };
+    _22 <- i_2;
+    _20 <- Index0.index _21 _22;
+    goto BB10
+  }
+  BB7 {
+    assume { Resolve1.resolve v_1 };
+    assume { Resolve0.resolve i_2 };
+    assume { Resolve2.resolve min_3 };
+    absurd
+  }
+  BB8 {
+    _15 <- v_1;
+    assume { Resolve0.resolve _16 };
+    _16 <- i_2;
+    _14 <- Index0.index _15 _16;
+    goto BB9
+  }
+  BB9 {
+    _13 <- _14;
+    assume { Resolve3.resolve _14 };
+    _12 <- Type.Core_Option_Option_Some _13;
+    assume { Resolve2.resolve min_3 };
+    min_3 <- _12;
+    _10 <- ();
+    assume { Resolve4.resolve _10 };
+    goto BB15
+  }
+  BB10 {
+    assume { Resolve0.resolve _19 };
+    _19 <- (let (a, _) = _20 in a);
+    assume { Resolve3.resolve _20 };
+    assume { Resolve0.resolve _23 };
+    _23 <- (let (a, _) = m_17 in a);
+    assume { Resolve3.resolve m_17 };
+    _18 <- _19 < _23;
+    switch (_18)
+      | False -> goto BB13
+      | _ -> goto BB11
+      end
+  }
+  BB11 {
+    assume { Resolve2.resolve min_3 };
+    _28 <- v_1;
+    assume { Resolve0.resolve _29 };
+    _29 <- i_2;
+    _27 <- Index0.index _28 _29;
+    goto BB12
+  }
+  BB12 {
+    _26 <- _27;
+    assume { Resolve3.resolve _27 };
+    _25 <- _26;
+    assume { Resolve3.resolve _26 };
+    _24 <- Type.Core_Option_Option_Some _25;
+    assume { Resolve2.resolve min_3 };
+    min_3 <- _24;
+    _10 <- ();
+    assume { Resolve4.resolve _10 };
+    goto BB14
+  }
+  BB13 {
+    _10 <- ();
+    assume { Resolve4.resolve _10 };
+    goto BB14
+  }
+  BB14 {
+    goto BB15
+  }
+  BB15 {
+    i_2 <- i_2 + (1 : usize);
+    _5 <- ();
+    assume { Resolve4.resolve _5 };
+    goto BB1
+  }
+  BB16 {
+    assume { Resolve1.resolve v_1 };
+    assume { Resolve0.resolve i_2 };
+    _4 <- ();
+    assume { Resolve4.resolve _4 };
+    assume { Resolve2.resolve _0 };
+    _0 <- min_3;
+    assume { Resolve2.resolve min_3 };
+    return _0
+  }
+  
+end
+module C06KnightsTour_Impl0_Mov_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.Prelude
+  use Type
+  val mov (self : Type.c06knightstour_point) (p : (isize, isize)) : Type.c06knightstour_point
+    requires {- 10000 <= Int64.to_int (let (_, a) = p in a) && Int64.to_int (let (_, a) = p in a) <= 10000}
+    requires {- 10000 <= Int64.to_int (let (a, _) = p in a) && Int64.to_int (let (a, _) = p in a) <= 10000}
+    requires {- 10000 <= Int64.to_int (Type.c06knightstour_point_Point_y self) && Int64.to_int (Type.c06knightstour_point_Point_y self) <= 10000}
+    requires {- 10000 <= Int64.to_int (Type.c06knightstour_point_Point_x self) && Int64.to_int (Type.c06knightstour_point_Point_x self) <= 10000}
+    ensures { Int64.to_int (Type.c06knightstour_point_Point_y result) = Int64.to_int (Type.c06knightstour_point_Point_y self) + Int64.to_int (let (_, a) = p in a) }
+    ensures { Int64.to_int (Type.c06knightstour_point_Point_x result) = Int64.to_int (Type.c06knightstour_point_Point_x self) + Int64.to_int (let (a, _) = p in a) }
+    
+end
+module C06KnightsTour_Impl0_Mov
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = isize
+  let rec cfg mov (self : Type.c06knightstour_point) (p : (isize, isize)) : Type.c06knightstour_point
+    requires {- 10000 <= Int64.to_int (let (_, a) = p in a) && Int64.to_int (let (_, a) = p in a) <= 10000}
+    requires {- 10000 <= Int64.to_int (let (a, _) = p in a) && Int64.to_int (let (a, _) = p in a) <= 10000}
+    requires {- 10000 <= Int64.to_int (Type.c06knightstour_point_Point_y self) && Int64.to_int (Type.c06knightstour_point_Point_y self) <= 10000}
+    requires {- 10000 <= Int64.to_int (Type.c06knightstour_point_Point_x self) && Int64.to_int (Type.c06knightstour_point_Point_x self) <= 10000}
+    ensures { Int64.to_int (Type.c06knightstour_point_Point_y result) = Int64.to_int (Type.c06knightstour_point_Point_y self) + Int64.to_int (let (_, a) = p in a) }
+    ensures { Int64.to_int (Type.c06knightstour_point_Point_x result) = Int64.to_int (Type.c06knightstour_point_Point_x self) + Int64.to_int (let (a, _) = p in a) }
+    
+   = 
+  var _0 : Type.c06knightstour_point;
+  var self_1 : Type.c06knightstour_point;
+  var p_2 : (isize, isize);
+  var _3 : isize;
+  var _4 : isize;
+  var _5 : isize;
+  var _6 : isize;
+  var _7 : isize;
+  var _8 : isize;
+  {
+    self_1 <- self;
+    p_2 <- p;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _4 };
+    _4 <- Type.c06knightstour_point_Point_x self_1;
+    assume { Resolve0.resolve _5 };
+    _5 <- (let (a, _) = p_2 in a);
+    _3 <- _4 + _5;
+    assume { Resolve0.resolve _7 };
+    _7 <- Type.c06knightstour_point_Point_y self_1;
+    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve _8 };
+    _8 <- (let (_, a) = p_2 in a);
+    assume { Resolve2.resolve p_2 };
+    _6 <- _7 + _8;
+    _0 <- Type.C06KnightsTour_Point _3 _6;
+    return _0
+  }
+  
+end
+module C06KnightsTour_Impl1_Wf_Interface
+  use Type
+  predicate wf (self : Type.c06knightstour_board)
+end
+module C06KnightsTour_Impl1_Wf
+  use Type
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  predicate wf (self : Type.c06knightstour_board) = 
+    UInt64.to_int (Type.c06knightstour_board_Board_size self) <= 1000 && Seq.length (Model0.model (Type.c06knightstour_board_Board_field self)) = UInt64.to_int (Type.c06knightstour_board_Board_size self) && (forall i : (int) . 0 <= i && i < UInt64.to_int (Type.c06knightstour_board_Board_size self) -> Seq.length (Model1.model (Seq.get (Model0.model (Type.c06knightstour_board_Board_field self)) i)) = UInt64.to_int (Type.c06knightstour_board_Board_size self))
+end
+module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use mach.int.UInt64
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
+    ensures { Seq.length (Model0.model result) = 0 }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_WithCapacity
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use mach.int.UInt64
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
+    ensures { Seq.length (Model0.model result) = 0 }
+    
+end
+module CreusotContracts_Std1_Vec_FromElem_Interface
+  type t   
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
+    ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { Seq.length (Model0.model result) = UInt64.to_int n }
+    
+end
+module CreusotContracts_Std1_Vec_FromElem
+  type t   
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
+    ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { Seq.length (Model0.model result) = UInt64.to_int n }
+    
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : borrowed t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : borrowed t) : ModelTy0.modelTy = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl1_Push_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module C06KnightsTour_Impl1_New_Interface
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone C06KnightsTour_Impl1_Wf_Interface as Wf0
+  val new (size : usize) : Type.c06knightstour_board
+    requires {UInt64.to_int size <= 1000}
+    ensures { Wf0.wf result }
+    ensures { Type.c06knightstour_board_Board_size result = size }
+    
+end
+module C06KnightsTour_Impl1_New
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  use mach.int.Int32
+  use seq.Seq
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = usize,
+  function Model0.model = Model1.model
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model0.model, function Model1.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model0.model
+  let rec cfg new (size : usize) : Type.c06knightstour_board
+    requires {UInt64.to_int size <= 1000}
+    ensures { Wf0.wf result }
+    ensures { Type.c06knightstour_board_Board_size result = size }
+    
+   = 
+  var _0 : Type.c06knightstour_board;
+  var size_1 : usize;
+  var rows_2 : Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize);
+  var _3 : usize;
+  var i_4 : usize;
+  var _5 : ();
+  var _6 : ();
+  var _7 : bool;
+  var _8 : usize;
+  var _9 : usize;
+  var _10 : ();
+  var _11 : borrowed (Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize));
+  var _12 : Type.creusotcontracts_std1_vec_vec usize;
+  var _13 : usize;
+  var _14 : ();
+  var _15 : ();
+  var _16 : ();
+  var _17 : usize;
+  var _18 : Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize);
+  {
+    size_1 <- size;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _3 };
+    _3 <- size_1;
+    rows_2 <- WithCapacity0.with_capacity _3;
+    goto BB1
+  }
+  BB1 {
+    i_4 <- (0 : usize);
+    goto BB2
+  }
+  BB2 {
+    goto BB3
+  }
+  BB3 {
+    goto BB4
+  }
+  BB4 {
+    invariant i_size { i_4 <= size_1 };
+    invariant rows { forall j : (int) . 0 <= j && j < UInt64.to_int i_4 -> Seq.length (Model1.model (Seq.get (Model0.model rows_2) j)) = UInt64.to_int size_1 };
+    invariant row_len { Seq.length (Model0.model rows_2) = UInt64.to_int i_4 };
+    goto BB5
+  }
+  BB5 {
+    assume { Resolve0.resolve _8 };
+    _8 <- i_4;
+    assume { Resolve0.resolve _9 };
+    _9 <- size_1;
+    _7 <- _8 < _9;
+    switch (_7)
+      | False -> goto BB9
+      | _ -> goto BB6
+      end
+  }
+  BB6 {
+    _11 <- borrow_mut rows_2;
+    rows_2 <-  ^ _11;
+    assume { Resolve0.resolve _13 };
+    _13 <- size_1;
+    _12 <- FromElem0.from_elem (0 : usize) _13;
+    goto BB7
+  }
+  BB7 {
+    _10 <- Push0.push _11 _12;
+    goto BB8
+  }
+  BB8 {
+    i_4 <- i_4 + (1 : usize);
+    _6 <- ();
+    assume { Resolve1.resolve _6 };
+    goto BB4
+  }
+  BB9 {
+    assume { Resolve0.resolve i_4 };
+    _5 <- ();
+    assume { Resolve1.resolve _5 };
+    assume { Resolve0.resolve _17 };
+    _17 <- size_1;
+    assume { Resolve0.resolve size_1 };
+    assume { Resolve2.resolve _18 };
+    _18 <- rows_2;
+    _0 <- Type.C06KnightsTour_Board _17 _18;
+    goto BB10
+  }
+  BB10 {
+    goto BB11
+  }
+  BB11 {
+    return _0
+  }
+  
+end
+module C06KnightsTour_Impl1_InBounds_Interface
+  use Type
+  predicate in_bounds (self : Type.c06knightstour_board) (p : Type.c06knightstour_point)
+end
+module C06KnightsTour_Impl1_InBounds
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt64
+  predicate in_bounds (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) = 
+    0 <= Int64.to_int (Type.c06knightstour_point_Point_x p) && Int64.to_int (Type.c06knightstour_point_Point_x p) < UInt64.to_int (Type.c06knightstour_board_Board_size self) && 0 <= Int64.to_int (Type.c06knightstour_point_Point_y p) && Int64.to_int (Type.c06knightstour_point_Point_y p) < UInt64.to_int (Type.c06knightstour_board_Board_size self)
+end
+module C06KnightsTour_Impl1_Available_Interface
+  use prelude.Prelude
+  use Type
+  clone C06KnightsTour_Impl1_InBounds_Interface as InBounds0
+  clone C06KnightsTour_Impl1_Wf_Interface as Wf0
+  val available (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : bool
+    requires {Wf0.wf self}
+    ensures { result -> InBounds0.in_bounds self p }
+    
+end
+module C06KnightsTour_Impl1_Available
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C06KnightsTour_Impl1_InBounds as InBounds0
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = usize
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = isize
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = usize,
+  function Model0.model = Model3.model
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model2.model
+  let rec cfg available (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : bool
+    requires {Wf0.wf self}
+    ensures { result -> InBounds0.in_bounds self p }
+    
+   = 
+  var _0 : bool;
+  var self_1 : Type.c06knightstour_board;
+  var p_2 : Type.c06knightstour_point;
+  var _3 : bool;
+  var _4 : bool;
+  var _5 : bool;
+  var _6 : bool;
+  var _7 : isize;
+  var _8 : bool;
+  var _9 : usize;
+  var _10 : isize;
+  var _11 : usize;
+  var _12 : bool;
+  var _13 : isize;
+  var _14 : bool;
+  var _15 : usize;
+  var _16 : isize;
+  var _17 : usize;
+  var _18 : bool;
+  var _19 : usize;
+  var _20 : usize;
+  var _21 : Type.creusotcontracts_std1_vec_vec usize;
+  var _22 : Type.creusotcontracts_std1_vec_vec usize;
+  var _23 : Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize);
+  var _24 : usize;
+  var _25 : isize;
+  var _26 : usize;
+  var _27 : isize;
+  {
+    self_1 <- self;
+    p_2 <- p;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _7 };
+    _7 <- Type.c06knightstour_point_Point_x p_2;
+    _6 <- (0 : isize) <= _7;
+    switch (_6)
+      | False -> goto BB10
+      | _ -> goto BB11
+      end
+  }
+  BB1 {
+    assume { Resolve3.resolve self_1 };
+    assume { Resolve5.resolve p_2 };
+    _0 <- false;
+    goto BB3
+  }
+  BB2 {
+    _23 <- Type.c06knightstour_board_Board_field self_1;
+    assume { Resolve3.resolve self_1 };
+    assume { Resolve0.resolve _25 };
+    _25 <- Type.c06knightstour_point_Point_x p_2;
+    _24 <- UInt64.of_int (Int64.to_int _25);
+    _22 <- Index0.index _23 _24;
+    goto BB13
+  }
+  BB3 {
+    return _0
+  }
+  BB4 {
+    _3 <- false;
+    goto BB6
+  }
+  BB5 {
+    assume { Resolve0.resolve _16 };
+    _16 <- Type.c06knightstour_point_Point_y p_2;
+    _15 <- UInt64.of_int (Int64.to_int _16);
+    assume { Resolve1.resolve _17 };
+    _17 <- Type.c06knightstour_board_Board_size self_1;
+    _14 <- _15 < _17;
+    assume { Resolve2.resolve _3 };
+    _3 <- _14;
+    goto BB6
+  }
+  BB6 {
+    switch (_3)
+      | False -> goto BB1
+      | _ -> goto BB2
+      end
+  }
+  BB7 {
+    _4 <- false;
+    goto BB9
+  }
+  BB8 {
+    assume { Resolve0.resolve _13 };
+    _13 <- Type.c06knightstour_point_Point_y p_2;
+    _12 <- (0 : isize) <= _13;
+    assume { Resolve2.resolve _4 };
+    _4 <- _12;
+    goto BB9
+  }
+  BB9 {
+    switch (_4)
+      | False -> goto BB4
+      | _ -> goto BB5
+      end
+  }
+  BB10 {
+    _5 <- false;
+    goto BB12
+  }
+  BB11 {
+    assume { Resolve0.resolve _10 };
+    _10 <- Type.c06knightstour_point_Point_x p_2;
+    _9 <- UInt64.of_int (Int64.to_int _10);
+    assume { Resolve1.resolve _11 };
+    _11 <- Type.c06knightstour_board_Board_size self_1;
+    _8 <- _9 < _11;
+    assume { Resolve2.resolve _5 };
+    _5 <- _8;
+    goto BB12
+  }
+  BB12 {
+    switch (_5)
+      | False -> goto BB7
+      | _ -> goto BB8
+      end
+  }
+  BB13 {
+    _21 <- _22;
+    assume { Resolve4.resolve _22 };
+    assume { Resolve0.resolve _27 };
+    _27 <- Type.c06knightstour_point_Point_y p_2;
+    assume { Resolve5.resolve p_2 };
+    _26 <- UInt64.of_int (Int64.to_int _27);
+    _20 <- Index1.index _21 _26;
+    goto BB14
+  }
+  BB14 {
+    assume { Resolve1.resolve _19 };
+    _19 <- _20;
+    assume { Resolve6.resolve _20 };
+    _18 <- _19 = (0 : usize);
+    assume { Resolve2.resolve _0 };
+    _0 <- _18;
+    goto BB3
+  }
+  
+end
+module C06KnightsTour_Moves_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  use mach.int.Int64
+  use Type
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = (isize, isize)
+  val moves () : Type.creusotcontracts_std1_vec_vec (isize, isize)
+    ensures { forall i : (int) . 0 <= i && i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) && Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 && - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) && Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
+    ensures { Seq.length (Model0.model result) = 8 }
+    
+end
+module C06KnightsTour_Moves
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  use mach.int.Int64
+  use Type
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = (isize, isize)
+  val moves () : Type.creusotcontracts_std1_vec_vec (isize, isize)
+    ensures { forall i : (int) . 0 <= i && i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) && Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 && - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) && Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
+    ensures { Seq.length (Model0.model result) = 8 }
+    
+end
+module C06KnightsTour_Impl1_CountDegree_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C06KnightsTour_Impl1_Wf_Interface as Wf0
+  clone C06KnightsTour_Impl1_InBounds_Interface as InBounds0
+  val count_degree (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : usize
+    requires {InBounds0.in_bounds self p}
+    requires {Wf0.wf self}
+    
+end
+module C06KnightsTour_Impl1_CountDegree
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone C06KnightsTour_Impl1_InBounds as InBounds0
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.c06knightstour_point
+  clone C06KnightsTour_Impl0_Mov_Interface as Mov0
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec (isize, isize)
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (isize, isize)
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = (isize, isize),
+  function Model0.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
+  function Model0.model = Model3.model
+  clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,
+  predicate InBounds0.in_bounds = InBounds0.in_bounds
+  let rec cfg count_degree (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : usize
+    requires {InBounds0.in_bounds self p}
+    requires {Wf0.wf self}
+    
+   = 
+  var _0 : usize;
+  var self_1 : Type.c06knightstour_board;
+  var p_2 : Type.c06knightstour_point;
+  var count_3 : usize;
+  var i_4 : usize;
+  var _5 : ();
+  var _6 : ();
+  var _7 : bool;
+  var _8 : usize;
+  var _9 : usize;
+  var _10 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _11 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var next_12 : Type.c06knightstour_point;
+  var _13 : Type.c06knightstour_point;
+  var _14 : (isize, isize);
+  var _15 : (isize, isize);
+  var _16 : (isize, isize);
+  var _17 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _18 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _19 : usize;
+  var _20 : ();
+  var _21 : bool;
+  var _22 : Type.c06knightstour_board;
+  var _23 : Type.c06knightstour_point;
+  var _24 : ();
+  var _25 : ();
+  var _26 : ();
+  {
+    self_1 <- self;
+    p_2 <- p;
+    goto BB0
+  }
+  BB0 {
+    count_3 <- (0 : usize);
+    i_4 <- (0 : usize);
+    goto BB1
+  }
+  BB1 {
+    invariant count { count_3 <= i_4 };
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _8 };
+    _8 <- i_4;
+    _11 <- Moves0.moves ();
+    goto BB3
+  }
+  BB3 {
+    _10 <- _11;
+    _9 <- Len0.len _10;
+    goto BB4
+  }
+  BB4 {
+    _7 <- _8 < _9;
+    goto BB5
+  }
+  BB5 {
+    assume { Resolve1.resolve _11 };
+    switch (_7)
+      | False -> goto BB15
+      | _ -> goto BB6
+      end
+  }
+  BB6 {
+    _13 <- p_2;
+    _18 <- Moves0.moves ();
+    goto BB7
+  }
+  BB7 {
+    _17 <- _18;
+    assume { Resolve0.resolve _19 };
+    _19 <- i_4;
+    _16 <- Index0.index _17 _19;
+    goto BB8
+  }
+  BB8 {
+    _15 <- _16;
+    assume { Resolve2.resolve _16 };
+    _14 <- _15;
+    assume { Resolve2.resolve _15 };
+    next_12 <- Mov0.mov _13 _14;
+    goto BB9
+  }
+  BB9 {
+    goto BB10
+  }
+  BB10 {
+    assume { Resolve1.resolve _18 };
+    _22 <- self_1;
+    assume { Resolve3.resolve _23 };
+    _23 <- next_12;
+    assume { Resolve3.resolve next_12 };
+    _21 <- Available0.available _22 _23;
+    goto BB11
+  }
+  BB11 {
+    switch (_21)
+      | False -> goto BB13
+      | _ -> goto BB12
+      end
+  }
+  BB12 {
+    count_3 <- count_3 + (1 : usize);
+    _20 <- ();
+    assume { Resolve4.resolve _20 };
+    goto BB14
+  }
+  BB13 {
+    _20 <- ();
+    assume { Resolve4.resolve _20 };
+    goto BB14
+  }
+  BB14 {
+    i_4 <- i_4 + (1 : usize);
+    _6 <- ();
+    assume { Resolve4.resolve _6 };
+    goto BB1
+  }
+  BB15 {
+    assume { Resolve5.resolve self_1 };
+    assume { Resolve3.resolve p_2 };
+    assume { Resolve0.resolve i_4 };
+    _5 <- ();
+    assume { Resolve4.resolve _5 };
+    assume { Resolve0.resolve _0 };
+    _0 <- count_3;
+    assume { Resolve0.resolve count_3 };
+    return _0
+  }
+  
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module Core_Ops_Index_IndexMut_IndexMut_Interface
+  type self   
+  type idx   
+  use prelude.Prelude
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index_mut (self : borrowed self) (index : idx) : borrowed Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Index_IndexMut_IndexMut
+  type self   
+  type idx   
+  use prelude.Prelude
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index_mut (self : borrowed self) (index : idx) : borrowed Output0.output
+    requires {false}
+    
+end
+module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
+    requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
+    ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = UInt64.to_int ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) (UInt64.to_int ix) }
+    ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl2_IndexMut
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
+    requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
+    ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
+    ensures { forall j : (int) . 0 <= j && j < Seq.length (Model0.model ( ^ self)) -> not (j = UInt64.to_int ix) -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures {  ^ result = Seq.get (Model0.model ( ^ self)) (UInt64.to_int ix) }
+    ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl2
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
+end
+module C06KnightsTour_Impl1_Set_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C06KnightsTour_Impl1_Wf_Interface as Wf0
+  clone C06KnightsTour_Impl1_InBounds_Interface as InBounds0
+  val set (self : borrowed (Type.c06knightstour_board)) (p : Type.c06knightstour_point) (v : usize) : ()
+    requires {InBounds0.in_bounds ( * self) p}
+    requires {Wf0.wf ( * self)}
+    ensures { Type.c06knightstour_board_Board_size ( ^ self) = Type.c06knightstour_board_Board_size ( * self) }
+    ensures { Wf0.wf ( ^ self) }
+    
+end
+module C06KnightsTour_Impl1_Set
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone C06KnightsTour_Impl1_InBounds as InBounds0
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
+  function Model0.model = Model1.model, function Model1.model = Model3.model
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model0.model, function Model1.model = Model2.model
+  let rec cfg set (self : borrowed (Type.c06knightstour_board)) (p : Type.c06knightstour_point) (v : usize) : ()
+    requires {InBounds0.in_bounds ( * self) p}
+    requires {Wf0.wf ( * self)}
+    ensures { Type.c06knightstour_board_Board_size ( ^ self) = Type.c06knightstour_board_Board_size ( * self) }
+    ensures { Wf0.wf ( ^ self) }
+    
+   = 
+  var _0 : ();
+  var self_1 : borrowed (Type.c06knightstour_board);
+  var p_2 : Type.c06knightstour_point;
+  var v_3 : usize;
+  var _4 : usize;
+  var _5 : borrowed usize;
+  var _6 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _7 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _8 : borrowed (Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize));
+  var _9 : usize;
+  var _10 : isize;
+  var _11 : usize;
+  var _12 : isize;
+  {
+    self_1 <- self;
+    p_2 <- p;
+    v_3 <- v;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _4 };
+    _4 <- v_3;
+    assume { Resolve0.resolve v_3 };
+    _8 <- borrow_mut (Type.c06knightstour_board_Board_field ( * self_1));
+    self_1 <- { self_1 with current = (let Type.C06KnightsTour_Board a b =  * self_1 in Type.C06KnightsTour_Board a ( ^ _8)) };
+    assume { Resolve1.resolve self_1 };
+    assume { Resolve2.resolve _10 };
+    _10 <- Type.c06knightstour_point_Point_x p_2;
+    _9 <- UInt64.of_int (Int64.to_int _10);
+    _7 <- IndexMut0.index_mut _8 _9;
+    goto BB1
+  }
+  BB1 {
+    _6 <- borrow_mut ( * _7);
+    _7 <- { _7 with current = ( ^ _6) };
+    assume { Resolve3.resolve _7 };
+    assume { Resolve2.resolve _12 };
+    _12 <- Type.c06knightstour_point_Point_y p_2;
+    assume { Resolve4.resolve p_2 };
+    _11 <- UInt64.of_int (Int64.to_int _12);
+    _5 <- IndexMut1.index_mut _6 _11;
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve ( * _5) };
+    _5 <- { _5 with current = _4 };
+    assume { Resolve5.resolve _5 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C06KnightsTour_DumbNonlinearArith_Interface
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  function dumb_nonlinear_arith (a : usize) : ()
+end
+module C06KnightsTour_DumbNonlinearArith
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  function dumb_nonlinear_arith (a : usize) : () = 
+    ()
+  axiom dumb_nonlinear_arith_spec : forall a : usize . UInt64.to_int a <= 1000 -> UInt64.to_int a * UInt64.to_int a <= 1000000
+end
+module C06KnightsTour_DumbNonlinearArith_Impl
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  let rec ghost function dumb_nonlinear_arith (a : usize) : ()
+    requires {UInt64.to_int a <= 1000}
+    ensures { UInt64.to_int a * UInt64.to_int a <= 1000000 }
+    
+   = 
+    ()
+end
+module CreusotContracts_Std1_Vec_Impl1_New_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val new () : Type.creusotcontracts_std1_vec_vec t
+    ensures { Seq.length (Model0.model result) = 0 }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_New
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val new () : Type.creusotcontracts_std1_vec_vec t
+    ensures { Seq.length (Model0.model result) = 0 }
+    
+end
+module C06KnightsTour_KnightsTour_Interface
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  use mach.int.Int32
+  use Type
+  val knights_tour (size : usize) (x : usize) (y : usize) : Type.core_option_option (Type.c06knightstour_board)
+    requires {y < size}
+    requires {x < size}
+    requires {0 < UInt64.to_int size && UInt64.to_int size <= 1000}
+    
+end
+module C06KnightsTour_KnightsTour
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  use mach.int.Int32
+  use Type
+  clone C06KnightsTour_Impl1_InBounds as InBounds0
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone C06KnightsTour_DumbNonlinearArith as DumbNonlinearArith0 with axiom .
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve8 with type self = Type.core_option_option (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = Type.c06knightstour_board
+  clone C06KnightsTour_Min_Interface as Min0
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = (usize, Type.c06knightstour_point)
+  clone C06KnightsTour_Impl0_Mov_Interface as Mov0
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.creusotcontracts_std1_vec_vec (isize, isize)
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = (isize, isize)
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model4 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = (isize, isize),
+  function Model0.model = Model4.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
+  function Model0.model = Model4.model
+  clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model5 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
+  type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model2.model, function Model1.model = Model5.model
+  clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New1 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone C06KnightsTour_Impl1_CountDegree_Interface as CountDegree0 with predicate InBounds0.in_bounds = InBounds0.in_bounds,
+  predicate Wf0.wf = Wf0.wf
+  clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,
+  predicate InBounds0.in_bounds = InBounds0.in_bounds
+  clone C06KnightsTour_Impl1_Set_Interface as Set0 with predicate InBounds0.in_bounds = InBounds0.in_bounds,
+  predicate Wf0.wf = Wf0.wf
+  clone C06KnightsTour_Impl1_New_Interface as New0 with predicate Wf0.wf = Wf0.wf
+  let rec cfg knights_tour (size : usize) (x : usize) (y : usize) : Type.core_option_option (Type.c06knightstour_board)
+    requires {y < size}
+    requires {x < size}
+    requires {0 < UInt64.to_int size && UInt64.to_int size <= 1000}
+    
+   = 
+  var _0 : Type.core_option_option (Type.c06knightstour_board);
+  var size_1 : usize;
+  var x_2 : usize;
+  var y_3 : usize;
+  var board_4 : Type.c06knightstour_board;
+  var _5 : usize;
+  var p_6 : Type.c06knightstour_point;
+  var _7 : isize;
+  var _8 : usize;
+  var _9 : isize;
+  var _10 : usize;
+  var step_11 : usize;
+  var _12 : ();
+  var _13 : borrowed (Type.c06knightstour_board);
+  var _14 : Type.c06knightstour_point;
+  var _15 : usize;
+  var _16 : ();
+  var _17 : ();
+  var _18 : ();
+  var _19 : bool;
+  var _20 : usize;
+  var _21 : usize;
+  var _22 : usize;
+  var _23 : usize;
+  var candidates_24 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var i_25 : usize;
+  var _26 : ();
+  var _27 : bool;
+  var _28 : usize;
+  var _29 : usize;
+  var _30 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _31 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _32 : ();
+  var adj_33 : Type.c06knightstour_point;
+  var _34 : Type.c06knightstour_point;
+  var _35 : (isize, isize);
+  var _36 : (isize, isize);
+  var _37 : (isize, isize);
+  var _38 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _39 : Type.creusotcontracts_std1_vec_vec (isize, isize);
+  var _40 : usize;
+  var _41 : bool;
+  var _42 : Type.c06knightstour_board;
+  var _43 : Type.c06knightstour_point;
+  var degree_44 : usize;
+  var _45 : Type.c06knightstour_board;
+  var _46 : Type.c06knightstour_point;
+  var _47 : ();
+  var _48 : borrowed (Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point));
+  var _49 : (usize, Type.c06knightstour_point);
+  var _50 : usize;
+  var _51 : Type.c06knightstour_point;
+  var _52 : ();
+  var _53 : ();
+  var _54 : ();
+  var _55 : ();
+  var _56 : Type.core_option_option (usize, Type.c06knightstour_point);
+  var _57 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _58 : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point);
+  var _59 : isize;
+  var adj_60 : Type.c06knightstour_point;
+  var _61 : Type.c06knightstour_point;
+  var _62 : ();
+  var _63 : ();
+  var _64 : borrowed (Type.c06knightstour_board);
+  var _65 : Type.c06knightstour_point;
+  var _66 : usize;
+  var _67 : ();
+  var _68 : ();
+  var _69 : ();
+  var _70 : Type.c06knightstour_board;
+  {
+    size_1 <- size;
+    x_2 <- x;
+    y_3 <- y;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _5 };
+    _5 <- size_1;
+    board_4 <- New0.new _5;
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve0.resolve _8 };
+    _8 <- x_2;
+    assume { Resolve0.resolve x_2 };
+    _7 <- Int64.of_int (UInt64.to_int _8);
+    assume { Resolve0.resolve _10 };
+    _10 <- y_3;
+    assume { Resolve0.resolve y_3 };
+    _9 <- Int64.of_int (UInt64.to_int _10);
+    p_6 <- Type.C06KnightsTour_Point _7 _9;
+    step_11 <- (1 : usize);
+    _13 <- borrow_mut board_4;
+    board_4 <-  ^ _13;
+    assume { Resolve1.resolve _14 };
+    _14 <- p_6;
+    assume { Resolve0.resolve _15 };
+    _15 <- step_11;
+    _12 <- Set0.set _13 _14 _15;
+    goto BB2
+  }
+  BB2 {
+    step_11 <- step_11 + (1 : usize);
+    assert { let _ = DumbNonlinearArith0.dumb_nonlinear_arith size_1 in true };
+    _16 <- ();
+    assume { Resolve2.resolve _16 };
+    goto BB3
+  }
+  BB3 {
+    goto BB4
+  }
+  BB4 {
+    goto BB5
+  }
+  BB5 {
+    invariant b { Type.c06knightstour_board_Board_size board_4 = size_1 };
+    invariant b { Wf0.wf board_4 };
+    invariant p { InBounds0.in_bounds board_4 p_6 };
+    goto BB6
+  }
+  BB6 {
+    assume { Resolve0.resolve _20 };
+    _20 <- step_11;
+    assume { Resolve0.resolve _22 };
+    _22 <- size_1;
+    assume { Resolve0.resolve _23 };
+    _23 <- size_1;
+    _21 <- _22 * _23;
+    _19 <- _20 <= _21;
+    switch (_19)
+      | False -> goto BB34
+      | _ -> goto BB7
+      end
+  }
+  BB7 {
+    candidates_24 <- New1.new ();
+    goto BB8
+  }
+  BB8 {
+    i_25 <- (0 : usize);
+    goto BB9
+  }
+  BB9 {
+    goto BB10
+  }
+  BB10 {
+    assume { Resolve0.resolve _28 };
+    _28 <- i_25;
+    _31 <- Moves0.moves ();
+    goto BB11
+  }
+  BB11 {
+    _30 <- _31;
+    _29 <- Len0.len _30;
+    goto BB12
+  }
+  BB12 {
+    _27 <- _28 < _29;
+    goto BB13
+  }
+  BB13 {
+    assume { Resolve3.resolve _31 };
+    switch (_27)
+      | False -> goto BB26
+      | _ -> goto BB14
+      end
+  }
+  BB14 {
+    assert { InBounds0.in_bounds board_4 p_6 };
+    goto BB15
+  }
+  BB15 {
+    _32 <- ();
+    assume { Resolve2.resolve _32 };
+    _34 <- p_6;
+    _39 <- Moves0.moves ();
+    goto BB16
+  }
+  BB16 {
+    _38 <- _39;
+    assume { Resolve0.resolve _40 };
+    _40 <- i_25;
+    _37 <- Index0.index _38 _40;
+    goto BB17
+  }
+  BB17 {
+    _36 <- _37;
+    assume { Resolve4.resolve _37 };
+    _35 <- _36;
+    assume { Resolve4.resolve _36 };
+    adj_33 <- Mov0.mov _34 _35;
+    goto BB18
+  }
+  BB18 {
+    goto BB19
+  }
+  BB19 {
+    assume { Resolve3.resolve _39 };
+    _42 <- board_4;
+    assume { Resolve1.resolve _43 };
+    _43 <- adj_33;
+    _41 <- Available0.available _42 _43;
+    goto BB20
+  }
+  BB20 {
+    switch (_41)
+      | False -> goto BB24
+      | _ -> goto BB21
+      end
+  }
+  BB21 {
+    _45 <- board_4;
+    assume { Resolve1.resolve _46 };
+    _46 <- adj_33;
+    degree_44 <- CountDegree0.count_degree _45 _46;
+    goto BB22
+  }
+  BB22 {
+    _48 <- borrow_mut candidates_24;
+    candidates_24 <-  ^ _48;
+    assume { Resolve0.resolve _50 };
+    _50 <- degree_44;
+    assume { Resolve0.resolve degree_44 };
+    assume { Resolve1.resolve _51 };
+    _51 <- adj_33;
+    assume { Resolve1.resolve adj_33 };
+    _49 <- (_50, _51);
+    _47 <- Push0.push _48 _49;
+    goto BB23
+  }
+  BB23 {
+    _18 <- ();
+    assume { Resolve2.resolve _18 };
+    goto BB25
+  }
+  BB24 {
+    assume { Resolve1.resolve adj_33 };
+    _18 <- ();
+    assume { Resolve2.resolve _18 };
+    goto BB25
+  }
+  BB25 {
+    goto BB9
+  }
+  BB26 {
+    assume { Resolve1.resolve p_6 };
+    assume { Resolve0.resolve i_25 };
+    _26 <- ();
+    assume { Resolve2.resolve _26 };
+    _58 <- candidates_24;
+    _57 <- _58;
+    assume { Resolve5.resolve _58 };
+    _56 <- Min0.min _57;
+    goto BB27
+  }
+  BB27 {
+    switch (_56)
+      | Type.Core_Option_Option_None -> goto BB28
+      | Type.Core_Option_Option_Some _ -> goto BB29
+      end
+  }
+  BB28 {
+    assume { Resolve0.resolve size_1 };
+    assume { Resolve0.resolve step_11 };
+    assume { Resolve8.resolve _56 };
+    _0 <- Type.Core_Option_Option_None;
+    goto BB37
+  }
+  BB29 {
+    goto BB31
+  }
+  BB30 {
+    assume { Resolve0.resolve size_1 };
+    assume { Resolve6.resolve board_4 };
+    assume { Resolve0.resolve step_11 };
+    assume { Resolve7.resolve candidates_24 };
+    assume { Resolve8.resolve _56 };
+    absurd
+  }
+  BB31 {
+    assume { Resolve1.resolve adj_60 };
+    adj_60 <- (let (_, a) = Type.core_option_option_Some_0 _56 in a);
+    assume { Resolve8.resolve _56 };
+    assume { Resolve1.resolve _61 };
+    _61 <- adj_60;
+    assume { Resolve1.resolve adj_60 };
+    assume { Resolve1.resolve p_6 };
+    p_6 <- _61;
+    _55 <- ();
+    assume { Resolve2.resolve _55 };
+    _64 <- borrow_mut board_4;
+    board_4 <-  ^ _64;
+    assume { Resolve1.resolve _65 };
+    _65 <- p_6;
+    assume { Resolve0.resolve _66 };
+    _66 <- step_11;
+    _63 <- Set0.set _64 _65 _66;
+    goto BB32
+  }
+  BB32 {
+    step_11 <- step_11 + (1 : usize);
+    _18 <- ();
+    assume { Resolve2.resolve _18 };
+    goto BB33
+  }
+  BB33 {
+    assume { Resolve7.resolve candidates_24 };
+    goto BB5
+  }
+  BB34 {
+    assume { Resolve0.resolve size_1 };
+    assume { Resolve1.resolve p_6 };
+    assume { Resolve0.resolve step_11 };
+    _17 <- ();
+    assume { Resolve2.resolve _17 };
+    assume { Resolve6.resolve _70 };
+    _70 <- board_4;
+    _0 <- Type.Core_Option_Option_Some _70;
+    goto BB35
+  }
+  BB35 {
+    goto BB36
+  }
+  BB36 {
+    goto BB39
+  }
+  BB37 {
+    assume { Resolve7.resolve candidates_24 };
+    goto BB38
+  }
+  BB38 {
+    assume { Resolve6.resolve board_4 };
+    goto BB39
+  }
+  BB39 {
+    return _0
+  }
+  
+end
+module C06KnightsTour_Impl2
+  
+end


### PR DESCRIPTION
Proves the (complete) safety of the Knight's tour, improving on Prusti's version by not axiomitizing the board access / setting and other auxiliary definitions.

There's currently one remaining goal which is driving me mad: proving that `i * i` doesn't overflow for unsigned 64 bit integers less than 1000! 
