### PR TITLE
Trait Laws

### DIFF
--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -300,6 +300,16 @@ fn logic_item(log: LogicItem) -> TS1 {
     })
 }
 
+#[proc_macro_attribute]
+pub fn law(_: TS1, tokens: TS1) -> TS1 {
+    let tokens = TokenStream::from(tokens);
+    TS1::from(quote! {
+        #[creusot::decl::law]
+        #[logic]
+        #tokens
+    })
+}
+
 struct PredicateItem {
     vis: Visibility,
     attrs: Vec<Attribute>,

--- a/creusot-contracts/src/logic/eq.rs
+++ b/creusot-contracts/src/logic/eq.rs
@@ -10,20 +10,20 @@ pub trait EqLogic {
     #[predicate]
     fn log_ne(self, _: Self) -> bool;
 
-    #[logic]
+    #[law]
     #[ensures(!(a.log_eq(b) === a.log_ne(b)))]
     fn eq_ne(a: Self, b: Self);
 
-    #[logic]
+    #[law]
     #[ensures(x == x)]
     fn refl(x: Self);
 
-    #[logic]
+    #[law]
     #[requires(x == y)]
     #[ensures(y == x)]
     fn symmetry(x: Self, y: Self);
 
-    #[logic]
+    #[law]
     #[requires(x == y)]
     #[requires(y == z)]
     #[ensures(x == z)]

--- a/creusot-contracts/src/logic/ord.rs
+++ b/creusot-contracts/src/logic/ord.rs
@@ -17,7 +17,7 @@ pub trait OrdLogic: EqLogic {
         }
     }
 
-    #[logic]
+    #[law]
     #[ensures(x.le_log(y) === ! (x.cmp_log(y) === Ordering::Greater))]
     fn cmp_le_log(x: Self, y: Self);
 
@@ -29,7 +29,7 @@ pub trait OrdLogic: EqLogic {
         }
     }
 
-    #[logic]
+    #[law]
     #[ensures(x.lt_log(y) === (x.cmp_log(y) === Ordering::Less))]
     fn cmp_lt_log(x: Self, y: Self);
 
@@ -41,7 +41,7 @@ pub trait OrdLogic: EqLogic {
         }
     }
 
-    #[logic]
+    #[law]
     #[ensures(x.ge_log(y) === ! (x.cmp_log(y) === Ordering::Less))]
     fn cmp_ge_log(x: Self, y: Self);
 
@@ -53,31 +53,31 @@ pub trait OrdLogic: EqLogic {
         }
     }
 
-    #[logic]
+    #[law]
     #[ensures(x.gt_log(y) === (x.cmp_log(y) === Ordering::Greater))]
     fn cmp_gt_log(x: Self, y: Self);
 
-    #[logic]
+    #[law]
     #[ensures(x.cmp_log(x) === Ordering::Equal)]
     fn refl(x: Self);
 
-    #[logic]
+    #[law]
     #[requires(x.cmp_log(y) === o)]
     #[requires(y.cmp_log(z) === o)]
     #[ensures(x.cmp_log(z) === o)]
     fn trans(x: Self, y: Self, z: Self, o: Ordering);
 
-    #[logic]
+    #[law]
     #[requires(x.cmp_log(y) === Ordering::Less)]
     #[ensures(y.cmp_log(x) === Ordering::Greater)]
     fn antisym1(x: Self, y: Self);
 
-    #[logic]
+    #[law]
     #[requires(x.cmp_log(y) === Ordering::Greater)]
     #[ensures(y.cmp_log(x) === Ordering::Less)]
     fn antisym2(x: Self, y: Self);
 
-    #[logic]
+    #[law]
     #[ensures(x == y ==> x.cmp_log(y) === Ordering::Equal)]
     #[ensures(y.cmp_log(x) === Ordering::Equal ==> x == y)]
     fn eq_cmp(x: Self, y: Self);

--- a/creusot-contracts/src/logic/ord.rs
+++ b/creusot-contracts/src/logic/ord.rs
@@ -30,7 +30,7 @@ pub trait OrdLogic: EqLogic {
     }
 
     #[logic]
-    #[ensures(x.le_log(y) === (x.cmp_log(y) === Ordering::Less))]
+    #[ensures(x.lt_log(y) === (x.cmp_log(y) === Ordering::Less))]
     fn cmp_lt_log(x: Self, y: Self);
 
     #[logic]
@@ -42,7 +42,7 @@ pub trait OrdLogic: EqLogic {
     }
 
     #[logic]
-    #[ensures(x.le_log(y) === ! (x.cmp_log(y) === Ordering::Less))]
+    #[ensures(x.ge_log(y) === ! (x.cmp_log(y) === Ordering::Less))]
     fn cmp_ge_log(x: Self, y: Self);
 
     #[logic]
@@ -54,7 +54,7 @@ pub trait OrdLogic: EqLogic {
     }
 
     #[logic]
-    #[ensures(x.le_log(y) === (x.cmp_log(y) === Ordering::Greater))]
+    #[ensures(x.gt_log(y) === (x.cmp_log(y) === Ordering::Greater))]
     fn cmp_gt_log(x: Self, y: Self);
 
     #[logic]

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_private, register_tool)]
 #![feature(box_syntax, box_patterns, control_flow_enum, drain_filter)]
-#![feature(in_band_lifetimes)]
+#![feature(in_band_lifetimes, let_else)]
 #![register_tool(creusot)]
 
 extern crate rustc_ast;
@@ -47,3 +47,4 @@ mod translation;
 pub mod util;
 use translation::*;
 pub mod metadata;
+mod validate;

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -24,10 +24,15 @@ use std::io::Result;
 use crate::ctx::TranslationCtx;
 use crate::ctx::TypeDeclaration;
 use crate::metadata;
+use crate::validate::validate_traits;
 use std::io::Write;
 use why3::mlcfg;
 
+// TODO: Move the main loop out of `translation.rs`
 pub fn translate(mut ctx: TranslationCtx<'_, '_>) -> Result<()> {
+    // Check that all trait laws are well-formed
+    validate_traits(&mut ctx);
+
     ctx.load_metadata();
 
     for def_id in ctx.tcx.hir().body_owners() {

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -12,7 +12,7 @@ pub fn default_decl(
 ) -> (Module, CloneSummary<'tcx>) {
     info!("generating default declaration for def_id={:?}", def_id);
     let mut names =
-        CloneMap::new(ctx.tcx, def_id, util::item_type(ctx.tcx, def_id).is_transparent());
+        CloneMap::new(ctx.tcx, def_id, !util::item_type(ctx.tcx, def_id).is_transparent());
 
     let mut decls: Vec<_> = Vec::new();
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -57,6 +57,10 @@ pub(crate) fn is_trusted(tcx: TyCtxt, def_id: DefId) -> bool {
     get_attr(tcx.get_attrs(def_id), &["creusot", "decl", "trusted"]).is_some()
 }
 
+pub(crate) fn is_law(tcx: TyCtxt, def_id: DefId) -> bool {
+    get_attr(tcx.get_attrs(def_id), &["creusot", "decl", "law"]).is_some()
+}
+
 pub(crate) fn should_translate(tcx: TyCtxt, mut def_id: DefId) -> bool {
     loop {
         if is_no_translate(tcx, def_id) {

--- a/creusot/src/validate.rs
+++ b/creusot/src/validate.rs
@@ -1,0 +1,34 @@
+use crate::ctx::TranslationCtx;
+use crate::util::is_law;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::itemlikevisit::ItemLikeVisitor;
+use rustc_hir::{ForeignItem, ImplItem, Item, TraitItem};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+struct LawParams<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    law_violations: Vec<(LocalDefId, Span)>,
+}
+
+impl<'tcx, 'v> ItemLikeVisitor<'v> for LawParams<'tcx> {
+    fn visit_item(&mut self, _: &'hir Item<'hir>) {}
+    fn visit_trait_item(&mut self, trait_item: &'hir TraitItem<'hir>) {
+        if is_law(self.tcx, trait_item.def_id.to_def_id()) && !trait_item.generics.params.is_empty()
+        {
+            self.law_violations.push((trait_item.def_id, trait_item.span))
+        }
+    }
+    fn visit_impl_item(&mut self, _: &'hir ImplItem<'hir>) {}
+    fn visit_foreign_item(&mut self, _: &'hir ForeignItem<'hir>) {}
+}
+
+pub fn validate_traits(ctx: &mut TranslationCtx) {
+    let mut law_visitor = LawParams { tcx: ctx.tcx, law_violations: Vec::new() };
+
+    ctx.tcx.hir().visit_all_item_likes(&mut law_visitor);
+
+    for (_, sp) in law_visitor.law_violations {
+        ctx.error(sp, "Laws cannot have additional generic parameters");
+    }
+}

--- a/creusot/tests/should_fail/bad_law.rs
+++ b/creusot/tests/should_fail/bad_law.rs
@@ -1,0 +1,11 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+trait BadLaw {
+    #[law]
+    fn my_law<T>(x: T);
+}
+
+impl BadLaw for () {
+    fn my_law<T>(x: T) {}
+}

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -91,7 +91,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     
@@ -157,9 +157,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
@@ -218,9 +218,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -275,9 +276,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -347,9 +349,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -87,7 +87,7 @@ module CreusotContracts_Std1_Vec_Impl1_New
   use mach.int.Int
   use mach.int.Int32
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val new () : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     
@@ -153,9 +153,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -158,9 +158,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -184,9 +185,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -363,9 +363,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -301,9 +301,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : int) : t
     requires {ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) ix }

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -226,9 +226,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -283,9 +284,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -330,7 +332,7 @@ module CreusotContracts_Std1_Vec_FromElem
   use seq.Seq
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
@@ -417,9 +419,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -270,7 +270,7 @@ module CreusotContracts_Std1_Vec_FromElem
   use seq.Seq
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
@@ -297,9 +297,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -354,9 +355,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -460,9 +462,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
@@ -526,7 +528,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     
@@ -550,9 +552,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -410,7 +410,7 @@ module CreusotContracts_Std1_Vec_FromElem
   use seq.Seq
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
@@ -437,9 +437,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -494,9 +495,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -600,9 +602,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
@@ -666,7 +668,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     
@@ -690,9 +692,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     

--- a/creusot/tests/should_succeed/ord_trait.rs
+++ b/creusot/tests/should_succeed/ord_trait.rs
@@ -5,15 +5,11 @@ use creusot_contracts::*;
 
 #[ensures(result === true)]
 fn x<T: Ord>(x: &T) -> bool {
-    proof_assert! { {OrdLogic::refl(*x); true} };
     x.le(x)
 }
 
 #[ensures(result === *y <= *x)]
 fn gt_or_le<T: Ord>(x: &T, y: &T) -> bool {
-    proof_assert! { {OrdLogic::antisym1(*x, *y); true} };
-    proof_assert! { {OrdLogic::antisym2(*x, *y); true} };
-    proof_assert! { {EqLogic::symmetry(*x, *x); true} };
     x.ge(y)
 }
 

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -378,9 +378,43 @@ end
 module OrdTrait_X
   type t   
   use prelude.Prelude
+  clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Symmetry as Symmetry0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Refl as Refl1 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_EqNe as EqNe0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  predicate LogNe0.log_ne = LogNe0.log_ne, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with type self = t,
+  function GtLog0.gt_log = GtLog0.gt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog as CmpGeLog0 with type self = t,
+  function GeLog0.ge_log = GeLog0.ge_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with type self = t,
+  function LtLog0.lt_log = LtLog0.lt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1 as Antisym10 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Trans as Trans0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog as CmpLeLog0 with type self = t,
+  function LeLog0.le_log = LeLog0.le_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, function LeLog0.le_log = LeLog0.le_log
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg x (x : t) : bool
@@ -418,12 +452,44 @@ end
 module OrdTrait_GtOrLe
   type t   
   use prelude.Prelude
+  clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Symmetry as Symmetry0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Refl as Refl1 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_EqNe as EqNe0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  predicate LogNe0.log_ne = LogNe0.log_ne, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with type self = t,
+  function GtLog0.gt_log = GtLog0.gt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog as CmpGeLog0 with type self = t,
+  function GeLog0.ge_log = GeLog0.ge_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with type self = t,
+  function LtLog0.lt_log = LtLog0.lt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1 as Antisym10 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Trans as Trans0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog as CmpLeLog0 with type self = t,
+  function LeLog0.le_log = LeLog0.le_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Std1_Ord_Ord_Ge_Interface as Ge0 with type self = t, function GeLog0.ge_log = GeLog0.ge_log
   let rec cfg gt_or_le (x : t) (y : t) : bool
     ensures { result = LeLog0.le_log y x }

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -15,6 +15,14 @@ module Type
     | Core_Cmp_Ordering_Greater
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
@@ -270,14 +278,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   function eq_cmp (x : self) (y : self) : ()
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
   type self   
   use prelude.Prelude
@@ -291,7 +291,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
   type self   
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
   val cmp (self : self) (o : self) : Type.core_cmp_ordering
     ensures { result = CmpLog0.cmp_log self o }
     
@@ -307,7 +307,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Le
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val le (self : self) (o : self) : bool
     ensures { result = LeLog0.le_log self o }
     
@@ -323,7 +325,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Ge
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val ge (self : self) (o : self) : bool
     ensures { result = GeLog0.ge_log self o }
     
@@ -339,7 +343,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Gt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val gt (self : self) (o : self) : bool
     ensures { result = GtLog0.gt_log self o }
     
@@ -355,7 +361,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Lt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val lt (self : self) (o : self) : bool
     ensures { result = LtLog0.lt_log self o }
     
@@ -371,34 +379,27 @@ module OrdTrait_X
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
-  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with type self = t,
-  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
   clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, function LeLog0.le_log = LeLog0.le_log
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg x (x : t) : bool
     ensures { result = true }
     
    = 
   var _0 : bool;
   var x_1 : t;
-  var _2 : ();
+  var _2 : t;
   var _3 : t;
-  var _4 : t;
   {
     x_1 <- x;
     goto BB0
   }
   BB0 {
-    assert { let _ = Refl0.refl x_1 in true };
-    _2 <- ();
-    assume { Resolve0.resolve _2 };
+    _2 <- x_1;
     _3 <- x_1;
-    _4 <- x_1;
-    assume { Resolve1.resolve x_1 };
-    _0 <- Le0.le _3 _4;
+    assume { Resolve0.resolve x_1 };
+    _0 <- Le0.le _2 _3;
     goto BB1
   }
   BB1 {
@@ -417,18 +418,10 @@ end
 module OrdTrait_GtOrLe
   type t   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
-  clone CreusotContracts_Logic_Eq_EqLogic_Symmetry as Symmetry0 with type self = t,
-  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with type self = t,
-  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
-  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1 as Antisym10 with type self = t,
-  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
   clone CreusotContracts_Std1_Ord_Ord_Ge_Interface as Ge0 with type self = t, function GeLog0.ge_log = GeLog0.ge_log
@@ -439,31 +432,19 @@ module OrdTrait_GtOrLe
   var _0 : bool;
   var x_1 : t;
   var y_2 : t;
-  var _3 : ();
-  var _4 : ();
-  var _5 : ();
-  var _6 : t;
-  var _7 : t;
+  var _3 : t;
+  var _4 : t;
   {
     x_1 <- x;
     y_2 <- y;
     goto BB0
   }
   BB0 {
-    assert { let _ = Antisym10.antisym1 x_1 y_2 in true };
-    _3 <- ();
-    assume { Resolve0.resolve _3 };
-    assert { let _ = Antisym20.antisym2 x_1 y_2 in true };
-    _4 <- ();
-    assume { Resolve0.resolve _4 };
-    assert { let _ = Symmetry0.symmetry x_1 x_1 in true };
-    _5 <- ();
-    assume { Resolve0.resolve _5 };
-    _6 <- x_1;
-    assume { Resolve1.resolve x_1 };
-    _7 <- y_2;
-    assume { Resolve1.resolve y_2 };
-    _0 <- Ge0.ge _6 _7;
+    _3 <- x_1;
+    assume { Resolve0.resolve x_1 };
+    _4 <- y_2;
+    assume { Resolve0.resolve y_2 };
+    _0 <- Ge0.ge _3 _4;
     goto BB1
   }
   BB1 {

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -80,16 +80,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
   type self   
@@ -109,16 +109,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
   type self   
@@ -138,16 +138,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   type self   

--- a/creusot/tests/should_succeed/traits/18_trait_laws.rs
+++ b/creusot/tests/should_succeed/traits/18_trait_laws.rs
@@ -1,0 +1,35 @@
+// WHY3PROVE NO_SPLIT Z3
+#![feature(unsized_fn_params)]
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+trait Symmetric {
+    #[logic]
+    fn op(self, _: Self) -> Self;
+
+    #[law]
+    #[ensures(a.op(b) === b.op(a))]
+    fn reflexive(a: Self, b: Self);
+}
+
+#[logic]
+#[ensures(result === true)]
+fn uses_op<T: Symmetric>(x: T, y: T) -> bool {
+    pearlite! { x.op(y) === y.op(x) }
+}
+
+impl Symmetric for () {
+    #[logic]
+    fn op(self, _: Self) -> Self {
+        ()
+    }
+
+    #[law]
+    fn reflexive(_: Self, _: Self) {}
+}
+
+#[logic]
+#[ensures(result === true)]
+fn impl_laws() -> bool {
+    pearlite! { ().op(()) === ().op(()) }
+}

--- a/creusot/tests/should_succeed/traits/18_trait_laws.stdout
+++ b/creusot/tests/should_succeed/traits/18_trait_laws.stdout
@@ -1,0 +1,91 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.Int64
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C18TraitLaws_Symmetric_Op_Interface
+  type self   
+  function op (self : self) (_2 : self) : self
+end
+module C18TraitLaws_Symmetric_Op
+  type self   
+  function op (self : self) (_2 : self) : self
+end
+module C18TraitLaws_Symmetric_Reflexive_Interface
+  type self   
+  clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = self
+  function reflexive (a : self) (b : self) : ()
+end
+module C18TraitLaws_Symmetric_Reflexive
+  type self   
+  clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = self
+  function reflexive (a : self) (b : self) : ()
+  axiom reflexive_spec : forall a : self, b : self . Op0.op a b = Op0.op b a
+end
+module C18TraitLaws_UsesOp_Interface
+  type t   
+  function uses_op (x : t) (y : t) : bool
+end
+module C18TraitLaws_UsesOp
+  type t   
+  clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = t
+  function uses_op (x : t) (y : t) : bool = 
+    Op0.op x y = Op0.op y x
+  axiom uses_op_spec : forall x : t, y : t . uses_op x y = true
+end
+module C18TraitLaws_UsesOp_Impl
+  type t   
+  clone C18TraitLaws_Symmetric_Op as Op0 with type self = t
+  clone C18TraitLaws_Symmetric_Reflexive as Reflexive0 with type self = t, function Op0.op = Op0.op, axiom .
+  let rec ghost function uses_op (x : t) (y : t) : bool
+    ensures { result = true }
+    
+   = 
+    let b = Op0.op y x in let a = Op0.op x y in pure {a = b}
+end
+module C18TraitLaws_Impl0_Op_Interface
+  function op (self : ()) (_2 : ()) : ()
+end
+module C18TraitLaws_Impl0_Op
+  function op (self : ()) (_2 : ()) : () = 
+    ()
+end
+module C18TraitLaws_Impl0_Reflexive_Interface
+  function reflexive (_1 : ()) (_2 : ()) : ()
+end
+module C18TraitLaws_Impl0_Reflexive
+  function reflexive (_1 : ()) (_2 : ()) : () = 
+    ()
+end
+module C18TraitLaws_Impl0
+  clone C18TraitLaws_Impl0_Reflexive as Reflexive0
+  clone C18TraitLaws_Impl0_Op as Op0
+  clone C18TraitLaws_Symmetric_Reflexive as Reflexive1 with type self = (), function Op0.op = Op0.op,
+  function reflexive = Reflexive0.reflexive, axiom .
+  clone C18TraitLaws_Symmetric_Op as Op1 with type self = (), function op = Op0.op
+end
+module C18TraitLaws_ImplLaws_Interface
+  function impl_laws () : bool
+end
+module C18TraitLaws_ImplLaws
+  clone C18TraitLaws_Impl0_Op_Interface as Op0
+  function impl_laws () : bool = 
+    Op0.op () () = Op0.op () ()
+  axiom impl_laws_spec : impl_laws () = true
+end
+module C18TraitLaws_ImplLaws_Impl
+  clone C18TraitLaws_Impl0_Reflexive as Reflexive0
+  clone C18TraitLaws_Impl0_Op as Op0
+  let rec ghost function impl_laws () : bool
+    ensures { result = true }
+    
+   = 
+    let b = Op0.op () () in let a = Op0.op () () in pure {a = b}
+end

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -193,9 +193,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -304,9 +305,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -42,7 +42,6 @@ fn sorted<T: Ord>(s: Seq<T>) -> bool {
 #[ensures((@^v).permutation_of(@*v))]
 fn gnome_sort<T: Ord>(v: &mut Vec<T>) {
     let old_v = Ghost::record(&v);
-    proof_assert! { {T::trans((@v)[0], (@v)[0], (@v)[0], Ordering::Equal) ; true} };
     let mut i = 0;
     #[invariant(sorted, sorted_range(@v, 0, @i))]
     #[invariant(proph_const, ^v === ^@old_v)]

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -150,16 +150,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
   type self   
@@ -179,16 +179,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
   type self   
@@ -208,16 +208,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   type self   

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -758,19 +758,50 @@ module C02Gnome_GnomeSort
   type t   
   use mach.int.Int
   use mach.int.Int32
-  use seq.Seq
-  use Type
   use mach.int.UInt64
   use prelude.Prelude
-  clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with type t = t
-  clone C02Gnome_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Symmetry as Symmetry0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Refl as Refl1 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_EqNe as EqNe0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  predicate LogNe0.log_ne = LogNe0.log_ne, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone C02Gnome_SortedRange as SortedRange0 with type t = t, function LeLog0.le_log = LeLog0.le_log
-  clone C02Gnome_Sorted as Sorted0 with type t = t, predicate SortedRange0.sorted_range = SortedRange0.sorted_range
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with type self = t,
+  function GtLog0.gt_log = GtLog0.gt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog as CmpGeLog0 with type self = t,
+  function GeLog0.ge_log = GeLog0.ge_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with type self = t,
+  function LtLog0.lt_log = LtLog0.lt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1 as Antisym10 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Trans as Trans0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog as CmpLeLog0 with type self = t,
+  function LeLog0.le_log = LeLog0.le_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone C02Gnome_SortedRange as SortedRange0 with type t = t, function LeLog0.le_log = LeLog0.le_log
+  clone C02Gnome_Sorted as Sorted0 with type t = t, predicate SortedRange0.sorted_range = SortedRange0.sorted_range
+  clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with type t = t
+  clone C02Gnome_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
@@ -778,13 +809,13 @@ module C02Gnome_GnomeSort
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c02gnome_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, function LeLog0.le_log = LeLog0.le_log
   clone C02Gnome_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
   function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, function LeLog0.le_log = LeLog0.le_log
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model3.model
@@ -801,35 +832,34 @@ module C02Gnome_GnomeSort
   var old_v_2 : Type.c02gnome_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
   var _3 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var _4 : borrowed (Type.creusotcontracts_std1_vec_vec t);
-  var _5 : ();
-  var i_6 : usize;
-  var _7 : ();
-  var _8 : bool;
+  var i_5 : usize;
+  var _6 : ();
+  var _7 : bool;
+  var _8 : usize;
   var _9 : usize;
-  var _10 : usize;
-  var _11 : Type.creusotcontracts_std1_vec_vec t;
+  var _10 : Type.creusotcontracts_std1_vec_vec t;
+  var _11 : bool;
   var _12 : bool;
-  var _13 : bool;
-  var _14 : usize;
-  var _15 : bool;
+  var _13 : usize;
+  var _14 : bool;
+  var _15 : t;
   var _16 : t;
-  var _17 : t;
-  var _18 : Type.creusotcontracts_std1_vec_vec t;
+  var _17 : Type.creusotcontracts_std1_vec_vec t;
+  var _18 : usize;
   var _19 : usize;
-  var _20 : usize;
+  var _20 : t;
   var _21 : t;
   var _22 : t;
-  var _23 : t;
-  var _24 : Type.creusotcontracts_std1_vec_vec t;
-  var _25 : usize;
-  var _26 : ();
-  var _27 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _23 : Type.creusotcontracts_std1_vec_vec t;
+  var _24 : usize;
+  var _25 : ();
+  var _26 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _27 : usize;
   var _28 : usize;
   var _29 : usize;
-  var _30 : usize;
+  var _30 : ();
   var _31 : ();
   var _32 : ();
-  var _33 : ();
   {
     v_1 <- v;
     goto BB0
@@ -843,102 +873,99 @@ module C02Gnome_GnomeSort
   }
   BB1 {
     assume { Resolve1.resolve old_v_2 };
-    assert { let _ = Trans0.trans (Seq.get (Model0.model v_1) 0) (Seq.get (Model0.model v_1) 0) (Seq.get (Model0.model v_1) 0) (Type.Core_Cmp_Ordering_Equal) in true };
-    _5 <- ();
-    assume { Resolve2.resolve _5 };
-    i_6 <- (0 : usize);
+    i_5 <- (0 : usize);
     goto BB2
   }
   BB2 {
-    invariant sorted { SortedRange0.sorted_range (Model0.model v_1) 0 (UInt64.to_int i_6) };
+    invariant sorted { SortedRange0.sorted_range (Model0.model v_1) 0 (UInt64.to_int i_5) };
     invariant proph_const {  ^ v_1 =  ^ Model1.model old_v_2 };
     invariant permutation { PermutationOf0.permutation_of (Model2.model ( * v_1)) (Model2.model ( * Model1.model old_v_2)) };
     goto BB3
   }
   BB3 {
-    assume { Resolve3.resolve _9 };
-    _9 <- i_6;
-    _11 <-  * v_1;
-    _10 <- Len0.len _11;
+    assume { Resolve2.resolve _8 };
+    _8 <- i_5;
+    _10 <-  * v_1;
+    _9 <- Len0.len _10;
     goto BB4
   }
   BB4 {
-    _8 <- _9 < _10;
-    switch (_8)
+    _7 <- _8 < _9;
+    switch (_7)
       | False -> goto BB16
       | _ -> goto BB5
       end
   }
   BB5 {
-    assume { Resolve3.resolve _14 };
-    _14 <- i_6;
-    _13 <- _14 = (0 : usize);
-    switch (_13)
+    assume { Resolve2.resolve _13 };
+    _13 <- i_5;
+    _12 <- _13 = (0 : usize);
+    switch (_12)
       | False -> goto BB7
       | _ -> goto BB6
       end
   }
   BB6 {
-    _12 <- true;
+    _11 <- true;
     goto BB8
   }
   BB7 {
-    _18 <-  * v_1;
-    assume { Resolve3.resolve _20 };
-    _20 <- i_6;
-    _19 <- _20 - (1 : usize);
-    _17 <- Index0.index _18 _19;
+    _17 <-  * v_1;
+    assume { Resolve2.resolve _19 };
+    _19 <- i_5;
+    _18 <- _19 - (1 : usize);
+    _16 <- Index0.index _17 _18;
     goto BB9
   }
   BB8 {
-    switch (_12)
+    switch (_11)
       | False -> goto BB13
       | _ -> goto BB12
       end
   }
   BB9 {
-    _16 <- _17;
-    assume { Resolve4.resolve _17 };
-    _24 <-  * v_1;
-    assume { Resolve3.resolve _25 };
-    _25 <- i_6;
-    _23 <- Index0.index _24 _25;
+    _15 <- _16;
+    assume { Resolve4.resolve _16 };
+    _23 <-  * v_1;
+    assume { Resolve2.resolve _24 };
+    _24 <- i_5;
+    _22 <- Index0.index _23 _24;
     goto BB10
   }
   BB10 {
-    _22 <- _23;
-    assume { Resolve4.resolve _23 };
     _21 <- _22;
     assume { Resolve4.resolve _22 };
-    _15 <- Le0.le _16 _21;
+    _20 <- _21;
+    assume { Resolve4.resolve _21 };
+    _14 <- Le0.le _15 _20;
     goto BB11
   }
   BB11 {
-    assume { Resolve5.resolve _12 };
-    _12 <- _15;
+    assume { Resolve5.resolve _11 };
+    _11 <- _14;
     goto BB8
   }
   BB12 {
-    i_6 <- i_6 + (1 : usize);
-    _7 <- ();
-    assume { Resolve2.resolve _7 };
+    i_5 <- i_5 + (1 : usize);
+    _6 <- ();
+    assume { Resolve3.resolve _6 };
     goto BB15
   }
   BB13 {
-    _27 <- borrow_mut ( * v_1);
-    v_1 <- { v_1 with current = ( ^ _27) };
-    assume { Resolve3.resolve _29 };
-    _29 <- i_6;
-    _28 <- _29 - (1 : usize);
-    assume { Resolve3.resolve _30 };
-    _30 <- i_6;
-    _26 <- Swap0.swap _27 _28 _30;
+    _26 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _26) };
+    assume { Resolve2.resolve _28 };
+    _28 <- i_5;
+    _27 <- _28 - (1 : usize);
+    assume { Resolve2.resolve _29 };
+    _29 <- i_5;
+    _25 <- Swap0.swap _26 _27 _29;
     goto BB14
   }
   BB14 {
-    i_6 <- i_6 - (1 : usize);
-    _7 <- ();
-    assume { Resolve2.resolve _7 };
+    i_5 <- i_5 - (1 : usize);
+    _6 <- ();
+    assume { Resolve3.resolve _6 };
     goto BB15
   }
   BB15 {
@@ -946,7 +973,7 @@ module C02Gnome_GnomeSort
   }
   BB16 {
     assume { Resolve6.resolve v_1 };
-    assume { Resolve3.resolve i_6 };
+    assume { Resolve2.resolve i_5 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -514,9 +514,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -547,10 +548,10 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
   use seq.Permut
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
     requires {UInt64.to_int j < Seq.length (Model0.model self)}
     requires {UInt64.to_int i < Seq.length (Model0.model self)}
@@ -607,9 +608,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -645,7 +647,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
   type self   
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
   val cmp (self : self) (o : self) : Type.core_cmp_ordering
     ensures { result = CmpLog0.cmp_log self o }
     
@@ -661,7 +663,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Le
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val le (self : self) (o : self) : bool
     ensures { result = LeLog0.le_log self o }
     
@@ -677,7 +681,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Ge
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val ge (self : self) (o : self) : bool
     ensures { result = GeLog0.ge_log self o }
     
@@ -693,7 +699,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Gt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val gt (self : self) (o : self) : bool
     ensures { result = GtLog0.gt_log self o }
     
@@ -709,7 +717,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Lt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val lt (self : self) (o : self) : bool
     ensures { result = LtLog0.lt_log self o }
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -242,9 +242,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -275,10 +276,10 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
   use seq.Permut
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val swap (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (i : usize) (j : usize) : ()
     requires {UInt64.to_int j < Seq.length (Model0.model self)}
     requires {UInt64.to_int i < Seq.length (Model0.model self)}

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -156,9 +156,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -221,9 +222,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
@@ -31,12 +31,6 @@ fn binary_search<T: Ord>(arr: &Vec<T>, elem: T) -> Result<usize, usize> {
     let mut size: usize = arr.len();
     let mut base: usize = 0;
 
-    proof_assert! { {T::trans(elem, elem, elem, Ordering::Equal); true} };
-    proof_assert! { {T::antisym1(elem, elem); true} };
-    proof_assert! { {T::antisym2(elem, elem); true} };
-    proof_assert! { {T::symmetry(elem, elem); true} };
-    proof_assert! { {T::eq_cmp(elem, elem); true} };
-
     #[invariant(size_valid, 0 < @size && @size + @base <= (@arr).len())]
     #[invariant(lower_b, forall<i : usize> i < base ==> (@arr)[@i] <= elem)]
     #[invariant(lower_b, forall<i : usize> @base + @size <= @i && @i < (@arr).len() ==> elem < (@arr)[@i])]

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -416,9 +416,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -481,9 +482,10 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
@@ -519,7 +521,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
   type self   
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
   val cmp (self : self) (o : self) : Type.core_cmp_ordering
     ensures { result = CmpLog0.cmp_log self o }
     
@@ -535,7 +537,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Le
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val le (self : self) (o : self) : bool
     ensures { result = LeLog0.le_log self o }
     
@@ -551,7 +555,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Ge
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val ge (self : self) (o : self) : bool
     ensures { result = GeLog0.ge_log self o }
     
@@ -567,7 +573,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Gt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val gt (self : self) (o : self) : bool
     ensures { result = GtLog0.gt_log self o }
     
@@ -583,7 +591,9 @@ end
 module CreusotContracts_Std1_Ord_Ord_Lt
   type self   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = self,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
   val lt (self : self) (o : self) : bool
     ensures { result = LtLog0.lt_log self o }
     

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -622,27 +622,31 @@ module C05BinarySearchGeneric_BinarySearch_Interface
 end
 module C05BinarySearchGeneric_BinarySearch
   type t   
-  use Type
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
+  clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
+  predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
   clone CreusotContracts_Logic_Eq_EqLogic_Symmetry as Symmetry0 with type self = t,
   predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_Refl as Refl1 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  axiom .
+  clone CreusotContracts_Logic_Eq_EqLogic_EqNe as EqNe0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
+  predicate LogNe0.log_ne = LogNe0.log_ne, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog as CmpLog0 with type self = t
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = t,
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with type self = t,
+  function GtLog0.gt_log = GtLog0.gt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone C05BinarySearchGeneric_SortedRange as SortedRange0 with type t = t, function LeLog0.le_log = LeLog0.le_log
-  clone C05BinarySearchGeneric_Sorted as Sorted0 with type t = t,
-  predicate SortedRange0.sorted_range = SortedRange0.sorted_range
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog as CmpGeLog0 with type self = t,
+  function GeLog0.ge_log = GeLog0.ge_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log, predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with type self = t,
@@ -651,6 +655,23 @@ module C05BinarySearchGeneric_BinarySearch
   function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Trans as Trans0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with type self = t,
+  function LtLog0.lt_log = LtLog0.lt_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with type self = t,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone C05BinarySearchGeneric_SortedRange as SortedRange0 with type t = t, function LeLog0.le_log = LeLog0.le_log
+  clone C05BinarySearchGeneric_Sorted as Sorted0 with type t = t,
+  predicate SortedRange0.sorted_range = SortedRange0.sorted_range
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog as CmpLeLog0 with type self = t,
+  function LeLog0.le_log = LeLog0.le_log, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   use prelude.Int8
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.core_cmp_ordering
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
@@ -658,13 +679,11 @@ module C05BinarySearchGeneric_BinarySearch
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with type self = t,
-  function CmpLog0.cmp_log = CmpLog0.cmp_log
-  clone CreusotContracts_Std1_Ord_Ord_Gt_Interface as Gt0 with type self = t, function GtLog0.gt_log = GtLog0.gt_log
   clone CreusotContracts_Std1_Ord_Ord_Cmp_Interface as Cmp0 with type self = t,
   function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Std1_Ord_Ord_Gt_Interface as Gt0 with type self = t, function GtLog0.gt_log = GtLog0.gt_log
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = t, function Model0.model = Model0.model
   let rec cfg binary_search (arr : Type.creusotcontracts_std1_vec_vec t) (elem : t) : Type.core_result_result usize usize
     requires {Sorted0.sorted (Model0.model arr)}
     requires {Seq.length (Model0.model arr) <= 18446744073709551615}
@@ -686,45 +705,40 @@ module C05BinarySearchGeneric_BinarySearch
   var base_10 : usize;
   var _11 : ();
   var _12 : ();
-  var _13 : ();
-  var _14 : ();
-  var _15 : ();
-  var _16 : ();
-  var _17 : ();
-  var _18 : bool;
+  var _13 : bool;
+  var _14 : usize;
+  var half_15 : usize;
+  var _16 : usize;
+  var _17 : bool;
+  var mid_18 : usize;
   var _19 : usize;
-  var half_20 : usize;
-  var _21 : usize;
-  var _22 : bool;
-  var mid_23 : usize;
+  var _20 : usize;
+  var x_21 : t;
+  var _22 : t;
+  var _23 : Type.creusotcontracts_std1_vec_vec t;
   var _24 : usize;
   var _25 : usize;
-  var x_26 : t;
+  var _26 : bool;
   var _27 : t;
-  var _28 : Type.creusotcontracts_std1_vec_vec t;
-  var _29 : usize;
+  var _28 : t;
+  var _29 : t;
   var _30 : usize;
-  var _31 : bool;
-  var _32 : t;
-  var _33 : t;
-  var _34 : t;
-  var _35 : usize;
-  var _36 : ();
-  var _37 : ();
-  var _38 : ();
-  var cmp_39 : t;
+  var _31 : ();
+  var _32 : ();
+  var _33 : ();
+  var cmp_34 : t;
+  var _35 : t;
+  var _36 : Type.creusotcontracts_std1_vec_vec t;
+  var _37 : usize;
+  var _38 : Type.core_cmp_ordering;
+  var _39 : t;
   var _40 : t;
-  var _41 : Type.creusotcontracts_std1_vec_vec t;
-  var _42 : usize;
-  var _43 : Type.core_cmp_ordering;
-  var _44 : t;
-  var _45 : t;
-  var _46 : t;
-  var _47 : int8;
-  var _48 : usize;
-  var _49 : usize;
-  var _50 : usize;
-  var _51 : usize;
+  var _41 : t;
+  var _42 : int8;
+  var _43 : usize;
+  var _44 : usize;
+  var _45 : usize;
+  var _46 : usize;
   {
     arr_1 <- arr;
     elem_2 <- elem;
@@ -754,7 +768,7 @@ module C05BinarySearchGeneric_BinarySearch
   BB5 {
     assume { Resolve0.resolve arr_1 };
     _0 <- Type.Core_Result_Result_Err (0 : usize);
-    goto BB34
+    goto BB29
   }
   BB6 {
     _3 <- ();
@@ -765,188 +779,158 @@ module C05BinarySearchGeneric_BinarySearch
   }
   BB7 {
     base_10 <- (0 : usize);
-    assert { let _ = Trans0.trans elem_2 elem_2 elem_2 (Type.Core_Cmp_Ordering_Equal) in true };
     goto BB8
   }
   BB8 {
-    _11 <- ();
-    assume { Resolve2.resolve _11 };
-    assert { let _ = Antisym10.antisym1 elem_2 elem_2 in true };
     goto BB9
   }
   BB9 {
-    _12 <- ();
-    assume { Resolve2.resolve _12 };
-    assert { let _ = Antisym20.antisym2 elem_2 elem_2 in true };
     goto BB10
   }
   BB10 {
-    _13 <- ();
-    assume { Resolve2.resolve _13 };
-    assert { let _ = Symmetry0.symmetry elem_2 elem_2 in true };
-    goto BB11
-  }
-  BB11 {
-    _14 <- ();
-    assume { Resolve2.resolve _14 };
-    assert { let _ = EqCmp0.eq_cmp elem_2 elem_2 in true };
-    goto BB12
-  }
-  BB12 {
-    _15 <- ();
-    assume { Resolve2.resolve _15 };
-    goto BB13
-  }
-  BB13 {
-    goto BB14
-  }
-  BB14 {
-    goto BB15
-  }
-  BB15 {
     invariant size_valid { 0 < UInt64.to_int size_8 && UInt64.to_int size_8 + UInt64.to_int base_10 <= Seq.length (Model0.model arr_1) };
     invariant lower_b { forall i : (usize) . i < base_10 -> LeLog0.le_log (Seq.get (Model0.model arr_1) (UInt64.to_int i)) elem_2 };
     invariant lower_b { forall i : (usize) . UInt64.to_int base_10 + UInt64.to_int size_8 <= UInt64.to_int i && UInt64.to_int i < Seq.length (Model0.model arr_1) -> LtLog0.lt_log elem_2 (Seq.get (Model0.model arr_1) (UInt64.to_int i)) };
-    goto BB16
+    goto BB11
   }
-  BB16 {
-    assume { Resolve3.resolve _19 };
-    _19 <- size_8;
-    _18 <- _19 > (1 : usize);
-    switch (_18)
-      | False -> goto BB24
-      | _ -> goto BB17
+  BB11 {
+    assume { Resolve3.resolve _14 };
+    _14 <- size_8;
+    _13 <- _14 > (1 : usize);
+    switch (_13)
+      | False -> goto BB19
+      | _ -> goto BB12
       end
   }
+  BB12 {
+    assume { Resolve3.resolve _16 };
+    _16 <- size_8;
+    _17 <- (2 : usize) = (0 : usize);
+    assert { not _17 };
+    goto BB13
+  }
+  BB13 {
+    half_15 <- _16 / (2 : usize);
+    assume { Resolve3.resolve _19 };
+    _19 <- base_10;
+    assume { Resolve3.resolve _20 };
+    _20 <- half_15;
+    mid_18 <- _19 + _20;
+    _23 <- arr_1;
+    assume { Resolve3.resolve _24 };
+    _24 <- mid_18;
+    _22 <- Index0.index _23 _24;
+    goto BB14
+  }
+  BB14 {
+    x_21 <- _22;
+    assume { Resolve4.resolve _22 };
+    _27 <- x_21;
+    assume { Resolve4.resolve x_21 };
+    _29 <- elem_2;
+    _28 <- _29;
+    assume { Resolve4.resolve _29 };
+    _26 <- Gt0.gt _27 _28;
+    goto BB15
+  }
+  BB15 {
+    switch (_26)
+      | False -> goto BB17
+      | _ -> goto BB16
+      end
+  }
+  BB16 {
+    assume { Resolve3.resolve mid_18 };
+    assume { Resolve3.resolve _25 };
+    _25 <- base_10;
+    assume { Resolve3.resolve base_10 };
+    goto BB18
+  }
   BB17 {
-    assume { Resolve3.resolve _21 };
-    _21 <- size_8;
-    _22 <- (2 : usize) = (0 : usize);
-    assert { not _22 };
+    assume { Resolve3.resolve base_10 };
+    assume { Resolve3.resolve _25 };
+    _25 <- mid_18;
+    assume { Resolve3.resolve mid_18 };
     goto BB18
   }
   BB18 {
-    half_20 <- _21 / (2 : usize);
-    assume { Resolve3.resolve _24 };
-    _24 <- base_10;
-    assume { Resolve3.resolve _25 };
-    _25 <- half_20;
-    mid_23 <- _24 + _25;
-    _28 <- arr_1;
-    assume { Resolve3.resolve _29 };
-    _29 <- mid_23;
-    _27 <- Index0.index _28 _29;
-    goto BB19
+    assume { Resolve3.resolve base_10 };
+    base_10 <- _25;
+    assume { Resolve3.resolve _30 };
+    _30 <- half_15;
+    assume { Resolve3.resolve half_15 };
+    size_8 <- size_8 - _30;
+    _12 <- ();
+    assume { Resolve2.resolve _12 };
+    goto BB10
   }
   BB19 {
-    x_26 <- _27;
-    assume { Resolve4.resolve _27 };
-    _32 <- x_26;
-    assume { Resolve4.resolve x_26 };
-    _34 <- elem_2;
-    _33 <- _34;
-    assume { Resolve4.resolve _34 };
-    _31 <- Gt0.gt _32 _33;
+    assume { Resolve3.resolve size_8 };
+    _11 <- ();
+    assume { Resolve2.resolve _11 };
+    _36 <- arr_1;
+    assume { Resolve0.resolve arr_1 };
+    assume { Resolve3.resolve _37 };
+    _37 <- base_10;
+    _35 <- Index0.index _36 _37;
     goto BB20
   }
   BB20 {
-    switch (_31)
-      | False -> goto BB22
-      | _ -> goto BB21
-      end
+    cmp_34 <- _35;
+    assume { Resolve4.resolve _35 };
+    _39 <- cmp_34;
+    assume { Resolve4.resolve cmp_34 };
+    _41 <- elem_2;
+    _40 <- _41;
+    assume { Resolve4.resolve _41 };
+    _38 <- Cmp0.cmp _39 _40;
+    goto BB21
   }
   BB21 {
-    assume { Resolve3.resolve mid_23 };
-    assume { Resolve3.resolve _30 };
-    _30 <- base_10;
-    assume { Resolve3.resolve base_10 };
-    goto BB23
-  }
-  BB22 {
-    assume { Resolve3.resolve base_10 };
-    assume { Resolve3.resolve _30 };
-    _30 <- mid_23;
-    assume { Resolve3.resolve mid_23 };
-    goto BB23
-  }
-  BB23 {
-    assume { Resolve3.resolve base_10 };
-    base_10 <- _30;
-    assume { Resolve3.resolve _35 };
-    _35 <- half_20;
-    assume { Resolve3.resolve half_20 };
-    size_8 <- size_8 - _35;
-    _17 <- ();
-    assume { Resolve2.resolve _17 };
-    goto BB15
-  }
-  BB24 {
-    assume { Resolve3.resolve size_8 };
-    _16 <- ();
-    assume { Resolve2.resolve _16 };
-    _41 <- arr_1;
-    assume { Resolve0.resolve arr_1 };
-    assume { Resolve3.resolve _42 };
-    _42 <- base_10;
-    _40 <- Index0.index _41 _42;
-    goto BB25
-  }
-  BB25 {
-    cmp_39 <- _40;
-    assume { Resolve4.resolve _40 };
-    _44 <- cmp_39;
-    assume { Resolve4.resolve cmp_39 };
-    _46 <- elem_2;
-    _45 <- _46;
-    assume { Resolve4.resolve _46 };
-    _43 <- Cmp0.cmp _44 _45;
-    goto BB26
-  }
-  BB26 {
-    assume { Resolve5.resolve _43 };
-    switch (_43)
-      | Type.Core_Cmp_Ordering_Less -> goto BB27
-      | Type.Core_Cmp_Ordering_Equal -> goto BB28
-      | Type.Core_Cmp_Ordering_Greater -> goto BB29
+    assume { Resolve5.resolve _38 };
+    switch (_38)
+      | Type.Core_Cmp_Ordering_Less -> goto BB22
+      | Type.Core_Cmp_Ordering_Equal -> goto BB23
+      | Type.Core_Cmp_Ordering_Greater -> goto BB24
       end
   }
-  BB27 {
-    goto BB32
+  BB22 {
+    goto BB27
   }
-  BB28 {
-    goto BB31
+  BB23 {
+    goto BB26
   }
-  BB29 {
-    assume { Resolve3.resolve _51 };
-    _51 <- base_10;
+  BB24 {
+    assume { Resolve3.resolve _46 };
+    _46 <- base_10;
     assume { Resolve3.resolve base_10 };
-    _0 <- Type.Core_Result_Result_Err _51;
-    goto BB33
+    _0 <- Type.Core_Result_Result_Err _46;
+    goto BB28
   }
-  BB30 {
+  BB25 {
     assume { Resolve1.resolve elem_2 };
     assume { Resolve3.resolve base_10 };
     absurd
   }
-  BB31 {
-    assume { Resolve3.resolve _48 };
-    _48 <- base_10;
+  BB26 {
+    assume { Resolve3.resolve _43 };
+    _43 <- base_10;
     assume { Resolve3.resolve base_10 };
-    _0 <- Type.Core_Result_Result_Ok _48;
-    goto BB33
+    _0 <- Type.Core_Result_Result_Ok _43;
+    goto BB28
   }
-  BB32 {
-    assume { Resolve3.resolve _50 };
-    _50 <- base_10;
+  BB27 {
+    assume { Resolve3.resolve _45 };
+    _45 <- base_10;
     assume { Resolve3.resolve base_10 };
-    _49 <- _50 + (1 : usize);
-    _0 <- Type.Core_Result_Result_Err _49;
-    goto BB33
+    _44 <- _45 + (1 : usize);
+    _0 <- Type.Core_Result_Result_Err _44;
+    goto BB28
   }
-  BB33 {
-    goto BB34
+  BB28 {
+    goto BB29
   }
-  BB34 {
+  BB29 {
     assume { Resolve1.resolve elem_2 };
     return _0
   }

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -94,16 +94,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
   type self   
@@ -123,16 +123,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
   type self   
@@ -152,16 +152,16 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self   
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   type self   

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -125,6 +125,28 @@ module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type modelTy  = 
     Seq.seq t
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
   use mach.int.UInt64
@@ -146,9 +168,10 @@ module CreusotContracts_Std1_Vec_Impl1_Len
   use prelude.Prelude
   use Type
   use mach.int.Int
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val len (self : Type.creusotcontracts_std1_vec_vec t) : usize
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
@@ -203,35 +226,14 @@ module CreusotContracts_Std1_Vec_Impl3_Index
   use mach.int.Int
   use prelude.Prelude
   use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   val index (self : Type.creusotcontracts_std1_vec_vec t) (ix : usize) : t
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
@@ -542,7 +544,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val with_capacity (capacity : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     
@@ -569,7 +571,7 @@ module CreusotContracts_Std1_Vec_FromElem
   use seq.Seq
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val from_elem (elem : t) (n : usize) : Type.creusotcontracts_std1_vec_vec t
     ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
@@ -628,9 +630,9 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val push (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
@@ -1233,9 +1235,9 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   val index_mut (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (ix : usize) : borrowed t
     requires {UInt64.to_int ix < Seq.length (Model0.model ( * self))}
     ensures { Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
@@ -1404,7 +1406,7 @@ module CreusotContracts_Std1_Vec_Impl1_New
   use mach.int.Int
   use mach.int.Int32
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   val new () : Type.creusotcontracts_std1_vec_vec t
     ensures { Seq.length (Model0.model result) = 0 }
     


### PR DESCRIPTION
Adds laws which auto-load whenever a trait or impl item is used.

TODO: Load the law when an impl item is used.

Unresolved Questions
-------------------- 

What are we supposed to do when the law has additional generic parameters?

I think for now we should just forbid laws from having additional generics, as we would not be able to guess what values to give them at clone-time.
