### PR TITLE
Closures

### DIFF
--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -91,8 +91,11 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
         RT::Repeat(_) => todo!("Repeat"),
         RT::Struct(_) => todo!("Struct"),
         RT::Tuple(TermTuple { elems, .. }) => {
+            if elems.is_empty() {
+                return Ok(quote! { () });
+            }
             let elems: Vec<_> = elems.into_iter().map(encode_term).collect::<Result<_, _>>()?;
-            Ok(quote! { (#(#elems),*) })
+            Ok(quote! { (#(#elems),*,) })
         }
         RT::Type(ty) => Ok(quote! { #ty }),
         RT::Unary(TermUnary { op, expr }) => {

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -1,4 +1,8 @@
-#![cfg_attr(feature = "contracts", feature(unsized_locals), allow(incomplete_features))]
+#![cfg_attr(
+    feature = "contracts",
+    feature(unsized_locals, fn_traits, unboxed_closures),
+    allow(incomplete_features)
+)]
 #![cfg_attr(feature = "typechecker", feature(rustc_private), feature(box_patterns, box_syntax))]
 
 #[cfg(feature = "contracts")]

--- a/creusot-contracts/src/std.rs
+++ b/creusot-contracts/src/std.rs
@@ -1,12 +1,13 @@
 pub mod clone;
 pub mod eq;
+mod fun;
 pub mod mem;
 pub mod ord;
-pub mod vec;
-
 mod slice;
+pub mod vec;
 
 pub use clone::*;
 pub use eq::*;
+pub use fun::*;
 pub use ord::*;
 pub use vec::*;

--- a/creusot-contracts/src/std/fun.rs
+++ b/creusot-contracts/src/std/fun.rs
@@ -1,0 +1,95 @@
+use crate as creusot_contracts;
+use creusot_contracts_proc::*;
+
+#[rustc_diagnostic_item = "fn_once_spec"]
+pub trait FnOnceSpec<Args>: FnOnce<Args> {
+    #[predicate]
+    fn precondition(self, a: Args) -> bool;
+
+    #[predicate]
+    fn postcondition_once(self, a: Args, res: Self::Output) -> bool;
+}
+
+#[rustc_diagnostic_item = "fn_mut_spec"]
+pub trait FnMutSpec<Args>: FnMut<Args> + FnOnceSpec<Args> {
+    #[predicate]
+    fn postcondition_mut(&mut self, a: Args, res: Self::Output) -> bool;
+
+    #[law]
+    #[ensures((exists<s: &mut Self> *s === self && s.postcondition_mut(a, res) && (^s).resolve()) ==> self.postcondition_once(a, res))]
+    #[ensures(self.postcondition_once(a, res) ==> exists<s: &mut Self> *s === self && s.postcondition_mut(a, res) && (^s).resolve())]
+    fn fn_mut_once(self, a: Args, res: Self::Output)
+    where
+        Self: crate::Resolve + Sized;
+}
+
+#[rustc_diagnostic_item = "fn_spec"]
+pub trait FnSpec<Args>: Fn<Args> + FnMutSpec<Args> {
+    #[predicate]
+    fn postcondition(&self, _: Args, _: Self::Output) -> bool;
+
+    #[law]
+    #[ensures(self.postcondition(args, res) ==> exists<s: &mut Self> *s === *self && s.resolve() && s.postcondition_mut(args, res))]
+    #[ensures((exists<s: &mut Self> *s === *self && s.resolve() && s.postcondition_mut(args, res)) ==> self.postcondition(args, res))]
+    fn fn_mut(&self, args: Args, res: Self::Output)
+    where
+        Self: crate::Resolve + Sized;
+}
+
+impl<Args, F: FnOnce<Args>> FnOnceSpec<Args> for F {
+    #[predicate]
+    #[trusted]
+    #[rustc_diagnostic_item = "fn_once_impl_precond"]
+    fn precondition(self, _: Args) -> bool {
+        std::process::abort()
+    }
+
+    #[predicate]
+    #[trusted]
+    #[rustc_diagnostic_item = "fn_once_impl_postcond"]
+    fn postcondition_once(self, _: Args, _: Self::Output) -> bool {
+        std::process::abort()
+    }
+}
+
+impl<Args, F: FnMut<Args>> FnMutSpec<Args> for F {
+    #[predicate]
+    #[trusted]
+    #[rustc_diagnostic_item = "fn_mut_impl_postcond"]
+    fn postcondition_mut(&mut self, _: Args, _: Self::Output) -> bool {
+        std::process::abort()
+    }
+
+    #[law]
+    fn fn_mut_once(self, _: Args, _: Self::Output) {}
+}
+
+impl<Args, F: Fn<Args>> FnSpec<Args> for F {
+    #[predicate]
+    #[trusted]
+    #[rustc_diagnostic_item = "fn_impl_postcond"]
+    fn postcondition(&self, _: Args, _: Self::Output) -> bool {
+        std::process::abort()
+    }
+
+    #[law]
+    fn fn_mut(&self, _: Args, _: Self::Output) {}
+}
+
+extern_spec! {
+    #[requires(f.precondition(a))]
+    #[ensures(f.postcondition_once(a, result))]
+    fn std::ops::FnOnce::call_once<A, F : FnOnceSpec<A>>(f: F, a: A) -> F::Output
+}
+
+extern_spec! {
+    #[requires((*f).precondition(a))]
+    #[ensures(f.postcondition_mut(a, result))]
+    fn std::ops::FnMut::call_mut<A, F : FnMutSpec<A>>(f: &mut F, a: A) -> F::Output
+}
+
+extern_spec! {
+    #[requires((*f).precondition(a))]
+    #[ensures(f.postcondition(a, result))]
+    fn std::ops::Fn::call<A, F : FnSpec<A>>(f: &F, a: A) -> F::Output
+}

--- a/creusot-contracts/src/stubs.rs
+++ b/creusot-contracts/src/stubs.rs
@@ -51,3 +51,12 @@ pub fn abs<T>() -> T {
 pub fn variant_check<R: crate::WellFounded>(r: R) -> R {
     r
 }
+
+// Used to create a constraint forcing the result of an ensures closure to agree with the outside
+// #[creusot::no_translate]
+// #[rustc_diagnostic_item = "closure_result_constraint"]
+// pub fn closure_result<Args, Args2, R, F : FnOnce<Args, Output=R>, G : FnOnce<Args2, Output=R>>(f: F, g: G) { }
+
+#[creusot::no_translate]
+#[rustc_diagnostic_item = "closure_result_constraint"]
+pub fn closure_result<Args, R, F: FnOnce<Args, Output = R>>(_: F, _: R) {}

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -1,21 +1,16 @@
-use std::ops::ControlFlow;
-
 use indexmap::IndexMap;
-
+use heck::CamelCase;
 use petgraph::graphmap::DiGraphMap;
 use petgraph::EdgeDirection::Incoming;
-use why3::declaration::{CloneKind, CloneSubst, Decl, DeclClone, Use};
-use why3::{Ident, QName};
-
-use heck::CamelCase;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{
     self,
-    fold::TypeVisitor,
     subst::{InternalSubsts, Subst, SubstsRef},
-    ProjectionTy, Ty, TyCtxt, TyKind,
+    TyCtxt,
 };
 use rustc_span::Symbol;
+use why3::declaration::{CloneKind, CloneSubst, Decl, DeclClone, Use};
+use why3::{Ident, QName};
 
 use crate::ctx::{self, *};
 use crate::translation::{interface, traits};
@@ -551,24 +546,5 @@ fn refinable_symbols(
         Trait | Impl => unreachable!("trait blocks have no refinable symbols"),
         Type => unreachable!("types have no refinable symbols"),
         _ => unreachable!(),
-    }
-}
-
-// A basic visitor which can be used to gether ProjectionTys containd in
-// a foldable struct
-struct ProjectionTyVisitor<'a, 'tcx> {
-    f: Box<dyn FnMut(ProjectionTy<'tcx>) + 'a>,
-}
-
-impl TypeVisitor<'tcx> for ProjectionTyVisitor<'a, 'tcx> {
-    // fn tcx_for_anon_const_substs(&self) -> Option<TyCtxt<'tcx>> {
-    //     None
-    // }
-
-    fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
-        if let TyKind::Projection(t) = t.kind() {
-            (*self.f)(*t)
-        }
-        ControlFlow::CONTINUE
     }
 }

--- a/creusot/src/translated_item.rs
+++ b/creusot/src/translated_item.rs
@@ -18,6 +18,7 @@ pub enum TranslatedItem<'tcx> {
         interface: Module,
         modl: Module,
         dependencies: CloneSummary<'tcx>,
+        has_axioms: bool,
     },
     Trait {
         laws: Vec<DefId>,
@@ -86,6 +87,7 @@ impl TranslatedItem<'tcx> {
     pub fn has_axioms(&self) -> bool {
         match self {
             TranslatedItem::Logic { has_axioms, .. } => *has_axioms,
+            TranslatedItem::Program { has_axioms, .. } => *has_axioms,
             _ => false,
         }
     }

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -8,6 +8,7 @@ pub mod traits;
 pub mod ty;
 
 use crate::ctx;
+use crate::ctx::load_extern_specs;
 use crate::ctx::TypeDeclaration;
 use crate::error::CrErr;
 use crate::metadata;
@@ -47,6 +48,7 @@ pub fn translate(tcx: TyCtxt, opts: &Options) -> Result<(), Box<dyn Error>> {
     for tr in ctx.tcx.traits_in_crate(LOCAL_CRATE) {
         ctx.translate_trait(*tr);
     }
+    load_extern_specs(&mut ctx);
 
     for def_id in ctx.tcx.hir().body_owners() {
         let def_id = def_id.to_def_id();

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -128,7 +128,7 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                 // Drop
                 let ty = place.ty(self.body, self.tcx).ty;
                 let pl_exp = self.translate_rplace(place);
-                let assumption: Exp = self.resolve_predicate_of(ty).app_to(pl_exp);
+                let assumption: Exp = self.resolve_ty(ty).app_to(pl_exp);
                 self.emit_statement(Statement::Assume(assumption));
 
                 // Assign

--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -5,21 +5,48 @@ use why3::{
     Ident,
 };
 
-use crate::{clone_map::CloneMap, ctx::*, translation::function::all_generic_decls_for, util};
+use crate::{clone_map::CloneMap, ctx::*, util};
 
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{ClosureKind, TyCtxt, TyKind};
+
+use super::{
+    function::{closure_contract, closure_generic_decls, closure_unnest},
+    ty::{closure_accessors, translate_closure_ty},
+};
 
 pub fn interface_for(
     ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
 ) -> (Module, CloneMap<'tcx>) {
+    debug!("interface_for: {def_id:?}");
     let mut names = CloneMap::new(ctx.tcx, def_id, false);
-
+    names.clone_self(def_id);
     let mut sig = util::signature_of(ctx, &mut names, def_id);
+
     sig.contract.variant = Vec::new();
 
-    let mut decls: Vec<_> = all_generic_decls_for(ctx.tcx, def_id).collect();
+    let mut decls: Vec<_> = closure_generic_decls(ctx.tcx, def_id).collect();
+
+    if ctx.tcx.is_closure(def_id) {
+        if let TyKind::Closure(_, subst) = ctx.tcx.type_of(def_id).kind() {
+            let tydecl = translate_closure_ty(ctx, &mut names, def_id, subst);
+            decls.extend(names.to_clones(ctx));
+
+            let accessors = closure_accessors(ctx, &mut names, def_id, subst.as_closure());
+            decls.extend(names.to_clones(ctx));
+            decls.push(Decl::TyDecl(tydecl));
+            decls.extend(accessors);
+
+            let contracts = closure_contract(ctx, &mut names, def_id);
+            decls.extend(names.to_clones(ctx));
+            decls.extend(contracts);
+
+            if subst.as_closure().kind() == ClosureKind::FnMut {
+                sig.contract.ensures.push(closure_unnest(ctx.tcx, &mut names, def_id, subst))
+            }
+        }
+    }
 
     decls.extend(names.to_clones(ctx));
 

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -31,6 +31,14 @@ impl PreContract {
         Self { func_id, variant: None, requires: Vec::new(), ensures: Vec::new() }
     }
 
+    pub fn iter_items(&self) -> impl Iterator<Item = DefId> + '_ {
+        self.variant
+            .iter()
+            .cloned()
+            .chain(self.requires.iter().cloned())
+            .chain(self.ensures.iter().cloned())
+    }
+
     pub fn check_and_lower<'tcx>(
         self,
         ctx: &mut TranslationCtx<'_, 'tcx>,
@@ -112,11 +120,11 @@ pub enum SpecAttrError {
     InvalidTokens,
 }
 
-pub fn contract_of(ctx: &TranslationCtx, def_id: DefId) -> Result<PreContract, SpecAttrError> {
+pub fn contract_of(ctx: &mut TranslationCtx, def_id: DefId) -> Result<PreContract, SpecAttrError> {
     use SpecAttrError::*;
 
-    if let Some(extern_spec) = ctx.extern_spec(def_id) {
-        return Ok(extern_spec.contract.clone());
+    if let Some(extern_spec) = ctx.extern_spec(def_id).cloned() {
+        return Ok(extern_spec.contract);
     }
 
     let attrs = ctx.tcx.get_attrs(def_id);

--- a/creusot/src/translation/specification/typing.rs
+++ b/creusot/src/translation/specification/typing.rs
@@ -88,343 +88,364 @@ pub fn typecheck(tcx: TyCtxt, id: LocalDefId) -> CreusotResult<Term> {
     if thir.exprs.is_empty() {
         return Err(Error::new(tcx.def_span(id), "type checking failed"));
     };
-    lower_expr(tcx, id, &thir, expr)
+
+    let lower = ThirTerm { tcx, item_id: id, thir: &thir };
+
+    lower.expr_term(expr)
 }
 
-fn lower_expr<'tcx>(
+struct ThirTerm<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     item_id: LocalDefId,
-    thir: &Thir<'tcx>,
-    expr: ExprId,
-) -> CreusotResult<Term<'tcx>> {
-    let ty = thir[expr].ty;
-    // eprintln!("{:?}", &thir[expr].kind);
-    match thir[expr].kind {
-        ExprKind::Scope { value, .. } => lower_expr(tcx, item_id, thir, value),
-        ExprKind::Block { body: Block { ref stmts, expr, .. } } => {
-            let mut inner = match expr {
-                Some(e) => lower_expr(tcx, item_id, thir, e)?,
-                None => Term { ty, kind: TermKind::Tuple { fields: vec![] } },
-            };
+    thir: &'a Thir<'tcx>,
+}
 
-            for stmt in stmts.iter().rev().filter(|id| not_spec(tcx, thir, **id)) {
-                inner = lower_stmt(tcx, item_id, thir, *stmt, inner)?;
+impl ThirTerm<'a, 'tcx> {
+    fn expr_term(&self, expr: ExprId) -> CreusotResult<Term<'tcx>> {
+        let ty = self.thir[expr].ty;
+        // eprintln!("{:?}", &thir[expr].kind);
+        match self.thir[expr].kind {
+            ExprKind::Scope { value, .. } => self.expr_term(value),
+            ExprKind::Block { body: Block { ref stmts, expr, .. } } => {
+                let mut inner = match expr {
+                    Some(e) => self.expr_term(e)?,
+                    None => Term { ty, kind: TermKind::Tuple { fields: vec![] } },
+                };
+
+                for stmt in stmts.iter().rev().filter(|id| not_spec(self.tcx, self.thir, **id)) {
+                    inner = self.stmt_term(*stmt, inner)?;
+                }
+                Ok(inner)
             }
-            Ok(inner)
-        }
-        ExprKind::Binary { op, lhs, rhs } => {
-            let operand_ty = thir[lhs].ty;
-            let lhs = lower_expr(tcx, item_id, thir, lhs)?;
-            let rhs = lower_expr(tcx, item_id, thir, rhs)?;
+            ExprKind::Binary { op, lhs, rhs } => {
+                let operand_ty = self.thir[lhs].ty;
+                let lhs = self.expr_term(lhs)?;
+                let rhs = self.expr_term(rhs)?;
 
-            let op = match op {
-                rustc_middle::mir::BinOp::Add => BinOp::Add,
-                rustc_middle::mir::BinOp::Sub => BinOp::Sub,
-                rustc_middle::mir::BinOp::Mul => BinOp::Mul,
-                rustc_middle::mir::BinOp::Div => BinOp::Div,
-                rustc_middle::mir::BinOp::Rem => BinOp::Rem,
-                rustc_middle::mir::BinOp::BitXor => {
-                    return Err(Error::new(thir[expr].span, "unsupported operation"))
-                }
-                rustc_middle::mir::BinOp::BitAnd => {
-                    return Err(Error::new(thir[expr].span, "unsupported operation"))
-                }
-                rustc_middle::mir::BinOp::BitOr => {
-                    return Err(Error::new(thir[expr].span, "unsupported operation"))
-                }
-                rustc_middle::mir::BinOp::Shl => {
-                    return Err(Error::new(thir[expr].span, "unsupported operation"))
-                }
-                rustc_middle::mir::BinOp::Shr => {
-                    return Err(Error::new(thir[expr].span, "unsupported operation"))
-                }
-                rustc_middle::mir::BinOp::Eq => BinOp::Eq,
-                rustc_middle::mir::BinOp::Lt => BinOp::Lt,
-                rustc_middle::mir::BinOp::Le => BinOp::Le,
-                rustc_middle::mir::BinOp::Ne => BinOp::Ne,
-                rustc_middle::mir::BinOp::Ge => BinOp::Ge,
-                rustc_middle::mir::BinOp::Gt => BinOp::Gt,
-                rustc_middle::mir::BinOp::Offset => todo!(),
-            };
-            Ok(Term { ty, kind: TermKind::Binary { op, operand_ty, lhs: box lhs, rhs: box rhs } })
-        }
-        ExprKind::LogicalOp { op, lhs, rhs } => {
-            let lhs = lower_expr(tcx, item_id, thir, lhs)?;
-            let rhs = lower_expr(tcx, item_id, thir, rhs)?;
-            let op = match op {
-                thir::LogicalOp::And => LogicalOp::And,
-                thir::LogicalOp::Or => LogicalOp::Or,
-            };
-            Ok(Term { ty, kind: TermKind::Logical { op, lhs: box lhs, rhs: box rhs } })
-        }
-        ExprKind::Unary { op, arg } => {
-            let arg = lower_expr(tcx, item_id, thir, arg)?;
-            let op = match op {
-                rustc_middle::mir::UnOp::Not => UnOp::Not,
-                rustc_middle::mir::UnOp::Neg => UnOp::Neg,
-            };
-            Ok(Term { ty, kind: TermKind::Unary { op, arg: box arg } })
-        }
-        ExprKind::VarRef { id } => {
-            let map = tcx.hir();
-            let name = map.name(id);
-            Ok(Term { ty, kind: TermKind::Var(name) })
-        }
-        // TODO: confirm this works
-        ExprKind::UpvarRef { var_hir_id: id, .. } => {
-            let map = tcx.hir();
-            let name = map.name(id);
-
-            Ok(Term { ty, kind: TermKind::Var(name) })
-        }
-        ExprKind::Literal { literal, .. } => Ok(Term { ty, kind: TermKind::Const(literal) }),
-        ExprKind::Call { ty: f_ty, fun, ref args, .. } => {
-            use Stub::*;
-            match pearlite_stub(tcx, f_ty) {
-                Some(Forall) => {
-                    let (binder, body) = lower_quantifier(tcx, thir, args[0])?;
-                    Ok(Term { ty, kind: TermKind::Forall { binder, body: box body } })
-                }
-                Some(Exists) => {
-                    let (binder, body) = lower_quantifier(tcx, thir, args[0])?;
-                    Ok(Term { ty, kind: TermKind::Exists { binder, body: box body } })
-                }
-                Some(Fin) => {
-                    let term = lower_expr(tcx, item_id, thir, args[0])?;
-
-                    Ok(Term { ty, kind: TermKind::Fin { term: box term } })
-                }
-                Some(Cur) => {
-                    let term = lower_expr(tcx, item_id, thir, args[0])?;
-
-                    Ok(Term { ty, kind: TermKind::Cur { term: box term } })
-                }
-                Some(Impl) => {
-                    let lhs = lower_expr(tcx, item_id, thir, args[0])?;
-                    let rhs = lower_expr(tcx, item_id, thir, args[1])?;
-
-                    Ok(Term { ty, kind: TermKind::Impl { lhs: box lhs, rhs: box rhs } })
-                }
-                Some(Equals) => {
-                    let lhs = lower_expr(tcx, item_id, thir, args[0])?;
-                    let rhs = lower_expr(tcx, item_id, thir, args[1])?;
-
-                    Ok(Term { ty, kind: TermKind::Equals { lhs: box lhs, rhs: box rhs } })
-                }
-                Some(VariantCheck) => lower_expr(tcx, item_id, thir, args[0]),
-                Some(Old) => {
-                    let term = lower_expr(tcx, item_id, thir, args[0])?;
-
-                    Ok(Term { ty, kind: TermKind::Old { term: box term } })
-                }
-                None => {
-                    let fun = lower_expr(tcx, item_id, thir, fun)?;
-                    let args = args
-                        .iter()
-                        .map(|arg| lower_expr(tcx, item_id, thir, *arg))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    let (id, subst) = if let TyKind::FnDef(id, subst) = f_ty.kind() {
-                        (*id, subst)
-                    } else {
-                        unreachable!("Call on non-function type");
-                    };
-
-                    Ok(Term { ty, kind: TermKind::Call { id, subst, fun: box fun, args } })
-                }
-            }
-        }
-        ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg } => {
-            lower_expr(tcx, item_id, thir, arg)
-        }
-        ExprKind::Borrow { arg, .. } => {
-            // Rust will introduce add unnecessary reborrows to code.
-            // Since we've syntactically ruled out borrowing at a higher level, we should
-            // be able erase it safely (:fingers_crossed:)
-            if let ExprKind::Deref { arg } = thir[arg].kind {
-                lower_expr(tcx, item_id, thir, arg)
-            } else {
-                unreachable!("unexpected borrow in pearlite");
-            }
-        }
-        ExprKind::Adt(box Adt { adt_def, variant_index, ref fields, .. }) => {
-            let fields = fields
-                .iter()
-                .map(|f| lower_expr(tcx, item_id, thir, f.expr))
-                .collect::<Result<_, _>>()?;
-            Ok(Term {
-                ty,
-                kind: TermKind::Constructor { adt: adt_def, variant: variant_index, fields },
-            })
-        }
-        // TODO: If we deref a shared borrow this should be erased?
-        // Can it happen?
-        ExprKind::Deref { arg } => {
-            if thir[arg].ty.is_box() || thir[arg].ty.ref_mutability() == Some(Not) {
-                lower_expr(tcx, item_id, thir, arg)
-            } else {
+                let op = match op {
+                    rustc_middle::mir::BinOp::Add => BinOp::Add,
+                    rustc_middle::mir::BinOp::Sub => BinOp::Sub,
+                    rustc_middle::mir::BinOp::Mul => BinOp::Mul,
+                    rustc_middle::mir::BinOp::Div => BinOp::Div,
+                    rustc_middle::mir::BinOp::Rem => BinOp::Rem,
+                    rustc_middle::mir::BinOp::BitXor => {
+                        return Err(Error::new(self.thir[expr].span, "unsupported operation"))
+                    }
+                    rustc_middle::mir::BinOp::BitAnd => {
+                        return Err(Error::new(self.thir[expr].span, "unsupported operation"))
+                    }
+                    rustc_middle::mir::BinOp::BitOr => {
+                        return Err(Error::new(self.thir[expr].span, "unsupported operation"))
+                    }
+                    rustc_middle::mir::BinOp::Shl => {
+                        return Err(Error::new(self.thir[expr].span, "unsupported operation"))
+                    }
+                    rustc_middle::mir::BinOp::Shr => {
+                        return Err(Error::new(self.thir[expr].span, "unsupported operation"))
+                    }
+                    rustc_middle::mir::BinOp::Eq => BinOp::Eq,
+                    rustc_middle::mir::BinOp::Lt => BinOp::Lt,
+                    rustc_middle::mir::BinOp::Le => BinOp::Le,
+                    rustc_middle::mir::BinOp::Ne => BinOp::Ne,
+                    rustc_middle::mir::BinOp::Ge => BinOp::Ge,
+                    rustc_middle::mir::BinOp::Gt => BinOp::Gt,
+                    rustc_middle::mir::BinOp::Offset => todo!(),
+                };
                 Ok(Term {
                     ty,
-                    kind: TermKind::Cur { term: box lower_expr(tcx, item_id, thir, arg)? },
+                    kind: TermKind::Binary { op, operand_ty, lhs: box lhs, rhs: box rhs },
                 })
             }
-        }
-        ExprKind::Match { scrutinee, ref arms } => {
-            let scrutinee = lower_expr(tcx, item_id, thir, scrutinee)?;
-            let arms = arms
-                .iter()
-                .map(|arm| lower_arm(tcx, item_id, thir, *arm))
-                .collect::<Result<_, _>>()?;
+            ExprKind::LogicalOp { op, lhs, rhs } => {
+                let lhs = self.expr_term(lhs)?;
+                let rhs = self.expr_term(rhs)?;
+                let op = match op {
+                    thir::LogicalOp::And => LogicalOp::And,
+                    thir::LogicalOp::Or => LogicalOp::Or,
+                };
+                Ok(Term { ty, kind: TermKind::Logical { op, lhs: box lhs, rhs: box rhs } })
+            }
+            ExprKind::Unary { op, arg } => {
+                let arg = self.expr_term(arg)?;
+                let op = match op {
+                    rustc_middle::mir::UnOp::Not => UnOp::Not,
+                    rustc_middle::mir::UnOp::Neg => UnOp::Neg,
+                };
+                Ok(Term { ty, kind: TermKind::Unary { op, arg: box arg } })
+            }
+            ExprKind::VarRef { id } => {
+                let map = self.tcx.hir();
+                let name = map.name(id);
+                Ok(Term { ty, kind: TermKind::Var(name) })
+            }
+            // TODO: confirm this works
+            ExprKind::UpvarRef { var_hir_id: id, .. } => {
+                let map = self.tcx.hir();
+                let name = map.name(id);
 
-            Ok(Term { ty, kind: TermKind::Match { scrutinee: box scrutinee, arms } })
-        }
-        ExprKind::If { cond, then, else_opt, .. } => {
-            let cond = lower_expr(tcx, item_id, thir, cond)?;
-            let then = lower_expr(tcx, item_id, thir, then)?;
-            let els = if let Some(els) = else_opt {
-                lower_expr(tcx, item_id, thir, els)?
-            } else {
-                Term { ty: tcx.types.unit, kind: TermKind::Tuple { fields: vec![] } }
-            };
-            Ok(Term {
-                ty,
-                kind: TermKind::Match {
-                    scrutinee: box cond,
-                    arms: vec![(Pattern::Boolean(true), then), (Pattern::Boolean(false), els)],
-                },
-            })
-        }
-        ExprKind::Field { lhs, name } => {
-            let pat = field_pattern(thir[lhs].ty, name)
-                .expect("lower_expr: could not make pattern for field");
+                Ok(Term { ty, kind: TermKind::Var(name) })
+            }
+            ExprKind::Literal { literal, .. } => Ok(Term { ty, kind: TermKind::Const(literal) }),
+            ExprKind::Call { ty: f_ty, fun, ref args, .. } => {
+                use Stub::*;
+                match pearlite_stub(self.tcx, f_ty) {
+                    Some(Forall) => {
+                        let (binder, body) = self.quant_term(args[0])?;
+                        Ok(Term { ty, kind: TermKind::Forall { binder, body: box body } })
+                    }
+                    Some(Exists) => {
+                        let (binder, body) = self.quant_term(args[0])?;
+                        Ok(Term { ty, kind: TermKind::Exists { binder, body: box body } })
+                    }
+                    Some(Fin) => {
+                        let term = self.expr_term(args[0])?;
 
-            match &thir[lhs].ty.kind() {
-                TyKind::Adt(def, _) => {
-                    let lhs = lower_expr(tcx, item_id, thir, lhs)?;
-                    Ok(Term { ty, kind: TermKind::Projection { lhs: box lhs, name, def: def.did } })
+                        Ok(Term { ty, kind: TermKind::Fin { term: box term } })
+                    }
+                    Some(Cur) => {
+                        let term = self.expr_term(args[0])?;
+
+                        Ok(Term { ty, kind: TermKind::Cur { term: box term } })
+                    }
+                    Some(Impl) => {
+                        let lhs = self.expr_term(args[0])?;
+                        let rhs = self.expr_term(args[1])?;
+
+                        Ok(Term { ty, kind: TermKind::Impl { lhs: box lhs, rhs: box rhs } })
+                    }
+                    Some(Equals) => {
+                        let lhs = self.expr_term(args[0])?;
+                        let rhs = self.expr_term(args[1])?;
+
+                        Ok(Term { ty, kind: TermKind::Equals { lhs: box lhs, rhs: box rhs } })
+                    }
+                    Some(VariantCheck) => self.expr_term(args[0]),
+                    Some(Old) => {
+                        let term = self.expr_term(args[0])?;
+
+                        Ok(Term { ty, kind: TermKind::Old { term: box term } })
+                    }
+
+                    None => {
+                        let fun = self.expr_term(fun)?;
+                        let args = args
+                            .iter()
+                            .map(|arg| self.expr_term(*arg))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        let (id, subst) = if let TyKind::FnDef(id, subst) = f_ty.kind() {
+                            (*id, subst)
+                        } else {
+                            unreachable!("Call on non-function type");
+                        };
+
+                        Ok(Term { ty, kind: TermKind::Call { id, subst, fun: box fun, args } })
+                    }
                 }
-                TyKind::Tuple(_) => {
-                    let lhs = lower_expr(tcx, item_id, thir, lhs)?;
-                    Ok(Term {
-                        ty,
-                        kind: TermKind::Let {
-                            pattern: pat,
-                            // this is the wrong type
-                            body: box Term { ty: lhs.ty, kind: TermKind::Var(Symbol::intern("a")) },
-                            arg: box lhs,
-                        },
-                    })
+            }
+            ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg } => self.expr_term(arg),
+            ExprKind::Borrow { arg, .. } => {
+                // Rust will introduce add unnecessary reborrows to code.
+                // Since we've syntactically ruled out borrowing at a higher level, we should
+                // be able erase it safely (:fingers_crossed:)
+                if let ExprKind::Deref { arg } = self.thir[arg].kind {
+                    self.expr_term(arg)
+                } else {
+                    unreachable!("unexpected borrow in pearlite");
                 }
-                _ => unreachable!(),
             }
-        }
-        ExprKind::Tuple { ref fields } => {
-            let fields: Vec<_> = fields
-                .iter()
-                .map(|f| lower_expr(tcx, item_id, thir, *f))
-                .collect::<Result<_, _>>()?;
-            Ok(Term { ty, kind: TermKind::Tuple { fields } })
-        }
-        ExprKind::Use { source } => lower_expr(tcx, item_id, thir, source),
-        ExprKind::NeverToAny { .. } => Ok(Term { ty, kind: TermKind::Absurd }),
-        ExprKind::ValueTypeAscription { source, .. } => lower_expr(tcx, item_id, thir, source),
-        ExprKind::Box { value } => lower_expr(tcx, item_id, thir, value),
-        ref ek => todo!("lower_expr: {:?}", ek),
-    }
-}
-
-fn lower_arm<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item_id: LocalDefId,
-    thir: &Thir<'tcx>,
-    arm: ArmId,
-) -> CreusotResult<(Pattern<'tcx>, Term<'tcx>)> {
-    let arm = &thir[arm];
-
-    if arm.guard.is_some() {
-        return Err(Error::new(arm.span, "match guards are unsupported"));
-    }
-
-    let pattern = lower_pattern(tcx, thir, &arm.pattern)?;
-    let body = lower_expr(tcx, item_id, thir, arm.body)?;
-
-    Ok((pattern, body))
-}
-
-fn lower_pattern<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    thir: &Thir<'tcx>,
-    pat: &Pat<'tcx>,
-) -> CreusotResult<Pattern<'tcx>> {
-    trace!("{:?}", pat);
-    match &*pat.kind {
-        PatKind::Wild => Ok(Pattern::Wildcard),
-        PatKind::Binding { name, .. } => Ok(Pattern::Binder(name.to_string())),
-        PatKind::Variant { subpatterns, adt_def, variant_index, .. } => {
-            let fields: Vec<_> = subpatterns
-                .iter()
-                .map(|pat| lower_pattern(tcx, thir, &pat.pattern))
-                .collect::<Result<_, _>>()?;
-
-            Ok(Pattern::Constructor { adt: adt_def, variant: *variant_index, fields })
-        }
-        PatKind::Leaf { subpatterns } => {
-            let fields: Vec<_> = subpatterns
-                .iter()
-                .map(|pat| lower_pattern(tcx, thir, &pat.pattern))
-                .collect::<Result<_, _>>()?;
-
-            if matches!(pat.ty.kind(), TyKind::Tuple(_)) {
-                Ok(Pattern::Tuple(fields))
-            } else {
-                let adt_def = pat.ty.ty_adt_def().unwrap();
-                Ok(Pattern::Constructor { adt: adt_def, variant: 0u32.into(), fields })
+            ExprKind::Adt(box Adt { adt_def, variant_index, ref fields, .. }) => {
+                let fields =
+                    fields.iter().map(|f| self.expr_term(f.expr)).collect::<Result<_, _>>()?;
+                Ok(Term {
+                    ty,
+                    kind: TermKind::Constructor { adt: adt_def, variant: variant_index, fields },
+                })
             }
-        }
-        PatKind::Deref { subpattern } => {
-            assert!(
-                pat.ty.is_box() || pat.ty.ref_mutability() == Some(Not),
-                "lower_pattern: only dereference over a box or shared reference is supported"
-            );
-            lower_pattern(tcx, thir, subpattern)
-        }
-        PatKind::Constant { value } => {
-            if !pat.ty.is_bool() {
-                return Err(Error::new(pat.span, "non-boolean constant patterns are unsupported"));
+            // TODO: If we deref a shared borrow this should be erased?
+            // Can it happen?
+            ExprKind::Deref { arg } => {
+                if self.thir[arg].ty.is_box() || self.thir[arg].ty.ref_mutability() == Some(Not) {
+                    self.expr_term(arg)
+                } else {
+                    Ok(Term { ty, kind: TermKind::Cur { term: box self.expr_term(arg)? } })
+                }
             }
-            Ok(Pattern::Boolean(value.val.try_to_bool().unwrap()))
-        }
-        ref pk => todo!("lower_pattern: unsupported pattern kind {:?}", pk),
-    }
-}
+            ExprKind::Match { scrutinee, ref arms } => {
+                let scrutinee = self.expr_term(scrutinee)?;
+                let arms = arms.iter().map(|arm| self.arm_term(*arm)).collect::<Result<_, _>>()?;
 
-fn lower_stmt<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item_id: LocalDefId,
-    thir: &Thir<'tcx>,
-    stmt: StmtId,
-    inner: Term<'tcx>,
-) -> CreusotResult<Term<'tcx>> {
-    match &thir[stmt].kind {
-        StmtKind::Expr { expr, .. } => Ok(Term {
-            ty: inner.ty,
-            kind: TermKind::Let {
-                pattern: Pattern::Wildcard,
-                arg: box lower_expr(tcx, item_id, thir, *expr)?,
-                body: box inner,
-            },
-        }),
-        StmtKind::Let { pattern, initializer, init_scope, .. } => {
-            let pattern = lower_pattern(tcx, thir, pattern)?;
-            if let Some(initializer) = initializer {
-                let initializer = lower_expr(tcx, item_id, thir, *initializer)?;
+                Ok(Term { ty, kind: TermKind::Match { scrutinee: box scrutinee, arms } })
+            }
+            ExprKind::If { cond, then, else_opt, .. } => {
+                let cond = self.expr_term(cond)?;
+                let then = self.expr_term(then)?;
+                let els = if let Some(els) = else_opt {
+                    self.expr_term(els)?
+                } else {
+                    Term { ty: self.tcx.types.unit, kind: TermKind::Tuple { fields: vec![] } }
+                };
+                Ok(Term {
+                    ty,
+                    kind: TermKind::Match {
+                        scrutinee: box cond,
+                        arms: vec![(Pattern::Boolean(true), then), (Pattern::Boolean(false), els)],
+                    },
+                })
+            }
+            ExprKind::Field { lhs, name } => {
+                let pat =
+                    field_pattern(self.thir[lhs].ty, name).expect("expr_term: no term for field");
+
+                match &self.thir[lhs].ty.kind() {
+                    TyKind::Adt(def, _) => {
+                        let lhs = self.expr_term(lhs)?;
+                        Ok(Term {
+                            ty,
+                            kind: TermKind::Projection { lhs: box lhs, name, def: def.did },
+                        })
+                    }
+                    TyKind::Tuple(_) => {
+                        let lhs = self.expr_term(lhs)?;
+                        Ok(Term {
+                            ty,
+                            kind: TermKind::Let {
+                                pattern: pat,
+                                // this is the wrong type
+                                body: box Term {
+                                    ty: lhs.ty,
+                                    kind: TermKind::Var(Symbol::intern("a")),
+                                },
+                                arg: box lhs,
+                            },
+                        })
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            ExprKind::Tuple { ref fields } => {
+                let fields: Vec<_> =
+                    fields.iter().map(|f| self.expr_term(*f)).collect::<Result<_, _>>()?;
+                Ok(Term { ty, kind: TermKind::Tuple { fields } })
+            }
+            ExprKind::Use { source } => self.expr_term(source),
+            ExprKind::NeverToAny { .. } => Ok(Term { ty, kind: TermKind::Absurd }),
+            ExprKind::ValueTypeAscription { source, .. } => self.expr_term(source),
+            ExprKind::Box { value } => self.expr_term(value),
+            ref ek => todo!("lower_expr: {:?}", ek),
+        }
+    }
+
+    fn arm_term(&self, arm: ArmId) -> CreusotResult<(Pattern<'tcx>, Term<'tcx>)> {
+        let arm = &self.thir[arm];
+
+        if arm.guard.is_some() {
+            return Err(Error::new(arm.span, "match guards are unsupported"));
+        }
+
+        let pattern = self.pattern_term(&arm.pattern)?;
+        let body = self.expr_term(arm.body)?;
+
+        Ok((pattern, body))
+    }
+
+    fn pattern_term(&self, pat: &Pat<'tcx>) -> CreusotResult<Pattern<'tcx>> {
+        trace!("{:?}", pat);
+        match &*pat.kind {
+            PatKind::Wild => Ok(Pattern::Wildcard),
+            PatKind::Binding { name, .. } => Ok(Pattern::Binder(name.to_string())),
+            PatKind::Variant { subpatterns, adt_def, variant_index, .. } => {
+                let fields: Vec<_> = subpatterns
+                    .iter()
+                    .map(|pat| self.pattern_term(&pat.pattern))
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Pattern::Constructor { adt: adt_def, variant: *variant_index, fields })
+            }
+            PatKind::Leaf { subpatterns } => {
+                let fields: Vec<_> = subpatterns
+                    .iter()
+                    .map(|pat| self.pattern_term(&pat.pattern))
+                    .collect::<Result<_, _>>()?;
+
+                if matches!(pat.ty.kind(), TyKind::Tuple(_)) {
+                    Ok(Pattern::Tuple(fields))
+                } else {
+                    let adt_def = pat.ty.ty_adt_def().unwrap();
+                    Ok(Pattern::Constructor { adt: adt_def, variant: 0u32.into(), fields })
+                }
+            }
+            PatKind::Deref { subpattern } => {
+                assert!(
+                    pat.ty.is_box() || pat.ty.ref_mutability() == Some(Not),
+                    "pattern_term: only dereference over a box or shared reference is supported"
+                );
+                self.pattern_term(subpattern)
+            }
+            PatKind::Constant { value } => {
+                if !pat.ty.is_bool() {
+                    return Err(Error::new(
+                        pat.span,
+                        "non-boolean constant patterns are unsupported",
+                    ));
+                }
+                Ok(Pattern::Boolean(value.val.try_to_bool().unwrap()))
+            }
+            ref pk => todo!("lower_pattern: unsupported pattern kind {:?}", pk),
+        }
+    }
+
+    fn stmt_term(&self, stmt: StmtId, inner: Term<'tcx>) -> CreusotResult<Term<'tcx>> {
+        match &self.thir[stmt].kind {
+            StmtKind::Expr { expr, .. } => {
+                let arg = self.expr_term(*expr)?;
+                if let TermKind::Tuple { fields } = &arg.kind {
+                    if fields.is_empty() {
+                        return Ok(inner);
+                    }
+                };
+
                 Ok(Term {
                     ty: inner.ty,
-                    kind: TermKind::Let { pattern, arg: box initializer, body: box inner },
+                    kind: TermKind::Let {
+                        pattern: Pattern::Wildcard,
+                        arg: box arg,
+                        body: box inner,
+                    },
                 })
-            } else {
-                let span = tcx.hir().span(HirId { owner: item_id, local_id: init_scope.id });
-                Err(Error::new(span, "let-bindings must have values"))
             }
+            StmtKind::Let { pattern, initializer, init_scope, .. } => {
+                let pattern = self.pattern_term(pattern)?;
+                if let Some(initializer) = initializer {
+                    let initializer = self.expr_term(*initializer)?;
+                    Ok(Term {
+                        ty: inner.ty,
+                        kind: TermKind::Let { pattern, arg: box initializer, body: box inner },
+                    })
+                } else {
+                    let span =
+                        self.tcx.hir().span(HirId { owner: self.item_id, local_id: init_scope.id });
+                    Err(Error::new(span, "let-bindings must have values"))
+                }
+            }
+        }
+    }
+
+    fn quant_term(&self, body: ExprId) -> Result<((String, Ty<'tcx>), Term<'tcx>), Error> {
+        trace!("{:?}", self.thir[body].kind);
+        match self.thir[body].kind {
+            ExprKind::Scope { value, .. } => self.quant_term(value),
+            ExprKind::Closure { closure_id, substs, .. } => {
+                let sig = match substs {
+                    UpvarSubsts::Closure(subst) => subst.as_closure().sig(),
+                    _ => unreachable!(),
+                };
+
+                let name = self.tcx.fn_arg_names(closure_id)[0];
+                let ty = sig.input(0).skip_binder();
+
+                Ok(((name.to_string(), ty), typecheck(self.tcx, closure_id.expect_local())?))
+            }
+            _ => Err(Error::new(self.thir[body].span, "unexpected error in quantifier")),
         }
     }
 }
@@ -470,29 +491,6 @@ fn pearlite_stub<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Stub> {
         None
     } else {
         None
-    }
-}
-
-fn lower_quantifier<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    thir: &Thir<'tcx>,
-    body: ExprId,
-) -> Result<((String, Ty<'tcx>), Term<'tcx>), Error> {
-    trace!("{:?}", thir[body].kind);
-    match thir[body].kind {
-        ExprKind::Scope { value, .. } => lower_quantifier(tcx, thir, value),
-        ExprKind::Closure { closure_id, substs, .. } => {
-            let sig = match substs {
-                UpvarSubsts::Closure(subst) => subst.as_closure().sig(),
-                _ => unreachable!(),
-            };
-
-            let name = tcx.fn_arg_names(closure_id)[0];
-            let ty = sig.input(0).skip_binder();
-
-            Ok(((name.to_string(), ty), typecheck(tcx, closure_id.expect_local())?))
-        }
-        _ => Err(Error::new(thir[body].span, "unexpected error in quantifier")),
     }
 }
 

--- a/creusot/src/translation/specification/typing.rs
+++ b/creusot/src/translation/specification/typing.rs
@@ -225,6 +225,7 @@ impl ThirTerm<'a, 'tcx> {
 
                         Ok(Term { ty, kind: TermKind::Old { term: box term } })
                     }
+                    Some(ResultCheck) => Ok(Term { ty, kind: TermKind::Tuple { fields: vec![] } }),
 
                     None => {
                         let fun = self.expr_term(fun)?;
@@ -460,6 +461,7 @@ enum Stub {
     Equals,
     VariantCheck,
     Old,
+    ResultCheck,
 }
 
 fn pearlite_stub<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Stub> {
@@ -487,6 +489,9 @@ fn pearlite_stub<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Stub> {
         }
         if Some(*id) == tcx.get_diagnostic_item(Symbol::intern("old")) {
             return Some(Stub::Old);
+        }
+        if Some(*id) == tcx.get_diagnostic_item(Symbol::intern("closure_result_constraint")) {
+            return Some(Stub::ResultCheck);
         }
         None
     } else {

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -14,6 +14,7 @@ use crate::util::{is_law, is_spec};
 impl<'tcx> TranslationCtx<'_, 'tcx> {
     // Translate a trait declaration
     pub fn translate_trait(&mut self, def_id: DefId) {
+        debug!("translating trait {def_id:?}");
         if !self.translated_items.insert(def_id) {
             return;
         }
@@ -225,6 +226,7 @@ pub fn resolve_assoc_item_opt(
             Some((leaf_def.item.def_id, leaf_substs))
         }
         ImplSource::Param(_, _) => Some((def_id, substs)),
+        ImplSource::Closure(impl_data) => Some((impl_data.closure_def_id, impl_data.substs)),
         _ => unimplemented!(),
     }
 }

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -15,6 +15,18 @@ module Type
   use prelude.Prelude
   type creusotcontracts_std1_vec_vec 't  
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -35,25 +47,13 @@ module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type modelTy  = 
     Seq.seq t
 end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0
   type t   
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -91,12 +91,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -111,19 +105,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
   type t   
@@ -151,12 +132,6 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -171,18 +146,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -235,11 +198,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -269,23 +227,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
@@ -345,6 +286,39 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
 module CreusotContracts_Std1_Vec_Impl2
   type t   
   use Type
@@ -359,18 +333,7 @@ module CreusotContracts_Std1_Vec_Impl2
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -378,6 +341,43 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module C100doors_Main_Interface
   val main [@cfg:stackify] () : ()

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -79,14 +79,6 @@ module AllZero_Get
       | Type.AllZero_List_Nil -> Type.Core_Option_Option_None
       end
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -97,6 +89,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -15,6 +15,18 @@ module Type
   use prelude.Prelude
   type creusotcontracts_std1_vec_vec 't  
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -35,25 +47,13 @@ module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type modelTy  = 
     Seq.seq t
 end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0
   type t   
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -87,12 +87,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -107,19 +101,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
   type t   
@@ -146,6 +127,25 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module C01ResolveUnsoundness_MakeVecOfSize_Interface
   use seq.Seq

--- a/creusot/tests/should_succeed/bug/02_derive.stdout
+++ b/creusot/tests/should_succeed/bug/02_derive.stdout
@@ -17,6 +17,28 @@ module Type
     | C02Derive_Lit
     
 end
+module C02Derive_Impl0_Clone_Interface
+  use prelude.Prelude
+  use Type
+  val clone' [@cfg:stackify] (self : Type.c02derive_lit) : Type.c02derive_lit
+end
+module C02Derive_Impl0_Clone
+  use prelude.Prelude
+  use Type
+  let rec cfg clone' [@cfg:stackify] (self : Type.c02derive_lit) : Type.c02derive_lit = 
+  var _0 : Type.c02derive_lit;
+  var self_1 : Type.c02derive_lit;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) self_1 };
+    _0 <- Type.C02Derive_Lit;
+    return _0
+  }
+  
+end
 module Core_Clone_Clone_Clone_Interface
   type self   
   use prelude.Prelude
@@ -44,28 +66,6 @@ module Core_Clone_Clone_CloneFrom
   val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
     requires {false}
     
-end
-module C02Derive_Impl0_Clone_Interface
-  use prelude.Prelude
-  use Type
-  val clone' [@cfg:stackify] (self : Type.c02derive_lit) : Type.c02derive_lit
-end
-module C02Derive_Impl0_Clone
-  use prelude.Prelude
-  use Type
-  let rec cfg clone' [@cfg:stackify] (self : Type.c02derive_lit) : Type.c02derive_lit = 
-  var _0 : Type.c02derive_lit;
-  var self_1 : Type.c02derive_lit;
-  {
-    self_1 <- self;
-    goto BB0
-  }
-  BB0 {
-    assume { (fun x -> true) self_1 };
-    _0 <- Type.C02Derive_Lit;
-    return _0
-  }
-  
 end
 module C02Derive_Impl0
   use Type

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -23,6 +23,18 @@ module Type
     
   axiom c206_a_A_0_acc : forall a : creusotcontracts_std1_vec_vec usize . c206_a_A_0 (C206_A a : c206_a) = a
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -43,25 +55,13 @@ module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type modelTy  = 
     Seq.seq t
 end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0
   type t   
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -15,6 +15,18 @@ module Type
   use prelude.Prelude
   type creusotcontracts_std1_vec_vec 't  
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -28,40 +40,6 @@ module CreusotContracts_Logic_Model_Model_Model
   type self   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -78,6 +56,28 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -86,16 +86,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -111,18 +105,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -178,14 +160,6 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -197,12 +171,38 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module TwoPhase_Test_Interface
   use seq.Seq

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -187,36 +187,6 @@ module C02_Impl1_Inv
       | Type.Core_Option_Option_Some i -> UInt64.to_int i = Fib0.fib (UInt64.to_int (Type.c02_fib_Fib_ix self))
       end
 end
-module C02_Impl1
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone C02_Fib as Fib0 with axiom .
-  clone C02_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
-  clone C02_Inv_Inv as Inv1 with type self = Type.c02_fib, type t = Type.core_option_option usize,
-  predicate inv = Inv0.inv
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -228,16 +198,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module C02_FibCell_Interface
   use Type
@@ -259,11 +219,19 @@ module C02_FibCell
    = 
     forall i : (int) . UInt64.to_int (Type.c02_fib_Fib_ix (Type.c02_cell_Cell_ghost_inv (Seq.get (Model0.model v) i))) = i
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -280,6 +248,18 @@ module CreusotContracts_Logic_Model_Impl0_Model
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl0
   type t   
   use prelude.Prelude
@@ -288,9 +268,19 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
@@ -323,11 +313,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -358,6 +343,11 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
   use Type
@@ -371,9 +361,19 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
   type output = Output0.output
+end
+module C02_Impl1
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone C02_Fib as Fib0 with axiom .
+  clone C02_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
+  clone C02_Inv_Inv as Inv1 with type self = Type.c02_fib, type t = Type.core_option_option usize,
+  predicate inv = Inv0.inv
 end
 module C02_FibMemo_Interface
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -133,34 +133,6 @@ module C03FibUnbounded_Impl1_Inv
       | Type.Core_Option_Option_Some i -> i = Fib0.fib (Type.c03fibunbounded_fib_Fib_ix self)
       end
 end
-module C03FibUnbounded_Impl1
-  use Type
-  use mach.int.Int
-  clone C03FibUnbounded_Fib as Fib0 with axiom .
-  clone C03FibUnbounded_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
-  clone C03FibUnbounded_Inv_Inv as Inv1 with type self = Type.c03fibunbounded_fib, type t = Type.core_option_option int,
-  predicate inv = Inv0.inv
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -172,16 +144,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module C03FibUnbounded_FibCell_Interface
   use Type
@@ -199,11 +161,19 @@ module C03FibUnbounded_FibCell
    = 
     forall i : (int) . Type.c03fibunbounded_fib_Fib_ix (Type.c03fibunbounded_cell_Cell_ghost_inv (Seq.get (Model0.model v) i)) = i
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -220,6 +190,18 @@ module CreusotContracts_Logic_Model_Impl0_Model
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl0
   type t   
   use prelude.Prelude
@@ -228,9 +210,19 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
@@ -263,11 +255,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use seq.Seq
@@ -296,6 +283,11 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) ix }
     
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
   use Type
@@ -307,9 +299,17 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = int, type Output0.output = Output0.output, val index = Index0.index
+  type idx = int, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = int,
   type output = Output0.output
+end
+module C03FibUnbounded_Impl1
+  use Type
+  use mach.int.Int
+  clone C03FibUnbounded_Fib as Fib0 with axiom .
+  clone C03FibUnbounded_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
+  clone C03FibUnbounded_Inv_Inv as Inv1 with type self = Type.c03fibunbounded_fib, type t = Type.core_option_option int,
+  predicate inv = Inv0.inv
 end
 module C03FibUnbounded_FibMemo_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/closures/01_basic.rs
+++ b/creusot/tests/should_succeed/closures/01_basic.rs
@@ -1,0 +1,12 @@
+fn uses_closure() {
+    let y = true;
+    let x = (|| y)();
+}
+
+// fn generic_closure<T>(x: T) -> T{
+//   (|| { x })()
+// }
+
+// fn call_closure() {
+//   closure_param(|x : u32| { () })
+// }

--- a/creusot/tests/should_succeed/closures/01_basic.stdout
+++ b/creusot/tests/should_succeed/closures/01_basic.stdout
@@ -1,0 +1,121 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C01Basic_UsesClosure_Closure0_Interface
+  use prelude.Prelude
+  type c01basic_usesclosure_closure0  = 
+    | C01Basic_UsesClosure_Closure0 bool
+    
+  function c01basic_usesclosure_closure0_0 (self : c01basic_usesclosure_closure0) : bool
+  val c01basic_usesclosure_closure0_0 (self : c01basic_usesclosure_closure0) : bool
+    ensures { result = c01basic_usesclosure_closure0_0 self }
+    
+  axiom c01basic_usesclosure_closure0_0_acc : forall a : bool . c01basic_usesclosure_closure0_0 (C01Basic_UsesClosure_Closure0 a : c01basic_usesclosure_closure0) = a
+  predicate precondition (_1' : c01basic_usesclosure_closure0) (_2' : ()) = 
+    true
+  predicate postcondition (_1' : c01basic_usesclosure_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c01basic_usesclosure_closure0) (_2' : ()) (result : bool) = 
+    true && true
+  predicate postcondition_once (_1' : c01basic_usesclosure_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate resolve (_1' : c01basic_usesclosure_closure0) = 
+    (fun x -> true) (c01basic_usesclosure_closure0_0 _1') && true
+  val c01Basic_UsesClosure_Closure0 (_1' : c01basic_usesclosure_closure0) (_2' : ()) : bool
+end
+module C01Basic_UsesClosure_Closure0
+  use prelude.Prelude
+  type c01basic_usesclosure_closure0  = 
+    | C01Basic_UsesClosure_Closure0 bool
+    
+  function c01basic_usesclosure_closure0_0 (self : c01basic_usesclosure_closure0) : bool
+  val c01basic_usesclosure_closure0_0 (self : c01basic_usesclosure_closure0) : bool
+    ensures { result = c01basic_usesclosure_closure0_0 self }
+    
+  axiom c01basic_usesclosure_closure0_0_acc : forall a : bool . c01basic_usesclosure_closure0_0 (C01Basic_UsesClosure_Closure0 a : c01basic_usesclosure_closure0) = a
+  let rec cfg c01Basic_UsesClosure_Closure0 (_1' : c01basic_usesclosure_closure0) (_2' : ()) : bool = 
+  var _0 : bool;
+  var _1 : c01basic_usesclosure_closure0;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) _0 };
+    _0 <- c01basic_usesclosure_closure0_0 _1;
+    assume { (fun x -> true) _1 };
+    return _0
+  }
+  
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module Core_Ops_Function_Fn_Call_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Function_Fn_Call
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module C01Basic_UsesClosure_Interface
+  val uses_closure [@cfg:stackify] () : ()
+end
+module C01Basic_UsesClosure
+  use prelude.Prelude
+  clone C01Basic_UsesClosure_Closure0_Interface as Closure00 with axiom .
+  let rec cfg uses_closure [@cfg:stackify] () : () = 
+  var _0 : ();
+  var y_1 : bool;
+  var x_2 : bool;
+  var _3 : Closure00.c01basic_usesclosure_closure0;
+  var _4 : Closure00.c01basic_usesclosure_closure0;
+  var _5 : bool;
+  var _6 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    y_1 <- true;
+    _5 <- y_1;
+    assume { (fun x -> true) y_1 };
+    _4 <- Closure00.C01Basic_UsesClosure_Closure0 _5;
+    _3 <- _4;
+    assume { (fun x -> true) _4 };
+    _6 <- ();
+    x_2 <- Closure00.c01Basic_UsesClosure_Closure0 _3 _6;
+    goto BB1
+  }
+  BB1 {
+    assume { (fun x -> true) x_2 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/02_nested.rs
+++ b/creusot/tests/should_succeed/closures/02_nested.rs
@@ -1,0 +1,7 @@
+fn nested_closure() {
+    let a = true;
+    let a = (|| {
+        let omg = || a;
+        (omg)()
+    })();
+}

--- a/creusot/tests/should_succeed/closures/02_nested.stdout
+++ b/creusot/tests/should_succeed/closures/02_nested.stdout
@@ -1,0 +1,182 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C02Nested_NestedClosure_Closure0_Closure0_Interface
+  use prelude.Prelude
+  type c02nested_nestedclosure_closure0_closure0  = 
+    | C02Nested_NestedClosure_Closure0_Closure0 bool
+    
+  function c02nested_nestedclosure_closure0_closure0_0 (self : c02nested_nestedclosure_closure0_closure0) : bool
+  val c02nested_nestedclosure_closure0_closure0_0 (self : c02nested_nestedclosure_closure0_closure0) : bool
+    ensures { result = c02nested_nestedclosure_closure0_closure0_0 self }
+    
+  axiom c02nested_nestedclosure_closure0_closure0_0_acc : forall a : bool . c02nested_nestedclosure_closure0_closure0_0 (C02Nested_NestedClosure_Closure0_Closure0 a : c02nested_nestedclosure_closure0_closure0) = a
+  predicate precondition (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) = 
+    true
+  predicate postcondition (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c02nested_nestedclosure_closure0_closure0) (_2' : ()) (result : bool) = 
+    true && true
+  predicate postcondition_once (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate resolve (_1' : c02nested_nestedclosure_closure0_closure0) = 
+    (fun x -> true) (c02nested_nestedclosure_closure0_closure0_0 _1') && true
+  val c02Nested_NestedClosure_Closure0_Closure0 (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) : bool
+end
+module C02Nested_NestedClosure_Closure0_Closure0
+  use prelude.Prelude
+  type c02nested_nestedclosure_closure0_closure0  = 
+    | C02Nested_NestedClosure_Closure0_Closure0 bool
+    
+  function c02nested_nestedclosure_closure0_closure0_0 (self : c02nested_nestedclosure_closure0_closure0) : bool
+  val c02nested_nestedclosure_closure0_closure0_0 (self : c02nested_nestedclosure_closure0_closure0) : bool
+    ensures { result = c02nested_nestedclosure_closure0_closure0_0 self }
+    
+  axiom c02nested_nestedclosure_closure0_closure0_0_acc : forall a : bool . c02nested_nestedclosure_closure0_closure0_0 (C02Nested_NestedClosure_Closure0_Closure0 a : c02nested_nestedclosure_closure0_closure0) = a
+  let rec cfg c02Nested_NestedClosure_Closure0_Closure0 (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) : bool
+    
+   = 
+  var _0 : bool;
+  var _1 : c02nested_nestedclosure_closure0_closure0;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    assume { (fun x -> true) _0 };
+    _0 <- c02nested_nestedclosure_closure0_closure0_0 _1;
+    assume { (fun x -> true) _1 };
+    return _0
+  }
+  
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module Core_Ops_Function_Fn_Call_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Function_Fn_Call
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module C02Nested_NestedClosure_Closure0_Interface
+  use prelude.Prelude
+  type c02nested_nestedclosure_closure0  = 
+    | C02Nested_NestedClosure_Closure0 bool
+    
+  function c02nested_nestedclosure_closure0_0 (self : c02nested_nestedclosure_closure0) : bool
+  val c02nested_nestedclosure_closure0_0 (self : c02nested_nestedclosure_closure0) : bool
+    ensures { result = c02nested_nestedclosure_closure0_0 self }
+    
+  axiom c02nested_nestedclosure_closure0_0_acc : forall a : bool . c02nested_nestedclosure_closure0_0 (C02Nested_NestedClosure_Closure0 a : c02nested_nestedclosure_closure0) = a
+  predicate precondition (_1' : c02nested_nestedclosure_closure0) (_2' : ()) = 
+    true
+  predicate postcondition (_1' : c02nested_nestedclosure_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c02nested_nestedclosure_closure0) (_2' : ()) (result : bool) = 
+    true && true
+  predicate postcondition_once (_1' : c02nested_nestedclosure_closure0) (_2' : ()) (result : bool) = 
+    true
+  predicate resolve (_1' : c02nested_nestedclosure_closure0) = 
+    (fun x -> true) (c02nested_nestedclosure_closure0_0 _1') && true
+  val c02Nested_NestedClosure_Closure0 (_1' : c02nested_nestedclosure_closure0) (_2' : ()) : bool
+end
+module C02Nested_NestedClosure_Closure0
+  use prelude.Prelude
+  type c02nested_nestedclosure_closure0  = 
+    | C02Nested_NestedClosure_Closure0 bool
+    
+  function c02nested_nestedclosure_closure0_0 (self : c02nested_nestedclosure_closure0) : bool
+  val c02nested_nestedclosure_closure0_0 (self : c02nested_nestedclosure_closure0) : bool
+    ensures { result = c02nested_nestedclosure_closure0_0 self }
+    
+  axiom c02nested_nestedclosure_closure0_0_acc : forall a : bool . c02nested_nestedclosure_closure0_0 (C02Nested_NestedClosure_Closure0 a : c02nested_nestedclosure_closure0) = a
+  clone C02Nested_NestedClosure_Closure0_Closure0_Interface as Closure00 with axiom .
+  let rec cfg c02Nested_NestedClosure_Closure0 (_1' : c02nested_nestedclosure_closure0) (_2' : ()) : bool = 
+  var _0 : bool;
+  var _1 : c02nested_nestedclosure_closure0;
+  var omg_2 : Closure00.c02nested_nestedclosure_closure0_closure0;
+  var _3 : bool;
+  var _4 : Closure00.c02nested_nestedclosure_closure0_closure0;
+  var _5 : ();
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    _3 <- c02nested_nestedclosure_closure0_0 _1;
+    assume { (fun x -> true) _1 };
+    omg_2 <- Closure00.C02Nested_NestedClosure_Closure0_Closure0 _3;
+    _4 <- omg_2;
+    assume { (fun x -> true) omg_2 };
+    _5 <- ();
+    _0 <- Closure00.c02Nested_NestedClosure_Closure0_Closure0 _4 _5;
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end
+module C02Nested_NestedClosure_Interface
+  val nested_closure [@cfg:stackify] () : ()
+end
+module C02Nested_NestedClosure
+  use prelude.Prelude
+  clone C02Nested_NestedClosure_Closure0_Interface as Closure00 with axiom .
+  let rec cfg nested_closure [@cfg:stackify] () : () = 
+  var _0 : ();
+  var a_1 : bool;
+  var a_2 : bool;
+  var _3 : Closure00.c02nested_nestedclosure_closure0;
+  var _4 : Closure00.c02nested_nestedclosure_closure0;
+  var _5 : bool;
+  var _6 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    a_1 <- true;
+    _5 <- a_1;
+    assume { (fun x -> true) a_1 };
+    _4 <- Closure00.C02Nested_NestedClosure_Closure0 _5;
+    _3 <- _4;
+    assume { (fun x -> true) _4 };
+    _6 <- ();
+    a_2 <- Closure00.c02Nested_NestedClosure_Closure0 _3 _6;
+    goto BB1
+  }
+  BB1 {
+    assume { (fun x -> true) a_2 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/03_generic_bound.rs
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.rs
@@ -1,0 +1,7 @@
+fn closure_param<F: Fn(u32)>(f: F) {
+    (f)(0)
+}
+
+fn caller() {
+    closure_param(|x: u32| ())
+}

--- a/creusot/tests/should_succeed/closures/03_generic_bound.stdout
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.stdout
@@ -1,0 +1,138 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module Core_Ops_Function_Fn_Call_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Function_Fn_Call
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module C03GenericBound_ClosureParam_Interface
+  type f   
+  val closure_param [@cfg:stackify] (f : f) : ()
+end
+module C03GenericBound_ClosureParam
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (uint32), type Output0.output = ()
+  let rec cfg closure_param [@cfg:stackify] (f : f) : () = 
+  var _0 : ();
+  var f_1 : f;
+  var _2 : f;
+  var _3 : (uint32);
+  {
+    f_1 <- f;
+    goto BB0
+  }
+  BB0 {
+    _2 <- f_1;
+    _3 <- ((0 : uint32));
+    _0 <- Call0.call _2 _3;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    assume { (fun x -> true) f_1 };
+    return _0
+  }
+  
+end
+module C03GenericBound_Caller_Closure0_Interface
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  type c03genericbound_caller_closure0  = 
+    | C03GenericBound_Caller_Closure0
+    
+  predicate precondition (_1' : c03genericbound_caller_closure0) (x : (uint32)) = 
+    true
+  predicate postcondition (_1' : c03genericbound_caller_closure0) (x : (uint32)) (result : ()) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c03genericbound_caller_closure0) (x : (uint32)) (result : ()) = 
+    true && true
+  predicate postcondition_once (_1' : c03genericbound_caller_closure0) (x : (uint32)) (result : ()) = 
+    true
+  predicate resolve (_1' : c03genericbound_caller_closure0) = 
+    true
+  val c03GenericBound_Caller_Closure0 (_1' : c03genericbound_caller_closure0) (x : (uint32)) : ()
+end
+module C03GenericBound_Caller_Closure0
+  type c03genericbound_caller_closure0  = 
+    | C03GenericBound_Caller_Closure0
+    
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  let rec cfg c03GenericBound_Caller_Closure0 (_1' : c03genericbound_caller_closure0) (x : (uint32)) : () = 
+  var _0 : ();
+  var _1 : c03genericbound_caller_closure0;
+  var x_2 : uint32;
+  {
+    _1 <- _1';
+    x_2 <- x;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    assume { (fun x -> true) _1 };
+    assume { (fun x -> true) x_2 };
+    return _0
+  }
+  
+end
+module C03GenericBound_Caller_Interface
+  val caller [@cfg:stackify] () : ()
+end
+module C03GenericBound_Caller
+  clone C03GenericBound_Caller_Closure0_Interface as Closure00 with axiom .
+  clone C03GenericBound_ClosureParam_Interface as ClosureParam0 with type f = Closure00.c03genericbound_caller_closure0
+  let rec cfg caller [@cfg:stackify] () : () = 
+  var _0 : ();
+  var _1 : Closure00.c03genericbound_caller_closure0;
+  {
+    goto BB0
+  }
+  BB0 {
+    _1 <- Closure00.C03GenericBound_Caller_Closure0;
+    _0 <- ClosureParam0.closure_param _1;
+    goto BB1
+  }
+  BB1 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/04_generic_closure.rs
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.rs
@@ -1,0 +1,7 @@
+fn generic_closure<A, B, F: Fn(A) -> B>(f: F, a: A) -> B {
+    f(a)
+}
+
+fn mapper<A>(x: A) {
+    generic_closure(|a| (), x)
+}

--- a/creusot/tests/should_succeed/closures/04_generic_closure.stdout
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.stdout
@@ -1,0 +1,163 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module Core_Ops_Function_Fn_Call_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Function_Fn_Call
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module C04GenericClosure_GenericClosure_Interface
+  type a   
+  type b   
+  type f   
+  val generic_closure [@cfg:stackify] (f : f) (a : a) : b
+end
+module C04GenericClosure_GenericClosure
+  type a   
+  type b   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (a), type Output0.output = b
+  let rec cfg generic_closure [@cfg:stackify] (f : f) (a : a) : b = 
+  var _0 : b;
+  var f_1 : f;
+  var a_2 : a;
+  var _3 : f;
+  var _4 : (a);
+  var _5 : a;
+  {
+    f_1 <- f;
+    a_2 <- a;
+    goto BB0
+  }
+  BB0 {
+    _3 <- f_1;
+    assume { (fun x -> true) _5 };
+    _5 <- a_2;
+    _4 <- (_5);
+    _0 <- Call0.call _3 _4;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    goto BB3
+  }
+  BB3 {
+    goto BB4
+  }
+  BB4 {
+    assume { (fun x -> true) f_1 };
+    return _0
+  }
+  
+end
+module C04GenericClosure_Mapper_Closure0_Interface
+  type a   
+  use prelude.Prelude
+  type c04genericclosure_mapper_closure0  = 
+    | C04GenericClosure_Mapper_Closure0
+    
+  predicate precondition (_1' : c04genericclosure_mapper_closure0) (a : (a)) = 
+    true
+  predicate postcondition (_1' : c04genericclosure_mapper_closure0) (a : (a)) (result : ()) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c04genericclosure_mapper_closure0) (a : (a)) (result : ()) = 
+    true && true
+  predicate postcondition_once (_1' : c04genericclosure_mapper_closure0) (a : (a)) (result : ()) = 
+    true
+  predicate resolve (_1' : c04genericclosure_mapper_closure0) = 
+    true
+  val c04GenericClosure_Mapper_Closure0 (_1' : c04genericclosure_mapper_closure0) (a : (a)) : ()
+end
+module C04GenericClosure_Mapper_Closure0
+  type a   
+  type c04genericclosure_mapper_closure0  = 
+    | C04GenericClosure_Mapper_Closure0
+    
+  use prelude.Prelude
+  let rec cfg c04GenericClosure_Mapper_Closure0 (_1' : c04genericclosure_mapper_closure0) (a : (a)) : () = 
+  var _0 : ();
+  var _1 : c04genericclosure_mapper_closure0;
+  var a_2 : a;
+  {
+    _1 <- _1';
+    a_2 <- a;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    assume { (fun x -> true) _1 };
+    goto BB1
+  }
+  BB1 {
+    assume { (fun x -> true) a_2 };
+    return _0
+  }
+  
+end
+module C04GenericClosure_Mapper_Interface
+  type a   
+  val mapper [@cfg:stackify] (x : a) : ()
+end
+module C04GenericClosure_Mapper
+  type a   
+  clone C04GenericClosure_Mapper_Closure0_Interface as Closure00 with type a = a, axiom .
+  clone C04GenericClosure_GenericClosure_Interface as GenericClosure0 with type a = a, type b = (),
+  type f = Closure00.c04genericclosure_mapper_closure0
+  let rec cfg mapper [@cfg:stackify] (x : a) : () = 
+  var _0 : ();
+  var x_1 : a;
+  var _2 : Closure00.c04genericclosure_mapper_closure0;
+  var _3 : a;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _2 <- Closure00.C04GenericClosure_Mapper_Closure0;
+    assume { (fun x -> true) _3 };
+    _3 <- x_1;
+    _0 <- GenericClosure0.generic_closure _2 _3;
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/05_map.rs
+++ b/creusot/tests/should_succeed/closures/05_map.rs
@@ -1,0 +1,21 @@
+trait FakeIterator {
+    type Item;
+
+    fn next(&mut self) -> Option<Self::Item>;
+}
+
+struct Map<I, F> {
+    iter: I,
+    func: F,
+}
+
+impl<A, B, F: Fn(A) -> B, I: FakeIterator<Item = A>> FakeIterator for Map<I, F> {
+    type Item = B;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter.next() {
+            None => None,
+            Some(e) => Some((self.func)(e)),
+        }
+    }
+}

--- a/creusot/tests/should_succeed/closures/05_map.stdout
+++ b/creusot/tests/should_succeed/closures/05_map.stdout
@@ -1,0 +1,189 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
+    
+  function core_option_option_Some_0 (self : core_option_option 't) : 't
+  val core_option_option_Some_0 (self : core_option_option 't) : 't
+    ensures { result = core_option_option_Some_0 self }
+    
+  axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
+  type c05map_map 'i 'f = 
+    | C05Map_Map 'i 'f
+    
+  function c05map_map_Map_iter (self : c05map_map 'i 'f) : 'i
+  val c05map_map_Map_iter (self : c05map_map 'i 'f) : 'i
+    ensures { result = c05map_map_Map_iter self }
+    
+  axiom c05map_map_Map_iter_acc : forall a : 'i, b : 'f . c05map_map_Map_iter (C05Map_Map a b : c05map_map 'i 'f) = a
+  function c05map_map_Map_func (self : c05map_map 'i 'f) : 'f
+  val c05map_map_Map_func (self : c05map_map 'i 'f) : 'f
+    ensures { result = c05map_map_Map_func self }
+    
+  axiom c05map_map_Map_func_acc : forall a : 'i, b : 'f . c05map_map_Map_func (C05Map_Map a b : c05map_map 'i 'f) = b
+end
+module C05Map_FakeIterator_Item
+  type self   
+  type item   
+end
+module C05Map_FakeIterator_Next_Interface
+  type self   
+  use prelude.Prelude
+  use Type
+  clone C05Map_FakeIterator_Item as Item0 with type self = self
+  val next [@cfg:stackify] (self : borrowed self) : Type.core_option_option Item0.item
+end
+module C05Map_FakeIterator_Next
+  type self   
+  use prelude.Prelude
+  use Type
+  clone C05Map_FakeIterator_Item as Item0 with type self = self
+  val next [@cfg:stackify] (self : borrowed self) : Type.core_option_option Item0.item
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module Core_Ops_Function_Fn_Call_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module Core_Ops_Function_Fn_Call
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  val call [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {false}
+    
+end
+module C05Map_Impl0_Next_Interface
+  type a   
+  type b   
+  type f   
+  type i   
+  use prelude.Prelude
+  use Type
+  val next [@cfg:stackify] (self : borrowed (Type.c05map_map i f)) : Type.core_option_option b
+end
+module C05Map_Impl0_Next
+  type a   
+  type b   
+  type f   
+  type i   
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.Int64
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (a), type Output0.output = b
+  clone C05Map_FakeIterator_Next_Interface as Next0 with type self = i, type Item0.item = a
+  let rec cfg next [@cfg:stackify] (self : borrowed (Type.c05map_map i f)) : Type.core_option_option b = 
+  var _0 : Type.core_option_option b;
+  var self_1 : borrowed (Type.c05map_map i f);
+  var _2 : Type.core_option_option a;
+  var _3 : borrowed i;
+  var _4 : isize;
+  var e_5 : a;
+  var _6 : b;
+  var _7 : f;
+  var _8 : (a);
+  var _9 : a;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    _3 <- borrow_mut (Type.c05map_map_Map_iter ( * self_1));
+    self_1 <- { self_1 with current = (let Type.C05Map_Map a b =  * self_1 in Type.C05Map_Map ( ^ _3) b) };
+    _2 <- Next0.next _3;
+    goto BB1
+  }
+  BB1 {
+    switch (_2)
+      | Type.Core_Option_Option_None -> goto BB4
+      | Type.Core_Option_Option_Some _ -> goto BB2
+      end
+  }
+  BB2 {
+    assume { (fun x -> true) e_5 };
+    e_5 <- Type.core_option_option_Some_0 _2;
+    _7 <- Type.c05map_map_Map_func ( * self_1);
+    assume { (fun x -> true) self_1 };
+    assume { (fun x -> true) _9 };
+    _9 <- e_5;
+    _8 <- (_9);
+    _6 <- Call0.call _7 _8;
+    goto BB5
+  }
+  BB3 {
+    assume { (fun x -> true) self_1 };
+    assume { (fun x -> true) _2 };
+    absurd
+  }
+  BB4 {
+    assume { (fun x -> true) self_1 };
+    _0 <- Type.Core_Option_Option_None;
+    goto BB9
+  }
+  BB5 {
+    goto BB6
+  }
+  BB6 {
+    _0 <- Type.Core_Option_Option_Some _6;
+    goto BB7
+  }
+  BB7 {
+    goto BB8
+  }
+  BB8 {
+    goto BB9
+  }
+  BB9 {
+    goto BB10
+  }
+  BB10 {
+    assume { (fun x -> true) _2 };
+    return _0
+  }
+  
+end
+module C05Map_Impl0_Item
+  type a   
+  type b   
+  type f   
+  type i   
+  type item  = 
+    b
+end
+module C05Map_Impl0
+  type a   
+  type b   
+  type f   
+  type i   
+  use Type
+  clone C05Map_Impl0_Next_Interface as Next0 with type a = a, type b = b, type f = f, type i = i
+  clone C05Map_Impl0_Item as Item0 with type a = a, type b = b, type f = f, type i = i
+  clone C05Map_FakeIterator_Next_Interface as Next1 with type self = Type.c05map_map i f, val next = Next0.next,
+  type Item0.item = Item0.item
+  clone C05Map_FakeIterator_Item as Item1 with type self = Type.c05map_map i f, type item = Item0.item
+end

--- a/creusot/tests/should_succeed/closures/06_fn_specs.rs
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.rs
@@ -1,0 +1,23 @@
+#![feature(unboxed_closures, fn_traits)]
+extern crate creusot_contracts;
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+#[requires(f.precondition(a))]
+#[ensures(f.postcondition(a, result))]
+fn weaken<A, F: FnSpec<A> + Resolve>(f: F, a: A) -> F::Output {
+    weaken_2(f, a)
+}
+
+#[requires(f.precondition(a))]
+#[ensures(exists<f2: &mut F> *f2 === f && f2.postcondition_mut(a, result))]
+#[ensures(f.resolve())]
+fn weaken_2<A, F: FnMutSpec<A> + Resolve>(f: F, a: A) -> F::Output {
+    weaken_3(f, a)
+}
+
+#[requires(f.precondition(a))]
+#[ensures(f.postcondition_once(a, result))]
+fn weaken_3<A, F: FnOnceSpec<A> + Resolve>(f: F, a: A) -> F::Output {
+    FnOnce::call_once(f, a)
+}

--- a/creusot/tests/should_succeed/closures/06_fn_specs.stdout
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.stdout
@@ -1,0 +1,376 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition (self : self) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnSpec_Postcondition
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition (self : self) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnSpec_FnMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  function fn_mut (self : self) (args : args) (res : Output0.output) : ()
+end
+module CreusotContracts_Std1_Fun_FnSpec_FnMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  function fn_mut (self : self) (args : args) (res : Output0.output) : ()
+  axiom fn_mut_spec : forall self : self, args : args, res : Output0.output . (Postcondition0.postcondition self args res -> (exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res)) && ((exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res) -> Postcondition0.postcondition self args res)
+end
+module Core_Ops_Function_FnOnce_CallOnce_Interface
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_once [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {Precondition0.precondition self args}
+    ensures { PostconditionOnce0.postcondition_once self args result }
+    
+end
+module Core_Ops_Function_FnOnce_CallOnce
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_once [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {Precondition0.precondition self args}
+    ensures { PostconditionOnce0.postcondition_once self args result }
+    
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
+  type self   
+  type args   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
+  axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
+end
+module C06FnSpecs_Weaken3_Interface
+  type a   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = f,
+  type args = a, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = f, type args = a
+  val weaken_3 [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { PostconditionOnce0.postcondition_once f a result }
+    
+end
+module C06FnSpecs_Weaken3
+  type a   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition as Precondition0 with type self = f, type args = a
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = a
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone Core_Ops_Function_FnOnce_CallOnce_Interface as CallOnce0 with type self = f, type args = a,
+  predicate Precondition0.precondition = Precondition0.precondition,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+  type Output0.output = Output0.output
+  let rec cfg weaken_3 [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { PostconditionOnce0.postcondition_once f a result }
+    
+   = 
+  var _0 : Output0.output;
+  var f_1 : f;
+  var a_2 : a;
+  var _3 : f;
+  var _4 : a;
+  {
+    f_1 <- f;
+    a_2 <- a;
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _3 };
+    _3 <- f_1;
+    assume { Resolve1.resolve _4 };
+    _4 <- a_2;
+    _0 <- CallOnce0.call_once _3 _4;
+    goto BB3
+  }
+  BB3 {
+    goto BB4
+  }
+  BB4 {
+    goto BB5
+  }
+  BB5 {
+    return _0
+  }
+  
+end
+module C06FnSpecs_Weaken2_Interface
+  type a   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = f,
+  type args = a, type Output0.output = Output0.output
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = f
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = f, type args = a
+  val weaken_2 [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { Resolve0.resolve f }
+    ensures { exists f2 : (borrowed f) .  * f2 = f && PostconditionMut0.postcondition_mut f2 a result }
+    
+end
+module C06FnSpecs_Weaken2
+  type a   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut as PostconditionMut0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce as FnMutOnce0 with type self = f, type args = a,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut,
+  predicate Resolve0.resolve = Resolve0.resolve, type Output0.output = Output0.output, axiom .
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition as Precondition0 with type self = f, type args = a
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = a
+  clone C06FnSpecs_Weaken3_Interface as Weaken30 with type a = a, type f = f,
+  predicate Precondition0.precondition = Precondition0.precondition,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+  type Output0.output = Output0.output
+  let rec cfg weaken_2 [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { Resolve0.resolve f }
+    ensures { exists f2 : (borrowed f) .  * f2 = f && PostconditionMut0.postcondition_mut f2 a result }
+    
+   = 
+  var _0 : Output0.output;
+  var f_1 : f;
+  var a_2 : a;
+  var _3 : f;
+  var _4 : a;
+  {
+    f_1 <- f;
+    a_2 <- a;
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    goto BB3
+  }
+  BB3 {
+    assume { Resolve0.resolve _3 };
+    _3 <- f_1;
+    assume { Resolve1.resolve _4 };
+    _4 <- a_2;
+    _0 <- Weaken30.weaken_3 _3 _4;
+    goto BB4
+  }
+  BB4 {
+    goto BB5
+  }
+  BB5 {
+    goto BB6
+  }
+  BB6 {
+    return _0
+  }
+  
+end
+module C06FnSpecs_Weaken_Interface
+  type a   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = f, type args = a
+  val weaken [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { Postcondition0.postcondition f a result }
+    
+end
+module C06FnSpecs_Weaken
+  type a   
+  type f   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut as PostconditionMut0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce as FnMutOnce0 with type self = f, type args = a,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut,
+  predicate Resolve0.resolve = Resolve0.resolve, type Output0.output = Output0.output, axiom .
+  clone CreusotContracts_Std1_Fun_FnSpec_Postcondition as Postcondition0 with type self = f, type args = a,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnSpec_FnMut as FnMut0 with type self = f, type args = a,
+  predicate Resolve0.resolve = Resolve0.resolve,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut,
+  predicate Postcondition0.postcondition = Postcondition0.postcondition, type Output0.output = Output0.output, axiom .
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition as Precondition0 with type self = f, type args = a
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = a
+  clone C06FnSpecs_Weaken2_Interface as Weaken20 with type a = a, type f = f,
+  predicate Precondition0.precondition = Precondition0.precondition, predicate Resolve0.resolve = Resolve0.resolve,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut,
+  type Output0.output = Output0.output
+  let rec cfg weaken [@cfg:stackify] (f : f) (a : a) : Output0.output
+    requires {Precondition0.precondition f a}
+    ensures { Postcondition0.postcondition f a result }
+    
+   = 
+  var _0 : Output0.output;
+  var f_1 : f;
+  var a_2 : a;
+  var _3 : f;
+  var _4 : a;
+  {
+    f_1 <- f;
+    a_2 <- a;
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _3 };
+    _3 <- f_1;
+    assume { Resolve1.resolve _4 };
+    _4 <- a_2;
+    _0 <- Weaken20.weaken_2 _3 _4;
+    goto BB3
+  }
+  BB3 {
+    goto BB4
+  }
+  BB4 {
+    goto BB5
+  }
+  BB5 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.rs
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.rs
@@ -1,0 +1,16 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[requires(@x === 100_000)]
+fn test_fnmut(mut x: u32) {
+    let mut c = (#[requires(@x < 1_000_000)]
+    #[ensures(@x === @(old(x)) + 1)]
+    || {
+        x += 1;
+        5
+    });
+    c();
+    c();
+
+    proof_assert! { @x === 100_002};
+}

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
@@ -1,0 +1,228 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module C07MutableCapture_TestFnmut_Closure2_Interface
+  use mach.int.UInt32
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  type c07mutablecapture_testfnmut_closure2  = 
+    | C07MutableCapture_TestFnmut_Closure2 (borrowed uint32)
+    
+  function c07mutablecapture_testfnmut_closure2_0 (self : c07mutablecapture_testfnmut_closure2) : borrowed uint32
+  val c07mutablecapture_testfnmut_closure2_0 (self : c07mutablecapture_testfnmut_closure2) : borrowed uint32
+    ensures { result = c07mutablecapture_testfnmut_closure2_0 self }
+    
+  axiom c07mutablecapture_testfnmut_closure2_0_acc : forall a : borrowed uint32 . c07mutablecapture_testfnmut_closure2_0 (C07MutableCapture_TestFnmut_Closure2 a : c07mutablecapture_testfnmut_closure2) = a
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = uint32
+  predicate precondition (_1' : c07mutablecapture_testfnmut_closure2) (_2' : ()) = 
+    UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') < 1000000
+  predicate postcondition_mut (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) (result : int32) = 
+    UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 &&  ^ c07mutablecapture_testfnmut_closure2_0 ( ^ _1') =  ^ c07mutablecapture_testfnmut_closure2_0 ( * _1') && true
+  predicate postcondition_once (_1' : c07mutablecapture_testfnmut_closure2) (_2' : ()) (result : int32) = 
+    UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') + 1
+  predicate resolve (_1' : c07mutablecapture_testfnmut_closure2) = 
+    Resolve0.resolve (c07mutablecapture_testfnmut_closure2_0 _1') && true
+  val c07MutableCapture_TestFnmut_Closure2 (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) : int32
+    requires {UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
+    ensures { UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
+    ensures {  ^ c07mutablecapture_testfnmut_closure2_0 ( ^ _1') =  ^ c07mutablecapture_testfnmut_closure2_0 ( * _1') && true }
+    
+end
+module C07MutableCapture_TestFnmut_Closure2
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  type c07mutablecapture_testfnmut_closure2  = 
+    | C07MutableCapture_TestFnmut_Closure2 (borrowed uint32)
+    
+  function c07mutablecapture_testfnmut_closure2_0 (self : c07mutablecapture_testfnmut_closure2) : borrowed uint32
+  val c07mutablecapture_testfnmut_closure2_0 (self : c07mutablecapture_testfnmut_closure2) : borrowed uint32
+    ensures { result = c07mutablecapture_testfnmut_closure2_0 self }
+    
+  axiom c07mutablecapture_testfnmut_closure2_0_acc : forall a : borrowed uint32 . c07mutablecapture_testfnmut_closure2_0 (C07MutableCapture_TestFnmut_Closure2 a : c07mutablecapture_testfnmut_closure2) = a
+  use mach.int.Int32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = c07mutablecapture_testfnmut_closure2
+  let rec cfg c07MutableCapture_TestFnmut_Closure2 (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) : int32
+    requires {UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
+    ensures { UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
+    
+   = 
+  var _0 : int32;
+  var _1 : borrowed c07mutablecapture_testfnmut_closure2;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    _1 <- { _1 with current = (let C07MutableCapture_TestFnmut_Closure2 a =  * _1 in C07MutableCapture_TestFnmut_Closure2 ({ (c07mutablecapture_testfnmut_closure2_0 ( * _1)) with current = ( * c07mutablecapture_testfnmut_closure2_0 ( * _1) + (1 : uint32)) })) };
+    assume { Resolve0.resolve _1 };
+    _0 <- (5 : int32);
+    return _0
+  }
+  
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module Core_Ops_Function_FnMut_CallMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_mut [@cfg:stackify] (self : borrowed self) (args : args) : Output0.output
+    requires {Precondition0.precondition ( * self) args}
+    ensures { PostconditionMut0.postcondition_mut self args result }
+    
+end
+module Core_Ops_Function_FnMut_CallMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_mut [@cfg:stackify] (self : borrowed self) (args : args) : Output0.output
+    requires {Precondition0.precondition ( * self) args}
+    ensures { PostconditionMut0.postcondition_mut self args result }
+    
+end
+module C07MutableCapture_TestFnmut_Interface
+  use mach.int.UInt32
+  use mach.int.Int
+  use mach.int.Int32
+  val test_fnmut [@cfg:stackify] (x : uint32) : ()
+    requires {UInt32.to_int x = 100000}
+    
+end
+module C07MutableCapture_TestFnmut
+  use mach.int.UInt32
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone C07MutableCapture_TestFnmut_Closure2_Interface as Closure20 with predicate Resolve0.resolve = Resolve2.resolve,
+  axiom .
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  let rec cfg test_fnmut [@cfg:stackify] (x : uint32) : ()
+    requires {UInt32.to_int x = 100000}
+    
+   = 
+  var _0 : ();
+  var x_1 : uint32;
+  var c_2 : Closure20.c07mutablecapture_testfnmut_closure2;
+  var closure_3 : Closure20.c07mutablecapture_testfnmut_closure2;
+  var _4 : borrowed uint32;
+  var _5 : int32;
+  var _6 : borrowed Closure20.c07mutablecapture_testfnmut_closure2;
+  var _7 : ();
+  var _8 : int32;
+  var _9 : borrowed Closure20.c07mutablecapture_testfnmut_closure2;
+  var _10 : ();
+  var _11 : ();
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _4 <- borrow_mut x_1;
+    x_1 <-  ^ _4;
+    assume { Resolve0.resolve x_1 };
+    closure_3 <- Closure20.C07MutableCapture_TestFnmut_Closure2 _4;
+    assume { Closure20.resolve c_2 };
+    c_2 <- closure_3;
+    _6 <- borrow_mut c_2;
+    c_2 <-  ^ _6;
+    _7 <- ();
+    _5 <- Closure20.c07MutableCapture_TestFnmut_Closure2 _6 _7;
+    goto BB1
+  }
+  BB1 {
+    _9 <- borrow_mut c_2;
+    c_2 <-  ^ _9;
+    assume { Closure20.resolve c_2 };
+    _10 <- ();
+    _8 <- Closure20.c07MutableCapture_TestFnmut_Closure2 _9 _10;
+    goto BB2
+  }
+  BB2 {
+    assert { UInt32.to_int x_1 = 100002 };
+    _11 <- ();
+    assume { Resolve1.resolve _11 };
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.rs
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.rs
@@ -1,0 +1,34 @@
+extern crate creusot_contracts;
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+fn multi_use<T>(x: &T) {
+    let c = #[requires(x === x)]
+    || {
+        x;
+        0
+    };
+
+    uses_fn(c);
+    uses_fnmut(c);
+    uses_fnonce(c);
+}
+
+#[trusted]
+#[requires(f.precondition(()))]
+#[ensures(exists<f2 : &F, r : _> *f2 === f && f2.postcondition((), r))]
+fn uses_fn<F: Fn() -> u32>(f: F) {
+    f();
+}
+
+#[requires(f.precondition(()))]
+#[ensures(exists<f2 : &mut F, r : _> *f2 === f && f2.postcondition_mut((), r))]
+fn uses_fnmut<F: FnMut() -> u32>(mut f: F) {
+    f();
+}
+
+#[requires(f.precondition(()))]
+#[ensures(exists<r : _> f.postcondition_once((), r))]
+fn uses_fnonce<F: FnOnce() -> u32>(f: F) {
+    f();
+}

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
@@ -1,0 +1,516 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module C08MultipleCalls_MultiUse_Closure1_Interface
+  type t   
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.UInt32
+  type c08multiplecalls_multiuse_closure1  = 
+    | C08MultipleCalls_MultiUse_Closure1 t
+    
+  function c08multiplecalls_multiuse_closure1_0 (self : c08multiplecalls_multiuse_closure1) : t
+  val c08multiplecalls_multiuse_closure1_0 (self : c08multiplecalls_multiuse_closure1) : t
+    ensures { result = c08multiplecalls_multiuse_closure1_0 self }
+    
+  axiom c08multiplecalls_multiuse_closure1_0_acc : forall a : t . c08multiplecalls_multiuse_closure1_0 (C08MultipleCalls_MultiUse_Closure1 a : c08multiplecalls_multiuse_closure1) = a
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  predicate precondition (_1' : c08multiplecalls_multiuse_closure1) (_2' : ()) = 
+    c08multiplecalls_multiuse_closure1_0 _1' = c08multiplecalls_multiuse_closure1_0 _1'
+  predicate postcondition (_1' : c08multiplecalls_multiuse_closure1) (_2' : ()) (result : uint32) = 
+    true
+  predicate postcondition_mut (_1' : borrowed c08multiplecalls_multiuse_closure1) (_2' : ()) (result : uint32) = 
+    true && true
+  predicate postcondition_once (_1' : c08multiplecalls_multiuse_closure1) (_2' : ()) (result : uint32) = 
+    true
+  predicate resolve (_1' : c08multiplecalls_multiuse_closure1) = 
+    Resolve0.resolve (c08multiplecalls_multiuse_closure1_0 _1') && true
+  val c08MultipleCalls_MultiUse_Closure1 (_1' : c08multiplecalls_multiuse_closure1) (_2' : ()) : uint32
+    requires {c08multiplecalls_multiuse_closure1_0 _1' = c08multiplecalls_multiuse_closure1_0 _1'}
+    
+end
+module C08MultipleCalls_MultiUse_Closure1
+  type t   
+  use prelude.Prelude
+  type c08multiplecalls_multiuse_closure1  = 
+    | C08MultipleCalls_MultiUse_Closure1 t
+    
+  function c08multiplecalls_multiuse_closure1_0 (self : c08multiplecalls_multiuse_closure1) : t
+  val c08multiplecalls_multiuse_closure1_0 (self : c08multiplecalls_multiuse_closure1) : t
+    ensures { result = c08multiplecalls_multiuse_closure1_0 self }
+    
+  axiom c08multiplecalls_multiuse_closure1_0_acc : forall a : t . c08multiplecalls_multiuse_closure1_0 (C08MultipleCalls_MultiUse_Closure1 a : c08multiplecalls_multiuse_closure1) = a
+  use mach.int.Int
+  use mach.int.UInt32
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = c08multiplecalls_multiuse_closure1
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
+  let rec cfg c08MultipleCalls_MultiUse_Closure1 (_1' : c08multiplecalls_multiuse_closure1) (_2' : ()) : uint32
+    requires {c08multiplecalls_multiuse_closure1_0 _1' = c08multiplecalls_multiuse_closure1_0 _1'}
+    
+   = 
+  var _0 : uint32;
+  var _1 : c08multiplecalls_multiuse_closure1;
+  var _2 : t;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve _2 };
+    _2 <- c08multiplecalls_multiuse_closure1_0 _1;
+    assume { Resolve1.resolve _1 };
+    assume { Resolve0.resolve _2 };
+    _0 <- (0 : uint32);
+    return _0
+  }
+  
+end
+module CreusotContracts_Std1_Fun_Impl0_Precondition_Interface
+  type args   
+  type f   
+  predicate precondition (self : f) (_2' : args)
+end
+module CreusotContracts_Std1_Fun_Impl0_Precondition
+  type args   
+  type f   
+  predicate precondition (self : f) (_2' : args)
+end
+module Core_Ops_Function_FnOnce_Output
+  type self   
+  type args   
+  type output   
+end
+module CreusotContracts_Std1_Fun_Impl2_Postcondition_Interface
+  type args   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition (self : f) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_Impl2_Postcondition
+  type args   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition (self : f) (_2' : args) (_3' : Output0.output)
+end
+module C08MultipleCalls_UsesFn_Interface
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Fun_Impl2_Postcondition_Interface as Postcondition0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = (), type f = f
+  val uses_fn [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . exists f2 : (f) . f2 = f && Postcondition0.postcondition f2 () r }
+    
+end
+module C08MultipleCalls_UsesFn
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (), type f = f
+  val uses_fn [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . exists f2 : (f) . f2 = f && Postcondition0.postcondition f2 () r }
+    
+end
+module CreusotContracts_Std1_Fun_Impl1_PostconditionMut_Interface
+  type args   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition_mut (self : borrowed f) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_Impl1_PostconditionMut
+  type args   
+  type f   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition_mut (self : borrowed f) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
+  type self   
+  type args   
+  predicate precondition (self : self) (a : args)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_once (self : self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_Impl0_PostconditionOnce_Interface
+  type args   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition_once (self : f) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_Impl0_PostconditionOnce
+  type args   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  predicate postcondition_once (self : f) (_2' : args) (_3' : Output0.output)
+end
+module CreusotContracts_Std1_Fun_Impl0
+  type args   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = args, type f = f,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce1 with type self = f,
+  type args = args, predicate postcondition_once = PostconditionOnce0.postcondition_once,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = args, type f = f
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition as Precondition1 with type self = f, type args = args,
+  predicate precondition = Precondition0.precondition
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
+end
+module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
+  type self   
+  type args   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
+  axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
+end
+module CreusotContracts_Std1_Fun_Impl1_FnMutOnce_Interface
+  type args   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  function fn_mut_once (self : f) (_2' : args) (_3' : Output0.output) : ()
+end
+module CreusotContracts_Std1_Fun_Impl1_FnMutOnce
+  type args   
+  type f   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  function fn_mut_once (self : f) (_2' : args) (_3' : Output0.output) : () = 
+    ()
+end
+module CreusotContracts_Std1_Fun_Impl1
+  type args   
+  type f   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
+  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = args, type f = f,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_Impl1_FnMutOnce as FnMutOnce0 with type args = args, type f = f,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_Impl1_PostconditionMut as PostconditionMut0 with type args = args, type f = f,
+  type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce as FnMutOnce1 with type self = f, type args = args,
+  function fn_mut_once = FnMutOnce0.fn_mut_once,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut,
+  predicate Resolve0.resolve = Resolve0.resolve, type Output0.output = Output0.output, axiom .
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut as PostconditionMut1 with type self = f, type args = args,
+  predicate postcondition_mut = PostconditionMut0.postcondition_mut, type Output0.output = Output0.output
+end
+module Core_Ops_Function_FnMut_CallMut_Interface
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_mut [@cfg:stackify] (self : borrowed self) (args : args) : Output0.output
+    requires {Precondition0.precondition ( * self) args}
+    ensures { PostconditionMut0.postcondition_mut self args result }
+    
+end
+module Core_Ops_Function_FnMut_CallMut
+  type self   
+  type args   
+  use prelude.Prelude
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_mut [@cfg:stackify] (self : borrowed self) (args : args) : Output0.output
+    requires {Precondition0.precondition ( * self) args}
+    ensures { PostconditionMut0.postcondition_mut self args result }
+    
+end
+module C08MultipleCalls_UsesFnmut_Interface
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Fun_Impl1_PostconditionMut_Interface as PostconditionMut0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = (), type f = f
+  val uses_fnmut [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . exists f2 : (borrowed f) .  * f2 = f && PostconditionMut0.postcondition_mut f2 () r }
+    
+end
+module C08MultipleCalls_UsesFnmut
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Fun_Impl1_FnMutOnce as FnMutOnce0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl1_PostconditionMut as PostconditionMut0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (), type f = f
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone Core_Ops_Function_FnMut_CallMut_Interface as CallMut0 with type self = f, type args = (),
+  predicate Precondition0.precondition = Precondition0.precondition,
+  predicate PostconditionMut0.postcondition_mut = PostconditionMut0.postcondition_mut, type Output0.output = uint32
+  let rec cfg uses_fnmut [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . exists f2 : (borrowed f) .  * f2 = f && PostconditionMut0.postcondition_mut f2 () r }
+    
+   = 
+  var _0 : ();
+  var f_1 : f;
+  var _2 : uint32;
+  var _3 : borrowed f;
+  var _4 : ();
+  {
+    f_1 <- f;
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    _3 <- borrow_mut f_1;
+    f_1 <-  ^ _3;
+    _4 <- ();
+    _2 <- CallMut0.call_mut _3 _4;
+    goto BB3
+  }
+  BB3 {
+    _0 <- ();
+    goto BB4
+  }
+  BB4 {
+    assume { Resolve0.resolve f_1 };
+    return _0
+  }
+  
+end
+module Core_Ops_Function_FnOnce_CallOnce_Interface
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_once [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {Precondition0.precondition self args}
+    ensures { PostconditionOnce0.postcondition_once self args result }
+    
+end
+module Core_Ops_Function_FnOnce_CallOnce
+  type self   
+  type args   
+  clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
+  type args = args, type Output0.output = Output0.output
+  clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = self,
+  type args = args
+  val call_once [@cfg:stackify] (self : self) (args : args) : Output0.output
+    requires {Precondition0.precondition self args}
+    ensures { PostconditionOnce0.postcondition_once self args result }
+    
+end
+module C08MultipleCalls_UsesFnonce_Interface
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce_Interface as PostconditionOnce0 with type args = (),
+  type f = f, type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = (), type f = f
+  val uses_fnonce [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . PostconditionOnce0.postcondition_once f () r }
+    
+end
+module C08MultipleCalls_UsesFnonce
+  type f   
+  use mach.int.Int
+  use mach.int.UInt32
+  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = (), type f = f,
+  type Output0.output = uint32
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (), type f = f
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
+  clone Core_Ops_Function_FnOnce_CallOnce_Interface as CallOnce0 with type self = f, type args = (),
+  predicate Precondition0.precondition = Precondition0.precondition,
+  predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once, type Output0.output = uint32
+  let rec cfg uses_fnonce [@cfg:stackify] (f : f) : ()
+    requires {Precondition0.precondition f ()}
+    ensures { exists r : (uint32) . PostconditionOnce0.postcondition_once f () r }
+    
+   = 
+  var _0 : ();
+  var f_1 : f;
+  var _2 : uint32;
+  var _3 : f;
+  var _4 : ();
+  {
+    f_1 <- f;
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    goto BB2
+  }
+  BB2 {
+    assume { Resolve0.resolve _3 };
+    _3 <- f_1;
+    _4 <- ();
+    _2 <- CallOnce0.call_once _3 _4;
+    goto BB3
+  }
+  BB3 {
+    _0 <- ();
+    goto BB4
+  }
+  BB4 {
+    return _0
+  }
+  
+end
+module C08MultipleCalls_MultiUse_Interface
+  type t   
+  use prelude.Prelude
+  val multi_use [@cfg:stackify] (x : t) : ()
+end
+module C08MultipleCalls_MultiUse
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
+  clone C08MultipleCalls_MultiUse_Closure1_Interface as Closure10 with type t = t,
+  predicate Resolve0.resolve = Resolve1.resolve, axiom .
+  clone C08MultipleCalls_UsesFnonce_Interface as UsesFnonce0 with type f = Closure10.c08multiplecalls_multiuse_closure1,
+  predicate Precondition0.precondition = Closure10.precondition,
+  predicate PostconditionOnce0.postcondition_once = Closure10.postcondition_once
+  clone C08MultipleCalls_UsesFnmut_Interface as UsesFnmut0 with type f = Closure10.c08multiplecalls_multiuse_closure1,
+  predicate Precondition0.precondition = Closure10.precondition,
+  predicate PostconditionMut0.postcondition_mut = Closure10.postcondition_mut
+  clone C08MultipleCalls_UsesFn_Interface as UsesFn0 with type f = Closure10.c08multiplecalls_multiuse_closure1,
+  predicate Precondition0.precondition = Closure10.precondition,
+  predicate Postcondition0.postcondition = Closure10.postcondition
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
+  let rec cfg multi_use [@cfg:stackify] (x : t) : () = 
+  var _0 : ();
+  var x_1 : t;
+  var c_2 : Closure10.c08multiplecalls_multiuse_closure1;
+  var _3 : t;
+  var _4 : ();
+  var _5 : Closure10.c08multiplecalls_multiuse_closure1;
+  var _6 : ();
+  var _7 : Closure10.c08multiplecalls_multiuse_closure1;
+  var _8 : ();
+  var _9 : Closure10.c08multiplecalls_multiuse_closure1;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _3 <- x_1;
+    assume { Resolve0.resolve x_1 };
+    c_2 <- Closure10.C08MultipleCalls_MultiUse_Closure1 _3;
+    assume { Closure10.resolve _5 };
+    _5 <- c_2;
+    _4 <- UsesFn0.uses_fn _5;
+    goto BB1
+  }
+  BB1 {
+    assume { Closure10.resolve _7 };
+    _7 <- c_2;
+    _6 <- UsesFnmut0.uses_fnmut _7;
+    goto BB2
+  }
+  BB2 {
+    assume { Closure10.resolve _9 };
+    _9 <- c_2;
+    assume { Closure10.resolve c_2 };
+    _8 <- UsesFnonce0.uses_fnonce _9;
+    goto BB3
+  }
+  BB3 {
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -105,6 +105,22 @@ module Core_Cmp_PartialOrd_Ge
     requires {false}
     
 end
+module Core_Tuple_Impl7_Lt_Interface
+  type a   
+  type b   
+  use prelude.Prelude
+  val lt [@cfg:stackify] (self : (a, b)) (other : (a, b)) : bool
+    requires {false}
+    
+end
+module Core_Tuple_Impl7_Lt
+  type a   
+  type b   
+  use prelude.Prelude
+  val lt [@cfg:stackify] (self : (a, b)) (other : (a, b)) : bool
+    requires {false}
+    
+end
 module Core_Tuple_Impl7_PartialCmp_Interface
   type a   
   type b   
@@ -120,22 +136,6 @@ module Core_Tuple_Impl7_PartialCmp
   use prelude.Prelude
   use Type
   val partial_cmp [@cfg:stackify] (self : (a, b)) (other : (a, b)) : Type.core_option_option (Type.core_cmp_ordering)
-    requires {false}
-    
-end
-module Core_Tuple_Impl7_Lt_Interface
-  type a   
-  type b   
-  use prelude.Prelude
-  val lt [@cfg:stackify] (self : (a, b)) (other : (a, b)) : bool
-    requires {false}
-    
-end
-module Core_Tuple_Impl7_Lt
-  type a   
-  type b   
-  use prelude.Prelude
-  val lt [@cfg:stackify] (self : (a, b)) (other : (a, b)) : bool
     requires {false}
     
 end

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -90,7 +90,8 @@ module DropPair_DropPair2
   use mach.int.UInt32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = borrowed uint32,
-  type t2 = borrowed uint32, predicate Resolve1.resolve = Resolve1.resolve
+  type t2 = borrowed uint32, predicate Resolve0.resolve = Resolve1.resolve,
+  predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair2 [@cfg:stackify] (x : (borrowed uint32, borrowed uint32)) : () = 
   var _0 : ();
   var x_1 : (borrowed uint32, borrowed uint32);
@@ -158,7 +159,8 @@ module DropPair_DropPair
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = borrowed uint32,
-  type t2 = borrowed uint32, predicate Resolve1.resolve = Resolve1.resolve
+  type t2 = borrowed uint32, predicate Resolve0.resolve = Resolve1.resolve,
+  predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg drop_pair [@cfg:stackify] (x : (borrowed uint32, borrowed uint32)) : ()
     ensures {  ^ (let (a, _) = x in a) =  * (let (a, _) = x in a) }
     ensures { Resolve0.resolve x }

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -15,26 +15,6 @@ module Type
   use prelude.Prelude
   type creusotcontracts_std1_vec_vec 't  
 end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -46,16 +26,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module FilterPositive_NumOfPos_Interface
   use mach.int.Int
@@ -151,6 +121,36 @@ module FilterPositive_LemmaNumOfPosIncreasing_Impl
    = 
     if j < k then lemma_num_of_pos_increasing i (j + 1) k t else ()
 end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -158,12 +158,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -179,18 +173,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -243,11 +225,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -277,23 +254,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
   type t   
@@ -341,12 +301,6 @@ module Core_Ops_Index_IndexMut_IndexMut
     requires {false}
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -361,19 +315,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
   type t   
@@ -415,6 +356,39 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
 module CreusotContracts_Std1_Vec_Impl2
   type t   
   use Type
@@ -429,18 +403,7 @@ module CreusotContracts_Std1_Vec_Impl2
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -448,6 +411,43 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module FilterPositive_M_Interface
   use Type

--- a/creusot/tests/should_succeed/heapsort_generic.stdout
+++ b/creusot/tests/should_succeed/heapsort_generic.stdout
@@ -36,12 +36,12 @@ end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
   type self   
@@ -53,6 +53,21 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
+end
+module HeapsortGeneric_HeapFrag_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  predicate heap_frag (s : Seq.seq t) (start : int) (end' : int)
+end
+module HeapsortGeneric_HeapFrag
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
+  clone HeapsortGeneric_Parent_Interface as Parent0
+  predicate heap_frag (s : Seq.seq t) (start : int) (end' : int) = 
+    forall i : (int) . start <= Parent0.parent i && i < end' -> LeLog0.le_log (Seq.get s i) (Seq.get s (Parent0.parent i))
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self   
@@ -201,19 +216,34 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -260,36 +290,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
-end
-module HeapsortGeneric_HeapFrag_Interface
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  predicate heap_frag (s : Seq.seq t) (start : int) (end' : int)
-end
-module HeapsortGeneric_HeapFrag
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
-  clone HeapsortGeneric_Parent_Interface as Parent0
-  predicate heap_frag (s : Seq.seq t) (start : int) (end' : int) = 
-    forall i : (int) . start <= Parent0.parent i && i < end' -> LeLog0.le_log (Seq.get s i) (Seq.get s (Parent0.parent i))
 end
 module HeapsortGeneric_HeapFragMax_Interface
   type t   
@@ -384,12 +384,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -405,25 +399,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -435,16 +410,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
   type t   
@@ -460,10 +425,11 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
     Permut.permut self o 0 (Seq.length self)
 end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
+  use seq.Seq
   type modelTy  = 
-    t
+    Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -475,14 +441,48 @@ module CreusotContracts_Logic_Ghost_Impl0_Model
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
@@ -522,13 +522,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module Core_Ops_Index_Index_Output
   type self   
   type idx   
@@ -552,17 +545,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -577,18 +559,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
@@ -619,23 +589,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
   type self   
@@ -754,6 +707,53 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     requires {UInt64.to_int i < Seq.length (Model0.model self)}
     ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module HeapsortGeneric_SiftDown_Interface
   type t   

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -180,12 +180,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -201,6 +195,17 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Logic_Int_Impl3_ModelTy
+  use mach.int.Int
+  type modelTy  = 
+    int
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -209,15 +214,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Int_Impl3_ModelTy
-  use mach.int.Int
-  type modelTy  = 
-    int
 end
 module CreusotContracts_Logic_Int_Impl3_Model_Interface
   use mach.int.Int
@@ -235,8 +235,8 @@ module CreusotContracts_Logic_Int_Impl3
   use mach.int.UInt32
   clone CreusotContracts_Logic_Int_Impl3_Model as Model0
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
@@ -250,13 +250,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module Rand_Random_Interface
   type t   
   val random [@cfg:stackify] () : t
@@ -268,6 +261,13 @@ module Rand_Random
   val random [@cfg:stackify] () : t
     requires {false}
     
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSome2List_Impl1_TakeSomeRest_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -203,12 +203,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -224,6 +218,17 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Logic_Int_Impl3_ModelTy
+  use mach.int.Int
+  type modelTy  = 
+    int
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -232,15 +237,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Int_Impl3_ModelTy
-  use mach.int.Int
-  type modelTy  = 
-    int
 end
 module CreusotContracts_Logic_Int_Impl3_Model_Interface
   use mach.int.Int
@@ -258,8 +258,8 @@ module CreusotContracts_Logic_Int_Impl3
   use mach.int.UInt32
   clone CreusotContracts_Logic_Int_Impl3_Model as Model0
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
@@ -273,13 +273,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module Rand_Random_Interface
   type t   
   val random [@cfg:stackify] () : t
@@ -291,6 +284,13 @@ module Rand_Random
   val random [@cfg:stackify] () : t
     requires {false}
     
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSome2Tree_Impl1_TakeSomeRest_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -186,12 +186,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -207,6 +201,17 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Logic_Int_Impl3_ModelTy
+  use mach.int.Int
+  type modelTy  = 
+    int
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -215,15 +220,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Int_Impl3_ModelTy
-  use mach.int.Int
-  type modelTy  = 
-    int
 end
 module CreusotContracts_Logic_Int_Impl3_Model_Interface
   use mach.int.Int
@@ -241,8 +241,8 @@ module CreusotContracts_Logic_Int_Impl3
   use mach.int.UInt32
   clone CreusotContracts_Logic_Int_Impl3_Model as Model0
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -203,12 +203,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -224,6 +218,17 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Logic_Int_Impl3_ModelTy
+  use mach.int.Int
+  type modelTy  = 
+    int
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -232,15 +237,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Int_Impl3_ModelTy
-  use mach.int.Int
-  type modelTy  = 
-    int
 end
 module CreusotContracts_Logic_Int_Impl3_Model_Interface
   use mach.int.Int
@@ -258,8 +258,8 @@ module CreusotContracts_Logic_Int_Impl3
   use mach.int.UInt32
   clone CreusotContracts_Logic_Int_Impl3_Model as Model0
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = uint32, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
@@ -273,13 +273,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module Rand_Random_Interface
   type t   
   val random [@cfg:stackify] () : t
@@ -291,6 +284,13 @@ module Rand_Random
   val random [@cfg:stackify] () : t
     requires {false}
     
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSomeTree_Impl1_TakeSome_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/inplace_list_reversal.stdout
+++ b/creusot/tests/should_succeed/inplace_list_reversal.stdout
@@ -43,6 +43,16 @@ module InplaceListReversal_RevAppend
       | Type.InplaceListReversal_List_Cons (hd, tl) -> rev_append tl (Type.InplaceListReversal_List_Cons (hd, o))
       end
 end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -62,23 +72,13 @@ module CreusotContracts_Logic_Ghost_Impl0_ModelTy
   type modelTy  = 
     t
 end
-module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
   type modelTy = ModelTy0.modelTy
 end

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -56,14 +56,6 @@ module Alloc_Vec_Impl1_Pop
     requires {false}
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -74,6 +66,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -53,26 +53,6 @@ module Type
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module IterMut_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module IterMut_Impl0_Model_Interface
   type t   
   use Type
@@ -84,23 +64,6 @@ module IterMut_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.itermut_vec t) : Seq.seq t
-end
-module IterMut_Impl0
-  type t   
-  use Type
-  clone IterMut_Impl0_Model as Model0 with type t = t
-  clone IterMut_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.itermut_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module IterMut_Impl2_ModelTy
-  type t   
-  use seq.Seq
-  use prelude.Prelude
-  type modelTy  = 
-    Seq.seq (borrowed t)
 end
 module IterMut_Impl2_Model_Interface
   type t   
@@ -115,16 +78,6 @@ module IterMut_Impl2_Model
   use seq.Seq
   use prelude.Prelude
   function model (self : Type.itermut_itermut t) : Seq.seq (borrowed t)
-end
-module IterMut_Impl2
-  type t   
-  use Type
-  clone IterMut_Impl2_Model as Model0 with type t = t
-  clone IterMut_Impl2_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.itermut_itermut t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_itermut t,
-  type modelTy = ModelTy0.modelTy
 end
 module IterMut_Impl1_IterMut_Interface
   type t   
@@ -230,11 +183,19 @@ module IterMut_Impl3_Next
     ensures { result = Get0.get (Model0.model ( * self)) 0 }
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -251,23 +212,11 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
-module CreusotContracts_Logic_Model_Impl1
+module IterMut_Impl0_ModelTy
   type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  use seq.Seq
   type modelTy  = 
-    t
+    Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -279,14 +228,65 @@ module CreusotContracts_Logic_Ghost_Impl0_Model
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module IterMut_Impl0
+  type t   
+  use Type
+  clone IterMut_Impl0_Model as Model0 with type t = t
+  clone IterMut_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.itermut_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_vec t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module IterMut_Impl2_ModelTy
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  type modelTy  = 
+    Seq.seq (borrowed t)
+end
+module IterMut_Impl2
+  type t   
+  use Type
+  clone IterMut_Impl2_Model as Model0 with type t = t
+  clone IterMut_Impl2_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.itermut_itermut t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_itermut t,
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -174,12 +174,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -194,18 +188,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
@@ -225,13 +207,31 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Std1_Vec_Impl0
   type t   
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -314,11 +314,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -349,23 +344,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
-end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
   type idx   
@@ -384,12 +362,6 @@ module Core_Ops_Index_IndexMut_IndexMut
     requires {false}
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -404,19 +376,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
   type t   
@@ -458,22 +417,6 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Std1_Vec_Impl2
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
-  function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -484,13 +427,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
-end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
   type t   
@@ -543,6 +479,70 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
+module CreusotContracts_Std1_Vec_Impl2
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module Knapsack_Knapsack01Dyn_Interface
   type name   

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -314,12 +314,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -335,24 +329,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
 end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -365,13 +341,37 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Std1_Vec_Impl0
   type t   
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -454,11 +454,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -489,23 +484,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
-end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
   type idx   
@@ -524,12 +502,6 @@ module Core_Ops_Index_IndexMut_IndexMut
     requires {false}
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -544,19 +516,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
   type t   
@@ -598,22 +557,6 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Std1_Vec_Impl2
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
-  function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -624,13 +567,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
-end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
   type t   
@@ -683,6 +619,70 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
+module CreusotContracts_Std1_Vec_Impl2
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module KnapsackFull_Knapsack01Dyn_Interface
   type name   

--- a/creusot/tests/should_succeed/mapping_test.stdout
+++ b/creusot/tests/should_succeed/mapping_test.stdout
@@ -25,6 +25,25 @@ module Type
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
+module MappingTest_Impl0_Model_Interface
+  use mach.int.Int
+  use map.Map
+  use mach.int.Int32
+  use Type
+  function model (self : Type.mappingtest_t) : Map.map int int
+end
+module MappingTest_Impl0_Model
+  use mach.int.Int
+  use map.Map
+  use mach.int.Int32
+  use Type
+  function model (self : Type.mappingtest_t) : Map.map int int
+  axiom model_spec : forall self : Type.mappingtest_t . forall i : (int) . Map.get (model self) i = (if 0 <= i && i < Int32.to_int (Type.mappingtest_t_T_a self) then
+    1
+  else
+    0
+  )
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -45,31 +64,12 @@ module MappingTest_Impl0_ModelTy
   type modelTy  = 
     Map.map int int
 end
-module MappingTest_Impl0_Model_Interface
-  use mach.int.Int
-  use map.Map
-  use mach.int.Int32
-  use Type
-  function model (self : Type.mappingtest_t) : Map.map int int
-end
-module MappingTest_Impl0_Model
-  use mach.int.Int
-  use map.Map
-  use mach.int.Int32
-  use Type
-  function model (self : Type.mappingtest_t) : Map.map int int
-  axiom model_spec : forall self : Type.mappingtest_t . forall i : (int) . Map.get (model self) i = (if 0 <= i && i < Int32.to_int (Type.mappingtest_t_T_a self) then
-    1
-  else
-    0
-  )
-end
 module MappingTest_Impl0
   use Type
   clone MappingTest_Impl0_Model as Model0 with axiom .
   clone MappingTest_Impl0_ModelTy as ModelTy0
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.mappingtest_t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.mappingtest_t,
   type modelTy = ModelTy0.modelTy
 end
@@ -81,11 +81,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
   use Type
@@ -96,13 +91,18 @@ module CreusotContracts_Logic_Ghost_Impl0_Model
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
   type modelTy = ModelTy0.modelTy
 end

--- a/creusot/tests/should_succeed/model.stdout
+++ b/creusot/tests/should_succeed/model.stdout
@@ -20,25 +20,6 @@ module Type
     | Model_Pair 't 'u
     
 end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module Model_Impl0_ModelTy
-  use mach.int.Int
-  type modelTy  = 
-    int
-end
 module Model_Impl0_Model_Interface
   use Type
   use mach.int.Int
@@ -48,15 +29,6 @@ module Model_Impl0_Model
   use Type
   use mach.int.Int
   function model (self : Type.model_seven) : int
-end
-module Model_Impl0
-  use Type
-  clone Model_Impl0_Model as Model0
-  clone Model_Impl0_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.model_seven,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.model_seven,
-  type modelTy = ModelTy0.modelTy
 end
 module Model_Seven_Interface
   use mach.int.Int
@@ -76,12 +48,6 @@ module Model_Seven
     ensures { Model0.model result = 7 }
     
 end
-module Model_Impl1_ModelTy
-  type t   
-  type u   
-  type modelTy  = 
-    (t, u)
-end
 module Model_Impl1_Model_Interface
   type t   
   type u   
@@ -93,17 +59,6 @@ module Model_Impl1_Model
   type u   
   use Type
   function model (self : Type.model_pair t u) : (t, u)
-end
-module Model_Impl1
-  type t   
-  type u   
-  use Type
-  clone Model_Impl1_Model as Model0 with type t = t, type u = u
-  clone Model_Impl1_ModelTy as ModelTy0 with type t = t, type u = u
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.model_pair t u,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.model_pair t u,
-  type modelTy = ModelTy0.modelTy
 end
 module Model_Pair_Interface
   type t   
@@ -122,4 +77,49 @@ module Model_Pair
   val pair [@cfg:stackify] (a : t) (b : u) : Type.model_pair t u
     ensures { Model0.model result = (a, b) }
     
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module Model_Impl0_ModelTy
+  use mach.int.Int
+  type modelTy  = 
+    int
+end
+module Model_Impl0
+  use Type
+  clone Model_Impl0_Model as Model0
+  clone Model_Impl0_ModelTy as ModelTy0
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.model_seven,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.model_seven,
+  type modelTy = ModelTy0.modelTy
+end
+module Model_Impl1_ModelTy
+  type t   
+  type u   
+  type modelTy  = 
+    (t, u)
+end
+module Model_Impl1
+  type t   
+  type u   
+  use Type
+  clone Model_Impl1_Model as Model0 with type t = t, type u = u
+  clone Model_Impl1_ModelTy as ModelTy0 with type t = t, type u = u
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.model_pair t u,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.model_pair t u,
+  type modelTy = ModelTy0.modelTy
 end

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -32,14 +32,6 @@ module Modules_Nested_Further_Another
   }
   
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module Modules_Nested_Impl0_Resolve_Interface
   use Type
   predicate resolve (self : Type.modules_nested_nested)
@@ -48,6 +40,14 @@ module Modules_Nested_Impl0_Resolve
   use Type
   predicate resolve (self : Type.modules_nested_nested) = 
     true
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
 end
 module Modules_Nested_Impl0
   use Type

--- a/creusot/tests/should_succeed/mut_call.stdout
+++ b/creusot/tests/should_succeed/mut_call.stdout
@@ -18,17 +18,17 @@ module MutCall_Kill_Interface
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  val kill [@cfg:stackify] (_1 : borrowed uint32) : ()
+  val kill [@cfg:stackify] (_1' : borrowed uint32) : ()
 end
 module MutCall_Kill
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  let rec cfg kill [@cfg:stackify] (_1 : borrowed uint32) : () = 
+  let rec cfg kill [@cfg:stackify] (_1' : borrowed uint32) : () = 
   var _0 : ();
   var _1 : borrowed uint32;
   {
-    _1 <- _1;
+    _1 <- _1';
     goto BB0
   }
   BB0 {

--- a/creusot/tests/should_succeed/mutex.stdout
+++ b/creusot/tests/should_succeed/mutex.stdout
@@ -94,12 +94,12 @@ end
 module Mutex_FakeFnOnce_Postcondition_Interface
   type self   
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
-  predicate postcondition (self : self) (_2 : Return0.return')
+  predicate postcondition (self : self) (_2' : Return0.return')
 end
 module Mutex_FakeFnOnce_Postcondition
   type self   
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
-  predicate postcondition (self : self) (_2 : Return0.return')
+  predicate postcondition (self : self) (_2' : Return0.return')
 end
 module Mutex_FakeFnOnce_Call_Interface
   type self   
@@ -122,28 +122,6 @@ module Mutex_FakeFnOnce_Call
     ensures { Postcondition0.postcondition self result }
     
 end
-module Mutex_Impl3_Return
-  type return'  = 
-    ()
-end
-module Mutex_Impl3_Precondition_Interface
-  use Type
-  predicate precondition (self : Type.mutex_addstwo)
-end
-module Mutex_Impl3_Precondition
-  use Type
-  predicate precondition (self : Type.mutex_addstwo) = 
-    true
-end
-module Mutex_Impl3_Postcondition_Interface
-  use Type
-  predicate postcondition (self : Type.mutex_addstwo) (_2 : ())
-end
-module Mutex_Impl3_Postcondition
-  use Type
-  predicate postcondition (self : Type.mutex_addstwo) (_2 : ()) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -151,25 +129,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -180,16 +139,6 @@ module CreusotContracts_Logic_Ghost_Impl0_Model
   type t   
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type modelTy = ModelTy0.modelTy
 end
 module Mutex_Impl0_Lock_Interface
   type t   
@@ -254,6 +203,35 @@ module Mutex_Impl1_Set
   val set [@cfg:stackify] (self : borrowed (Type.mutex_mutexguard t i)) (v : t) : ()
     requires {Inv0.inv (Model0.model (Type.mutex_mutexguard_MutexGuard_1 ( * self))) v}
     
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
 end
 module Mutex_Impl2_Inv_Interface
   use prelude.Prelude
@@ -375,22 +353,6 @@ module Mutex_Impl3_Call
   }
   
 end
-module Mutex_Impl3
-  use Type
-  clone Mutex_Impl3_Call_Interface as Call0
-  clone Mutex_Impl3_Postcondition as Postcondition0
-  clone Mutex_Impl3_Precondition as Precondition0
-  clone Mutex_FakeFnOnce_Precondition as Precondition1 with type self = Type.mutex_addstwo,
-  predicate precondition = Precondition0.precondition
-  clone Mutex_Impl3_Return as Return0
-  clone Mutex_FakeFnOnce_Call_Interface as Call1 with type self = Type.mutex_addstwo,
-  predicate Precondition0.precondition = Precondition0.precondition,
-  predicate Postcondition0.postcondition = Postcondition0.postcondition, type Return0.return' = Return0.return',
-  val call = Call0.call
-  clone Mutex_FakeFnOnce_Postcondition as Postcondition1 with type self = Type.mutex_addstwo,
-  type Return0.return' = Return0.return', predicate postcondition = Postcondition0.postcondition
-  clone Mutex_FakeFnOnce_Return as Return1 with type self = Type.mutex_addstwo, type return' = Return0.return'
-end
 module Mutex_Impl0_New_Interface
   type t   
   type i   
@@ -433,13 +395,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
-end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
 end
 module Mutex_Spawn_Interface
   type t   
@@ -484,6 +439,50 @@ module Mutex_Impl4_Join
       | _ -> true
       end }
     
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module Mutex_Impl3_Precondition_Interface
+  use Type
+  predicate precondition (self : Type.mutex_addstwo)
+end
+module Mutex_Impl3_Precondition
+  use Type
+  predicate precondition (self : Type.mutex_addstwo) = 
+    true
+end
+module Mutex_Impl3_Return
+  type return'  = 
+    ()
+end
+module Mutex_Impl3_Postcondition_Interface
+  use Type
+  predicate postcondition (self : Type.mutex_addstwo) (_2' : ())
+end
+module Mutex_Impl3_Postcondition
+  use Type
+  predicate postcondition (self : Type.mutex_addstwo) (_2' : ()) = 
+    true
+end
+module Mutex_Impl3
+  use Type
+  clone Mutex_Impl3_Call_Interface as Call0
+  clone Mutex_Impl3_Postcondition as Postcondition0
+  clone Mutex_Impl3_Precondition as Precondition0
+  clone Mutex_FakeFnOnce_Precondition as Precondition1 with type self = Type.mutex_addstwo,
+  predicate precondition = Precondition0.precondition
+  clone Mutex_Impl3_Return as Return0
+  clone Mutex_FakeFnOnce_Call_Interface as Call1 with type self = Type.mutex_addstwo, val call = Call0.call,
+  predicate Precondition0.precondition = Precondition0.precondition,
+  predicate Postcondition0.postcondition = Postcondition0.postcondition, type Return0.return' = Return0.return'
+  clone Mutex_FakeFnOnce_Postcondition as Postcondition1 with type self = Type.mutex_addstwo,
+  predicate postcondition = Postcondition0.postcondition, type Return0.return' = Return0.return'
+  clone Mutex_FakeFnOnce_Return as Return1 with type self = Type.mutex_addstwo, type return' = Return0.return'
 end
 module Mutex_Impl5_Inv_Interface
   type f   

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -30,12 +30,30 @@ end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
+end
+module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
+  type self   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  val cmp [@cfg:stackify] (self : self) (o : self) : Type.core_cmp_ordering
+    ensures { result = CmpLog0.cmp_log self o }
+    
+end
+module CreusotContracts_Std1_Ord_Ord_Cmp
+  type self   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  val cmp [@cfg:stackify] (self : self) (o : self) : Type.core_cmp_ordering
+    ensures { result = CmpLog0.cmp_log self o }
+    
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
   type self   
@@ -47,6 +65,103 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
+end
+module CreusotContracts_Std1_Ord_Ord_Le_Interface
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  val le [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LeLog0.le_log self o }
+    
+end
+module CreusotContracts_Std1_Ord_Ord_Le
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  val le [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LeLog0.le_log self o }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
+  type self   
+  predicate ge_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate ge_log (self : self) (o : self) = 
+    not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
+end
+module CreusotContracts_Std1_Ord_Ord_Ge_Interface
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  val ge [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = GeLog0.ge_log self o }
+    
+end
+module CreusotContracts_Std1_Ord_Ord_Ge
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  val ge [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = GeLog0.ge_log self o }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
+  type self   
+  predicate gt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate gt_log (self : self) (o : self) = 
+    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
+end
+module CreusotContracts_Std1_Ord_Ord_Gt_Interface
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  val gt [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = GtLog0.gt_log self o }
+    
+end
+module CreusotContracts_Std1_Ord_Ord_Gt
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  val gt [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = GtLog0.gt_log self o }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
+  type self   
+  predicate lt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate lt_log (self : self) (o : self) = 
+    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
+end
+module CreusotContracts_Std1_Ord_Ord_Lt_Interface
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  val lt [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LtLog0.lt_log self o }
+    
+end
+module CreusotContracts_Std1_Ord_Ord_Lt
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  val lt [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LtLog0.lt_log self o }
+    
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self   
@@ -63,17 +178,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   function cmp_le_log (x : self) (y : self) : ()
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
-module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
-  predicate lt_log (self : self) (o : self)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  predicate lt_log (self : self) (o : self) = 
-    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
-end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self   
   use Type
@@ -89,17 +193,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   function cmp_lt_log (x : self) (y : self) : ()
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
-module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
-  predicate ge_log (self : self) (o : self)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  predicate ge_log (self : self) (o : self) = 
-    not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
-end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   type self   
   use Type
@@ -114,17 +207,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
-  predicate gt_log (self : self) (o : self)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  predicate gt_log (self : self) (o : self) = 
-    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   type self   
@@ -195,19 +277,34 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -254,103 +351,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
-end
-module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
-  use prelude.Prelude
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  val cmp [@cfg:stackify] (self : self) (o : self) : Type.core_cmp_ordering
-    ensures { result = CmpLog0.cmp_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
-  use prelude.Prelude
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  val cmp [@cfg:stackify] (self : self) (o : self) : Type.core_cmp_ordering
-    ensures { result = CmpLog0.cmp_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
-  val le [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LeLog0.le_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
-  val le [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LeLog0.le_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
-  val ge [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = GeLog0.ge_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
-  val ge [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = GeLog0.ge_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
-  val gt [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = GtLog0.gt_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
-  val gt [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = GtLog0.gt_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
-  val lt [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LtLog0.lt_log self o }
-    
-end
-module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
-  val lt [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LtLog0.lt_log self o }
-    
 end
 module OrdTrait_X_Interface
   type t   

--- a/creusot/tests/should_succeed/selection_sort_generic.stdout
+++ b/creusot/tests/should_succeed/selection_sort_generic.stdout
@@ -26,12 +26,12 @@ end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
   type self   
@@ -43,6 +43,164 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
+end
+module SelectionSortGeneric_SortedRange_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
+end
+module SelectionSortGeneric_SortedRange
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
+    forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+end
+module SelectionSortGeneric_Sorted_Interface
+  type t   
+  use seq.Seq
+  predicate sorted (s : Seq.seq t)
+end
+module SelectionSortGeneric_Sorted
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  clone SelectionSortGeneric_SortedRange_Interface as SortedRange0 with type t = t
+  predicate sorted (s : Seq.seq t) = 
+    SortedRange0.sorted_range s 0 (Seq.length s)
+end
+module SelectionSortGeneric_Partition_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  predicate partition (v : Seq.seq t) (i : int)
+end
+module SelectionSortGeneric_Partition
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
+  predicate partition (v : Seq.seq t) (i : int) = 
+    forall k2 : (int) . forall k1 : (int) . 0 <= k1 && k1 < i && i <= k2 && k2 < Seq.length v -> LeLog0.le_log (Seq.get v k1) (Seq.get v k2)
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : borrowed t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : borrowed t) : ModelTy0.modelTy = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
+  type t   
+  use seq.Seq
+  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
+end
+module CreusotContracts_Logic_Seq_Impl1_PermutationOf
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Permut
+  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
+    Permut.permut self o 0 (Seq.length self)
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self   
@@ -191,19 +349,34 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -251,179 +424,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
-end
-module SelectionSortGeneric_SortedRange_Interface
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
-end
-module SelectionSortGeneric_SortedRange
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
-    forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
-end
-module SelectionSortGeneric_Sorted_Interface
-  type t   
-  use seq.Seq
-  predicate sorted (s : Seq.seq t)
-end
-module SelectionSortGeneric_Sorted
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  clone SelectionSortGeneric_SortedRange_Interface as SortedRange0 with type t = t
-  predicate sorted (s : Seq.seq t) = 
-    SortedRange0.sorted_range s 0 (Seq.length s)
-end
-module SelectionSortGeneric_Partition_Interface
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  predicate partition (v : Seq.seq t) (i : int)
-end
-module SelectionSortGeneric_Partition
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
-  predicate partition (v : Seq.seq t) (i : int) = 
-    forall k2 : (int) . forall k1 : (int) . 0 <= k1 && k1 < i && i <= k2 && k2 < Seq.length v -> LeLog0.le_log (Seq.get v k1) (Seq.get v k2)
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  function model (self : borrowed t) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  function model (self : borrowed t) : ModelTy0.modelTy = 
-    Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
-  use seq.Seq
-  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
-end
-module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  use seq.Permut
-  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
-    Permut.permut self o 0 (Seq.length self)
-end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -450,12 +450,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -470,18 +464,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -534,11 +516,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -568,23 +545,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
   type self   
@@ -715,12 +675,52 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module SelectionSortGeneric_SelectionSort_Interface
   type t   

--- a/creusot/tests/should_succeed/slices/01.stdout
+++ b/creusot/tests/should_succeed/slices/01.stdout
@@ -32,12 +32,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -52,18 +46,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl2_ModelTy
   type t   
@@ -105,6 +87,24 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl2_Model_Interface
   type t   
   use prelude.Prelude
@@ -124,8 +124,8 @@ module CreusotContracts_Logic_Model_Impl2
   use seq.Seq
   clone CreusotContracts_Logic_Model_Impl2_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Model_Impl2_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = seq t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = seq t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = seq t, type modelTy = ModelTy0.modelTy
 end
 module C01_SliceFirst_Interface

--- a/creusot/tests/should_succeed/sparse_array.stdout
+++ b/creusot/tests/should_succeed/sparse_array.stdout
@@ -61,12 +61,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -82,6 +76,12 @@ module CreusotContracts_Logic_Model_Impl0_Model
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
 end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl0
   type t   
   use prelude.Prelude
@@ -90,8 +90,8 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Int_Impl5_ModelTy
@@ -115,8 +115,8 @@ module CreusotContracts_Logic_Int_Impl5
   use mach.int.Int32
   clone CreusotContracts_Logic_Int_Impl5_Model as Model0
   clone CreusotContracts_Logic_Int_Impl5_ModelTy as ModelTy0
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = int32,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = int32, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = int32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
@@ -126,19 +126,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
-end
-module SparseArray_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  use Type
-  type modelTy  = 
-    Seq.seq (Type.core_option_option t)
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
@@ -151,16 +138,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module SparseArray_Impl1_IsElt_Interface
   type t   
@@ -206,22 +183,12 @@ module SparseArray_Impl0_Model
     Type.Core_Option_Option_None
   ))
 end
-module SparseArray_Impl0
+module SparseArray_Impl0_ModelTy
   type t   
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
+  use seq.Seq
   use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = usize
-  clone SparseArray_Impl1_IsElt as IsElt0 with type t = t, function Model0.model = Model3.model
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
-  clone SparseArray_Impl0_Model as Model0 with type t = t, predicate IsElt0.is_elt = IsElt0.is_elt,
-  function Model0.model = Model2.model, axiom .
-  clone SparseArray_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.sparsearray_sparse t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.sparsearray_sparse t,
-  type modelTy = ModelTy0.modelTy
+  type modelTy  = 
+    Seq.seq (Type.core_option_option t)
 end
 module SparseArray_Impl1_SparseInv_Interface
   type t   
@@ -246,6 +213,39 @@ module SparseArray_Impl1_SparseInv
     UInt64.to_int (Type.sparsearray_sparse_Sparse_n self) <= UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && Seq.length (Model0.model self) = UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && Seq.length (Model1.model (Type.sparsearray_sparse_Sparse_values self)) = UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && Seq.length (Model2.model (Type.sparsearray_sparse_Sparse_idx self)) = UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && Seq.length (Model2.model (Type.sparsearray_sparse_Sparse_back self)) = UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && (forall i : (int) . 0 <= i && i < UInt64.to_int (Type.sparsearray_sparse_Sparse_n self) -> match (Seq.get (Model2.model (Type.sparsearray_sparse_Sparse_back self)) i) with
       | j -> 0 <= UInt64.to_int j && UInt64.to_int j < UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && UInt64.to_int (Seq.get (Model2.model (Type.sparsearray_sparse_Sparse_idx self)) (UInt64.to_int j)) = i
       end)
+end
+module SparseArray_Impl0
+  type t   
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = usize
+  clone SparseArray_Impl1_IsElt as IsElt0 with type t = t, function Model0.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
+  clone SparseArray_Impl0_Model as Model0 with type t = t, predicate IsElt0.is_elt = IsElt0.is_elt,
+  function Model0.model = Model2.model, axiom .
+  clone SparseArray_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.sparsearray_sparse t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.sparsearray_sparse t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
   type t   
@@ -399,11 +399,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -434,6 +429,11 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
   use Type
@@ -447,7 +447,7 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
   type output = Output0.output
 end
@@ -691,12 +691,6 @@ module Core_Ops_Index_IndexMut_IndexMut
     requires {false}
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -711,19 +705,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
   type t   
@@ -765,6 +746,17 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
 module CreusotContracts_Std1_Vec_Impl2
   type t   
   use Type
@@ -779,18 +771,7 @@ module CreusotContracts_Std1_Vec_Impl2
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -798,6 +779,25 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module SparseArray_Impl1_Set_Interface
   type t   

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -66,13 +66,6 @@ module TraitImpl_Impl0_X
   }
   
 end
-module TraitImpl_Impl0
-  type b   
-  type t2   
-  type t1   
-  clone TraitImpl_Impl0_X_Interface as X0 with type b = b, type t2 = t2, type t1 = t1
-  clone TraitImpl_T_X_Interface as X1 with type self = (t1, t2), type b = b, val x = X0.x
-end
 module TraitImpl_Impl1_X_Interface
   type b   
   use mach.int.Int
@@ -96,6 +89,13 @@ module TraitImpl_Impl1_X
     return _0
   }
   
+end
+module TraitImpl_Impl0
+  type b   
+  type t2   
+  type t1   
+  clone TraitImpl_Impl0_X_Interface as X0 with type b = b, type t2 = t2, type t1 = t1
+  clone TraitImpl_T_X_Interface as X1 with type self = (t1, t2), type b = b, val x = X0.x
 end
 module TraitImpl_Impl1
   type b   

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -83,12 +83,6 @@ module C03_Impl0_F
   }
   
 end
-module C03_Impl0
-  use mach.int.Int
-  use mach.int.Int32
-  clone C03_Impl0_F_Interface as F0
-  clone C03_A_F_Interface as F1 with type self = int32, val f = F0.f
-end
 module C03_Impl1_G_Interface
   use prelude.Prelude
   use mach.int.Int
@@ -114,12 +108,6 @@ module C03_Impl1_G
   }
   
 end
-module C03_Impl1
-  use mach.int.Int
-  use mach.int.UInt32
-  clone C03_Impl1_G_Interface as G0
-  clone C03_B_G_Interface as G1 with type self = uint32, val g = G0.g
-end
 module C03_Impl2_H_Interface
   type g   
   use prelude.Prelude
@@ -143,6 +131,18 @@ module C03_Impl2_H
     return _0
   }
   
+end
+module C03_Impl0
+  use mach.int.Int
+  use mach.int.Int32
+  clone C03_Impl0_F_Interface as F0
+  clone C03_A_F_Interface as F1 with type self = int32, val f = F0.f
+end
+module C03_Impl1
+  use mach.int.Int
+  use mach.int.UInt32
+  clone C03_Impl1_G_Interface as G0
+  clone C03_B_G_Interface as G1 with type self = uint32, val g = G0.g
 end
 module C03_Impl2
   type g   

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -30,10 +30,6 @@ module C07_Ix_Ix
   clone C07_Ix_Tgt as Tgt0 with type self = self
   val ix [@cfg:stackify] (self : self) : Tgt0.tgt
 end
-module C07_Impl0_Tgt
-  type tgt  = 
-    ()
-end
 module C07_Impl0_Ix_Interface
   use prelude.Prelude
   use mach.int.Int
@@ -57,14 +53,6 @@ module C07_Impl0_Ix
     return _0
   }
   
-end
-module C07_Impl0
-  use mach.int.Int
-  use mach.int.Int32
-  clone C07_Impl0_Ix_Interface as Ix0
-  clone C07_Impl0_Tgt as Tgt0
-  clone C07_Ix_Ix_Interface as Ix1 with type self = int32, type Tgt0.tgt = Tgt0.tgt, val ix = Ix0.ix
-  clone C07_Ix_Tgt as Tgt1 with type self = int32, type tgt = Tgt0.tgt
 end
 module C07_Test_Interface
   type g   
@@ -98,6 +86,18 @@ module C07_Test
     return _0
   }
   
+end
+module C07_Impl0_Tgt
+  type tgt  = 
+    ()
+end
+module C07_Impl0
+  use mach.int.Int
+  use mach.int.Int32
+  clone C07_Impl0_Ix_Interface as Ix0
+  clone C07_Impl0_Tgt as Tgt0
+  clone C07_Ix_Ix_Interface as Ix1 with type self = int32, val ix = Ix0.ix, type Tgt0.tgt = Tgt0.tgt
+  clone C07_Ix_Tgt as Tgt1 with type self = int32, type tgt = Tgt0.tgt
 end
 module C07_Test2_Interface
   use prelude.Prelude

--- a/creusot/tests/should_succeed/traits/08.stdout
+++ b/creusot/tests/should_succeed/traits/08.stdout
@@ -69,16 +69,16 @@ module C08_Tr_Program
 end
 module C08_Test_Interface
   type t   
-  val test [@cfg:stackify] (_1 : t) : ()
+  val test [@cfg:stackify] (_1' : t) : ()
 end
 module C08_Test
   type t   
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
-  let rec cfg test [@cfg:stackify] (_1 : t) : () = 
+  let rec cfg test [@cfg:stackify] (_1' : t) : () = 
   var _0 : ();
   var _1 : t;
   {
-    _1 <- _1;
+    _1 <- _1';
     goto BB0
   }
   BB0 {

--- a/creusot/tests/should_succeed/traits/11.stdout
+++ b/creusot/tests/should_succeed/traits/11.stdout
@@ -53,16 +53,16 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
 end
 module C11_Test_Interface
   type t   
-  val test [@cfg:stackify] (_1 : t) : ()
+  val test [@cfg:stackify] (_1' : t) : ()
 end
 module C11_Test
   type t   
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
-  let rec cfg test [@cfg:stackify] (_1 : t) : () = 
+  let rec cfg test [@cfg:stackify] (_1' : t) : () = 
   var _0 : ();
   var _1 : t;
   {
-    _1 <- _1;
+    _1 <- _1';
     goto BB0
   }
   BB0 {

--- a/creusot/tests/should_succeed/traits/13_assoc_types.stdout
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.stdout
@@ -28,12 +28,6 @@ module C13AssocTypes_Model_Model
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = self
   val model [@cfg:stackify] (self : self) : ModelTy0.modelTy
 end
-module C13AssocTypes_Impl0_ModelTy
-  type t   
-  clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -72,13 +66,19 @@ module C13AssocTypes_Impl0_Model
   }
   
 end
+module C13AssocTypes_Impl0_ModelTy
+  type t   
+  clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module C13AssocTypes_Impl0
   type t   
   use prelude.Prelude
   clone C13AssocTypes_Model_ModelTy as ModelTy2 with type self = t
   clone C13AssocTypes_Impl0_Model_Interface as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
   clone C13AssocTypes_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone C13AssocTypes_Model_Model_Interface as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  val model = Model0.model
+  clone C13AssocTypes_Model_Model_Interface as Model1 with type self = t, val model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone C13AssocTypes_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -32,6 +32,10 @@ module C15ImplInterfaces_Impl0_A
   type a  = 
     ()
 end
+module C15ImplInterfaces_Impl0
+  clone C15ImplInterfaces_Impl0_A as A0
+  clone C15ImplInterfaces_Tr_A as A1 with type self = (), type a = A0.a
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -67,8 +71,4 @@ module C15ImplInterfaces_Calls
     return _0
   }
   
-end
-module C15ImplInterfaces_Impl0
-  clone C15ImplInterfaces_Impl0_A as A0
-  clone C15ImplInterfaces_Tr_A as A1 with type self = (), type a = A0.a
 end

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
@@ -32,6 +32,18 @@ module Type
     | C16ImplCloning_Vec (alloc_vec_vec 't (alloc_alloc_global))
     
 end
+module C16ImplCloning_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.c16implcloning_vec t) : Seq.seq t
+end
+module C16ImplCloning_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.c16implcloning_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -45,40 +57,6 @@ module CreusotContracts_Logic_Model_Model_Model
   type self   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
-end
-module C16ImplCloning_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module C16ImplCloning_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.c16implcloning_vec t) : Seq.seq t
-end
-module C16ImplCloning_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.c16implcloning_vec t) : Seq.seq t
-end
-module C16ImplCloning_Impl0
-  type t   
-  use Type
-  clone C16ImplCloning_Impl0_Model as Model0 with type t = t
-  clone C16ImplCloning_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.c16implcloning_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.c16implcloning_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -95,6 +73,18 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module C16ImplCloning_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -103,18 +93,20 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module C16ImplCloning_Impl0
+  type t   
+  use Type
+  clone C16ImplCloning_Impl0_Model as Model0 with type t = t
+  clone C16ImplCloning_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.c16implcloning_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.c16implcloning_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -126,6 +118,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   

--- a/creusot/tests/should_succeed/traits/18_trait_laws.stdout
+++ b/creusot/tests/should_succeed/traits/18_trait_laws.stdout
@@ -16,11 +16,11 @@ module Type
 end
 module C18TraitLaws_Symmetric_Op_Interface
   type self   
-  function op (self : self) (_2 : self) : self
+  function op (self : self) (_2' : self) : self
 end
 module C18TraitLaws_Symmetric_Op
   type self   
-  function op (self : self) (_2 : self) : self
+  function op (self : self) (_2' : self) : self
 end
 module C18TraitLaws_Symmetric_Reflexive_Interface
   type self   
@@ -55,24 +55,24 @@ module C18TraitLaws_UsesOp_Impl
     let b = Op0.op y x in let a = Op0.op x y in pure {a = b}
 end
 module C18TraitLaws_Impl0_Op_Interface
-  function op (self : ()) (_2 : ()) : ()
+  function op (self : ()) (_2' : ()) : ()
 end
 module C18TraitLaws_Impl0_Op
-  function op (self : ()) (_2 : ()) : () = 
+  function op (self : ()) (_2' : ()) : () = 
     ()
 end
 module C18TraitLaws_Impl0_Reflexive_Interface
-  function reflexive (_1 : ()) (_2 : ()) : ()
+  function reflexive (_1' : ()) (_2' : ()) : ()
 end
 module C18TraitLaws_Impl0_Reflexive
-  function reflexive (_1 : ()) (_2 : ()) : () = 
+  function reflexive (_1' : ()) (_2' : ()) : () = 
     ()
 end
 module C18TraitLaws_Impl0
   clone C18TraitLaws_Impl0_Reflexive as Reflexive0
   clone C18TraitLaws_Impl0_Op as Op0
-  clone C18TraitLaws_Symmetric_Reflexive as Reflexive1 with type self = (), function Op0.op = Op0.op,
-  function reflexive = Reflexive0.reflexive, axiom .
+  clone C18TraitLaws_Symmetric_Reflexive as Reflexive1 with type self = (), function reflexive = Reflexive0.reflexive,
+  function Op0.op = Op0.op, axiom .
   clone C18TraitLaws_Symmetric_Op as Op1 with type self = (), function op = Op0.op
 end
 module C18TraitLaws_ImplLaws_Interface

--- a/creusot/tests/should_succeed/unnest.stdout
+++ b/creusot/tests/should_succeed/unnest.stdout
@@ -29,14 +29,6 @@ module Unnest_Main
   }
   
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -47,6 +39,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -33,6 +33,28 @@ module C01_Main
   }
   
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -47,48 +69,10 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
   type t   
   type modelTy  = 
     t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
@@ -96,8 +80,24 @@ module CreusotContracts_Logic_Ghost_Impl0
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
@@ -126,12 +126,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -146,18 +140,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -192,24 +174,6 @@ module Core_Ops_Index_Index_Output
   type idx   
   type output   
 end
-module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
-  use prelude.Prelude
-  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
-  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
-    requires {false}
-    
-end
-module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
-  use prelude.Prelude
-  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
-  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
-    requires {false}
-    
-end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
   type idx   
@@ -228,12 +192,6 @@ module Core_Ops_Index_IndexMut_IndexMut
     requires {false}
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -248,19 +206,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
   type t   
@@ -302,6 +247,17 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -321,18 +277,7 @@ module CreusotContracts_Std1_Vec_Impl2
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
-  use prelude.Prelude
-  predicate resolve (self : borrowed t) = 
-     ^ self =  * self
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -340,6 +285,43 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module C01_AllZero_Interface
   use seq.Seq

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -26,12 +26,12 @@ end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
   type self   
@@ -43,6 +43,149 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
+end
+module C02Gnome_SortedRange_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
+end
+module C02Gnome_SortedRange
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
+    forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+end
+module C02Gnome_Sorted_Interface
+  type t   
+  use seq.Seq
+  predicate sorted (s : Seq.seq t)
+end
+module C02Gnome_Sorted
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  clone C02Gnome_SortedRange_Interface as SortedRange0 with type t = t
+  predicate sorted (s : Seq.seq t) = 
+    SortedRange0.sorted_range s 0 (Seq.length s)
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
+  type t   
+  use seq.Seq
+  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
+end
+module CreusotContracts_Logic_Seq_Impl1_PermutationOf
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Permut
+  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
+    Permut.permut self o 0 (Seq.length self)
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : borrowed t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : borrowed t) : ModelTy0.modelTy = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self   
@@ -191,19 +334,34 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -251,164 +409,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
-end
-module C02Gnome_SortedRange_Interface
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
-end
-module C02Gnome_SortedRange
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
-    forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
-end
-module C02Gnome_Sorted_Interface
-  type t   
-  use seq.Seq
-  predicate sorted (s : Seq.seq t)
-end
-module C02Gnome_Sorted
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  clone C02Gnome_SortedRange_Interface as SortedRange0 with type t = t
-  predicate sorted (s : Seq.seq t) = 
-    SortedRange0.sorted_range s 0 (Seq.length s)
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
-  use seq.Seq
-  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
-end
-module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  use seq.Permut
-  predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
-    Permut.permut self o 0 (Seq.length self)
-end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  function model (self : borrowed t) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  function model (self : borrowed t) : ModelTy0.modelTy = 
-    Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
-  type modelTy  = 
-    t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
-  use Type
-  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
-end
-module CreusotContracts_Logic_Ghost_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type modelTy = ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -435,12 +435,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -455,18 +449,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -555,11 +537,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -589,23 +566,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
   type self   
@@ -700,12 +660,52 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module C02Gnome_GnomeSort_Interface
   type t   

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -34,6 +34,18 @@ module C03KnuthShuffle_RandInRange
     ensures { UInt64.to_int l <= UInt64.to_int result && UInt64.to_int result < UInt64.to_int u }
     
 end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -47,40 +59,6 @@ module CreusotContracts_Logic_Model_Model_Model
   type self   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
-  use Type
-  use seq.Seq
-  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -97,19 +75,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
   type t   
   use seq.Seq
@@ -124,10 +89,11 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) = 
     Permut.permut self o 0 (Seq.length self)
 end
-module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
+  use seq.Seq
   type modelTy  = 
-    t
+    Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -139,14 +105,48 @@ module CreusotContracts_Logic_Ghost_Impl0_Model
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
 module CreusotContracts_Logic_Ghost_Impl0
   type t   
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
@@ -175,12 +175,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -195,18 +189,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t   
@@ -289,6 +271,24 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module C03KnuthShuffle_KnuthShuffle_Interface
   type t   

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -61,12 +61,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -82,6 +76,18 @@ module CreusotContracts_Logic_Model_Impl0_Model
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl0
   type t   
   use prelude.Prelude
@@ -90,15 +96,9 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
@@ -118,7 +118,7 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -181,11 +181,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -216,6 +211,11 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
   use Type
@@ -229,7 +229,7 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
   type output = Output0.output
 end

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -27,12 +27,12 @@ end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
   type self   
   use Type
-  function cmp_log (self : self) (_2 : self) : Type.core_cmp_ordering
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
   type self   
@@ -44,6 +44,106 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
+end
+module C05BinarySearchGeneric_SortedRange_Interface
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
+end
+module C05BinarySearchGeneric_SortedRange
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
+  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
+    forall j : (int) . forall i : (int) . l <= i && i <= j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+end
+module C05BinarySearchGeneric_Sorted_Interface
+  type t   
+  use seq.Seq
+  predicate sorted (s : Seq.seq t)
+end
+module C05BinarySearchGeneric_Sorted
+  type t   
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  clone C05BinarySearchGeneric_SortedRange_Interface as SortedRange0 with type t = t
+  predicate sorted (s : Seq.seq t) = 
+    SortedRange0.sorted_range s 0 (Seq.length s)
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : t) : ModelTy0.modelTy = 
+    Model0.model self
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
+  type self   
+  predicate lt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog
+  type self   
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate lt_log (self : self) (o : self) = 
+    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
+end
+module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
+  type self   
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Eq_EqLogic_LogEq
+  type self   
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self   
@@ -59,17 +159,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
-  predicate lt_log (self : self) (o : self)
-end
-module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  predicate lt_log (self : self) (o : self) = 
-    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self   
@@ -190,21 +279,28 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
-module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
 end
-module CreusotContracts_Logic_Eq_EqLogic_LogEq
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self   
-  predicate log_eq (self : self) (_2 : self)
+  use Type
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -252,102 +348,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-end
-module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
-  use Type
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
-  function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
-end
-module C05BinarySearchGeneric_SortedRange_Interface
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
-end
-module C05BinarySearchGeneric_SortedRange
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
-  predicate sorted_range (s : Seq.seq t) (l : int) (u : int) = 
-    forall j : (int) . forall i : (int) . l <= i && i <= j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
-end
-module C05BinarySearchGeneric_Sorted_Interface
-  type t   
-  use seq.Seq
-  predicate sorted (s : Seq.seq t)
-end
-module C05BinarySearchGeneric_Sorted
-  type t   
-  use seq.Seq
-  use mach.int.Int
-  use mach.int.Int32
-  clone C05BinarySearchGeneric_SortedRange_Interface as SortedRange0 with type t = t
-  predicate sorted (s : Seq.seq t) = 
-    SortedRange0.sorted_range s 0 (Seq.length s)
-end
-module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
-end
-module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Model_Model
-  type self   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
-  function model (self : self) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  function model (self : t) : ModelTy0.modelTy
-end
-module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
-  type ModelTy0.modelTy = ModelTy0.modelTy
-  function model (self : t) : ModelTy0.modelTy = 
-    Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -366,7 +366,7 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -429,11 +429,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -463,23 +458,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Std1_Vec_Impl3
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
-  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
-  type output = Output0.output
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
   type self   
@@ -562,6 +540,28 @@ module CreusotContracts_Std1_Ord_Ord_Lt
   val lt [@cfg:stackify] (self : self) (o : self) : bool
     ensures { result = LtLog0.lt_log self o }
     
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl3
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
+  clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
+  type output = Output0.output
 end
 module C05BinarySearchGeneric_BinarySearch_Interface
   type t   

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -73,12 +73,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -93,18 +87,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
   type t   
@@ -163,11 +145,6 @@ module Core_Ops_Index_Index_Index
     requires {false}
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
   use mach.int.UInt64
@@ -198,6 +175,11 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
   use Type
@@ -209,16 +191,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
-end
-module CreusotContracts_Std1_Vec_Impl0
-  type t   
-  use Type
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
@@ -233,9 +205,37 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
   type output = Output0.output
+end
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
 end
 module C06KnightsTour_Min_Interface
   use prelude.Prelude
@@ -421,34 +421,6 @@ module C06KnightsTour_Min
   }
   
 end
-module Core_Clone_Clone_Clone_Interface
-  type self   
-  use prelude.Prelude
-  val clone' [@cfg:stackify] (self : self) : self
-    requires {false}
-    
-end
-module Core_Clone_Clone_Clone
-  type self   
-  use prelude.Prelude
-  val clone' [@cfg:stackify] (self : self) : self
-    requires {false}
-    
-end
-module Core_Clone_Clone_CloneFrom_Interface
-  type self   
-  use prelude.Prelude
-  val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
-    requires {false}
-    
-end
-module Core_Clone_Clone_CloneFrom
-  type self   
-  use prelude.Prelude
-  val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
-    requires {false}
-    
-end
 module C06KnightsTour_Impl3_Clone_Interface
   use prelude.Prelude
   use Type
@@ -473,12 +445,6 @@ module C06KnightsTour_Impl3_Clone
     return _0
   }
   
-end
-module C06KnightsTour_Impl3
-  use Type
-  clone C06KnightsTour_Impl3_Clone_Interface as Clone0
-  clone Core_Clone_Clone_Clone_Interface as Clone1 with type self = Type.c06knightstour_point,
-  val clone' = Clone0.clone'
 end
 module C06KnightsTour_Impl0_Mov_Interface
   use mach.int.Int
@@ -615,12 +581,6 @@ module CreusotContracts_Std1_Vec_FromElem
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -635,19 +595,6 @@ module CreusotContracts_Logic_Model_Impl1_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
-end
-module CreusotContracts_Logic_Model_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
-  type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
   type t   
@@ -674,6 +621,25 @@ module CreusotContracts_Std1_Vec_Impl1_Push
   val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
 end
 module C06KnightsTour_Impl1_New_Interface
   use mach.int.UInt64
@@ -1213,13 +1179,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
   type idx   
@@ -1278,6 +1237,13 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl2
   type t   
   use Type
@@ -1292,7 +1258,7 @@ module CreusotContracts_Std1_Vec_Impl2
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module C06KnightsTour_Impl1_Set_Interface
   use prelude.Prelude
@@ -1842,4 +1808,38 @@ module C06KnightsTour_KnightsTour
 end
 module C06KnightsTour_Impl2
   
+end
+module Core_Clone_Clone_Clone_Interface
+  type self   
+  use prelude.Prelude
+  val clone' [@cfg:stackify] (self : self) : self
+    requires {false}
+    
+end
+module Core_Clone_Clone_Clone
+  type self   
+  use prelude.Prelude
+  val clone' [@cfg:stackify] (self : self) : self
+    requires {false}
+    
+end
+module Core_Clone_Clone_CloneFrom_Interface
+  type self   
+  use prelude.Prelude
+  val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
+    requires {false}
+    
+end
+module Core_Clone_Clone_CloneFrom
+  type self   
+  use prelude.Prelude
+  val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
+    requires {false}
+    
+end
+module C06KnightsTour_Impl3
+  use Type
+  clone C06KnightsTour_Impl3_Clone_Interface as Clone0
+  clone Core_Clone_Clone_Clone_Interface as Clone1 with type self = Type.c06knightstour_point,
+  val clone' = Clone0.clone'
 end

--- a/creusot/tests/should_succeed/vector/07_read_write.stdout
+++ b/creusot/tests/should_succeed/vector/07_read_write.stdout
@@ -29,12 +29,6 @@ module CreusotContracts_Logic_Model_Model_Model
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
   use prelude.Prelude
@@ -50,6 +44,18 @@ module CreusotContracts_Logic_Model_Impl1_Model
   function model (self : borrowed t) : ModelTy0.modelTy = 
     Model0.model ( * self)
 end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
 module CreusotContracts_Logic_Model_Impl1
   type t   
   use prelude.Prelude
@@ -58,16 +64,10 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
   function Model0.model = Model2.model
   clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
-end
-module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
-  use seq.Seq
-  type modelTy  = 
-    Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
@@ -87,7 +87,7 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function model = Model0.model
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
@@ -103,24 +103,6 @@ module Core_Ops_Index_Index_Output
   type self   
   type idx   
   type output   
-end
-module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
-  use prelude.Prelude
-  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
-  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
-    requires {false}
-    
-end
-module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
-  use prelude.Prelude
-  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
-  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
-    requires {false}
-    
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self   
@@ -180,27 +162,6 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     ensures {  * result = Seq.get (Model1.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
-  type output  = 
-    t
-end
-module CreusotContracts_Std1_Vec_Impl2
-  type t   
-  use Type
-  use mach.int.Int
-  use prelude.Prelude
-  use mach.int.UInt64
-  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
-  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
-  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
-  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
-  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
-  function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index_mut = IndexMut0.index_mut
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -212,18 +173,23 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+module Core_Ops_Index_Index_Index_Interface
+  type self   
+  type idx   
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
+    requires {false}
+    
 end
-module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
-  type modelTy  = 
-    ModelTy0.modelTy
+module Core_Ops_Index_Index_Index
+  type self   
+  type idx   
+  use prelude.Prelude
+  clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
+  val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
+    requires {false}
+    
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -239,18 +205,6 @@ module CreusotContracts_Logic_Model_Impl0_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy = 
     Model0.model self
-end
-module CreusotContracts_Logic_Model_Impl0
-  type t   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
-  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
-  function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
-  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, type ModelTy0.modelTy = ModelTy0.modelTy,
-  function model = Model0.model
-  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
   type t   
@@ -282,6 +236,58 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
+  type self   
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Logic_Eq_EqLogic_LogEq
+  type self   
+  predicate log_eq (self : self) (_2' : self)
+end
+module CreusotContracts_Std1_Eq_Eq_Eq_Interface
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  val eq [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LogEq0.log_eq self o }
+    
+end
+module CreusotContracts_Std1_Eq_Eq_Eq
+  type self   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
+  val eq [@cfg:stackify] (self : self) (o : self) : bool
+    ensures { result = LogEq0.log_eq self o }
+    
+end
+module CreusotContracts_Std1_Vec_Impl3_Output
+  type t   
+  type output  = 
+    t
+end
+module CreusotContracts_Std1_Vec_Impl2
+  type t   
+  use Type
+  use mach.int.Int
+  use prelude.Prelude
+  use mach.int.UInt64
+  clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
+  clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = t,
+  function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3
   type t   
   use Type
@@ -295,25 +301,35 @@ module CreusotContracts_Std1_Vec_Impl3
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Output as Output0 with type t = t
   clone Core_Ops_Index_Index_Index_Interface as Index1 with type self = Type.creusotcontracts_std1_vec_vec t,
-  type idx = usize, type Output0.output = Output0.output, val index = Index0.index
+  type idx = usize, val index = Index0.index, type Output0.output = Output0.output
   clone Core_Ops_Index_Index_Output as Output1 with type self = Type.creusotcontracts_std1_vec_vec t, type idx = usize,
   type output = Output0.output
 end
-module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
-  predicate log_eq (self : self) (_2 : self)
+module CreusotContracts_Logic_Model_Impl0_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
-  predicate log_eq (self : self) (_2 : self)
+module CreusotContracts_Logic_Model_Impl0
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl0_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
   type self   
-  predicate log_ne (self : self) (_2 : self)
+  predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
   type self   
@@ -360,22 +376,6 @@ module CreusotContracts_Logic_Eq_EqLogic_Transitivity
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
-end
-module CreusotContracts_Std1_Eq_Eq_Eq_Interface
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  val eq [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LogEq0.log_eq self o }
-    
-end
-module CreusotContracts_Std1_Eq_Eq_Eq
-  type self   
-  use prelude.Prelude
-  clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
-  val eq [@cfg:stackify] (self : self) (o : self) : bool
-    ensures { result = LogEq0.log_eq self o }
-    
 end
 module C07ReadWrite_ReadWrite_Interface
   type t   

--- a/why3/src/mlcfg.rs
+++ b/why3/src/mlcfg.rs
@@ -654,6 +654,10 @@ impl Exp {
         }
         self
     }
+
+    pub fn and(self, other: Self) -> Self {
+        Exp::BinaryOp(BinOp::And, box self, box other)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -585,7 +585,7 @@ impl Print for Exp {
             Exp::QVar(v, _) => v.pretty(alloc, env),
             Exp::RecUp { box record, label, box val } => alloc
                 .space()
-                .append(parens!(alloc, env, self, record))
+                .append(parens!(alloc, env, self.precedence().next(), record))
                 .append(" with ")
                 .append(alloc.text(label))
                 .append(" = ")

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -21,6 +21,14 @@ impl Ident {
     pub fn to_string(self) -> String {
         self.0
     }
+
+    pub fn decapitalize(&mut self) {
+        self.0[..1].make_ascii_lowercase();
+    }
+
+    pub fn capitalize(&mut self) {
+        self.0[..1].make_ascii_uppercase();
+    }
 }
 
 // TODO: Make this try_from and test for validity


### PR DESCRIPTION
Adds initial support for closures to Creusot.

This allows the usage, specification and proof of code involving all three closure traits. One key limitation that remains is that it is not possible to call `resolve` on an actual closure type, at least, not yet. 

I'm going to merge this now as this branch has also accumulated a bunch of fixes and refactors which will make parallel work more difficult. Follow up PRs will expand the test suite and fix bugs as they occur. 