### PR TITLE
Actual error handling

### DIFF
--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -167,7 +167,7 @@ impl<'tcx, 'opts> TranslationCtx<'opts, 'tcx> {
 
     pub fn term(&mut self, def_id: DefId) -> CreusotResult<&Term<'tcx>> {
         if !def_id.is_local() {
-            return Ok(self.externs.term(def_id).unwrap());
+            return self.externs.term(def_id);
         }
 
         if util::has_body(self, def_id) {

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -6,11 +6,8 @@ use crate::error::CreusotResult;
 use crate::metadata::{BinaryMetadata, Metadata};
 use crate::translation::external::ExternSpec;
 use crate::translation::{
-    self,
-    external::extract_extern_specs_from_item,
-    interface::interface_for,
-    specification::typing::Term,
-    ty,
+    self, external::extract_extern_specs_from_item, interface::interface_for,
+    specification::typing::Term, ty,
 };
 use crate::util::item_type;
 use crate::{options::Options, util};

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -27,20 +27,20 @@ use why3::declaration::{Module, TyDecl};
 pub use crate::translated_item::*;
 
 // TODO: The state in here should be as opaque as possible...
-pub struct TranslationCtx<'sess, 'tcx> {
+pub struct TranslationCtx<'opts, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub translated_items: IndexSet<DefId>,
     pub types: IndexMap<DefId, TypeDeclaration>,
     functions: IndexMap<DefId, TranslatedItem<'tcx>>,
     terms: IndexMap<DefId, Term<'tcx>>,
     pub externs: Metadata<'tcx>,
-    pub opts: &'sess Options,
+    pub opts: &'opts Options,
     creusot_items: CreusotItems,
     extern_specs: HashMap<DefId, ExternSpec<'tcx>>,
 }
 
-impl<'tcx, 'sess> TranslationCtx<'sess, 'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, opts: &'sess Options) -> Self {
+impl<'tcx, 'opts> TranslationCtx<'opts, 'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>, opts: &'opts Options) -> Self {
         let creusot_items = creusot_items::local_creusot_items(tcx);
 
         let mut ctx = Self {
@@ -100,12 +100,12 @@ impl<'tcx, 'sess> TranslationCtx<'sess, 'tcx> {
         if let Some(assoc) = self.tcx.opt_associated_item(def_id) {
             match assoc.container {
                 AssocItemContainer::TraitContainer(id) => {
-                    self.translate(id);
+                    self.translate(id)?;
                     ()
                 }
                 AssocItemContainer::ImplContainer(id) => {
                     if let Some(_) = self.tcx.trait_id_of_impl(id) {
-                        self.translate(id);
+                        self.translate(id)?;
                     }
                 }
             }

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -46,7 +46,7 @@ mod rustc_extensions;
 mod translation;
 pub mod util;
 use translation::*;
-mod error;
+pub mod error;
 pub mod metadata;
 mod translated_item;
 mod validate;

--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -1,6 +1,7 @@
 use super::specification::typing::Term;
 use crate::creusot_items::CreusotItems;
 use crate::ctx::*;
+use crate::error::CreusotResult;
 use crate::external::ExternSpec;
 use creusot_metadata::decoder::{Decodable, MetadataBlob, MetadataDecoder};
 use creusot_metadata::encoder::{Encodable, MetadataEncoder};
@@ -48,9 +49,11 @@ impl Metadata<'tcx> {
         self.get(def_id.krate)?.dependencies.get(&def_id)
     }
 
-    pub fn term(&self, def_id: DefId) -> Option<&Term<'tcx>> {
+    pub fn term(&self, def_id: DefId) -> CreusotResult<&Term<'tcx>> {
         assert!(!def_id.is_local());
-        self.get(def_id.krate)?.terms.get(&def_id)
+        self.get(def_id.krate).and_then(|i| i.terms.get(&def_id)).ok_or_else(|| {
+            crate::error::Error::new(rustc_span::DUMMY_SP, "omg")
+        })
     }
 
     pub fn debug_creusot_items(&self) {

--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -51,9 +51,9 @@ impl Metadata<'tcx> {
 
     pub fn term(&self, def_id: DefId) -> CreusotResult<&Term<'tcx>> {
         assert!(!def_id.is_local());
-        self.get(def_id.krate).and_then(|i| i.terms.get(&def_id)).ok_or_else(|| {
-            crate::error::Error::new(rustc_span::DUMMY_SP, "omg")
-        })
+        self.get(def_id.krate)
+            .and_then(|i| i.terms.get(&def_id))
+            .ok_or_else(|| crate::error::Error::new(rustc_span::DUMMY_SP, "omg"))
     }
 
     pub fn debug_creusot_items(&self) {

--- a/creusot/src/translated_item.rs
+++ b/creusot/src/translated_item.rs
@@ -1,6 +1,6 @@
 pub use crate::clone_map::*;
-use crate::{metadata::Metadata, translation::LogicItem};
 use crate::util;
+use crate::{metadata::Metadata, translation::LogicItem};
 use indexmap::IndexMap;
 use rustc_hir::def_id::DefId;
 pub use util::{item_name, module_name, ItemType};

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -1,5 +1,5 @@
 use crate::function::all_generic_decls_for;
-use crate::translation::translate_logic_or_predicate;
+use crate::translation;
 use crate::util::item_type;
 use crate::{ctx::*, util};
 use indexmap::IndexSet;
@@ -58,7 +58,7 @@ pub fn extern_module(
             match item_type(ctx.tcx, def_id) {
                 // the dependencies should be what was already stored in the metadata...
                 ItemType::Logic | ItemType::Predicate => {
-                    (translate_logic_or_predicate(ctx, def_id, span).0, Err(def_id))
+                    (translation::logic_or_predicate(ctx, def_id, span).unwrap().body, Err(def_id))
                 }
                 _ => unreachable!("extern_module: unexpected term for {:?}", def_id),
             }

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -53,7 +53,7 @@ pub fn extern_module(
     def_id: DefId,
 ) -> (Module, Result<CloneSummary<'tcx>, DefId>) {
     match ctx.externs.term(def_id) {
-        Some(_) => {
+        Ok(_) => {
             let span = ctx.tcx.def_span(def_id);
             match item_type(ctx.tcx, def_id) {
                 // the dependencies should be what was already stored in the metadata...
@@ -63,7 +63,7 @@ pub fn extern_module(
                 _ => unreachable!("extern_module: unexpected term for {:?}", def_id),
             }
         }
-        None => {
+        Err(_) => {
             let (modl, deps) = default_decl(ctx, def_id);
             // Why do we ever want to return `Err` shouldn't `deps` already be correct?
             let deps =

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -40,12 +40,12 @@ pub fn logic_or_predicate(
     decls.extend(all_generic_decls_for(ctx.tcx, def_id));
     decls.extend(names.to_clones(ctx));
 
-    let proof_modl = proof_module(ctx, def_id);
+    let proof_modl = proof_module(ctx, def_id)?;
     if util::is_trusted(ctx.tcx, def_id) || !util::has_body(ctx, def_id) {
         let val = util::item_type(ctx.tcx, def_id).val(sig);
         decls.push(Decl::ValDecl(val));
     } else {
-        let term = ctx.term(def_id).unwrap().clone();
+        let term = ctx.term(def_id)?.clone();
         let body = specification::lower_pure(ctx, &mut names, def_id, term);
         decls.extend(names.to_clones(ctx));
 
@@ -83,9 +83,9 @@ pub fn logic_or_predicate(
     })
 }
 
-fn proof_module(ctx: &mut TranslationCtx, def_id: DefId) -> Option<Module> {
+fn proof_module(ctx: &mut TranslationCtx, def_id: DefId) -> CreusotResult<Option<Module>> {
     if util::is_trusted(ctx.tcx, def_id) || !util::has_body(ctx, def_id) {
-        return None;
+        return Ok(None);
     }
 
     let mut names = CloneMap::new(ctx.tcx, def_id, false);
@@ -94,12 +94,12 @@ fn proof_module(ctx: &mut TranslationCtx, def_id: DefId) -> Option<Module> {
     let sig = crate::util::signature_of(ctx, &mut names, def_id);
 
     if sig.contract.is_empty() {
-        return None;
+        return Ok(None);
     }
-    let term = ctx.term(def_id).unwrap().clone();
+    let term = ctx.term(def_id)?.clone();
     let body = specification::lower_impure(ctx, &mut names, def_id, term);
 
-    Some(implementation_module(ctx, def_id, &names, sig, body))
+    Ok(Some(implementation_module(ctx, def_id, &names, sig, body)))
 }
 
 fn spec_axiom(sig: &Signature) -> Axiom {

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -10,14 +10,17 @@ use why3::declaration::*;
 use why3::mlcfg::{BinOp, Exp};
 use why3::Ident;
 
+use super::interface::interface_for;
+
 pub struct LogicItem<'tcx> {
+    pub interface: Module,
     pub body: Module,
     pub proof_obligations: Option<Module>,
     pub has_axioms: bool,
     pub dependencies: CloneSummary<'tcx>,
 }
 
-pub fn translate_logic_or_predicate(
+pub fn logic_or_predicate(
     ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
     _span: rustc_span::Span,
@@ -70,7 +73,9 @@ pub fn translate_logic_or_predicate(
     }
 
     let name = module_name(ctx.tcx, def_id);
+    let (interface, _) = interface_for(ctx, def_id);
     Ok(LogicItem {
+        interface,
         body: Module { name, decls },
         proof_obligations: proof_modl,
         has_axioms,

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -85,7 +85,7 @@ pub(crate) fn has_body(ctx: &mut TranslationCtx, def_id: DefId) -> bool {
         ctx.tcx.hir().maybe_body_owned_by(hir_id).is_some()
     } else {
         match item_type(ctx.tcx, def_id) {
-            ItemType::Logic | ItemType::Predicate => ctx.term(def_id).is_some(),
+            ItemType::Logic | ItemType::Predicate => ctx.term(def_id).is_ok(),
             _ => false,
         }
     }

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -236,7 +236,7 @@ pub fn signature_of<'tcx>(
 
     let mut contract = names.with_public_clones(|names| {
         let pre_contract = crate::specification::contract_of(ctx, def_id).unwrap();
-        pre_contract.check_and_lower(ctx, names, def_id)
+        pre_contract.check_and_lower(ctx, names).unwrap_or_else(|e| e.emit(ctx.tcx.sess))
     });
 
     if sig.output().is_never() {


### PR DESCRIPTION
Actually makes use of `Result` to return error messages rather than just semi-randomly panic-ing in creusot. 
Tough we made use of rustc's nice diagnostic apis to return nice panic messages this still felt very ad-hoc, and I think overall it will be nicer to have the errors visible in types, even if that means that they are everywhere now. 
