### PR TITLE
Add #[trusted] annotations for types

### DIFF
--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -367,11 +367,11 @@ fn predicate_item(log: PredicateItem) -> TS1 {
 
 #[proc_macro_attribute]
 pub fn trusted(_: TS1, tokens: TS1) -> TS1 {
-    let p: ItemFn = parse_macro_input!(tokens);
-
+    // let p: ItemFn = parse_macro_input!(tokens);
+    let tokens = TokenStream::from(tokens);
     TS1::from(quote! {
         #[creusot::decl::trusted]
-        #p
+        #tokens
     })
 }
 

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -3,6 +3,7 @@ use crate::logic::*;
 use crate::{std::clone::Clone, Int, Model, Seq};
 use creusot_contracts_proc::*;
 
+#[trusted]
 pub struct Vec<T>(std::vec::Vec<T>);
 
 impl<T> Model for Vec<T> {

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -26,8 +26,11 @@ use crate::util::{self, ident_of, ident_of_ty, item_name};
 pub enum PreludeModule {
     Int,
     Int8,
+    Int16,
     Int32,
     Int64,
+    UInt8,
+    UInt16,
     UInt32,
     UInt64,
     Char,
@@ -43,8 +46,11 @@ impl PreludeModule {
         match self {
             PreludeModule::Int => QName::from_string("mach.int.Int").unwrap(),
             PreludeModule::Int8 => QName::from_string("prelude.Int8").unwrap(),
+            PreludeModule::Int16 => QName::from_string("prelude.Int16").unwrap(),
             PreludeModule::Int32 => QName::from_string("mach.int.Int32").unwrap(),
             PreludeModule::Int64 => QName::from_string("mach.int.Int64").unwrap(),
+            PreludeModule::UInt8 => QName::from_string("mach.int.UInt8").unwrap(),
+            PreludeModule::UInt16 => QName::from_string("mach.int.UInt16").unwrap(),
             PreludeModule::UInt32 => QName::from_string("mach.int.UInt32").unwrap(),
             PreludeModule::UInt64 => QName::from_string("mach.int.UInt64").unwrap(),
             PreludeModule::Char => QName::from_string("string.Char").unwrap(),

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
   type c206_a  = 
     | C206_A (creusotcontracts_std1_vec_vec usize)
     

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -40,24 +40,7 @@ module Type
     ensures { result = core_option_option_Some_0 self }
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module C02_Inv_Inv_Interface
   type self   

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -40,24 +40,7 @@ module Type
     ensures { result = core_option_option_Some_0 self }
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) int 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) int
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module C03FibUnbounded_Inv_Inv_Interface
   type self   

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -22,24 +22,7 @@ module Type
     ensures { result = knapsack_item_Item_value self }
     
   axiom knapsack_item_Item_value_acc : forall a : 'name, b : usize, c : usize . knapsack_item_Item_value (Knapsack_Item a b c : knapsack_item 'name) = c
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module Knapsack_MaxLog_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -22,24 +22,7 @@ module Type
     ensures { result = knapsackfull_item_Item_value self }
     
   axiom knapsackfull_item_Item_value_acc : forall a : 'name, b : usize, c : usize . knapsackfull_item_Item_value (KnapsackFull_Item a b c : knapsackfull_item 'name) = c
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module KnapsackFull_MaxLog_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -14,24 +14,7 @@ module Type
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
     
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -13,24 +13,7 @@ module Type
     | Core_Result_Result_Ok 't
     | Core_Result_Result_Err 'e
     
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module C04BinarySearch_SortedRange_Interface
   use seq.Seq

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -18,24 +18,7 @@ module Type
     | Core_Result_Result_Ok 't
     | Core_Result_Result_Err 'e
     
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -9,24 +9,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type core_marker_phantomdata 't = 
-    | Core_Marker_PhantomData
-    
-  type core_ptr_unique_unique 't = 
-    | Core_Ptr_Unique_Unique opaque_ptr (core_marker_phantomdata 't)
-    
-  type alloc_rawvec_rawvec 't 'a = 
-    | Alloc_RawVec_RawVec (core_ptr_unique_unique 't) usize 'a
-    
-  type alloc_vec_vec 't 'a = 
-    | Alloc_Vec_Vec (alloc_rawvec_rawvec 't 'a) usize
-    
-  type alloc_alloc_global  = 
-    | Alloc_Alloc_Global
-    
-  type creusotcontracts_std1_vec_vec 't = 
-    | CreusotContracts_Std1_Vec_Vec (alloc_vec_vec 't (alloc_alloc_global))
-    
+  type creusotcontracts_std1_vec_vec 't  
   type c06knightstour_point  = 
     | C06KnightsTour_Point isize isize
     

--- a/prelude/prelude.mlw
+++ b/prelude/prelude.mlw
@@ -27,9 +27,7 @@ module Prelude
     | _ -> False
     end
 end
-
 module Int8
-
   use int.Int
 
   type int8 = < range -0x80 0x7f >
@@ -45,5 +43,56 @@ module Int8
     function to_int = int8'int,
     lemma to_int_in_bounds,
     lemma extensionality
-
 end
+module Int16
+  use int.Int
+
+  type int16 = < range -0x8000 0x7fff >
+
+  let constant min_int16 : int = - 0x8000
+  let constant max_int16 : int =   0x7fff
+  function to_int (x : int16) : int = int16'int x
+
+  clone export mach.int.Bounded_int with
+    type t = int16,
+    constant min = int16'minInt,
+    constant max = int16'maxInt,
+    function to_int = int16'int,
+    lemma to_int_in_bounds,
+    lemma extensionality
+end
+module UInt8
+  use int.Int
+
+  type uint8 = < range 0x0 0xff >
+
+  let constant min_uint8 : int =  0x00
+  let constant max_uint8 : int =  0xff
+  function to_int (x : uint8) : int = uint8'int x
+
+  clone export mach.int.Bounded_int with
+    type t = uint8,
+    constant min = uint8'minInt,
+    constant max = uint8'maxInt,
+    function to_int = uint8'int,
+    lemma to_int_in_bounds,
+    lemma extensionality
+end
+module UInt16
+  use int.Int
+
+  type uint16 = < range 0x0 0xffff >
+
+  let constant min_uint16 : int =  0x00
+  let constant max_uint16 : int =  0xffff
+  function to_int (x : uint16) : int = uint16'int x
+
+  clone export mach.int.Bounded_int with
+    type t = uint16,
+    constant min = uint16'minInt,
+    constant max = uint16'maxInt,
+    function to_int = uint16'int,
+    lemma to_int_in_bounds,
+    lemma extensionality
+end
+


### PR DESCRIPTION
This allows us to entirely avoid translating the internals of a type like `Vec<T>`. 
