### PR TITLE
Use specialization to give a global Resolve instance

### DIFF
--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -361,6 +361,7 @@ pub fn proof_assert(assertion: TS1) -> TS1 {
 
 struct LogicItem {
     vis: Visibility,
+    defaultness: Option<Token![default]>,
     attrs: Vec<Attribute>,
     sig: Signature,
     body: Box<TBlock>,
@@ -376,6 +377,7 @@ impl Parse for LogicInput {
         let attrs = input.call(Attribute::parse_outer)?;
         // Infalliable, no visibility = inherited
         let vis: Visibility = input.parse()?;
+        let default = input.parse()?;
         let sig: Signature = input.parse()?;
         let lookahead = input.lookahead1();
         if lookahead.peek(Token![;]) {
@@ -388,6 +390,7 @@ impl Parse for LogicInput {
 
             Ok(LogicInput::Item(LogicItem {
                 vis,
+                defaultness: default,
                 attrs,
                 sig,
                 body: Box::new(TBlock { brace_token, stmts }),
@@ -415,6 +418,7 @@ fn logic_sig(sig: TraitItemSignature) -> TS1 {
 fn logic_item(log: LogicItem) -> TS1 {
     let term = log.body;
     let vis = log.vis;
+    let def = log.defaultness;
     let sig = log.sig;
     let attrs = log.attrs;
 
@@ -423,7 +427,7 @@ fn logic_item(log: LogicItem) -> TS1 {
     TS1::from(quote! {
         #[creusot::decl::logic]
         #(#attrs)*
-        #vis #sig {
+        #vis #def #sig {
             #req_body
         }
     })
@@ -459,6 +463,7 @@ fn predicate_sig(sig: TraitItemSignature) -> TS1 {
 fn predicate_item(log: LogicItem) -> TS1 {
     let term = log.body;
     let vis = log.vis;
+    let def = log.defaultness;
     let sig = log.sig;
     let attrs = log.attrs;
 
@@ -467,7 +472,7 @@ fn predicate_item(log: LogicItem) -> TS1 {
     TS1::from(quote! {
         #[creusot::decl::predicate]
         #(#attrs)*
-        #vis #sig {
+        #vis #def #sig {
             #req_body
         }
     })

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     feature = "contracts",
-    feature(unsized_locals, fn_traits, unboxed_closures),
+    feature(unsized_locals, fn_traits, unboxed_closures, min_specialization),
     allow(incomplete_features)
 )]
 #![cfg_attr(feature = "typechecker", feature(rustc_private), feature(box_patterns, box_syntax))]

--- a/creusot-contracts/src/logic/resolve.rs
+++ b/creusot-contracts/src/logic/resolve.rs
@@ -8,7 +8,7 @@ pub unsafe trait Resolve {
     fn resolve(self) -> bool;
 }
 
-unsafe impl<T1: Resolve, T2: Resolve> Resolve for (T1, T2) {
+unsafe impl<T1, T2> Resolve for (T1, T2) {
     #[predicate]
     fn resolve(self) -> bool {
         Resolve::resolve(self.0) && Resolve::resolve(self.1)
@@ -19,5 +19,13 @@ unsafe impl<T> Resolve for &mut T {
     #[predicate]
     fn resolve(self) -> bool {
         pearlite! { ^self === *self }
+    }
+}
+
+unsafe impl<T> Resolve for T {
+    #[predicate]
+    #[rustc_diagnostic_item = "creusot_resolve_default"]
+    default fn resolve(self) -> bool {
+        true
     }
 }

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -100,7 +100,7 @@ impl<T: Clone> Clone for Vec<T> {
     }
 }
 
-unsafe impl<T: Resolve> Resolve for Vec<T> {
+unsafe impl<T> Resolve for Vec<T> {
     #[predicate]
     fn resolve(self) -> bool {
         pearlite! { forall<i : Int> 0 <= i && i < (@self).len() ==> (@self)[i].resolve() }

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -282,6 +282,15 @@ impl<'tcx> CloneMap<'tcx> {
             }
         };
 
+        if self.tcx.is_diagnostic_item(Symbol::intern("creusot_resolve_default"), def_id)
+            || self.tcx.is_diagnostic_item(Symbol::intern("creusot_resolve_method"), def_id)
+        {
+            let self_ty = subst.types().nth(0).unwrap();
+            if let TyKind::Closure(id, csubst) = self_ty.kind() {
+                return (*id, csubst);
+            }
+        }
+
         (def_id, subst)
     }
 

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -622,11 +622,6 @@ fn resolve_predicate_of(
         return Exp::Abs("x".into(), box Exp::Const(Constant::const_true()));
     }
 
-    // BIG HACK: Pretend closures have a Resolve instance.
-    if let TyKind::Closure(def_id, subst) = ty.kind() {
-        return Exp::impure_qvar(names.insert(*def_id, subst).qname_ident(Ident::build("resolve")));
-    }
-
     let trait_id = ctx.get_diagnostic_item(Symbol::intern("creusot_resolve")).unwrap();
     let trait_meth_id = ctx.get_diagnostic_item(Symbol::intern("creusot_resolve_method")).unwrap();
     let subst = ctx.mk_substs([GenericArg::from(ty)].iter());

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -192,6 +192,8 @@ pub fn resolve_assoc_item_opt(
         return None;
     }
 
+    let trait_ref = TraitRef::from_method(tcx, tcx.trait_of_item(def_id).unwrap(), substs);
+    use crate::rustc_middle::ty::TypeFoldable;
     let source = resolve_impl_source_opt(tcx, param_env, def_id, substs)?;
 
     match source {
@@ -209,6 +211,9 @@ pub fn resolve_assoc_item_opt(
                 });
             use rustc_trait_selection::infer::TyCtxtInferExt;
 
+            if !leaf_def.is_final() && trait_ref.still_further_specializable() {
+                return Some((def_id, substs));
+            }
             // Translate the original substitution into one on the selected impl method
             let leaf_substs = tcx.infer_ctxt().enter(|infcx| {
                 let param_env = param_env.with_reveal_all_normalized(tcx);

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -83,13 +83,14 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     ensures { Seq.length (Model0.model result) = 0 }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -297,6 +298,36 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -340,6 +371,16 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
@@ -390,13 +431,12 @@ module C100doors_Main
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = bool
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.creusotcontracts_std1_vec_vec bool
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec bool,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = bool,
@@ -408,6 +448,8 @@ module C100doors_Main
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = bool,
   function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = bool, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = bool,
   function Model0.model = Model0.model
   let rec cfg main [@cfg:stackify] () : () = 

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -90,6 +90,15 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -103,6 +112,12 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module AllZero_AllZero_Interface
@@ -127,7 +142,7 @@ module AllZero_AllZero
   clone AllZero_Get as Get0
   clone AllZero_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.allzero_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.allzero_list

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -85,6 +85,15 @@ module BinarySearch_Impl0_Get
       | Type.BinarySearch_List_Nil -> Type.Core_Option_Option_None
       end
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -92,6 +101,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module BinarySearch_Impl0_Index_Interface
   type t   
@@ -117,9 +132,9 @@ module BinarySearch_Impl0_Index
   use mach.int.Int64
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.binarysearch_list t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg index [@cfg:stackify] (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
     ensures { Type.Core_Option_Option_Some result = Get0.get self (UInt64.to_int ix) }
@@ -231,8 +246,8 @@ module BinarySearch_Impl0_Len
   clone BinarySearch_Impl0_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.binarysearch_list t
   let rec cfg len [@cfg:stackify] (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
@@ -358,11 +373,11 @@ module BinarySearch_BinarySearch
   clone BinarySearch_Impl1_IsSorted as IsSorted0 with function Get0.get = Get0.get
   clone BinarySearch_Impl0_GetDefault as GetDefault0 with type t = uint32, function Get0.get = Get0.get
   clone BinarySearch_Impl0_LenLogic as LenLogic0 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.binarysearch_list uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.binarysearch_list uint32
   clone BinarySearch_Impl0_Index_Interface as Index0 with type t = uint32,
   function LenLogic0.len_logic = LenLogic0.len_logic, function Get0.get = Get0.get
   clone BinarySearch_Impl0_Len_Interface as Len0 with type t = uint32,

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -79,13 +79,14 @@ module CreusotContracts_Std1_Vec_Impl1_New
     ensures { Seq.length (Model0.model result) = 0 }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t   
@@ -128,6 +129,46 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
   type t   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
@@ -165,14 +206,16 @@ module C01ResolveUnsoundness_MakeVecOfSize
   use seq.Seq
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec bool,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = bool,
   function Model0.model = Model0.model, function Model1.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve2 with type t = bool, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve3.resolve
   clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New0 with type t = bool, function Model0.model = Model0.model
   let rec cfg make_vec_of_size [@cfg:stackify] (n : usize) : Type.creusotcontracts_std1_vec_vec bool
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }

--- a/creusot/tests/should_succeed/bug/173.stdout
+++ b/creusot/tests/should_succeed/bug/173.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -22,14 +31,20 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C173_Test233_Interface
   val test_233 [@cfg:stackify] () : ()
 end
 module C173_Test233
   use mach.int.Int32
   use mach.int.Int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg test_233 [@cfg:stackify] () : () = 
   var _0 : ();
   var x_1 : int32;
@@ -71,8 +86,8 @@ module C173_Knapsack01Dyn
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg knapsack01_dyn [@cfg:stackify] (n : usize) : ()
     requires {0 < UInt64.to_int n && UInt64.to_int n < 10000}
     

--- a/creusot/tests/should_succeed/bug/195.stdout
+++ b/creusot/tests/should_succeed/bug/195.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -22,13 +31,19 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C195_Example_Interface
   val example [@cfg:stackify] (exampleParameter : bool) : ()
     requires {exampleParameter = exampleParameter}
     
 end
 module C195_Example
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg example [@cfg:stackify] (exampleParameter : bool) : ()
     requires {exampleParameter = exampleParameter}
     

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -109,6 +109,15 @@ module C206_U
   function u (a : Type.c206_a) : () = 
     U20.u2 a
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -116,6 +125,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C206_Ex_Interface
   use prelude.Prelude
@@ -133,7 +148,7 @@ module C206_Ex
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = usize
   clone C206_U2 as U20 with function Model0.model = Model0.model, axiom .
   clone C206_U as U0 with function U20.u2 = U20.u2, function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.c206_a
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c206_a
   let rec cfg ex [@cfg:stackify] (a : Type.c206_a) : ()
     ensures { U0.u a = U0.u a }
     

--- a/creusot/tests/should_succeed/bug/235.stdout
+++ b/creusot/tests/should_succeed/bug/235.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -22,13 +31,19 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C235_Main_Interface
   val main [@cfg:stackify] () : ()
 end
 module C235_Main
   use mach.int.Int
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var _1 : ();

--- a/creusot/tests/should_succeed/bug/256.stdout
+++ b/creusot/tests/should_succeed/bug/256.stdout
@@ -32,6 +32,15 @@ module Type
     | Alloc_String_String (alloc_vec_vec uint8 (alloc_alloc_global))
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -39,6 +48,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C256_U8Safe_Interface
   use mach.int.Int
@@ -50,7 +65,7 @@ module C256_U8Safe
   use mach.int.Int
   use prelude.Prelude
   use prelude.UInt8
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint8
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint8
   let rec cfg u8_safe [@cfg:stackify] (u : uint8) : () = 
   var _0 : ();
   var u_1 : uint8;
@@ -77,7 +92,7 @@ module C256_Bug256_Interface
 end
 module C256_Bug256
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.alloc_string_string
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.alloc_string_string
   let rec cfg bug_256 [@cfg:stackify] (x : Type.alloc_string_string) : () = 
   var _0 : ();
   var x_1 : Type.alloc_string_string;

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -59,13 +59,14 @@ module C01_Impl0_Get
     ensures { Inv0.inv result }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module C01_Impl0_Set_Interface
   type t   
@@ -86,6 +87,20 @@ module C01_Impl0_Set
   val set [@cfg:stackify] (self : Type.c01_cell t i) (v : t) : ()
     requires {Inv0.inv v}
     
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C01_Impl1_Inv_Interface
   use mach.int.Int
@@ -117,8 +132,8 @@ module C01_AddsTwo
   use Type
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c01_cell uint32 (Type.c01_even)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c01_cell uint32 (Type.c01_even)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone C01_Impl1_Inv as Inv0
   clone C01_Impl0_Set_Interface as Set0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv
   clone C01_Impl0_Get_Interface as Get0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -282,13 +282,14 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module Core_Ops_Index_Index_Output
   type self   
@@ -342,6 +343,20 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
@@ -410,11 +425,11 @@ module C02_FibMemo
   clone C02_LemmaFibBound as LemmaFibBound0 with function Fib0.fib = Fib0.fib, axiom .
   clone C02_LemmaMaxInt as LemmaMaxInt0 with axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.core_option_option usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib))
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.core_option_option usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib))
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib),
   function Model0.model = Model0.model
   clone C02_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -224,13 +224,14 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module Core_Ops_Index_Index_Output
   type self   
@@ -282,6 +283,20 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) ix }
     
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
@@ -339,11 +354,11 @@ module C03FibUnbounded_FibMemo
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone C03FibUnbounded_Fib as Fib0 with axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.core_option_option int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib))
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.core_option_option int
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib))
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib),
   function Model0.model = Model0.model
   clone C03FibUnbounded_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -49,6 +49,15 @@ module C04_C
   function c (x : uint32) : bool = 
     x < (50 : uint32) && B0.b x
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -56,6 +65,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C04_F_Interface
   use mach.int.Int
@@ -71,7 +86,7 @@ module C04_F
   clone C04_A as A0
   clone C04_B as B0 with function A0.a = A0.a
   clone C04_C as C0 with function B0.b = B0.b
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg f [@cfg:stackify] (x : uint32) : ()
     requires {C0.c x}
     

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
@@ -101,6 +101,15 @@ module C07MutableCapture_TestFnmut_Closure2
   }
   
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
   type self   
   type args   
@@ -158,6 +167,12 @@ module Core_Ops_Function_FnMut_CallMut
     ensures { PostconditionMut0.postcondition_mut self args result }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C07MutableCapture_TestFnmut_Interface
   use mach.int.UInt32
   use mach.int.Int
@@ -171,11 +186,11 @@ module C07MutableCapture_TestFnmut
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
   clone C07MutableCapture_TestFnmut_Closure2_Interface as Closure20 with predicate Resolve0.resolve = Resolve2.resolve,
   axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg test_fnmut [@cfg:stackify] (x : uint32) : ()
     requires {UInt32.to_int x = 100000}
     

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -151,13 +151,14 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
@@ -367,6 +368,36 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -410,6 +441,16 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
@@ -468,13 +509,12 @@ module FilterPositive_M
   axiom .
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.creusotcontracts_std1_vec_vec int32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = int32
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec int32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = int32,
@@ -484,6 +524,8 @@ module FilterPositive_M
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = int32,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = int32, function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = int32, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve1.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = int32,
   function Model0.model = Model0.model
   let rec cfg m [@cfg:stackify] (t : Type.creusotcontracts_std1_vec_vec int32) : Type.creusotcontracts_std1_vec_vec int32

--- a/creusot/tests/should_succeed/heapsort_generic.stdout
+++ b/creusot/tests/should_succeed/heapsort_generic.stdout
@@ -511,6 +511,15 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -708,6 +717,12 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
@@ -834,11 +849,11 @@ module HeapsortGeneric_SiftDown
   clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Lt_Interface as Lt0 with type self = t, predicate LtLog0.lt_log = LtLog0.lt_log
@@ -1238,8 +1253,8 @@ module HeapsortGeneric_HeapSort
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -14,13 +14,14 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -32,6 +33,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -53,7 +68,7 @@ module IncMax_TakeMax
   use mach.int.UInt32
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -122,8 +137,8 @@ module IncMax_IncMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMax_TakeMax_Interface as TakeMax0
   let rec cfg inc_max [@cfg:stackify] (a : uint32) (b : uint32) : ()

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -30,13 +30,14 @@ module IncMax3_Swap
     ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -48,6 +49,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -70,10 +85,10 @@ module IncMax3_IncMax3
   use mach.int.UInt32
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = borrowed uint32
   clone IncMax3_Swap_Interface as Swap0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_3 [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
@@ -244,9 +259,9 @@ module IncMax3_TestIncMax3
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMax3_IncMax3_Interface as IncMax30
   let rec cfg test_inc_max_3 [@cfg:stackify] (a : uint32) (b : uint32) (c : uint32) : ()

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -14,13 +14,14 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -32,6 +33,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -53,7 +68,7 @@ module IncMaxMany_TakeMax
   use mach.int.UInt32
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -122,9 +137,9 @@ module IncMaxMany_IncMaxMany
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMaxMany_TakeMax_Interface as TakeMax0
   let rec cfg inc_max_many [@cfg:stackify] (a : uint32) (b : uint32) (k : uint32) : ()

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -14,13 +14,14 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -32,6 +33,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -53,7 +68,7 @@ module IncMaxRepeat_TakeMax
   use mach.int.UInt32
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -122,11 +137,11 @@ module IncMaxRepeat_IncMaxRepeat
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone IncMaxRepeat_TakeMax_Interface as TakeMax0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_repeat [@cfg:stackify] (a : uint32) (b : uint32) (n : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
     

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -81,6 +81,15 @@ module IncSome2List_Impl1_LemmaSumNonneg_Impl
       | Type.IncSome2List_List_Nil -> ()
       end
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -88,6 +97,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSome2List_Impl1_SumX_Interface
   use mach.int.Int
@@ -109,10 +124,10 @@ module IncSome2List_Impl1_SumX
   use Type
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.incsome2list_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.incsome2list_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsome2list_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsome2list_list
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -299,7 +314,7 @@ module IncSome2List_Impl1_TakeSomeRest
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.incsome2list_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsome2list_list
   let rec cfg take_some_rest [@cfg:stackify] (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -427,9 +442,9 @@ module IncSome2List_IncSome2List
   clone IncSome2List_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl3_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.incsome2list_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.incsome2list_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsome2list_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -86,6 +86,15 @@ module IncSome2Tree_Impl1_LemmaSumNonneg_Impl
       | Type.IncSome2Tree_Tree_Leaf -> ()
       end
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -93,6 +102,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSome2Tree_Impl1_SumX_Interface
   use mach.int.Int
@@ -115,11 +130,11 @@ module IncSome2Tree_Impl1_SumX
   clone IncSome2Tree_Impl1_Sum as Sum0
   clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.incsome2tree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsome2tree_tree
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -322,7 +337,7 @@ module IncSome2Tree_Impl1_TakeSomeRest
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.incsome2tree_tree
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsome2tree_tree
   let rec cfg take_some_rest [@cfg:stackify] (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -510,9 +525,9 @@ module IncSome2Tree_IncSome2Tree
   clone IncSome2Tree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl3_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.incsome2tree_tree
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsome2tree_tree
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -87,6 +87,15 @@ module IncSomeList_Impl1_LemmaSumNonneg_Impl
       | Type.IncSomeList_List_Nil -> ()
       end
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -94,6 +103,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSomeList_Impl1_SumX_Interface
   use mach.int.Int
@@ -115,10 +130,10 @@ module IncSomeList_Impl1_SumX
   use Type
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.incsomelist_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.incsomelist_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsomelist_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsomelist_list
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -292,7 +307,7 @@ module IncSomeList_Impl1_TakeSome
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsomelist_list
   clone IncSomeList_Random_Interface as Random0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsomelist_list
   let rec cfg take_some [@cfg:stackify] (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
@@ -415,10 +430,10 @@ module IncSomeList_IncSomeList
   clone IncSomeList_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl3_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.incsomelist_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsomelist_list
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -86,6 +86,15 @@ module IncSomeTree_Impl1_LemmaSumNonneg_Impl
       | Type.IncSomeTree_Tree_Leaf -> ()
       end
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -93,6 +102,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module IncSomeTree_Impl1_SumX_Interface
   use mach.int.Int
@@ -115,11 +130,11 @@ module IncSomeTree_Impl1_SumX
   clone IncSomeTree_Impl1_Sum as Sum0
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.incsometree_tree
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.incsometree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.incsometree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsometree_tree
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -321,7 +336,7 @@ module IncSomeTree_Impl1_TakeSome
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsometree_tree
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsometree_tree
   let rec cfg take_some [@cfg:stackify] (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
@@ -483,10 +498,10 @@ module IncSomeTree_IncSomeTree
   clone IncSomeTree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl3_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.incsometree_tree
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsometree_tree
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Int_Impl3_ModelTy as ModelTy0
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model

--- a/creusot/tests/should_succeed/inplace_list_reversal.stdout
+++ b/creusot/tests/should_succeed/inplace_list_reversal.stdout
@@ -124,6 +124,15 @@ module CreusotContracts_Std1_Mem_Replace
     ensures {  ^ dest = src }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
   use prelude.Prelude
@@ -134,6 +143,12 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -162,7 +177,7 @@ module InplaceListReversal_Rev
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = (t, Type.inplacelistreversal_list t)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.inplacelistreversal_list t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.inplacelistreversal_list t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Std1_Mem_Replace_Interface as Replace0 with type t = Type.inplacelistreversal_list t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (Type.inplacelistreversal_list t)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.inplacelistreversal_list t

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -67,6 +67,15 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -82,6 +91,12 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module InvariantMoves_TestInvariantMove_Interface
   use Type
   use mach.int.Int
@@ -94,10 +109,10 @@ module InvariantMoves_TestInvariantMove
   use mach.int.UInt32
   use prelude.Prelude
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.core_option_option uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.core_option_option uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
   clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
   let rec cfg test_invariant_move [@cfg:stackify] (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : () = 

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -289,13 +289,14 @@ module IterMut_Impl2
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_itermut t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
   type t   
@@ -325,6 +326,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -358,16 +373,16 @@ module IterMut_IncVec
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.itermut_vec int,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.itermut_vec int)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.core_option_option (borrowed int)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.itermut_itermut int
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.core_option_option (borrowed int)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = int
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.itermut_itermut int
   clone CreusotContracts_Logic_Seq_Impl1_Get as Get0 with type t = borrowed int
   clone CreusotContracts_Logic_Seq_Impl1_Tail as Tail0 with type t = borrowed int
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.itermut_vec int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.itermut_vec int))
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.itermut_vec int)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.itermut_vec int))
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = borrowed (Type.itermut_vec int)
   clone IterMut_Impl3_Next_Interface as Next0 with type t = int, function Model0.model = Model3.model,
   function Tail0.tail = Tail0.tail, function Get0.get = Get0.get
   clone IterMut_Impl1_IterMut_Interface as IterMut0 with type t = int, function Model0.model = Model1.model,

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -37,6 +37,15 @@ module Knapsack_MaxLog
   function max_log (a : int) (b : int) : int = 
     if a < b then b else a
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -44,6 +53,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module Knapsack_Max_Interface
   use mach.int.UInt64
@@ -60,7 +75,7 @@ module Knapsack_Max
   use mach.int.Int
   use prelude.Prelude
   clone Knapsack_MaxLog as MaxLog0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg max [@cfg:stackify] (a : usize) (b : usize) : usize
     requires {true}
     ensures { UInt64.to_int result = MaxLog0.max_log (UInt64.to_int a) (UInt64.to_int b) }
@@ -480,6 +495,22 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -523,6 +554,16 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
@@ -577,8 +618,6 @@ module Knapsack_Knapsack01Dyn
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.knapsack_item name
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve9 with type self = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve8 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy3 with type t = Type.knapsack_item name
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model8 with type t = Type.knapsack_item name
@@ -588,16 +627,20 @@ module Knapsack_Knapsack01Dyn
   function Model0.model = Model8.model, function Model1.model = Model9.model
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.knapsack_item name,
   function Model0.model = Model8.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.knapsack_item name
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve8 with type t = Type.knapsack_item name,
+  function Model0.model = Model8.model, predicate Resolve0.resolve = Resolve1.resolve
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone Knapsack_Max_Interface as Max0 with function MaxLog0.max_log = MaxLog0.max_log
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve10 with type t = usize, function Model0.model = Model2.model,
+  predicate Resolve0.resolve = Resolve0.resolve
   clone CreusotContracts_Logic_Model_Impl1_Model as Model7 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -616,6 +659,8 @@ module Knapsack_Knapsack01Dyn
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model4.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve9 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve10.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.knapsack_item name,

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -37,6 +37,15 @@ module KnapsackFull_MaxLog
   function max_log (a : int) (b : int) : int = 
     if a < b then b else a
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -44,6 +53,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module KnapsackFull_Max_Interface
   use mach.int.UInt64
@@ -59,7 +74,7 @@ module KnapsackFull_Max
   use mach.int.Int
   use prelude.Prelude
   clone KnapsackFull_MaxLog as MaxLog0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg max [@cfg:stackify] (a : usize) (b : usize) : usize
     ensures { UInt64.to_int result = MaxLog0.max_log (UInt64.to_int a) (UInt64.to_int b) }
     
@@ -620,6 +635,22 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -663,6 +694,16 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
@@ -730,26 +771,28 @@ module KnapsackFull_Knapsack01Dyn
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.knapsackfull_item name
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model4.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve9 with type self = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve8 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy3 with type t = Type.knapsackfull_item name
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.knapsackfull_item name
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model9 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name),
   type ModelTy0.modelTy = ModelTy3.modelTy, function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = Type.knapsackfull_item name,
   function Model0.model = Model3.model, function Model1.model = Model9.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve8 with type t = Type.knapsackfull_item name,
+  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve1.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.knapsackfull_item name,
   function Model0.model = Model3.model
   clone KnapsackFull_Max_Interface as Max0 with function MaxLog0.max_log = MaxLog0.max_log
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve10 with type t = usize, function Model0.model = Model2.model,
+  predicate Resolve0.resolve = Resolve0.resolve
   clone CreusotContracts_Logic_Model_Impl1_Model as Model8 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -768,6 +811,8 @@ module KnapsackFull_Knapsack01Dyn
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model5.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve9 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve10.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.knapsackfull_item name,

--- a/creusot/tests/should_succeed/list_index_mut.rs
+++ b/creusot/tests/should_succeed/list_index_mut.rs
@@ -1,4 +1,5 @@
 // SHOULD_SUCCEED: parse-print
+#![feature(min_specialization)]
 extern crate creusot_contracts;
 
 use creusot_contracts::*;

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -72,13 +72,14 @@ module ListIndexMut_Get
       Type.ListIndexMut_Option_Some i
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -91,11 +92,25 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module ListIndexMut_IndexMut_Interface
@@ -126,9 +141,9 @@ module ListIndexMut_IndexMut
   clone ListIndexMut_Len as Len0
   use mach.int.Int64
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.listindexmut_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg index_mut [@cfg:stackify] (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
@@ -260,8 +275,8 @@ module ListIndexMut_Write
   clone ListIndexMut_Len as Len0
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.listindexmut_list
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write [@cfg:stackify] (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {UInt64.to_int ix < Len0.len ( * l)}

--- a/creusot/tests/should_succeed/mapping_test.stdout
+++ b/creusot/tests/should_succeed/mapping_test.stdout
@@ -73,13 +73,14 @@ module MappingTest_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.mappingtest_t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -135,6 +136,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
@@ -164,9 +179,9 @@ module MappingTest_Incr
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model1 with type t = Type.mappingtest_t
   clone MappingTest_Impl0_Model as Model0 with axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.creusotcontracts_logic_ghost_ghost (Type.mappingtest_t)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.creusotcontracts_logic_ghost_ghost (Type.mappingtest_t)
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = Type.mappingtest_t,
   function Model0.model = Model1.model
   let rec cfg incr [@cfg:stackify] (t : borrowed (Type.mappingtest_t)) : ()
@@ -212,8 +227,8 @@ module MappingTest_Main
   use Type
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.mappingtest_t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   clone MappingTest_Incr_Interface as Incr0 with function Model0.model = Model0.model
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -29,6 +29,15 @@ module Mc91_Main
   }
   
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -36,6 +45,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module Mc91_Mc91_Interface
   use mach.int.Int
@@ -47,7 +62,7 @@ end
 module Mc91_Mc91
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg mc91 [@cfg:stackify] (x : uint32) : uint32
     ensures { x <= (100 : uint32) -> result = (91 : uint32) && x > (100 : uint32) -> result = x - (10 : uint32) }
     

--- a/creusot/tests/should_succeed/modules.rs
+++ b/creusot/tests/should_succeed/modules.rs
@@ -1,3 +1,4 @@
+#![feature(min_specialization)]
 extern crate creusot_contracts;
 
 pub mod nested {

--- a/creusot/tests/should_succeed/mutex.stdout
+++ b/creusot/tests/should_succeed/mutex.stdout
@@ -122,13 +122,14 @@ module Mutex_FakeFnOnce_Call
     ensures { Postcondition0.postcondition self result }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t   
@@ -204,6 +205,20 @@ module Mutex_Impl1_Set
     requires {Inv0.inv (Model0.model (Type.mutex_mutexguard_MutexGuard_1 ( * self))) v}
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
   type modelTy   
@@ -264,9 +279,9 @@ module Mutex_Impl3_Call
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.mutex_mutexguard uint32 (Type.mutex_even)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.mutex_mutexguard uint32 (Type.mutex_even)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone Mutex_Impl2_Inv as Inv0
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = Type.mutex_even
   clone Mutex_Impl1_Set_Interface as Set0 with type t = uint32, type i = Type.mutex_even,
@@ -275,7 +290,7 @@ module Mutex_Impl3_Call
   function Model0.model = Model0.model, predicate Inv0.inv = Inv0.inv
   clone Mutex_Impl0_Lock_Interface as Lock0 with type t = uint32, type i = Type.mutex_even,
   function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.mutex_addstwo
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.mutex_addstwo
   let rec cfg call [@cfg:stackify] (self : Type.mutex_addstwo) : () = 
   var _0 : ();
   var self_1 : Type.mutex_addstwo;
@@ -526,13 +541,13 @@ module Mutex_Concurrent
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = Type.mutex_spawnpostcond (Type.mutex_addstwo)
   clone Mutex_Impl4_Join_Interface as Join0 with type t = (), type i = Type.mutex_spawnpostcond (Type.mutex_addstwo),
   function Model0.model = Model0.model, predicate Inv0.inv = Inv1.inv
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.mutex_joinhandle () (Type.mutex_spawnpostcond (Type.mutex_addstwo))
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.mutex_mutex uint32 (Type.mutex_even)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.mutex_joinhandle () (Type.mutex_spawnpostcond (Type.mutex_addstwo))
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Impl3_Precondition as Precondition0
   clone Mutex_Spawn_Interface as Spawn0 with type t = (), type f = Type.mutex_addstwo,
   predicate Precondition0.precondition = Precondition0.precondition
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.mutex_addstwo
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.mutex_mutex uint32 (Type.mutex_even)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.mutex_addstwo
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Leak_Interface as Leak0 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Impl2_Inv as Inv0

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -502,6 +502,21 @@ module OrdTrait_GtOrLe
   }
   
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module OrdTrait_GtOrLeInt_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -514,7 +529,7 @@ module OrdTrait_GtOrLeInt
   use mach.int.UInt64
   use mach.int.Int
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg gt_or_le_int [@cfg:stackify] (x : usize) (y : usize) : bool
     ensures { result = (UInt64.to_int x <= UInt64.to_int y) }
     

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -14,13 +14,14 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -32,6 +33,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -51,7 +66,7 @@ module ProjectionToggle_ProjToggle
   type t   
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg proj_toggle [@cfg:stackify] (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { if toggle then result = a &&  ^ b =  * b else result = b &&  ^ a =  * a }
     
@@ -114,10 +129,10 @@ module ProjectionToggle_Main
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = int32
   clone ProjectionToggle_ProjToggle_Interface as ProjToggle0 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var a_1 : int32;

--- a/creusot/tests/should_succeed/selection_sort_generic.stdout
+++ b/creusot/tests/should_succeed/selection_sort_generic.stdout
@@ -450,6 +450,15 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -675,6 +684,12 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -793,9 +808,9 @@ module SelectionSortGeneric_SelectionSort
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Lt_Interface as Lt0 with type self = t, predicate LtLog0.lt_log = LtLog0.lt_log

--- a/creusot/tests/should_succeed/slices/01.stdout
+++ b/creusot/tests/should_succeed/slices/01.stdout
@@ -87,6 +87,21 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
   type t   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
@@ -144,7 +159,7 @@ module C01_SliceFirst
   use mach.int.UInt64
   clone CreusotContracts_Logic_Model_Impl2_Model as Model1 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = seq t
   clone CreusotContracts_Logic_Model_Impl2_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = seq t,

--- a/creusot/tests/should_succeed/sparse_array.stdout
+++ b/creusot/tests/should_succeed/sparse_array.stdout
@@ -119,13 +119,14 @@ module CreusotContracts_Logic_Int_Impl5
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = int32, type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t   
@@ -247,6 +248,14 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
 module CreusotContracts_Std1_Vec_FromElem_Interface
   type t   
   use mach.int.Int
@@ -274,6 +283,12 @@ module CreusotContracts_Std1_Vec_FromElem
     ensures { forall i : (int) . 0 <= i && i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module SparseArray_Create_Interface
   type t   
@@ -311,7 +326,7 @@ module SparseArray_Create
   clone SparseArray_Impl1_SparseInv as SparseInv0 with type t = t, function Model0.model = Model2.model,
   function Model1.model = Model1.model, function Model2.model = Model3.model
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = usize,
   function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = t, function Model0.model = Model1.model
@@ -495,10 +510,10 @@ module SparseArray_Impl1_Get
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.sparsearray_sparse t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model4 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = usize,
@@ -841,13 +856,13 @@ module SparseArray_Impl1_Set
   predicate SparseInv0.sparse_inv = SparseInv0.sparse_inv, predicate IsElt0.is_elt = IsElt0.is_elt, axiom .
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve7 with type t = Type.sparsearray_sparse t
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model6 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model3.model
@@ -1051,9 +1066,9 @@ module SparseArray_Main
   use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model5 with type t = usize
   clone SparseArray_Impl1_IsElt as IsElt0 with type t = int32, function Model0.model = Model5.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.sparsearray_sparse int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.core_option_option int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.sparsearray_sparse int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.core_option_option int32
   clone SparseArray_Impl0_ModelTy as ModelTy1 with type t = int32
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = int32
   clone SparseArray_Impl0_Model as Model2 with type t = int32, predicate IsElt0.is_elt = IsElt0.is_elt,
@@ -1070,7 +1085,7 @@ module SparseArray_Main
   clone SparseArray_Create_Interface as Create0 with type t = int32, function Model0.model = Model2.model,
   predicate SparseInv0.sparse_inv = SparseInv0.sparse_inv, predicate IsElt0.is_elt = IsElt0.is_elt,
   function Model1.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var default_1 : int32;

--- a/creusot/tests/should_succeed/specification/division.stdout
+++ b/creusot/tests/should_succeed/specification/division.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -21,6 +30,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module Division_Divide_Interface
   use mach.int.Int
@@ -32,7 +47,7 @@ end
 module Division_Divide
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg divide [@cfg:stackify] (y : uint32) (x : uint32) : uint32
     requires {x <> (0 : uint32)}
     

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -29,6 +29,15 @@ module Sum_Main
   }
   
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -36,6 +45,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module Sum_SumFirstN_Interface
   use mach.int.Int
@@ -47,8 +62,8 @@ end
 module Sum_SumFirstN
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg sum_first_n [@cfg:stackify] (n : uint32) : uint32
     ensures { result = div (n * (n + (1 : uint32))) (2 : uint32) }
     

--- a/creusot/tests/should_succeed/sum_of_odds.stdout
+++ b/creusot/tests/should_succeed/sum_of_odds.stdout
@@ -82,6 +82,15 @@ module SumOfOdds_SumOfOddIsSqr_Impl
    = 
     if x > 0 then sum_of_odd_is_sqr (x - 1) else ()
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -89,6 +98,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module SumOfOdds_ComputeSumOfOdd_Interface
   use mach.int.UInt32
@@ -108,8 +123,8 @@ module SumOfOdds_ComputeSumOfOdd
   clone SumOfOdds_SumOfOdd as SumOfOdd0 with axiom .
   clone SumOfOdds_SumOfOddIsSqr as SumOfOddIsSqr0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd,
   function Sqr0.sqr = Sqr0.sqr, axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg compute_sum_of_odd [@cfg:stackify] (x : uint32) : uint32
     requires {UInt32.to_int x < 65536}
     ensures { UInt32.to_int result = SumOfOdd0.sum_of_odd (UInt32.to_int x) }
@@ -197,7 +212,7 @@ module SumOfOdds_Test
   clone SumOfOdds_SumOfOdd as SumOfOdd0 with axiom .
   clone SumOfOdds_SumOfOddIsSqr as SumOfOddIsSqr0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd,
   function Sqr0.sqr = Sqr0.sqr, axiom .
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone SumOfOdds_ComputeSumOfOdd_Interface as ComputeSumOfOdd0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd
   let rec cfg test [@cfg:stackify] (x : uint32) : ()
     requires {UInt32.to_int x < 65536}

--- a/creusot/tests/should_succeed/syntax/02_operators.stdout
+++ b/creusot/tests/should_succeed/syntax/02_operators.stdout
@@ -22,6 +22,15 @@ module Type
     
   axiom c02operators_x_X_a_acc : forall a : usize . c02operators_x_X_a (C02Operators_X a : c02operators_x) = a
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -29,6 +38,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C02Operators_Division_Interface
   use mach.int.Int
@@ -40,7 +55,7 @@ module C02Operators_Division
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg division [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -80,7 +95,7 @@ module C02Operators_Modulus
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg modulus [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -120,7 +135,7 @@ module C02Operators_Multiply
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg multiply [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -154,7 +169,7 @@ module C02Operators_Add
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg add [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -188,7 +203,7 @@ module C02Operators_Sub
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg sub [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -222,7 +237,7 @@ module C02Operators_Expression
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg expression [@cfg:stackify] (x : usize) (y : usize) (z : usize) : bool = 
   var _0 : bool;
   var x_1 : usize;
@@ -353,7 +368,7 @@ module C02Operators_PrimitiveComparison
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.c02operators_x
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c02operators_x
   let rec cfg primitive_comparison [@cfg:stackify] (x : Type.c02operators_x) : ()
     ensures { Type.c02operators_x_X_a x <= Type.c02operators_x_X_a x }
     
@@ -378,7 +393,7 @@ module C02Operators_BoolEq_Interface
 end
 module C02Operators_BoolEq
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg bool_eq [@cfg:stackify] (a : bool) (b : bool) : bool
     ensures { result = (a = b) }
     
@@ -411,7 +426,7 @@ module C02Operators_OldTest_Interface
     
 end
 module C02Operators_OldTest
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg old_test [@cfg:stackify] (x : bool) : ()
     ensures { old(x) = x }
     

--- a/creusot/tests/should_succeed/syntax/03_unbounded.stdout
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -21,6 +30,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C03Unbounded_NoBoundsCheck_Interface
   use mach.int.Int
@@ -30,7 +45,7 @@ module C03Unbounded_NoBoundsCheck_Interface
 end
 module C03Unbounded_NoBoundsCheck
   use mach.int.Int
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int
   let rec cfg no_bounds_check [@cfg:stackify] (x : int) (y : int) : int
     ensures { result = (4294967294 : int) }
     

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
@@ -22,6 +22,44 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
+  type t1   
+  type t2   
+  predicate resolve (self : (t1, t2))
+end
+module CreusotContracts_Logic_Resolve_Impl0_Resolve
+  type t1   
+  type t2   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
+  predicate resolve (self : (t1, t2)) = 
+    Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
+end
+module CreusotContracts_Logic_Resolve_Impl0
+  type t1   
+  type t2   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,
+  predicate Resolve0.resolve = Resolve2.resolve, predicate Resolve1.resolve = Resolve3.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = (t1, t2),
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C04AssocPrec_RespectPrec_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -36,7 +74,9 @@ module C04AssocPrec_RespectPrec
   use mach.int.Int
   use mach.int.UInt32
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = (uint32, uint32)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = uint32, type t2 = uint32,
+  predicate Resolve0.resolve = Resolve1.resolve, predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg respect_prec [@cfg:stackify] (x : (uint32, uint32)) : ()
     ensures { (let (a, _) = x in a) = (let (_, a) = x in a) }
     ensures { div (5 * 3) 2 <> 4 * (40 + 1) }

--- a/creusot/tests/should_succeed/syntax/05_annotations.stdout
+++ b/creusot/tests/should_succeed/syntax/05_annotations.stdout
@@ -14,6 +14,15 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -22,6 +31,12 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C05Annotations_Assertion_Interface
   type t   
   val assertion [@cfg:stackify] (x : t) : ()
@@ -29,7 +44,7 @@ end
 module C05Annotations_Assertion
   type t   
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg assertion [@cfg:stackify] (x : t) : () = 
   var _0 : ();
   var x_1 : t;

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
@@ -43,6 +43,15 @@ module Alloc_Vec_Impl0_New
     requires {true = true}
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -51,12 +60,18 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C07ExternSpec_Main_Interface
   val main [@cfg:stackify] () : ()
 end
 module C07ExternSpec_Main
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.alloc_vec_vec bool (Type.alloc_alloc_global)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.alloc_vec_vec bool (Type.alloc_alloc_global)
   clone Alloc_Vec_Impl0_New_Interface as New0 with type t = bool
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -50,6 +50,15 @@ module C03_A_F
   use prelude.Prelude
   val f [@cfg:stackify] (self : self) : self
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -57,6 +66,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C03_Impl0_F_Interface
   use prelude.Prelude
@@ -68,7 +83,7 @@ module C03_Impl0_F
   use prelude.Prelude
   use mach.int.Int
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg f [@cfg:stackify] (self : int32) : int32 = 
   var _0 : int32;
   var self_1 : int32;
@@ -93,7 +108,7 @@ module C03_Impl1_G
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg g [@cfg:stackify] (self : uint32) : uint32 = 
   var _0 : uint32;
   var self_1 : uint32;

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -44,6 +44,15 @@ module C04_A_Func3
   use prelude.Prelude
   val func3 [@cfg:stackify] (self : self) (o : self) : bool
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -51,6 +60,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C04_User_Interface
   type t   
@@ -64,7 +79,7 @@ module C04_User
   use prelude.Prelude
   clone C04_A_Func3_Interface as Func30 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   clone C04_A_Func2_Interface as Func20 with type self = t
   clone C04_A_Func1_Interface as Func10 with type self = t
   let rec cfg user [@cfg:stackify] (a : t) (b : t) : bool

--- a/creusot/tests/should_succeed/traits/10.rs
+++ b/creusot/tests/should_succeed/traits/10.rs
@@ -1,10 +1,11 @@
+#![feature(min_specialization)]
 extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
 struct Pair<T, U>(T, U);
 
-unsafe impl<T1: Resolve, T2: Resolve> Resolve for Pair<T1, T2> {
+unsafe impl<T1, T2> Resolve for Pair<T1, T2> {
     #[predicate]
     fn resolve(self) -> bool {
         Resolve::resolve(self.0) && Resolve::resolve(self.1)

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -58,6 +58,21 @@ module C12DefaultMethod_T_LogicDefault
   function logic_default (self : self) : bool = 
     true
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C12DefaultMethod_ShouldUseImpl_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -72,7 +87,7 @@ module C12DefaultMethod_ShouldUseImpl
   clone C12DefaultMethod_T_LogicDefault as LogicDefault0 with type self = uint32
   use prelude.Prelude
   clone C12DefaultMethod_T_Default_Interface as Default0 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg should_use_impl [@cfg:stackify] (x : uint32) : ()
     ensures { LogicDefault0.logic_default x }
     

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -36,6 +36,15 @@ module C15ImplInterfaces_Impl0
   clone C15ImplInterfaces_Impl0_A as A0
   clone C15ImplInterfaces_Tr_A as A1 with type self = (), type a = A0.a
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -43,6 +52,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C15ImplInterfaces_Calls_Interface
   clone C15ImplInterfaces_Impl0_A as A0
@@ -54,7 +69,7 @@ end
 module C15ImplInterfaces_Calls
   clone C15ImplInterfaces_Impl0_A as A0
   clone C15ImplInterfaces_X as X0 with type t = (), type A0.a = A0.a
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg calls [@cfg:stackify] (a : ()) : ()
     requires {X0.x a = ()}
     

--- a/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
+++ b/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
@@ -34,6 +34,15 @@ module C17ImplRefinement_Tr_MyFunction
     ensures { UInt64.to_int result >= 10 }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -41,6 +50,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module C17ImplRefinement_Impl0_MyFunction_Interface
   use mach.int.UInt64
@@ -57,7 +72,7 @@ module C17ImplRefinement_Impl0_MyFunction
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg my_function [@cfg:stackify] (self : ()) : usize
     requires {true}
     ensures { UInt64.to_int result >= 15 }

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -29,6 +29,15 @@ module UnusedInLoop_Main
   }
   
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self   
   predicate resolve (self : self)
@@ -36,6 +45,12 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module UnusedInLoop_UnusedInLoop_Interface
   use mach.int.Int
@@ -47,9 +62,9 @@ end
 module UnusedInLoop_UnusedInLoop
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg unused_in_loop [@cfg:stackify] (b : bool) : uint32
     ensures { result = (10 : uint32) }
     

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -100,13 +100,14 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
   type t   
@@ -258,6 +259,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -347,12 +362,12 @@ module C01_AllZero
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = uint32
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32))
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32))
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = uint32,

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -435,6 +435,15 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -660,6 +669,12 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -772,10 +787,10 @@ module C02Gnome_GnomeSort
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = bool
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, predicate LeLog0.le_log = LeLog0.le_log

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -175,6 +175,15 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t   
   use prelude.Prelude
@@ -265,6 +274,12 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
   use prelude.Prelude
@@ -316,9 +331,9 @@ module C03KnuthShuffle_KnuthShuffle
   use mach.int.Int
   use mach.int.UInt64
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
   clone C03KnuthShuffle_RandInRange_Interface as RandInRange0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -150,13 +150,14 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module Core_Ops_Index_Index_Output
   type self   
@@ -210,6 +211,20 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
@@ -266,11 +281,11 @@ module C04BinarySearch_BinarySearch
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = uint32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.creusotcontracts_std1_vec_vec uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.creusotcontracts_std1_vec_vec uint32
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = uint32,
   function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = uint32, function Model0.model = Model0.model

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -406,6 +406,15 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module Core_Ops_Index_Index_Output
   type self   
   type idx   
@@ -541,6 +550,12 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     ensures { result = LtLog0.lt_log self o }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -638,10 +653,10 @@ module C05BinarySearchGeneric_BinarySearch
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   use prelude.Int8
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.core_cmp_ordering
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.core_cmp_ordering
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Std1_Ord_Ord_Cmp_Interface as Cmp0 with type self = t,

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -51,13 +51,14 @@ module Type
     
   axiom c06knightstour_board_Board_field_acc : forall a : usize, b : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize) . c06knightstour_board_Board_field (C06KnightsTour_Board a b : c06knightstour_board) = b
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self   
@@ -175,6 +176,20 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -252,10 +267,10 @@ module C06KnightsTour_Min
   use mach.int.UInt64
   use mach.int.Int64
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.core_option_option (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.core_option_option (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (usize, Type.c06knightstour_point)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -263,7 +278,7 @@ module C06KnightsTour_Min
   function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (usize, Type.c06knightstour_point),
   function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg min [@cfg:stackify] (v : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)) : Type.core_option_option (usize, Type.c06knightstour_point)
     
    = 
@@ -429,8 +444,8 @@ end
 module C06KnightsTour_Impl3_Clone
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c06knightstour_point
   let rec cfg clone' [@cfg:stackify] (self : Type.c06knightstour_point) : Type.c06knightstour_point = 
   var _0 : Type.c06knightstour_point;
   var self_1 : Type.c06knightstour_point;
@@ -467,9 +482,9 @@ module C06KnightsTour_Impl0_Mov
   use mach.int.Int64
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = (isize, isize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = isize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = isize
   let rec cfg mov [@cfg:stackify] (self : Type.c06knightstour_point) (p : (isize, isize)) : Type.c06knightstour_point
     requires {- 10000 <= Int64.to_int (let (_, a) = p in a) && Int64.to_int (let (_, a) = p in a) <= 10000}
     requires {- 10000 <= Int64.to_int (let (a, _) = p in a) && Int64.to_int (let (a, _) = p in a) <= 10000}
@@ -622,6 +637,32 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
+module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
+  type t   
+  use Type
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
+end
+module CreusotContracts_Std1_Vec_Impl5_Resolve
+  type t   
+  use Type
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
+    forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+end
+module CreusotContracts_Std1_Vec_Impl5
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = t, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
   type t   
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
@@ -664,16 +705,19 @@ module C06KnightsTour_Impl1_New
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve3 with type t = usize, function Model0.model = Model1.model,
+  predicate Resolve0.resolve = Resolve0.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model0.model, function Model1.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model0.model, predicate Resolve0.resolve = Resolve3.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model0.model
   let rec cfg new [@cfg:stackify] (size : usize) : Type.c06knightstour_board
@@ -806,15 +850,15 @@ module C06KnightsTour_Impl1_Available
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = isize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = isize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = usize,
@@ -995,6 +1039,29 @@ module C06KnightsTour_Moves
     ensures { Seq.length (Model0.model result) = 8 }
     
 end
+module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
+  type t1   
+  type t2   
+  predicate resolve (self : (t1, t2))
+end
+module CreusotContracts_Logic_Resolve_Impl0_Resolve
+  type t1   
+  type t2   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
+  predicate resolve (self : (t1, t2)) = 
+    Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
+end
+module CreusotContracts_Logic_Resolve_Impl0
+  type t1   
+  type t2   
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,
+  predicate Resolve0.resolve = Resolve2.resolve, predicate Resolve1.resolve = Resolve3.resolve
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = (t1, t2),
+  predicate resolve = Resolve0.resolve
+end
 module C06KnightsTour_Impl1_CountDegree_Interface
   use prelude.Prelude
   use Type
@@ -1017,12 +1084,14 @@ module C06KnightsTour_Impl1_CountDegree
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   clone C06KnightsTour_Impl1_InBounds as InBounds0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = isize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve6 with type t1 = isize, type t2 = isize,
+  predicate Resolve0.resolve = Resolve7.resolve, predicate Resolve1.resolve = Resolve7.resolve
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.c06knightstour_point
   clone C06KnightsTour_Impl0_Mov_Interface as Mov0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = (isize, isize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_std1_vec_vec (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (isize, isize)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
@@ -1031,8 +1100,10 @@ module C06KnightsTour_Impl1_CountDegree
   function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
   function Model0.model = Model3.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = (isize, isize),
+  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve6.resolve
   clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,
   predicate InBounds0.in_bounds = InBounds0.in_bounds
   let rec cfg count_degree [@cfg:stackify] (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : usize
@@ -1286,12 +1357,12 @@ module C06KnightsTour_Impl1_Set
   use mach.int.Int64
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.c06knightstour_point
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = isize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = isize
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -1433,15 +1504,16 @@ module C06KnightsTour_KnightsTour
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   clone C06KnightsTour_DumbNonlinearArith as DumbNonlinearArith0 with axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve8 with type self = Type.core_option_option (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve6 with type self = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve11 with type t = isize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve9 with type t1 = isize, type t2 = isize,
+  predicate Resolve0.resolve = Resolve11.resolve, predicate Resolve1.resolve = Resolve11.resolve
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve8 with type t = Type.core_option_option (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = Type.c06knightstour_board
   clone C06KnightsTour_Min_Interface as Min0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = (usize, Type.c06knightstour_point)
   clone C06KnightsTour_Impl0_Mov_Interface as Mov0
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = (isize, isize)
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.creusotcontracts_std1_vec_vec (isize, isize)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = (isize, isize)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model4 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
@@ -1450,6 +1522,8 @@ module C06KnightsTour_KnightsTour
   function Model0.model = Model4.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
   function Model0.model = Model4.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve3 with type t = (isize, isize),
+  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve9.resolve
   clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (usize, Type.c06knightstour_point)
   clone CreusotContracts_Logic_Model_Impl1_Model as Model5 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
@@ -1458,9 +1532,14 @@ module C06KnightsTour_KnightsTour
   function Model0.model = Model2.model, function Model1.model = Model5.model
   clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New1 with type t = (usize, Type.c06knightstour_point),
   function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve10 with type t1 = usize,
+  type t2 = Type.c06knightstour_point, predicate Resolve0.resolve = Resolve0.resolve,
+  predicate Resolve1.resolve = Resolve1.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve7 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve10.resolve
   clone C06KnightsTour_Impl1_CountDegree_Interface as CountDegree0 with predicate InBounds0.in_bounds = InBounds0.in_bounds,
   predicate Wf0.wf = Wf0.wf
   clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,

--- a/creusot/tests/should_succeed/vector/07_read_write.stdout
+++ b/creusot/tests/should_succeed/vector/07_read_write.stdout
@@ -99,6 +99,15 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self   
   predicate resolve (self : self)
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
 module Core_Ops_Index_Index_Output
   type self   
   type idx   
@@ -260,6 +269,12 @@ module CreusotContracts_Std1_Eq_Eq_Eq
     ensures { result = LogEq0.log_eq self o }
     
 end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t   
   type output  = 
@@ -403,7 +418,7 @@ module C07ReadWrite_ReadWrite
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = ()
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
   clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
   predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
@@ -417,7 +432,7 @@ module C07ReadWrite_ReadWrite
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -18,13 +18,14 @@ module Type
     | WhileLet_Option_None
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
-  predicate resolve (self : self)
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t   
@@ -36,6 +37,20 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t   
@@ -53,9 +68,9 @@ module WhileLet_Main
   use Type
   use prelude.Prelude
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.whilelet_option int32
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.whilelet_option int32
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.whilelet_option int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var a_1 : Type.whilelet_option int32;


### PR DESCRIPTION
Using a `default` instance on `Resolve` we can attain the expected behavior for it: every type can be resolved, with simple types only giving `true`. More complex types like mutable borrows can be given more specialized instances that reflect their improved information. 