### PR TITLE
Fix unsoundness of 2-phase borrows, properly

### DIFF
--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -4,19 +4,20 @@
 #![register_tool(creusot)]
 
 extern crate rustc_ast;
+extern crate rustc_borrowck;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_index;
+extern crate rustc_infer;
 extern crate rustc_interface;
 extern crate rustc_macros;
 extern crate rustc_metadata;
 extern crate rustc_middle;
+extern crate rustc_mir_build;
 extern crate rustc_mir_dataflow;
 extern crate rustc_mir_transform;
-// extern   crate rustc_mir;
-extern crate rustc_mir_build;
 extern crate rustc_resolve;
 extern crate rustc_serialize;
 extern crate rustc_session;

--- a/creusot/src/resolve.rs
+++ b/creusot/src/resolve.rs
@@ -1,7 +1,10 @@
+use std::rc::Rc;
+
 use crate::analysis::uninit_locals::MaybeUninitializedLocals;
+use rustc_borrowck::borrow_set::{BorrowSet, TwoPhaseActivation};
 use rustc_index::bit_set::BitSet;
 use rustc_middle::{
-    mir::{Body, Local},
+    mir::{BasicBlock, Body, Local, Location},
     ty::TyCtxt,
 };
 use rustc_mir_dataflow::{
@@ -22,10 +25,14 @@ pub struct EagerResolver<'body, 'tcx> {
 
     // Locals that are never read
     never_live: BitSet<Local>,
+
+    body: &'body Body<'tcx>,
+
+    borrows: Rc<BorrowSet<'tcx>>,
 }
 
 impl<'body, 'tcx> EagerResolver<'body, 'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, body: &'body Body<'tcx>) -> Self {
+    pub fn new(tcx: TyCtxt<'tcx>, body: &'body Body<'tcx>, borrows: Rc<BorrowSet<'tcx>>) -> Self {
         let local_init = MaybeInitializedLocals
             .into_engine(tcx, body)
             .iterate_to_fixpoint()
@@ -41,13 +48,74 @@ impl<'body, 'tcx> EagerResolver<'body, 'tcx> {
         let local_live =
             MaybeLiveLocals.into_engine(tcx, body).iterate_to_fixpoint().into_results_cursor(body);
         let never_live = crate::analysis::NeverLive::for_body(body);
-        EagerResolver { local_live, local_init, local_uninit, never_live }
+        EagerResolver { local_live, local_init, local_uninit, never_live, body, borrows }
     }
 
-    pub fn locals_resolved_between(
+    fn unactivated_borrows(&self, loc: Location) -> BitSet<Local> {
+        let dom = self.body.dominators();
+
+        let mut bits = BitSet::new_empty(self.body.local_decls.len());
+
+        self.borrows
+            .location_map
+            .iter()
+            .filter(|(_, bd)| {
+                let res_loc = bd.reserve_location;
+                if res_loc.block == loc.block {
+                    res_loc.statement_index <= loc.statement_index
+                } else {
+                    dom.is_dominated_by(loc.block, res_loc.block)
+                }
+            })
+            .filter(|(_, bd)| {
+                if let TwoPhaseActivation::ActivatedAt(act_loc) = bd.activation_location {
+                    if act_loc.block == loc.block {
+                        loc.statement_index <= act_loc.statement_index
+                    } else {
+                        dom.is_dominated_by(act_loc.block, loc.block)
+                    }
+                } else {
+                    false
+                }
+            })
+            .for_each(|(_, bd)| {
+                bits.insert(bd.borrowed_place.local);
+            });
+
+        bits
+    }
+
+    pub fn locals_resolved_at_loc(&mut self, loc: Location) -> BitSet<Local> {
+        self.locals_resolved_between(
+            ExtendedLocation::Start(loc),
+            ExtendedLocation::Mid(loc),
+            loc,
+            loc.successor_within_block(),
+        )
+    }
+
+    pub fn locals_resolved_between_blocks(
+        &mut self,
+        from: BasicBlock,
+        to: BasicBlock,
+    ) -> BitSet<Local> {
+        let term = self.body.terminator_loc(from);
+        let start = to.start_location();
+
+        self.locals_resolved_between(
+            ExtendedLocation::Start(term),
+            ExtendedLocation::Start(start),
+            term,
+            start,
+        )
+    }
+
+    fn locals_resolved_between(
         &mut self,
         start: ExtendedLocation,
         end: ExtendedLocation,
+        two_phase_start: Location,
+        two_phase_end: Location,
     ) -> BitSet<Local> {
         start.seek_to(&mut self.local_live);
         let mut live_at_start = self.local_live.get().clone();
@@ -56,8 +124,11 @@ impl<'body, 'tcx> EagerResolver<'body, 'tcx> {
             live_at_start.union(&self.never_live);
         }
 
+        live_at_start.union(&self.unactivated_borrows(two_phase_start));
+
         end.seek_to(&mut self.local_live);
-        let live_at_end = self.local_live.get();
+        let mut live_at_end = self.local_live.get().clone();
+        live_at_end.union(&self.unactivated_borrows(two_phase_end));
 
         start.seek_to(&mut self.local_init);
         let init_at_start = self.local_init.get().clone();
@@ -100,17 +171,19 @@ impl<'body, 'tcx> EagerResolver<'body, 'tcx> {
 
         // Locals that were initialized but never live
         let mut zombies = just_init.clone();
-        zombies.subtract(live_at_end);
+        zombies.subtract(&live_at_end);
         trace!("zombies: {:?}", zombies);
 
         let mut dying = live_at_start;
 
         // Variables that died in the span
-        dying.subtract(live_at_end);
+        dying.subtract(&live_at_end);
         // And were initialized
         let mut init = def_init_at_start;
         init.intersect(&def_init_at_end);
         dying.intersect(&init);
+
+        // dying.subtract(&unactivated);
 
         let same_point = start.same_block(end);
         trace!("same_block: {:?}", same_point);

--- a/creusot/src/rustc_extensions.rs
+++ b/creusot/src/rustc_extensions.rs
@@ -1,1 +1,2 @@
 pub mod codegen;
+pub mod renumber;

--- a/creusot/src/rustc_extensions/renumber.rs
+++ b/creusot/src/rustc_extensions/renumber.rs
@@ -1,0 +1,87 @@
+use rustc_index::vec::IndexVec;
+use rustc_middle::mir::visit::{MutVisitor, TyContext};
+use rustc_middle::mir::{Body, Location, PlaceElem, Promoted};
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable};
+use rustc_trait_selection::infer::InferCtxt;
+use rustc_trait_selection::infer::NllRegionVariableOrigin;
+
+/// Replaces all free regions appearing in the MIR with fresh
+/// inference variables, returning the number of variables created.
+pub fn renumber_mir<'tcx>(
+    infcx: &InferCtxt<'_, 'tcx>,
+    body: &mut Body<'tcx>,
+    promoted: &mut IndexVec<Promoted, Body<'tcx>>,
+) {
+    let mut visitor = NllVisitor { infcx };
+
+    for body in promoted.iter_mut() {
+        visitor.visit_body(body);
+    }
+
+    visitor.visit_body(body);
+}
+
+/// Replaces all regions appearing in `value` with fresh inference
+/// variables.
+pub fn renumber_regions<'tcx, T>(infcx: &InferCtxt<'_, 'tcx>, value: T) -> T
+where
+    T: TypeFoldable<'tcx>,
+{
+    infcx.tcx.fold_regions(value, &mut false, |_region, _depth| {
+        let origin = NllRegionVariableOrigin::Existential { from_forall: false };
+        infcx.next_nll_region_var(origin)
+    })
+}
+
+struct NllVisitor<'a, 'tcx> {
+    infcx: &'a InferCtxt<'a, 'tcx>,
+}
+
+impl<'a, 'tcx> NllVisitor<'a, 'tcx> {
+    fn renumber_regions<T>(&mut self, value: T) -> T
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        renumber_regions(self.infcx, value)
+    }
+}
+
+impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.infcx.tcx
+    }
+
+    fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _ty_context: TyContext) {
+        *ty = self.renumber_regions(ty);
+    }
+
+    fn process_projection_elem(
+        &mut self,
+        elem: PlaceElem<'tcx>,
+        _: Location,
+    ) -> Option<PlaceElem<'tcx>> {
+        if let PlaceElem::Field(field, ty) = elem {
+            let new_ty = self.renumber_regions(ty);
+
+            if new_ty != ty {
+                return Some(PlaceElem::Field(field, new_ty));
+            }
+        }
+
+        None
+    }
+
+    fn visit_substs(&mut self, substs: &mut SubstsRef<'tcx>, _location: Location) {
+        *substs = self.renumber_regions(*substs);
+    }
+
+    fn visit_region(&mut self, region: &mut ty::Region<'tcx>, _location: Location) {
+        let old_region = *region;
+        *region = self.renumber_regions(&old_region);
+    }
+
+    fn visit_const(&mut self, constant: &mut &'tcx ty::Const<'tcx>, _location: Location) {
+        *constant = self.renumber_regions(&*constant);
+    }
+}

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -1,25 +1,28 @@
 use crate::{
-    extended_location::*,
     gather_spec_closures::GatherSpecClosures,
+    rustc_extensions::renumber,
     util::{self, signature_of},
 };
+use rustc_borrowck::borrow_set::BorrowSet;
 use rustc_hir::def_id::DefId;
 use rustc_index::bit_set::BitSet;
+use rustc_infer::infer::TyCtxtInferExt;
+use rustc_middle::mir::Place;
+use rustc_middle::ty::subst::GenericArg;
+use rustc_middle::ty::Ty;
+use rustc_middle::ty::{GenericParamDef, GenericParamDefKind};
 use rustc_middle::{
     mir::traversal::preorder,
     mir::{visit::MutVisitor, BasicBlock, Body, Local, Location, Operand, VarDebugInfo},
     ty::TyCtxt,
     ty::{TyKind, WithOptConstParam},
 };
+use rustc_mir_dataflow::move_paths::MoveData;
+use rustc_span::Symbol;
 use std::collections::{BTreeMap, HashMap};
+use std::rc::Rc;
 use why3::declaration::*;
 use why3::mlcfg::{self, Statement::*, *};
-
-use rustc_middle::mir::Place;
-use rustc_middle::ty::subst::GenericArg;
-use rustc_middle::ty::Ty;
-use rustc_middle::ty::{GenericParamDef, GenericParamDefKind};
-use rustc_span::Symbol;
 
 use indexmap::IndexMap;
 
@@ -112,6 +115,7 @@ pub struct FunctionTranslator<'body, 'sess, 'tcx> {
     invariants: IndexMap<BasicBlock, Vec<(Symbol, Exp)>>,
 
     assertions: IndexMap<DefId, Exp>,
+    borrows: Rc<BorrowSet<'tcx>>,
 }
 
 impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
@@ -134,8 +138,16 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             }
         });
 
+        let mut clean_body = body.clone();
+
+        tcx.infer_ctxt().enter(|infcx| {
+            renumber::renumber_mir(&infcx, &mut clean_body, &mut Default::default());
+        });
+        let move_paths = MoveData::gather_moves(&clean_body, tcx, tcx.param_env(def_id)).unwrap();
+        let borrows = BorrowSet::build(tcx, &clean_body, true, &move_paths);
         let local_map = real_locals(tcx, body);
-        let resolver = EagerResolver::new(tcx, body);
+        let borrows = Rc::new(borrows);
+        let resolver = EagerResolver::new(tcx, body, borrows.clone());
 
         FunctionTranslator {
             tcx,
@@ -151,6 +163,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             invariants,
             assertions,
             local_map,
+            borrows,
         }
     }
 
@@ -215,7 +228,7 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
             let mut loc = bb.start_location();
 
             for statement in &bbd.statements {
-                self.translate_statement(statement);
+                self.translate_statement(statement, loc);
                 self.freeze_borrows_dying_at(loc);
                 loc = loc.successor_within_block();
             }
@@ -305,43 +318,36 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
 
     // Inserts drop statements for variables which died over the course of a goto or switch
     fn freeze_locals_between_blocks(&mut self, bb: BasicBlock) {
-        use ExtendedLocation::*;
-
         let pred_blocks = &self.body.predecessors()[bb];
 
         if pred_blocks.is_empty() {
             return;
         }
 
-        let term_loc = self.body.terminator_loc(pred_blocks[0]);
-        let dying_in_first =
-            self.resolver.locals_resolved_between(Start(term_loc), Start(bb.start_location()));
+        let dying_in_first = self.resolver.locals_resolved_between_blocks(pred_blocks[0], bb);
         let mut same_deaths = true;
 
         // If we have multiple predecessors (join point) but all of them agree on the deaths, then don't introduce a dedicated block.
         for pred in pred_blocks {
-            let term_loc = self.body.terminator_loc(*pred);
-            let dying =
-                self.resolver.locals_resolved_between(Start(term_loc), Start(bb.start_location()));
+            let dying = self.resolver.locals_resolved_between_blocks(*pred, bb);
             same_deaths = same_deaths && dying_in_first == dying
         }
 
         if same_deaths {
-            self.freeze_borrows_dying_between(Start(term_loc), Start(bb.start_location()));
+            let dying = self.resolver.locals_resolved_between_blocks(pred_blocks[0], bb);
+            self.freeze_locals(dying);
             return;
         }
 
         for pred in pred_blocks {
-            let term_loc = self.body.terminator_loc(*pred);
-            let dying =
-                self.resolver.locals_resolved_between(Start(term_loc), Start(bb.start_location()));
+            let dying = self.resolver.locals_resolved_between_blocks(*pred, bb);
 
             // If no deaths occured in block transition then skip entirely
             if dying.is_empty() {
                 continue;
             };
 
-            self.freeze_borrows_dying_between(Start(term_loc), Start(bb.start_location()));
+            self.freeze_locals(dying);
             let deaths = std::mem::take(&mut self.current_block.0);
 
             let drop_block = self.fresh_block_id();
@@ -367,12 +373,11 @@ impl<'body, 'sess, 'tcx> FunctionTranslator<'body, 'sess, 'tcx> {
     }
 
     fn freeze_borrows_dying_at(&mut self, loc: Location) {
-        use ExtendedLocation::*;
-        self.freeze_borrows_dying_between(Start(loc), Mid(loc));
+        let dying = self.resolver.locals_resolved_at_loc(loc);
+        self.freeze_locals(dying);
     }
 
-    fn freeze_borrows_dying_between(&mut self, start: ExtendedLocation, end: ExtendedLocation) {
-        let mut dying = self.resolver.locals_resolved_between(start, end);
+    fn freeze_locals(&mut self, mut dying: BitSet<Local>) {
         dying.subtract(&self.erased_locals);
 
         for local in dying.iter() {

--- a/creusot/tests/should_succeed/bug/two_phase.rs
+++ b/creusot/tests/should_succeed/bug/two_phase.rs
@@ -1,0 +1,10 @@
+// WHY3PROVE Z3
+extern crate creusot_contracts;
+
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+#[ensures(@(@^v)[(@v).len()] === (@v).len())]
+fn test(v: &mut Vec<usize>) {
+    v.push(v.len());
+}

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -1,0 +1,281 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type core_marker_phantomdata 't = 
+    | Core_Marker_PhantomData
+    
+  type core_ptr_unique_unique 't = 
+    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
+    
+  type alloc_rawvec_rawvec 't 'a = 
+    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
+    
+  type alloc_vec_vec 't 'a = 
+    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
+    
+  type alloc_alloc_global  = 
+    | Alloc_Alloc_Global
+    
+  type creusotcontracts_std1_vec_vec 't = 
+    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
+    
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelty   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelty
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelty  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelty = ModelTy0.modelty, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelty = ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelty  = 
+    ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : borrowed t) : ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  function model (self : borrowed t) : ModelTy0.modelty = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelty = ModelTy2.modelty
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelty = ModelTy2.modelty,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelty = ModelTy2.modelty
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
+  type ModelTy0.modelty = ModelTy0.modelty, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelty = ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelty  = 
+    ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl0_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : t) : ModelTy0.modelty
+end
+module CreusotContracts_Logic_Model_Impl0_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  function model (self : t) : ModelTy0.modelty = 
+    Model0.model self
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelty = ModelTy2.modelty
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelty = ModelTy2.modelty,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelty = ModelTy2.modelty
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelty = ModelTy0.modelty,
+  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelty = ModelTy0.modelty
+end
+module CreusotContracts_Std1_Vec_Impl1_Len_Interface
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Len
+  type t   
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
+    ensures { UInt64.to_int result = Seq.length (Model0.model self) }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelty = ModelTy0.modelty
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module TwoPhase_Test_Interface
+  use seq.Seq
+  use mach.int.UInt64
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = usize
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type ModelTy0.modelty = ModelTy0.modelty
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = usize
+  val test (v : borrowed (Type.creusotcontracts_std1_vec_vec usize)) : ()
+    ensures { UInt64.to_int (Seq.get (Model0.model ( ^ v)) (Seq.length (Model1.model v))) = Seq.length (Model1.model v) }
+    
+end
+module TwoPhase_Test
+  use seq.Seq
+  use mach.int.UInt64
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = usize
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type ModelTy0.modelty = ModelTy0.modelty, function Model0.model = Model0.model
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  type ModelTy0.modelty = ModelTy0.modelty, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = usize, function Model0.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = usize,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  let rec cfg test (v : borrowed (Type.creusotcontracts_std1_vec_vec usize)) : ()
+    ensures { UInt64.to_int (Seq.get (Model0.model ( ^ v)) (Seq.length (Model1.model v))) = Seq.length (Model1.model v) }
+    
+   = 
+  var _0 : ();
+  var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _2 : ();
+  var _3 : borrowed (Type.creusotcontracts_std1_vec_vec usize);
+  var _4 : usize;
+  var _5 : Type.creusotcontracts_std1_vec_vec usize;
+  {
+    v_1 <- v;
+    goto BB0
+  }
+  BB0 {
+    _3 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _3) };
+    _5 <-  * _3;
+    _4 <- Len0.len _5;
+    goto BB1
+  }
+  BB1 {
+    _2 <- Push0.push _3 _4;
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve v_1 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/inc_max.rs
+++ b/creusot/tests/should_succeed/inc_max.rs
@@ -1,3 +1,4 @@
+// WHY3PROVE Z3
 extern crate creusot_contracts;
 use creusot_contracts::*;
 

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -120,8 +120,8 @@ module IncMax_IncMax
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone IncMax_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
+  clone IncMax_TakeMax_Interface as TakeMax0
   let rec cfg inc_max (a : uint32) (b : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32)}
     
@@ -150,16 +150,16 @@ module IncMax_IncMax
     a_1 <-  ^ _5;
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve0.resolve _5 };
     _7 <- borrow_mut b_2;
     b_2 <-  ^ _7;
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
-    assume { Resolve0.resolve _7 };
     mc_3 <- TakeMax0.take_max _4 _6;
     goto BB1
   }
   BB1 {
+    assume { Resolve0.resolve _5 };
+    assume { Resolve0.resolve _7 };
     mc_3 <- { mc_3 with current = ( * mc_3 + (1 : uint32)) };
     assume { Resolve0.resolve mc_3 };
     assume { Resolve1.resolve _11 };

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -67,8 +67,8 @@ module IncMax3_IncMax3
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone IncMax3_Swap_Interface as Swap0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = borrowed uint32
+  clone IncMax3_Swap_Interface as Swap0
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
   let rec cfg inc_max_3 (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
@@ -128,16 +128,16 @@ module IncMax3_IncMax3
     ma_1 <-  ^ _10;
     _9 <- borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _9) };
-    assume { Resolve1.resolve _10 };
     _12 <- borrow_mut mb_2;
     mb_2 <-  ^ _12;
     _11 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _11) };
-    assume { Resolve1.resolve _12 };
     _8 <- Swap0.swap _9 _11;
     goto BB2
   }
   BB2 {
+    assume { Resolve1.resolve _10 };
+    assume { Resolve1.resolve _12 };
     _4 <- ();
     assume { Resolve2.resolve _4 };
     goto BB4
@@ -163,17 +163,17 @@ module IncMax3_IncMax3
     mb_2 <-  ^ _19;
     _18 <- borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
-    assume { Resolve1.resolve _19 };
     _21 <- borrow_mut mc_3;
     mc_3 <-  ^ _21;
     assume { Resolve3.resolve mc_3 };
     _20 <- borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
-    assume { Resolve1.resolve _21 };
     _17 <- Swap0.swap _18 _20;
     goto BB6
   }
   BB6 {
+    assume { Resolve1.resolve _19 };
+    assume { Resolve1.resolve _21 };
     _13 <- ();
     assume { Resolve2.resolve _13 };
     goto BB8
@@ -200,16 +200,16 @@ module IncMax3_IncMax3
     ma_1 <-  ^ _28;
     _27 <- borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _27) };
-    assume { Resolve1.resolve _28 };
     _30 <- borrow_mut mb_2;
     mb_2 <-  ^ _30;
     _29 <- borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
-    assume { Resolve1.resolve _30 };
     _26 <- Swap0.swap _27 _29;
     goto BB10
   }
   BB10 {
+    assume { Resolve1.resolve _28 };
+    assume { Resolve1.resolve _30 };
     _22 <- ();
     assume { Resolve2.resolve _22 };
     goto BB12
@@ -243,8 +243,8 @@ module IncMax3_TestIncMax3
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone IncMax3_IncMax3_Interface as IncMax30
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
+  clone IncMax3_IncMax3_Interface as IncMax30
   let rec cfg test_inc_max_3 (a : uint32) (b : uint32) (c : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && c <= (1000000 : uint32)}
     
@@ -285,21 +285,21 @@ module IncMax3_TestIncMax3
     a_1 <-  ^ _6;
     _5 <- borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
-    assume { Resolve0.resolve _6 };
     _8 <- borrow_mut b_2;
     b_2 <-  ^ _8;
     _7 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
-    assume { Resolve0.resolve _8 };
     _10 <- borrow_mut c_3;
     c_3 <-  ^ _10;
     _9 <- borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _9) };
-    assume { Resolve0.resolve _10 };
     _4 <- IncMax30.inc_max_3 _5 _7 _9;
     goto BB1
   }
   BB1 {
+    assume { Resolve0.resolve _6 };
+    assume { Resolve0.resolve _8 };
+    assume { Resolve0.resolve _10 };
     assume { Resolve1.resolve _16 };
     _16 <- a_1;
     assume { Resolve1.resolve _17 };

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -121,8 +121,8 @@ module IncMaxMany_IncMaxMany
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone IncMaxMany_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
+  clone IncMaxMany_TakeMax_Interface as TakeMax0
   let rec cfg inc_max_many (a : uint32) (b : uint32) (k : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && k <= (1000000 : uint32)}
     
@@ -162,16 +162,16 @@ module IncMaxMany_IncMaxMany
     a_1 <-  ^ _6;
     _5 <- borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
-    assume { Resolve0.resolve _6 };
     _8 <- borrow_mut b_2;
     b_2 <-  ^ _8;
     _7 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
-    assume { Resolve0.resolve _8 };
     mc_4 <- TakeMax0.take_max _5 _7;
     goto BB1
   }
   BB1 {
+    assume { Resolve0.resolve _6 };
+    assume { Resolve0.resolve _8 };
     assume { Resolve1.resolve _9 };
     _9 <- k_3;
     mc_4 <- { mc_4 with current = ( * mc_4 + _9) };

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -120,8 +120,8 @@ module IncMaxRepeat_IncMaxRepeat
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone IncMaxRepeat_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
+  clone IncMaxRepeat_TakeMax_Interface as TakeMax0
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
   let rec cfg inc_max_repeat (a : uint32) (b : uint32) (n : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
@@ -191,16 +191,16 @@ module IncMaxRepeat_IncMaxRepeat
     a_1 <-  ^ _12;
     _11 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _11) };
-    assume { Resolve1.resolve _12 };
     _14 <- borrow_mut b_2;
     b_2 <-  ^ _14;
     _13 <- borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
-    assume { Resolve1.resolve _14 };
     mc_10 <- TakeMax0.take_max _11 _13;
     goto BB4
   }
   BB4 {
+    assume { Resolve1.resolve _12 };
+    assume { Resolve1.resolve _14 };
     mc_10 <- { mc_10 with current = ( * mc_10 + (1 : uint32)) };
     assume { Resolve1.resolve mc_10 };
     i_4 <- i_4 + (1 : uint32);

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -371,11 +371,11 @@ module IncSome2List_Impl1_TakeSomeRest
     assume { Resolve2.resolve ma_3 };
     _9 <- borrow_mut ( * ml_4);
     ml_4 <- { ml_4 with current = ( ^ _9) };
-    assume { Resolve3.resolve ml_4 };
     _0 <- take_some_rest _9;
     goto BB8
   }
   BB8 {
+    assume { Resolve3.resolve ml_4 };
     goto BB9
   }
   BB9 {
@@ -504,11 +504,11 @@ module IncSome2List_IncSome2List
     assume { Resolve2.resolve _8 };
     _12 <- borrow_mut ( * ml_7);
     ml_7 <- { ml_7 with current = ( ^ _12) };
-    assume { Resolve1.resolve ml_7 };
     _11 <- TakeSomeRest0.take_some_rest _12;
     goto BB4
   }
   BB4 {
+    assume { Resolve1.resolve ml_7 };
     assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
     assume { Resolve2.resolve _11 };

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -440,22 +440,22 @@ module IncSome2Tree_Impl1_TakeSomeRest
     assume { Resolve3.resolve mtr_5 };
     _14 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _14) };
-    assume { Resolve3.resolve mtl_3 };
     _0 <- take_some_rest _14;
     goto BB14
   }
   BB14 {
+    assume { Resolve3.resolve mtl_3 };
     goto BB17
   }
   BB15 {
     assume { Resolve3.resolve mtl_3 };
     _15 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _15) };
-    assume { Resolve3.resolve mtr_5 };
     _0 <- take_some_rest _15;
     goto BB16
   }
   BB16 {
+    assume { Resolve3.resolve mtr_5 };
     goto BB17
   }
   BB17 {
@@ -587,11 +587,11 @@ module IncSome2Tree_IncSome2Tree
     assume { Resolve2.resolve _8 };
     _12 <- borrow_mut ( * mt_7);
     mt_7 <- { mt_7 with current = ( ^ _12) };
-    assume { Resolve1.resolve mt_7 };
     _11 <- TakeSomeRest0.take_some_rest _12;
     goto BB4
   }
   BB4 {
+    assume { Resolve1.resolve mt_7 };
     assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
     assume { Resolve2.resolve _11 };

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -373,11 +373,11 @@ module IncSomeList_Impl1_TakeSome
     assume { Resolve3.resolve ma_5 };
     _13 <- borrow_mut ( * ml_6);
     ml_6 <- { ml_6 with current = ( ^ _13) };
-    assume { Resolve2.resolve ml_6 };
     _12 <- take_some _13;
     goto BB8
   }
   BB8 {
+    assume { Resolve2.resolve ml_6 };
     _9 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _9) };
     assume { Resolve3.resolve _12 };

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -415,11 +415,11 @@ module IncSomeTree_Impl1_TakeSome
     assume { Resolve2.resolve mtr_7 };
     _16 <- borrow_mut ( * mtl_5);
     mtl_5 <- { mtl_5 with current = ( ^ _16) };
-    assume { Resolve2.resolve mtl_5 };
     _15 <- take_some _16;
     goto BB10
   }
   BB10 {
+    assume { Resolve2.resolve mtl_5 };
     _14 <- borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _14) };
     assume { Resolve3.resolve _15 };
@@ -432,11 +432,11 @@ module IncSomeTree_Impl1_TakeSome
     assume { Resolve2.resolve mtl_5 };
     _18 <- borrow_mut ( * mtr_7);
     mtr_7 <- { mtr_7 with current = ( ^ _18) };
-    assume { Resolve2.resolve mtr_7 };
     _17 <- take_some _18;
     goto BB12
   }
   BB12 {
+    assume { Resolve2.resolve mtr_7 };
     _10 <- borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _10) };
     assume { Resolve3.resolve _17 };

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -34,6 +34,24 @@ module Type
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
 end
+module Alloc_Vec_Impl1_Pop_Interface
+  type t   
+  type a   
+  use prelude.Prelude
+  use Type
+  val pop (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
+    requires {false}
+    
+end
+module Alloc_Vec_Impl1_Pop
+  type t   
+  type a   
+  use prelude.Prelude
+  use Type
+  val pop (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
+    requires {false}
+    
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -60,24 +78,6 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
-module Alloc_Vec_Impl1_Pop_Interface
-  type t   
-  type a   
-  use prelude.Prelude
-  use Type
-  val pop (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
-    requires {false}
-    
-end
-module Alloc_Vec_Impl1_Pop
-  type t   
-  type a   
-  use prelude.Prelude
-  use Type
-  val pop (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
-    requires {false}
-    
-end
 module InvariantMoves_TestInvariantMove_Interface
   use Type
   use mach.int.Int
@@ -94,8 +94,8 @@ module InvariantMoves_TestInvariantMove
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.core_option_option uint32
-  clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
+  clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
   let rec cfg test_invariant_move (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : () = 
   var _0 : ();
   var x_1 : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global);
@@ -127,11 +127,11 @@ module InvariantMoves_TestInvariantMove
     x_1 <-  ^ _5;
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve0.resolve _5 };
     _3 <- Pop0.pop _4;
     goto BB4
   }
   BB4 {
+    assume { Resolve0.resolve _5 };
     switch (_3)
       | Type.Core_Option_Option_Some _ -> goto BB5
       | _ -> goto BB7

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -406,11 +406,11 @@ module IterMut_IncVec
     assume { Resolve1.resolve old_v_2 };
     _6 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _6) };
-    assume { Resolve2.resolve v_1 };
     it_5 <- IterMut0.iter_mut _6;
     goto BB2
   }
   BB2 {
+    assume { Resolve2.resolve v_1 };
     _ghost_seen_7 <- (0 : int);
     goto BB3
   }

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -32,32 +32,6 @@ module Type
     
   axiom listindexmut_list_List_0_acc : forall a : uint32, b : listindexmut_option (listindexmut_list) . listindexmut_list_List_0 (ListIndexMut_List a b : listindexmut_list) = a
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
-end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module ListIndexMut_Len_Interface
   use Type
   use mach.int.Int
@@ -93,6 +67,32 @@ module ListIndexMut_Get
     else
       Type.ListIndexMut_Option_Some i
     
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
 end
 module ListIndexMut_IndexMut_Interface
   use mach.int.UInt64
@@ -261,8 +261,8 @@ module ListIndexMut_Write
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.listindexmut_list
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.listindexmut_list
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
@@ -292,14 +292,14 @@ module ListIndexMut_Write
     assume { Resolve0.resolve v_3 };
     _6 <- borrow_mut ( * l_1);
     l_1 <- { l_1 with current = ( ^ _6) };
-    assume { Resolve1.resolve l_1 };
-    assume { Resolve2.resolve _7 };
+    assume { Resolve1.resolve _7 };
     _7 <- ix_2;
-    assume { Resolve2.resolve ix_2 };
+    assume { Resolve1.resolve ix_2 };
     _5 <- IndexMut0.index_mut _6 _7;
     goto BB1
   }
   BB1 {
+    assume { Resolve2.resolve l_1 };
     assume { Resolve0.resolve ( * _5) };
     _5 <- { _5 with current = _4 };
     assume { Resolve3.resolve _5 };
@@ -333,10 +333,10 @@ module ListIndexMut_Main
   use mach.int.UInt64
   use Type
   clone ListIndexMut_Impl0_Resolve as Resolve1
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   clone ListIndexMut_Write_Interface as Write0 with function Len0.len = Len0.len, function Get0.get = Get0.get
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg main () : () = 
   var _0 : ();
   var l_1 : Type.listindexmut_list;
@@ -372,11 +372,11 @@ module ListIndexMut_Main
     l_1 <-  ^ _8;
     _7 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
-    assume { Resolve0.resolve _8 };
     _6 <- Write0.write _7 (0 : usize) (2 : uint32);
     goto BB5
   }
   BB5 {
+    assume { Resolve0.resolve _8 };
     _0 <- ();
     goto BB6
   }

--- a/creusot/tests/should_succeed/mut_call.stdout
+++ b/creusot/tests/should_succeed/mut_call.stdout
@@ -58,11 +58,11 @@ module MutCall_Test
     assume { (fun x -> true) a_1 };
     _3 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _3) };
-    assume { (fun x -> true) _4 };
     _2 <- Kill0.kill _3;
     goto BB1
   }
   BB1 {
+    assume { (fun x -> true) _4 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -111,9 +111,9 @@ module ProjectionToggle_Main
   use mach.int.Int32
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = int32
   clone ProjectionToggle_ProjToggle_Interface as ProjToggle0 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = int32
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = int32
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int32
   let rec cfg main () : () = 
   var _0 : ();
   var a_1 : int32;
@@ -138,22 +138,22 @@ module ProjectionToggle_Main
     a_1 <-  ^ _5;
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve0.resolve _5 };
     _7 <- borrow_mut b_2;
     b_2 <-  ^ _7;
-    assume { Resolve1.resolve b_2 };
+    assume { Resolve0.resolve b_2 };
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
-    assume { Resolve0.resolve _7 };
     x_3 <- ProjToggle0.proj_toggle true _4 _6;
     goto BB1
   }
   BB1 {
+    assume { Resolve1.resolve _5 };
+    assume { Resolve1.resolve _7 };
     x_3 <- { x_3 with current = ( * x_3 + (5 : int32)) };
-    assume { Resolve0.resolve x_3 };
-    assume { Resolve1.resolve _11 };
+    assume { Resolve1.resolve x_3 };
+    assume { Resolve0.resolve _11 };
     _11 <- a_1;
-    assume { Resolve1.resolve a_1 };
+    assume { Resolve0.resolve a_1 };
     _10 <- _11 = (15 : int32);
     _9 <- not _10;
     switch (_9)

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -44,9 +44,8 @@ fn knuth_shuffle<T>(v: &mut Vec<T>) {
     while n < v.len() {
         // We assign the length to a variable to work around a limitation with two-phase borrows
         // where we forget the value stored in the reference.
-        let l = v.len();
-        let i = rand_in_range(0, l - n);
-        v.swap(i, l - n - 1);
+        let i = rand_in_range(0, v.len() - n);
+        v.swap(i, v.len() - n - 1);
         n += 1;
     }
 }

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -356,18 +356,18 @@ module C03KnuthShuffle_KnuthShuffle
   var _8 : usize;
   var _9 : usize;
   var _10 : Type.creusotcontracts_std1_vec_vec t;
-  var l_11 : usize;
-  var _12 : Type.creusotcontracts_std1_vec_vec t;
-  var i_13 : usize;
-  var _14 : usize;
+  var i_11 : usize;
+  var _12 : usize;
+  var _13 : usize;
+  var _14 : Type.creusotcontracts_std1_vec_vec t;
   var _15 : usize;
-  var _16 : usize;
-  var _17 : ();
-  var _18 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _16 : ();
+  var _17 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _18 : usize;
   var _19 : usize;
   var _20 : usize;
   var _21 : usize;
-  var _22 : usize;
+  var _22 : Type.creusotcontracts_std1_vec_vec t;
   var _23 : usize;
   var _24 : ();
   var _25 : ();
@@ -403,47 +403,47 @@ module C03KnuthShuffle_KnuthShuffle
   BB4 {
     _7 <- _8 < _9;
     switch (_7)
-      | False -> goto BB9
+      | False -> goto BB10
       | _ -> goto BB5
       end
   }
   BB5 {
-    _12 <-  * v_1;
-    l_11 <- Len0.len _12;
+    _14 <-  * v_1;
+    _13 <- Len0.len _14;
     goto BB6
   }
   BB6 {
     assume { Resolve2.resolve _15 };
-    _15 <- l_11;
-    assume { Resolve2.resolve _16 };
-    _16 <- n_5;
-    _14 <- _15 - _16;
-    i_13 <- RandInRange0.rand_in_range (0 : usize) _14;
+    _15 <- n_5;
+    _12 <- _13 - _15;
+    i_11 <- RandInRange0.rand_in_range (0 : usize) _12;
     goto BB7
   }
   BB7 {
-    _18 <- borrow_mut ( * v_1);
-    v_1 <- { v_1 with current = ( ^ _18) };
-    assume { Resolve2.resolve _19 };
-    _19 <- i_13;
-    assume { Resolve2.resolve i_13 };
-    assume { Resolve2.resolve _22 };
-    _22 <- l_11;
-    assume { Resolve2.resolve l_11 };
-    assume { Resolve2.resolve _23 };
-    _23 <- n_5;
-    _21 <- _22 - _23;
-    _20 <- _21 - (1 : usize);
-    _17 <- Swap0.swap _18 _19 _20;
+    _17 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _17) };
+    assume { Resolve2.resolve _18 };
+    _18 <- i_11;
+    assume { Resolve2.resolve i_11 };
+    _22 <-  * _17;
+    _21 <- Len0.len _22;
     goto BB8
   }
   BB8 {
+    assume { Resolve2.resolve _23 };
+    _23 <- n_5;
+    _20 <- _21 - _23;
+    _19 <- _20 - (1 : usize);
+    _16 <- Swap0.swap _17 _18 _19;
+    goto BB9
+  }
+  BB9 {
     n_5 <- n_5 + (1 : usize);
     _6 <- ();
     assume { Resolve3.resolve _6 };
     goto BB2
   }
-  BB9 {
+  BB10 {
     assume { Resolve4.resolve v_1 };
     assume { Resolve2.resolve n_5 };
     _0 <- ();


### PR DESCRIPTION
Using the new `BorrowSet` apis, we can finally fix the unsoundness of two-phase borrows properly. 
For context, a two-phase borrow weakens the rules of mutable borrowing by introducing a separation between the point a borrow is 'created' (reservation point) and the moment it becomes a mutable borrow (activation point). In the intervening period it acts as if the location was borrowed immutably.
In particular, we can create further immutable borrows, so long as they resolve before the activation of the two-phase borrow. 
Previously, an unsoundness existed whichh allowed us to 'leak' the prophecy of a two-phase borrow during this period. 

I've fixed the issue by tracking whether we are immutably borrowing a local which has an unactivated two-phase borrow that is pending, if there is one, then we use that borrow's current value. 
You can see that this has changed several test cases of the test-suite, which were subtly unsound.
