### PR TITLE
Allow extern specs to refine trait bounds

### DIFF
--- a/creusot/src/callbacks.rs
+++ b/creusot/src/callbacks.rs
@@ -34,11 +34,7 @@ impl Callbacks for ToWhy {
             .global_ctxt()
             .unwrap()
             .peek_mut()
-            .enter(|tcx| {
-                let session = c.session();
-
-                crate::translation::translate(tcx, session, &self.opts)
-            })
+            .enter(|tcx| crate::translation::translate(tcx, &self.opts))
             .unwrap();
 
         c.session().abort_if_errors();

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -37,13 +37,13 @@ impl GatherSpecClosures {
         for clos in visitor.closures.into_iter() {
             if let Some(name) = util::invariant_name(ctx.tcx, clos) {
                 let term = specification::typing::typecheck(ctx.tcx, clos.expect_local())
-                    .unwrap_or_else(|e| e.emit(ctx.sess));
+                    .unwrap_or_else(|e| e.emit(ctx.tcx.sess));
                 let exp = lower_pure(ctx, names, clos, term);
 
                 invariants.insert(clos, (name, exp));
             } else if util::is_assertion(ctx.tcx, clos) {
                 let term = specification::typing::typecheck(ctx.tcx, clos.expect_local())
-                    .unwrap_or_else(|e| e.emit(ctx.sess));
+                    .unwrap_or_else(|e| e.emit(ctx.tcx.sess));
                 let exp = lower_pure(ctx, names, clos, term);
 
                 assertions.insert(clos, exp);

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -11,18 +11,15 @@ pub use function::translate_function;
 pub use function::LocalIdent;
 pub use logic::*;
 
-use heck::CamelCase;
-
 use crate::ctx;
-
 use crate::ctx::TypeDeclaration;
 use crate::metadata;
 use crate::options::Options;
 use crate::translation::external::extract_extern_specs_from_item;
 use crate::validate::validate_traits;
+use heck::CamelCase;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::ty::TyCtxt;
-use rustc_session::Session;
 use std::io::Result;
 use std::io::Write;
 use why3::mlcfg;
@@ -32,8 +29,8 @@ use why3::{
 };
 
 // TODO: Move the main loop out of `translation.rs`
-pub fn translate(tcx: TyCtxt, sess: &Session, opts: &Options) -> Result<()> {
-    let mut ctx = ctx::TranslationCtx::new(tcx, sess, &opts);
+pub fn translate(tcx: TyCtxt, opts: &Options) -> Result<()> {
+    let mut ctx = ctx::TranslationCtx::new(tcx, &opts);
 
     // Check that all trait laws are well-formed
     validate_traits(&mut ctx);

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -127,7 +127,7 @@ pub fn contract_of(ctx: &TranslationCtx, def_id: DefId) -> Result<PreContract, S
     let mut contract = PreContract::new();
 
     if let Some(extern_spec) = ctx.extern_spec(def_id) {
-        return Ok(extern_spec.clone());
+        return Ok(extern_spec.contract.clone());
     }
 
     for attr in attrs {

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.rs
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.rs
@@ -9,3 +9,23 @@ extern_spec! {
 fn main() {
     let v: Vec<bool> = Vec::new();
 }
+
+fn has_params<V, U, X>(a: V, b: U, c: X) {}
+
+extern_spec! {
+    fn has_params<C,B,A>(a: A, b: B, c: C)
+}
+
+trait A {}
+
+trait B: A {}
+
+fn uses_a<T: A>(x: T) {}
+
+extern_spec! {
+    fn uses_a<T : B>(x : T)
+}
+
+fn client<T: B>(y: T) {
+    uses_a(y)
+}

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
@@ -79,3 +79,99 @@ module C07ExternSpec_Main
   }
   
 end
+module C07ExternSpec_HasParams_Interface
+  type v   
+  type u   
+  type x   
+  val has_params [@cfg:stackify] (a : v) (b : u) (c : x) : ()
+end
+module C07ExternSpec_HasParams
+  type v   
+  type u   
+  type x   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = v
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = u
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = x
+  let rec cfg has_params [@cfg:stackify] (a : v) (b : u) (c : x) : () = 
+  var _0 : ();
+  var a_1 : v;
+  var b_2 : u;
+  var c_3 : x;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    c_3 <- c;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve0.resolve c_3 };
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve1.resolve b_2 };
+    goto BB3
+  }
+  BB3 {
+    assume { Resolve2.resolve a_1 };
+    return _0
+  }
+  
+end
+module C07ExternSpec_UsesA_Interface
+  type t   
+  val uses_a [@cfg:stackify] (x : t) : ()
+end
+module C07ExternSpec_UsesA
+  type t   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
+  let rec cfg uses_a [@cfg:stackify] (x : t) : () = 
+  var _0 : ();
+  var x_1 : t;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve0.resolve x_1 };
+    return _0
+  }
+  
+end
+module C07ExternSpec_Client_Interface
+  type t   
+  val client [@cfg:stackify] (y : t) : ()
+end
+module C07ExternSpec_Client
+  type t   
+  clone C07ExternSpec_UsesA_Interface as UsesA0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
+  let rec cfg client [@cfg:stackify] (y : t) : () = 
+  var _0 : ();
+  var y_1 : t;
+  var _2 : t;
+  {
+    y_1 <- y;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _2 };
+    _2 <- y_1;
+    _0 <- UsesA0.uses_a _2;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    return _0
+  }
+  
+end


### PR DESCRIPTION
This PR adds the ability for `extern_specs` to refine trait bounds. This will allow us to attach good specifications to functions like `eq`. 