### PR TITLE
Macro Passthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,14 @@ dependencies = [
 name = "creusot-contracts"
 version = "0.1.0"
 dependencies = [
+ "creusot-contracts-dummy",
  "creusot-contracts-proc",
  "rand",
 ]
+
+[[package]]
+name = "creusot-contracts-dummy"
+version = "0.1.0"
 
 [[package]]
 name = "creusot-contracts-proc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "creusot",
   "creusot-contracts",
   "creusot-contracts-proc",
+  "creusot-contracts-dummy",
   "creusot-metadata",
   "why3",
   "why3tests",

--- a/creusot-contracts-dummy/Cargo.toml
+++ b/creusot-contracts-dummy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "creusot-contracts-dummy"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -1,0 +1,53 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream as TS1;
+
+#[proc_macro_attribute]
+pub fn requires(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
+#[proc_macro_attribute]
+pub fn ensures(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
+#[proc_macro_attribute]
+pub fn variant(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
+#[proc_macro_attribute]
+pub fn invariant(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
+#[proc_macro]
+pub fn proof_assert(_: TS1) -> TS1 {
+    TS1::new()
+}
+
+#[proc_macro]
+pub fn pearlite(_: TS1) -> TS1 {
+    TS1::new()
+}
+
+#[proc_macro_attribute]
+pub fn logic(_: TS1, _: TS1) -> TS1 {
+    TS1::new()
+}
+
+#[proc_macro_attribute]
+pub fn predicate(_: TS1, _: TS1) -> TS1 {
+    TS1::new()
+}
+
+#[proc_macro_attribute]
+pub fn law(_: TS1, _: TS1) -> TS1 {
+    TS1::new()
+}
+
+#[proc_macro_attribute]
+pub fn trusted(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}

--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "*" }
+creusot-contracts-dummy = { path = "../creusot-contracts-dummy", version = "*" }
 rand = "*"
 
 [features]

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -1,7 +1,95 @@
 #![cfg_attr(feature = "contracts", feature(unsized_fn_params))]
 #![cfg_attr(feature = "typechecker", feature(rustc_private), feature(box_patterns, box_syntax))]
 
-pub use creusot_contracts_proc::*;
+#[cfg(feature = "contracts")]
+mod macros {
+    /// A pre-condition of a function or trait item
+    pub use creusot_contracts_proc::requires;
+
+    /// A post-condition of a function or trait item
+    pub use creusot_contracts_proc::ensures;
+
+    /// A loop invariant
+    /// The first argument should be a name for the invariant
+    /// The second argument is the Pearlite expression for the loop invariant
+    pub use creusot_contracts_proc::invariant;
+
+    /// Declares a trait item as being a law which is autoloaded as soon another
+    /// trait item is used in a function
+    pub use creusot_contracts_proc::law;
+
+    /// Declare a function as being a logical function, this declaration must be pure and
+    /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
+    /// use logical operations and syntax with the help of the [pearlite] macro.
+    pub use creusot_contracts_proc::logic;
+
+    /// Declare a function as being a logical function, this declaration must be pure and
+    /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
+    /// use logical operations and syntax with the help of the [pearlite] macro.
+    pub use creusot_contracts_proc::predicate;
+
+    /// Inserts a *logical* assertion into the code. This assertion will not be checked at runtime
+    /// but only during proofs. However, it has access to the ghost context and can use logical operations
+    /// and syntax.
+    pub use creusot_contracts_proc::proof_assert;
+
+    /// Instructs Pearlite to ignore the body of a declaration, assuming any contract the declaration has is
+    /// valid.
+    pub use creusot_contracts_proc::trusted;
+
+    /// Declares a variant for a function, this is primarily used in combination with logical functions
+    /// The variant must be an expression which returns a type implementing [WellFounded]
+    pub use creusot_contracts_proc::variant;
+
+    /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
+    pub use creusot_contracts_proc::pearlite;
+}
+
+#[cfg(not(feature = "contracts"))]
+mod macros {
+    /// A pre-condition of a function or trait item
+    pub use creusot_contracts_dummy::requires;
+
+    /// A post-condition of a function or trait item
+    pub use creusot_contracts_dummy::ensures;
+
+    /// A loop invariant
+    /// The first argument should be a name for the invariant
+    /// The second argument is the Pearlite expression for the loop invariant
+    pub use creusot_contracts_dummy::invariant;
+
+    /// Declares a trait item as being a law which is autoloaded as soon another
+    /// trait item is used in a function
+    pub use creusot_contracts_dummy::law;
+
+    /// Declare a function as being a logical function, this declaration must be pure and
+    /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
+    /// use logical operations and syntax with the help of the [pearlite] macro.
+    pub use creusot_contracts_dummy::logic;
+
+    /// Declare a function as being a logical function, this declaration must be pure and
+    /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
+    /// use logical operations and syntax with the help of the [pearlite] macro.
+    pub use creusot_contracts_dummy::predicate;
+
+    /// Inserts a *logical* assertion into the code. This assertion will not be checked at runtime
+    /// but only during proofs. However, it has access to the ghost context and can use logical operations
+    /// and syntax.
+    pub use creusot_contracts_dummy::proof_assert;
+
+    /// Instructs Pearlite to ignore the body of a declaration, assuming any contract the declaration has is
+    /// valid.
+    pub use creusot_contracts_dummy::trusted;
+
+    /// Declares a variant for a function, this is primarily used in combination with logical functions
+    /// The variant must be an expression which returns a type implementing [WellFounded]
+    pub use creusot_contracts_dummy::variant;
+
+    /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
+    pub use creusot_contracts_proc::pearlite;
+}
+
+pub use macros::*;
 
 #[cfg(feature = "contracts")]
 pub mod stubs;
@@ -10,10 +98,27 @@ pub mod stubs;
 pub mod logic;
 
 #[cfg(feature = "contracts")]
-pub use logic::*;
-
-#[cfg(feature = "contracts")]
 pub mod std;
+
+#[cfg(not(feature = "contracts"))]
+pub mod std {
+    pub use std::vec;
+}
+
+#[cfg(not(feature = "contracts"))]
+pub mod logic {
+    pub struct Ghost<T>(std::marker::PhantomData<T>)
+    where
+        T: ?Sized;
+
+    impl<T> Ghost<T> {
+        pub fn record(_: &T) -> Ghost<T> {
+            Ghost(std::marker::PhantomData)
+        }
+    }
+}
+
+pub use logic::*;
 
 // Re-export the rand crate
 pub use rand;

--- a/creusot-contracts/src/logic.rs
+++ b/creusot-contracts/src/logic.rs
@@ -1,4 +1,5 @@
 pub mod eq;
+mod ghost;
 mod int;
 mod model;
 pub mod ord;
@@ -7,6 +8,7 @@ mod seq;
 pub mod well_founded;
 
 pub use eq::*;
+pub use ghost::*;
 pub use int::*;
 pub use model::*;
 pub use ord::*;

--- a/creusot-contracts/src/logic/ghost.rs
+++ b/creusot-contracts/src/logic/ghost.rs
@@ -1,0 +1,24 @@
+use crate as creusot_contracts;
+use crate::logic::*;
+use creusot_contracts_proc::*;
+
+pub struct Ghost<T>(*mut T)
+where
+    T: ?Sized;
+
+impl<T> Model for Ghost<T> {
+    type ModelTy = T;
+    #[logic]
+    #[trusted]
+    fn model(self) -> Self::ModelTy {
+        panic!()
+    }
+}
+
+impl<T> Ghost<T> {
+    #[trusted]
+    #[ensures(@result === *a)]
+    pub fn record(a: &T) -> Ghost<T> {
+        panic!()
+    }
+}

--- a/creusot/tests/should_succeed/100doors.rs
+++ b/creusot/tests/should_succeed/100doors.rs
@@ -1,3 +1,4 @@
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
 //! An adaptation of
 //!
 //! https://rosettacode.org/wiki/100_doors#Rust

--- a/creusot/tests/should_succeed/iter_mut.rs
+++ b/creusot/tests/should_succeed/iter_mut.rs
@@ -55,27 +55,6 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-pub struct Ghost<T>(*mut T)
-where
-    T: ?Sized;
-
-impl<T> Model for Ghost<T> {
-    type ModelTy = T;
-    #[logic]
-    #[trusted]
-    fn model(self) -> Self::ModelTy {
-        panic!()
-    }
-}
-
-impl<T> Ghost<T> {
-    #[trusted]
-    #[ensures(@result === *a)]
-    fn record(a: &T) -> Ghost<T> {
-        panic!()
-    }
-}
-
 #[ensures((@^v).len() === (@v).len())]
 #[ensures(forall<i : Int> 0 <= i && i < (@^v).len() ==> @(@^v)[i] === @(@v)[i] + 5)]
 fn inc_vec(v: &mut Vec<u32>) {

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -45,8 +45,8 @@ module Type
     ensures { result = core_option_option_Some_0 self }
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
-  type itermut_ghost 't = 
-    | IterMut_Ghost opaque_ptr
+  type creusotcontracts_logic_ghost_ghost 't = 
+    | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
@@ -226,49 +226,6 @@ module IterMut_Impl3_Next
     ensures { result = Get0.get (Model0.model ( * self)) 0 }
     
 end
-module IterMut_Impl4_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module IterMut_Impl4_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.itermut_ghost t) : t
-end
-module IterMut_Impl4_Model
-  type t   
-  use Type
-  function model (self : Type.itermut_ghost t) : t
-end
-module IterMut_Impl4
-  type t   
-  use Type
-  clone IterMut_Impl4_Model as Model0 with type t = t
-  clone IterMut_Impl4_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.itermut_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
-module IterMut_Impl5_Record_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  clone IterMut_Impl4_Model_Interface as Model0 with type t = t
-  val record (a : t) : Type.itermut_ghost t
-    ensures { Model0.model result = a }
-    
-end
-module IterMut_Impl5_Record
-  type t   
-  use prelude.Prelude
-  use Type
-  clone IterMut_Impl4_Model as Model0 with type t = t
-  val record (a : t) : Type.itermut_ghost t
-    ensures { Model0.model result = a }
-    
-end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
   type t   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
@@ -303,6 +260,31 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -310,6 +292,24 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -353,7 +353,7 @@ module IterMut_IncVec
   clone IterMut_Impl0_Model as Model1 with type t = int
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.itermut_vec int,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone IterMut_Impl4_Model as Model0 with type t = borrowed (Type.itermut_vec int)
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.itermut_vec int)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = int
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.core_option_option (borrowed int)
@@ -362,13 +362,13 @@ module IterMut_IncVec
   clone CreusotContracts_Logic_Seq_Impl0_Get as Get0 with type t = borrowed int
   clone CreusotContracts_Logic_Seq_Impl0_Tail as Tail0 with type t = borrowed int
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.itermut_vec int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.itermut_ghost (borrowed (Type.itermut_vec int))
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.itermut_vec int))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.itermut_vec int)
   clone IterMut_Impl3_Next_Interface as Next0 with type t = int, function Model0.model = Model3.model,
   function Tail0.tail = Tail0.tail, function Get0.get = Get0.get
   clone IterMut_Impl1_IterMut_Interface as IterMut0 with type t = int, function Model0.model = Model1.model,
   function Model1.model = Model3.model
-  clone IterMut_Impl5_Record_Interface as Record0 with type t = borrowed (Type.itermut_vec int),
+  clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.itermut_vec int),
   function Model0.model = Model0.model
   let rec cfg inc_vec (v : borrowed (Type.itermut_vec int)) : ()
     ensures { forall i : (int) . 0 <= i && i < Seq.length (Model1.model ( ^ v)) -> Seq.get (Model1.model ( ^ v)) i = Seq.get (Model2.model v) i + 5 }
@@ -377,7 +377,7 @@ module IterMut_IncVec
    = 
   var _0 : ();
   var v_1 : borrowed (Type.itermut_vec int);
-  var old_v_2 : Type.itermut_ghost (borrowed (Type.itermut_vec int));
+  var old_v_2 : Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.itermut_vec int));
   var _3 : borrowed (Type.itermut_vec int);
   var _4 : borrowed (Type.itermut_vec int);
   var it_5 : Type.itermut_itermut int;

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -1,31 +1,8 @@
 // WHY3PROVE Z3
-#![feature(type_ascription)]
-
 extern crate creusot_contracts;
 
 use creusot_contracts::std::*;
 use creusot_contracts::*;
-
-pub struct Ghost<T>
-where
-    T: ?Sized;
-
-impl<T> Model for Ghost<T> {
-    type ModelTy = T;
-    #[logic]
-    #[trusted]
-    fn model(self) -> Self::ModelTy {
-        panic!()
-    }
-}
-
-impl<T> Ghost<T> {
-    #[trusted]
-    #[ensures(@result === *a)]
-    fn record(a: &T) -> Ghost<T> {
-        Ghost::<T>
-    }
-}
 
 #[ensures(forall<i : Int> 0 <= i && i < (@^v).len() ==> (@^v)[i] === 0u32)]
 #[ensures((@*v).len() === (@^v).len())]

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -9,9 +9,6 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type c01_ghost 't = 
-    | C01_Ghost
-    
   type core_marker_phantomdata 't = 
     | Core_Marker_PhantomData
     
@@ -29,6 +26,9 @@ module Type
     
   type creusotcontracts_std1_vec_vec 't = 
     | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
+    
+  type creusotcontracts_logic_ghost_ghost 't = 
+    | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module C01_Main_Interface
@@ -60,49 +60,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module C01_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module C01_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.c01_ghost t) : t
-end
-module C01_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.c01_ghost t) : t
-end
-module C01_Impl0
-  type t   
-  use Type
-  clone C01_Impl0_Model as Model0 with type t = t
-  clone C01_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.c01_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.c01_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
-module C01_Impl1_Record_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C01_Impl0_Model_Interface as Model0 with type t = t
-  val record (a : t) : Type.c01_ghost t
-    ensures { Model0.model result = a }
-    
-end
-module C01_Impl1_Record
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C01_Impl0_Model as Model0 with type t = t
-  val record (a : t) : Type.c01_ghost t
-    ensures { Model0.model result = a }
-    
-end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
   use seq.Seq
@@ -131,6 +88,31 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -138,6 +120,24 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
   type t   
@@ -377,13 +377,13 @@ module C01_AllZero
   use prelude.Prelude
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = uint32
-  clone C01_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec uint32
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c01_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32))
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -392,7 +392,7 @@ module C01_AllZero
   clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = uint32, function Model0.model = Model2.model
-  clone C01_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32),
+  clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32),
   function Model0.model = Model0.model
   let rec cfg all_zero (v : borrowed (Type.creusotcontracts_std1_vec_vec uint32)) : ()
     ensures { Seq.length (Model1.model ( * v)) = Seq.length (Model1.model ( ^ v)) }
@@ -402,7 +402,7 @@ module C01_AllZero
   var _0 : ();
   var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec uint32);
   var i_2 : usize;
-  var old_v_3 : Type.c01_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32));
+  var old_v_3 : Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32));
   var _4 : borrowed (Type.creusotcontracts_std1_vec_vec uint32);
   var _5 : borrowed (Type.creusotcontracts_std1_vec_vec uint32);
   var _6 : ();

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -5,27 +5,6 @@ extern crate creusot_contracts;
 use creusot_contracts::std::*;
 use creusot_contracts::*;
 
-pub struct Ghost<T>(*mut T)
-where
-    T: ?Sized;
-
-impl<T> Model for Ghost<T> {
-    type ModelTy = T;
-    #[logic]
-    #[trusted]
-    fn model(self) -> Self::ModelTy {
-        panic!()
-    }
-}
-
-impl<T> Ghost<T> {
-    #[trusted]
-    #[ensures(@result === *a)]
-    fn record(a: &T) -> Ghost<T> {
-        panic!()
-    }
-}
-
 #[predicate]
 fn sorted_range<T: Ord>(s: Seq<T>, l: Int, u: Int) -> bool {
     pearlite! {

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -9,9 +9,6 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type c02gnome_ghost 't = 
-    | C02Gnome_Ghost opaque_ptr
-    
   type core_cmp_ordering  = 
     | Core_Cmp_Ordering_Less
     | Core_Cmp_Ordering_Equal
@@ -35,62 +32,8 @@ module Type
   type creusotcontracts_std1_vec_vec 't = 
     | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
     
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module C02Gnome_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module C02Gnome_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.c02gnome_ghost t) : t
-end
-module C02Gnome_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.c02gnome_ghost t) : t
-end
-module C02Gnome_Impl0
-  type t   
-  use Type
-  clone C02Gnome_Impl0_Model as Model0 with type t = t
-  clone C02Gnome_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.c02gnome_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.c02gnome_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
-module C02Gnome_Impl1_Record_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C02Gnome_Impl0_Model_Interface as Model0 with type t = t
-  val record (a : t) : Type.c02gnome_ghost t
-    ensures { Model0.model result = a }
-    
-end
-module C02Gnome_Impl1_Record
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C02Gnome_Impl0_Model as Model0 with type t = t
-  val record (a : t) : Type.c02gnome_ghost t
-    ensures { Model0.model result = a }
+  type creusotcontracts_logic_ghost_ghost 't = 
+    | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
@@ -376,6 +319,20 @@ module C02Gnome_Sorted
   predicate sorted (s : Seq.seq t) = 
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
   use seq.Seq
@@ -452,6 +409,31 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -459,6 +441,24 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
   type t   
@@ -801,7 +801,7 @@ module C02Gnome_GnomeSort
   clone C02Gnome_SortedRange as SortedRange0 with type t = t, function LeLog0.le_log = LeLog0.le_log
   clone C02Gnome_Sorted as Sorted0 with type t = t, predicate SortedRange0.sorted_range = SortedRange0.sorted_range
   clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with type t = t
-  clone C02Gnome_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
@@ -811,10 +811,10 @@ module C02Gnome_GnomeSort
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c02gnome_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, function LeLog0.le_log = LeLog0.le_log
-  clone C02Gnome_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
+  clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
   function Model0.model = Model1.model
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
@@ -829,7 +829,7 @@ module C02Gnome_GnomeSort
    = 
   var _0 : ();
   var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec t);
-  var old_v_2 : Type.c02gnome_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
+  var old_v_2 : Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
   var _3 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var _4 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var i_5 : usize;

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -6,27 +6,6 @@ extern crate creusot_contracts;
 use creusot_contracts::std::*;
 use creusot_contracts::*;
 
-pub struct Ghost<T>(*mut T)
-where
-    T: ?Sized;
-
-impl<T> Model for Ghost<T> {
-    type ModelTy = T;
-    #[logic]
-    #[trusted]
-    fn model(self) -> Self::ModelTy {
-        panic!()
-    }
-}
-
-impl<T> Ghost<T> {
-    #[trusted]
-    #[ensures(@result === *a)]
-    fn record(a: &T) -> Ghost<T> {
-        panic!()
-    }
-}
-
 #[trusted]
 #[ensures(@l <= @result && @result  < @u)]
 fn rand_in_range(l: usize, u: usize) -> usize {

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -9,9 +9,6 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type c03knuthshuffle_ghost 't = 
-    | C03KnuthShuffle_Ghost opaque_ptr
-    
   type core_marker_phantomdata 't = 
     | Core_Marker_PhantomData
     
@@ -30,62 +27,8 @@ module Type
   type creusotcontracts_std1_vec_vec 't = 
     | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
     
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module C03KnuthShuffle_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module C03KnuthShuffle_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.c03knuthshuffle_ghost t) : t
-end
-module C03KnuthShuffle_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.c03knuthshuffle_ghost t) : t
-end
-module C03KnuthShuffle_Impl0
-  type t   
-  use Type
-  clone C03KnuthShuffle_Impl0_Model as Model0 with type t = t
-  clone C03KnuthShuffle_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.c03knuthshuffle_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.c03knuthshuffle_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
-module C03KnuthShuffle_Impl1_Record_Interface
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C03KnuthShuffle_Impl0_Model_Interface as Model0 with type t = t
-  val record (a : t) : Type.c03knuthshuffle_ghost t
-    ensures { Model0.model result = a }
-    
-end
-module C03KnuthShuffle_Impl1_Record
-  type t   
-  use prelude.Prelude
-  use Type
-  clone C03KnuthShuffle_Impl0_Model as Model0 with type t = t
-  val record (a : t) : Type.c03knuthshuffle_ghost t
-    ensures { Model0.model result = a }
+  type creusotcontracts_logic_ghost_ghost 't = 
+    | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module C03KnuthShuffle_RandInRange_Interface
@@ -103,6 +46,20 @@ module C03KnuthShuffle_RandInRange
   val rand_in_range (l : usize) (u : usize) : usize
     ensures { UInt64.to_int l <= UInt64.to_int result && UInt64.to_int result < UInt64.to_int u }
     
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
@@ -180,6 +137,31 @@ module CreusotContracts_Logic_Seq_Impl0_PermutationOf
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
     Permut.permut self o 0 (Seq.length self)
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -187,6 +169,24 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  val record (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
   type t   
@@ -322,7 +322,7 @@ module C03KnuthShuffle_KnuthShuffle
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with type t = t
-  clone C03KnuthShuffle_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
@@ -333,9 +333,9 @@ module C03KnuthShuffle_KnuthShuffle
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
   clone C03KnuthShuffle_RandInRange_Interface as RandInRange0
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c03knuthshuffle_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
-  clone C03KnuthShuffle_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
+  clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
   function Model0.model = Model1.model
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
@@ -348,7 +348,7 @@ module C03KnuthShuffle_KnuthShuffle
    = 
   var _0 : ();
   var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec t);
-  var old_v_2 : Type.c03knuthshuffle_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
+  var old_v_2 : Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
   var _3 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var _4 : borrowed (Type.creusotcontracts_std1_vec_vec t);
   var n_5 : usize;


### PR DESCRIPTION
Adds a set of dummy macros which are on by default when compiling with normal `rustc`. This makes it possible to actually compile Creusot programs and execute them.

This still requires being a little careful around imports of things from `creusot_contracts::logic` but maybe we can think up a more coherent story. 

Additionally, when compiling with rustc it is necessary to manually set the `expr_stmt_attributes` and `proc_macro_hygiene` flags if any loop invariants are used, nothing I can do about that sadly. 

cc @claudemarche @sarsko I know both of you have wanted this feature.
