### PR TITLE
New parsers for pearlite

### DIFF
--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -290,11 +290,20 @@ pub fn invariant(invariant: TS1, loopb: TS1) -> TS1 {
     })
 }
 
+struct Assertion(TBlock);
+
+impl Parse for Assertion {
+    fn parse(input: parse::ParseStream) -> Result<Self> {
+        let stmts = input.call(TBlock::parse_within)?;
+        Ok(Assertion(TBlock { brace_token: Brace { span: Span::call_site() }, stmts }))
+    }
+}
+
 #[proc_macro]
 pub fn proof_assert(assertion: TS1) -> TS1 {
-    let assert: pearlite_syn::Term = parse_macro_input!(assertion);
+    let assert = parse_macro_input!(assertion as Assertion);
 
-    let assert_body = pretyping::encode_term(assert).unwrap();
+    let assert_body = pretyping::encode_block(assert.0).unwrap();
 
     TS1::from(quote! {
         {

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -1,9 +1,10 @@
 extern crate proc_macro;
-
-mod pretyping;
-
 use pearlite_syn::*;
+use proc_macro::TokenStream as TS1;
 use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens, TokenStreamExt};
+use std::iter;
 use syn::{
     parse::{Parse, Result},
     punctuated::{Pair, Punctuated},
@@ -11,9 +12,38 @@ use syn::{
     *,
 };
 
-use proc_macro::TokenStream as TS1;
-use proc_macro2::TokenStream;
-use quote::quote;
+mod pretyping;
+
+trait FilterAttrs<'a> {
+    type Ret: Iterator<Item = &'a Attribute>;
+
+    fn outer(self) -> Self::Ret;
+    fn inner(self) -> Self::Ret;
+}
+
+impl<'a> FilterAttrs<'a> for &'a [Attribute] {
+    type Ret = iter::Filter<std::slice::Iter<'a, Attribute>, fn(&&Attribute) -> bool>;
+
+    fn outer(self) -> Self::Ret {
+        fn is_outer(attr: &&Attribute) -> bool {
+            match attr.style {
+                AttrStyle::Outer => true,
+                AttrStyle::Inner(_) => false,
+            }
+        }
+        self.iter().filter(is_outer)
+    }
+
+    fn inner(self) -> Self::Ret {
+        fn is_inner(attr: &&Attribute) -> bool {
+            match attr.style {
+                AttrStyle::Inner(_) => true,
+                AttrStyle::Outer => false,
+            }
+        }
+        self.iter().filter(is_inner)
+    }
+}
 
 fn generate_unique_ident(prefix: &str) -> Ident {
     let uuid = uuid::Uuid::new_v4();
@@ -22,35 +52,75 @@ fn generate_unique_ident(prefix: &str) -> Ident {
     Ident::new(&ident, Span::call_site())
 }
 
-// TODO: Add custom parse instance
-enum FnOrTraitSig {
-    Fn(ItemFn),
-    TraitSig(TraitItemMethod),
+struct TraitItemSignature {
+    attrs: Vec<Attribute>,
+    sig: Signature,
+    semi_token: Token![;],
 }
 
-impl FnOrTraitSig {
-    pub fn sig(&self) -> Signature {
+impl ToTokens for TraitItemSignature {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(self.attrs.outer());
+        self.sig.to_tokens(tokens);
+        self.semi_token.to_tokens(tokens);
+    }
+}
+
+enum ContractItem {
+    Fn(ItemFn),
+    TraitSig(TraitItemSignature),
+    Closure(ExprClosure),
+}
+
+impl ContractItem {
+    fn name(&self) -> String {
         match self {
-            FnOrTraitSig::Fn(i) => i.sig.clone(),
-            FnOrTraitSig::TraitSig(s) => s.sig.clone(),
+            ContractItem::Fn(i) => i.sig.ident.to_string(),
+            ContractItem::TraitSig(tr) => tr.sig.ident.to_string(),
+            ContractItem::Closure(_) => "closure".to_string(),
         }
     }
 }
 
-fn parse_def_or_decl(tokens: TS1) -> Result<FnOrTraitSig> {
-    syn::parse::<ItemFn>(tokens.clone())
-        .map(FnOrTraitSig::Fn)
-        .or_else(|_| syn::parse::<TraitItemMethod>(tokens.clone()).map(FnOrTraitSig::TraitSig))
+impl Parse for ContractItem {
+    fn parse(input: parse::ParseStream) -> Result<Self> {
+        let mut attrs = input.call(Attribute::parse_outer)?;
+        // Infalliable, no visibility = inherited
+        let vis: Visibility = input.parse()?;
+        let sig: Signature = input.parse()?;
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Token![;]) {
+            let semi_token: Token![;] = input.parse()?;
+            return Ok(ContractItem::TraitSig(TraitItemSignature { attrs, sig, semi_token }));
+        } else if input.peek(Token![|])
+            || input.peek(Token![async]) && (input.peek2(Token![|]) || input.peek2(Token![move]))
+            || input.peek(Token![static])
+            || input.peek(Token![move])
+        {
+            return Ok(ContractItem::Closure(input.parse()?));
+        } else {
+            let content;
+            let brace_token = braced!(content in input);
+            attrs.extend(Attribute::parse_inner(input)?);
+            let stmts = content.call(Block::parse_within)?;
+
+            return Ok(ContractItem::Fn(ItemFn {
+                attrs,
+                vis,
+                sig,
+                block: Box::new(Block { brace_token, stmts }),
+            }));
+        }
+    }
 }
 
 // Generate a token stream for the item representing a specific
 // `requires` or `ensures`
-fn fn_spec_item(tag: Ident, result: Option<FnArg>, tokens: TS1) -> Result<TokenStream> {
-    let p: pearlite_syn::Term = parse(tokens)?;
+fn fn_spec_item2(tag: Ident, result: Option<FnArg>, p: Term) -> TokenStream {
     let req_body = pretyping::encode_term(p).unwrap();
     let name_tag = format!("{}", quote! { #tag });
 
-    Ok(quote! {
+    quote! {
         #[allow(unused_must_use)]
         let _ =
             #[creusot::no_translate]
@@ -58,103 +128,92 @@ fn fn_spec_item(tag: Ident, result: Option<FnArg>, tokens: TS1) -> Result<TokenS
             #[creusot::decl::spec]
             |#result|{ #req_body }
         ;
-    })
+    }
 }
 
-fn sig_spec_item(tag: Ident, mut sig: Signature, tokens: TS1) -> Result<TokenStream> {
-    let p: pearlite_syn::Term = parse(tokens)?;
+fn sig_spec_item2(tag: Ident, mut sig: Signature, p: Term) -> TokenStream {
     let req_body = pretyping::encode_term(p).unwrap();
     let name_tag = format!("{}", quote! { #tag });
     sig.ident = tag;
     sig.output = parse_quote! { -> bool };
 
-    Ok(quote! {
+    quote! {
         #[creusot::no_translate]
         #[creusot::item=#name_tag]
         #[creusot::decl::spec]
         #sig { #req_body }
-    })
+    }
 }
 
 #[proc_macro_attribute]
 pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
-    match requires_inner(attr, tokens) {
-        Ok(r) => r,
-        Err(err) => return TS1::from(err.to_compile_error()),
-    }
-}
+    let item = parse_macro_input!(tokens as ContractItem);
+    let term = parse_macro_input!(attr as Term);
 
-fn requires_inner(attr: TS1, tokens: TS1) -> Result<TS1> {
-    let parse_res = parse_def_or_decl(tokens);
-
-    let item = parse_res?;
-
-    let req_name = generate_unique_ident(&item.sig().ident.to_string());
+    let req_name = generate_unique_ident(&item.name());
 
     let name_tag = format!("{}", quote! { #req_name });
 
     match item {
-        FnOrTraitSig::Fn(mut f) => {
-            let requires_tokens = fn_spec_item(req_name, None, attr)?;
+        ContractItem::Fn(mut f) => {
+            let requires_tokens = fn_spec_item2(req_name, None, term);
 
             f.block.stmts.insert(0, Stmt::Item(Item::Verbatim(requires_tokens)));
-            Ok(TS1::from(quote! {
+            TS1::from(quote! {
               #[creusot::spec::requires=#name_tag]
               #f
-            }))
+            })
         }
-        FnOrTraitSig::TraitSig(s) => {
-            let requires_tokens = sig_spec_item(req_name, s.sig.clone(), attr)?;
-            Ok(TS1::from(quote! {
-
+        ContractItem::TraitSig(s) => {
+            let requires_tokens = sig_spec_item2(req_name, s.sig.clone(), term);
+            TS1::from(quote! {
               #requires_tokens
-
               #[creusot::spec::requires=#name_tag]
               #s
-            }))
+            })
         }
+        _ => panic!(),
     }
 }
 
 #[proc_macro_attribute]
 pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {
-    match ensures_inner(attr, tokens) {
-        Ok(r) => r,
-        Err(err) => return TS1::from(err.to_compile_error()),
-    }
-}
+    let item = parse_macro_input!(tokens as ContractItem);
+    let term = parse_macro_input!(attr as Term);
 
-fn ensures_inner(attr: TS1, tokens: TS1) -> Result<TS1> {
-    let item = parse_def_or_decl(tokens)?;
-
-    let result = match item.sig().output {
-        ReturnType::Default => parse_quote! { result : () },
-        ReturnType::Type(_, ref ty) => parse_quote! { result : #ty },
-    };
-
-    let ens_name = generate_unique_ident(&item.sig().ident.to_string());
+    let ens_name = generate_unique_ident(&item.name());
     let name_tag = format!("{}", quote! { #ens_name });
 
     match item {
-        FnOrTraitSig::Fn(mut f) => {
-            let ensures_tokens = fn_spec_item(ens_name, Some(result), attr)?;
+        ContractItem::Fn(mut f) => {
+            let result = match f.sig.output {
+                ReturnType::Default => parse_quote! { result : () },
+                ReturnType::Type(_, ref ty) => parse_quote! { result : #ty },
+            };
+            let ensures_tokens = fn_spec_item2(ens_name, Some(result), term);
 
             f.block.stmts.insert(0, Stmt::Item(Item::Verbatim(ensures_tokens)));
-            Ok(TS1::from(quote! {
+            TS1::from(quote! {
                 #[creusot::spec::ensures=#name_tag]
                 #f
-            }))
+            })
         }
-        FnOrTraitSig::TraitSig(s) => {
+        ContractItem::TraitSig(s) => {
+            let result = match s.sig.output {
+                ReturnType::Default => parse_quote! { result : () },
+                ReturnType::Type(_, ref ty) => parse_quote! { result : #ty },
+            };
+
             let mut sig = s.sig.clone();
             sig.inputs.push(result);
-            let ensures_tokens = sig_spec_item(ens_name, sig, attr)?;
-            Ok(TS1::from(quote! {
+            let ensures_tokens = sig_spec_item2(ens_name, sig, term);
+            TS1::from(quote! {
               #ensures_tokens
               #[creusot::spec::ensures=#name_tag]
               #s
-            }))
+            })
         }
+        _ => panic!(),
     }
 }
 

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -27,11 +27,7 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
                 _ => Ok(quote! { #left #op #right }),
             }
         }
-        RT::Block(TermBlock { block, .. }) => {
-            let stmts: Vec<_> =
-                block.stmts.into_iter().map(encode_stmt).collect::<Result<_, _>>()?;
-            Ok(quote! { { #(#stmts)* } })
-        }
+        RT::Block(TermBlock { block, .. }) => encode_block(block),
         RT::Call(TermCall { func, args, .. }) => {
             let func = encode_term(*func)?;
             let args: Vec<_> = args.into_iter().map(encode_term).collect::<Result<_, _>>()?;
@@ -154,6 +150,11 @@ pub fn encode_term(term: RT) -> Result<TokenStream, EncodeError> {
         RT::Pearlite(term) => Ok(quote! { (#term) }),
         RT::__Nonexhaustive => todo!(),
     }
+}
+
+pub fn encode_block(block: TBlock) -> Result<TokenStream, EncodeError> {
+    let stmts: Vec<_> = block.stmts.into_iter().map(encode_stmt).collect::<Result<_, _>>()?;
+    Ok(quote! { { #(#stmts)* } })
 }
 
 fn encode_stmt(stmt: TermStmt) -> Result<TokenStream, EncodeError> {

--- a/creusot-contracts/src/logic/ghost.rs
+++ b/creusot-contracts/src/logic/ghost.rs
@@ -11,7 +11,7 @@ impl<T> Model for Ghost<T> {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot-contracts/src/logic/int.rs
+++ b/creusot-contracts/src/logic/int.rs
@@ -25,7 +25,7 @@ impl From<u32> for Int {
     #[rustc_diagnostic_item = "u32_to_int"]
     #[creusot::builtins = "mach.int.UInt32.to_int"]
     fn from(_: u32) -> Self {
-        panic!()
+        std::process::abort()
     }
 }
 impl Model for u32 {
@@ -44,7 +44,7 @@ impl From<i32> for Int {
     #[rustc_diagnostic_item = "i32_to_int"]
     #[creusot::builtins = "mach.int.Int32.to_int"]
     fn from(_: i32) -> Self {
-        panic!()
+        std::process::abort()
     }
 }
 impl Model for i32 {
@@ -63,7 +63,7 @@ impl From<usize> for Int {
     #[rustc_diagnostic_item = "usize_to_int"]
     #[creusot::builtins = "mach.int.UInt64.to_int"]
     fn from(_: usize) -> Self {
-        panic!()
+        std::process::abort()
     }
 }
 impl Model for usize {
@@ -81,7 +81,7 @@ impl From<isize> for Int {
     #[trusted]
     #[rustc_diagnostic_item = "isize_to_int"]
     fn from(_: isize) -> Self {
-        panic!()
+        std::process::abort()
     }
 }
 impl Model for isize {

--- a/creusot-contracts/src/logic/ord.rs
+++ b/creusot-contracts/src/logic/ord.rs
@@ -114,31 +114,49 @@ macro_rules! ord_logic_impl {
             }
 
             #[logic]
-            fn cmp_le_log(_: Self, _: Self) {}
+            fn cmp_le_log(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn cmp_lt_log(_: Self, _: Self) {}
+            fn cmp_lt_log(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn cmp_ge_log(_: Self, _: Self) {}
+            fn cmp_ge_log(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn cmp_gt_log(_: Self, _: Self) {}
+            fn cmp_gt_log(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn refl(_: Self) {}
+            fn refl(_: Self) {
+                ()
+            }
 
             #[logic]
-            fn trans(_: Self, _: Self, _: Self, _: Ordering) {}
+            fn trans(_: Self, _: Self, _: Self, _: Ordering) {
+                ()
+            }
 
             #[logic]
-            fn antisym1(_: Self, _: Self) {}
+            fn antisym1(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn antisym2(_: Self, _: Self) {}
+            fn antisym2(_: Self, _: Self) {
+                ()
+            }
 
             #[logic]
-            fn eq_cmp(_: Self, _: Self) {}
+            fn eq_cmp(_: Self, _: Self) {
+                ()
+            }
         }
     };
 }

--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -20,16 +20,24 @@ impl<T> EqLogic for Seq<T> {
     }
 
     #[logic]
-    fn eq_ne(_: Self, _: Self) {}
+    fn eq_ne(_: Self, _: Self) {
+        ()
+    }
 
     #[logic]
-    fn refl(_: Self) {}
+    fn refl(_: Self) {
+        ()
+    }
 
     #[logic]
-    fn symmetry(_: Self, _: Self) {}
+    fn symmetry(_: Self, _: Self) {
+        ()
+    }
 
     #[logic]
-    fn transitivity(_: Self, _: Self, _: Self) {}
+    fn transitivity(_: Self, _: Self, _: Self) {
+        ()
+    }
 }
 
 impl<T> Seq<T> {

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -11,7 +11,7 @@ impl<T> Model for Vec<T> {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot/tests/should_succeed/bug/269.rs
+++ b/creusot/tests/should_succeed/bug/269.rs
@@ -1,0 +1,6 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+#[logic]
+pub fn my_lemma() {}

--- a/creusot/tests/should_succeed/bug/269.stdout
+++ b/creusot/tests/should_succeed/bug/269.stdout
@@ -1,0 +1,23 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module C269_MyLemma_Interface
+  function my_lemma () : ()
+end
+module C269_MyLemma
+  function my_lemma () : () = 
+    ()
+end

--- a/creusot/tests/should_succeed/cell/02.rs
+++ b/creusot/tests/should_succeed/cell/02.rs
@@ -101,8 +101,8 @@ fn fib_memo(mem: &FibCache, i: usize) -> usize {
             } else if i == 1 {
                 1
             } else {
-                proof_assert! { {lemma_max_int(); true} };
-                proof_assert! { {lemma_fib_bound(0); true} };
+                proof_assert! { lemma_max_int(); true };
+                proof_assert! { lemma_fib_bound(0); true };
                 fib_memo(mem, i - 1) + fib_memo(mem, i - 2)
             };
             proof_assert! { @fib_i === fib(@i)};

--- a/creusot/tests/should_succeed/filter_positive.rs
+++ b/creusot/tests/should_succeed/filter_positive.rs
@@ -100,10 +100,14 @@ fn m(t: Vec<i32>) -> Vec<i32> {
     while i < t.len() {
         if t[i] > 0 {
             // the tricky assertions, that needs lemmas
-            proof_assert! { {lemma_num_of_pos_strictly_increasing(@i,@u);
-            num_of_pos(0,@i,@t) < num_of_pos(0,@i+1,@t) } };
-            proof_assert! { {lemma_num_of_pos_increasing(0,@i+1,(@t).len(),@t);
-            @count < (@u).len() } };
+            proof_assert! {
+                lemma_num_of_pos_strictly_increasing(@i,@u);
+                num_of_pos(0,@i,@t) < num_of_pos(0,@i+1,@t)
+            };
+            proof_assert! {
+                lemma_num_of_pos_increasing(0,@i+1,(@t).len(),@t);
+                @count < (@u).len()
+            };
             u[count] = t[i];
             count += 1;
         }

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -112,9 +112,11 @@ fn heap_sort<T: Ord>(v: &mut Vec<T>) {
     while end > 1 {
         end -= 1;
         v.swap(0, end);
-        proof_assert! {{heap_frag_max(@v, 0/*dummy*/, @end);
-        forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < (@v).len() ==>
-                        (@v)[i] <= (@v)[j] }}
+        proof_assert! {
+            heap_frag_max(@v, 0/*dummy*/, @end);
+            forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < (@v).len() ==>
+                        (@v)[i] <= (@v)[j]
+        };
         sift_down(v, 0, end);
     }
 }

--- a/creusot/tests/should_succeed/inc_some_2_list.rs
+++ b/creusot/tests/should_succeed/inc_some_2_list.rs
@@ -44,7 +44,7 @@ impl List {
     fn take_some_rest(&mut self) -> (&mut u32, &mut List) {
         match self {
             Cons(ma, ml) => {
-                proof_assert! { {ml.lemma_sum_nonneg(); true} };
+                proof_assert! { ml.lemma_sum_nonneg(); true };
                 if rand::random() {
                     (ma, ml)
                 } else {

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -36,11 +36,11 @@ impl Tree {
     fn sum_x(&self) -> u32 {
         match self {
             Node(tl, a, tr) => {
-                proof_assert! {{
+                proof_assert! {
                     tl.lemma_sum_nonneg();
                     tr.lemma_sum_nonneg();
                     true
-                }};
+                };
                 tl.sum_x() + *a + tr.sum_x()
             }
             Leaf => 0,
@@ -54,11 +54,11 @@ impl Tree {
     fn take_some_rest(&mut self) -> (&mut u32, &mut Tree) {
         match self {
             Node(mtl, ma, mtr) => {
-                proof_assert! {{
+                proof_assert! {
                     mtl.lemma_sum_nonneg();
                     mtr.lemma_sum_nonneg();
                     true
-                }};
+                };
                 if rand::random() {
                     (ma, if rand::random() { mtl } else { mtr })
                 } else if rand::random() {

--- a/creusot/tests/should_succeed/inc_some_list.rs
+++ b/creusot/tests/should_succeed/inc_some_list.rs
@@ -47,7 +47,7 @@ impl List {
     fn take_some(&mut self) -> &mut u32 {
         match self {
             Cons(ma, ml) => {
-                proof_assert! {{ ml.lemma_sum_nonneg(); true }};
+                proof_assert! { ml.lemma_sum_nonneg(); true };
                 if random() {
                     ma
                 } else {

--- a/creusot/tests/should_succeed/inc_some_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_tree.rs
@@ -36,11 +36,11 @@ impl Tree {
     fn sum_x(&self) -> u32 {
         match self {
             Node(tl, a, tr) => {
-                proof_assert! {{
+                proof_assert! {
                     tl.lemma_sum_nonneg();
                     tr.lemma_sum_nonneg();
                     true
-                }};
+                };
                 tl.sum_x() + *a + tr.sum_x()
             }
             Leaf => 0,
@@ -52,11 +52,11 @@ impl Tree {
     fn take_some(&mut self) -> &mut u32 {
         match self {
             Node(mtl, ma, mtr) => {
-                proof_assert! {{
+                proof_assert! {
                     mtl.lemma_sum_nonneg();
                     mtr.lemma_sum_nonneg();
                     true
-                }};
+                };
                 if rand::random() {
                     ma
                 } else if rand::random() {

--- a/creusot/tests/should_succeed/iter_mut.rs
+++ b/creusot/tests/should_succeed/iter_mut.rs
@@ -13,7 +13,7 @@ impl<T: ?Sized> Model for Vec<T> {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 
@@ -42,7 +42,7 @@ impl<'a, T: ?Sized> Model for IterMut<'a, T> {
     #[trusted]
     #[logic]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot/tests/should_succeed/model.rs
+++ b/creusot/tests/should_succeed/model.rs
@@ -8,7 +8,7 @@ impl Model for Seven {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 
@@ -25,7 +25,7 @@ impl<T, U> Model for Pair<T, U> {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -40,7 +40,7 @@ impl<T> Model for Sparse<T> {
     fn model(self) -> Self::ModelTy {
         // we miss a way to define the sequence, we need
         // a higher-order definition by comprehension
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -119,12 +119,7 @@ impl<T> Sparse<T> {
         let index = self.idx[i];
         if !(index < self.n && self.back[index] == i) {
             // the hard assertion!
-            proof_assert!(pearlite! {
-                {
-                    self.lemma_permutation(@i);
-                    true
-                }
-            });
+            proof_assert!( self.lemma_permutation(@i); true );
             proof_assert!(@(self.n) < @(self.size));
             // assert!(self.n < self.size);
             self.idx[i] = self.n;

--- a/creusot/tests/should_succeed/sum_of_odds.rs
+++ b/creusot/tests/should_succeed/sum_of_odds.rs
@@ -39,9 +39,10 @@ fn compute_sum_of_odd(x: u32) -> u32 {
     #[invariant(i_bound, @i <= @x)]
     #[invariant(s_is_sum, @s === sum_of_odd(@i))]
     while i < x {
-        proof_assert! { {
-        sum_of_odd_is_sqr(@i);
-        true }}
+        proof_assert! {
+            sum_of_odd_is_sqr(@i);
+            true
+        };
         s += 2 * i + 1;
         i += 1;
     }
@@ -51,8 +52,8 @@ fn compute_sum_of_odd(x: u32) -> u32 {
 #[requires(@x < 0x10000)]
 fn test(x: u32) {
     let y = compute_sum_of_odd(x);
-    proof_assert! { {
+    proof_assert! {
         sum_of_odd_is_sqr(@x);
         is_square(@y)
-    } }
+    }
 }

--- a/creusot/tests/should_succeed/traits/14_assoc_in_logic.rs
+++ b/creusot/tests/should_succeed/traits/14_assoc_in_logic.rs
@@ -9,13 +9,13 @@ trait Assoc {
 #[logic]
 #[trusted]
 fn from_ty<T: Assoc>(x: T::Ty) -> T {
-    panic!()
+    std::process::abort()
 }
 
 #[logic]
 #[trusted]
 fn to_ty<T: Assoc>(x: T) -> T::Ty {
-    panic!()
+    std::process::abort()
 }
 
 #[trusted]

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.rs
@@ -16,7 +16,7 @@ impl Tr for () {
 #[trusted]
 #[logic]
 fn x<T: Tr>(x: T) -> T::A {
-    panic!()
+    std::process::abort()
 }
 
 #[requires(x(a) === ())]

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.rs
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.rs
@@ -8,7 +8,7 @@ impl<T: ?Sized> Model for Vec<T> {
     #[logic]
     #[trusted]
     fn model(self) -> Self::ModelTy {
-        panic!()
+        std::process::abort()
     }
 }
 

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -149,7 +149,7 @@ fn knights_tour(size: usize, x: usize, y: usize) -> Option<Board> {
     board.set(p, step);
     step += 1;
 
-    proof_assert! {{ dumb_nonlinear_arith(size); true }}
+    proof_assert! { dumb_nonlinear_arith(size); true }
     #[invariant(b, board.size === size)]
     #[invariant(b, board.wf())]
     #[invariant(p, board.in_bounds(p))]

--- a/pearlite-syn/src/term.rs
+++ b/pearlite-syn/src/term.rs
@@ -647,15 +647,14 @@ pub(crate) mod parsing {
                 while let Some(semi) = input.parse::<Option<Token![;]>>()? {
                     stmts.push(TermStmt::Semi(Term::Verbatim(TokenStream::new()), semi));
                 }
+                if input.is_empty() {
+                    break;
+                }
                 let s = parse_stmt(input, true)?;
                 let requires_semicolon =
                     if let TermStmt::Expr(s) = &s { super::requires_terminator(s) } else { false };
                 stmts.push(s);
                 if input.is_empty() {
-                    if let TermStmt::Semi(_, _) = stmts.last().unwrap() {
-                        // TODO: Fix error span, how?
-                        return Err(input.error("unexpected semicolon"));
-                    }
                     break;
                 } else if requires_semicolon {
                     return Err(input.error("unexpected token"));


### PR DESCRIPTION
I overhauled the Pearlite parsers to not backtrack, working instead much like `syn` does itself. As a result we should get better error messages in certain cases as well as improving the parse of things like lemmas. I also slightly loosened some bits of the Pearlite grammar so that `{}` implicitly returns `()` (like in Rust). 

Fixes #269 in the process.
