### PR TITLE
Add push-pop example

### DIFF
--- a/creusot/tests/should_succeed/vector/08_push_pop.rs
+++ b/creusot/tests/should_succeed/vector/08_push_pop.rs
@@ -1,0 +1,22 @@
+// WHY3PROVE Z3
+extern crate creusot_contracts;
+
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+
+fn vec_push_pop<T>(v: &mut Vec<T>, e: T) {
+    let old_v = Ghost::record(&v);
+
+    v.push(e);
+    let r = v.pop();
+
+    match r {
+      Some(v) => (),
+      None => (),
+    };
+
+    proof_assert!(@v == @@old_v);
+    // Unprovable (automatically at least) without the previous line
+    proof_assert!(@v === @@old_v);
+}

--- a/creusot/tests/should_succeed/vector/08_push_pop.stdout
+++ b/creusot/tests/should_succeed/vector/08_push_pop.stdout
@@ -1,0 +1,371 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_logic_ghost_ghost 't = 
+    | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
+    
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
+    
+  function core_option_option_Some_0 (self : core_option_option 't) : 't
+  val core_option_option_Some_0 (self : core_option_option 't) : 't
+    ensures { result = core_option_option_Some_0 self }
+    
+  axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self   
+  type modelTy   
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model_Interface
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  function model (self : borrowed t) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1_Model
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  function model (self : borrowed t) : ModelTy0.modelTy = 
+    Model0.model ( * self)
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Ghost_Impl0_Model
+  type t   
+  use Type
+  function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
+end
+module CreusotContracts_Logic_Model_Impl1_ModelTy
+  type t   
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
+  type modelTy  = 
+    ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy,
+  function Model0.model = Model2.model
+  clone CreusotContracts_Logic_Model_Impl1_ModelTy as ModelTy0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = borrowed t, function model = Model0.model,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ghost_Impl0_ModelTy
+  type t   
+  type modelTy  = 
+    t
+end
+module CreusotContracts_Logic_Ghost_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_logic_ghost_ghost t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Std1_Vec_Impl0_ModelTy
+  type t   
+  use seq.Seq
+  type modelTy  = 
+    Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model_Interface
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0_Model
+  type t   
+  use Type
+  use seq.Seq
+  function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
+end
+module CreusotContracts_Std1_Vec_Impl0
+  type t   
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
+  type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record [@cfg:stackify] (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Logic_Ghost_Impl1_Record
+  type t   
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
+  val record [@cfg:stackify] (a : t) : Type.creusotcontracts_logic_ghost_ghost t
+    ensures { Model0.model result = a }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push_Interface
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Push
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t
+  val push [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) (v : t) : ()
+    ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Pop_Interface
+  type t   
+  use Type
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val pop [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) : Type.core_option_option t
+    ensures { match (result) with
+      | Type.Core_Option_Option_Some t -> Model0.model self = Seq.snoc (Model1.model ( ^ self)) t
+      | Type.Core_Option_Option_None -> Seq.length (Model0.model self) = Seq.length (Model1.model ( ^ self)) && Seq.length (Model0.model self) = 0
+      end }
+    
+end
+module CreusotContracts_Std1_Vec_Impl1_Pop
+  type t   
+  use Type
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use prelude.Prelude
+  clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model1 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model_Interface as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val pop [@cfg:stackify] (self : borrowed (Type.creusotcontracts_std1_vec_vec t)) : Type.core_option_option t
+    ensures { match (result) with
+      | Type.Core_Option_Option_Some t -> Model0.model self = Seq.snoc (Model1.model ( ^ self)) t
+      | Type.Core_Option_Option_None -> Seq.length (Model0.model self) = Seq.length (Model1.model ( ^ self)) && Seq.length (Model0.model self) = 0
+      end }
+    
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
+module C08PushPop_VecPushPop_Interface
+  type t   
+  use prelude.Prelude
+  use Type
+  val vec_push_pop [@cfg:stackify] (v : borrowed (Type.creusotcontracts_std1_vec_vec t)) (e : t) : ()
+end
+module C08PushPop_VecPushPop
+  type t   
+  use seq.Seq
+  use prelude.Prelude
+  use Type
+  clone CreusotContracts_Logic_Ghost_Impl0_Model as Model1 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = t
+  clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
+  clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
+  type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
+  use mach.int.Int
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.core_option_option t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
+  clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
+  function Model0.model = Model1.model
+  clone CreusotContracts_Std1_Vec_Impl1_Pop_Interface as Pop0 with type t = t, function Model0.model = Model0.model,
+  function Model1.model = Model2.model
+  clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = t, function Model0.model = Model2.model,
+  function Model1.model = Model0.model
+  let rec cfg vec_push_pop [@cfg:stackify] (v : borrowed (Type.creusotcontracts_std1_vec_vec t)) (e : t) : () = 
+  var _0 : ();
+  var v_1 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var e_2 : t;
+  var old_v_3 : Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t));
+  var _4 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _5 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _6 : ();
+  var _7 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _8 : t;
+  var r_9 : Type.core_option_option t;
+  var _10 : borrowed (Type.creusotcontracts_std1_vec_vec t);
+  var _11 : ();
+  var _12 : isize;
+  var v_13 : t;
+  var _14 : ();
+  var _15 : ();
+  {
+    v_1 <- v;
+    e_2 <- e;
+    goto BB0
+  }
+  BB0 {
+    _5 <- v_1;
+    _4 <- _5;
+    assume { Resolve0.resolve _5 };
+    old_v_3 <- Record0.record _4;
+    goto BB1
+  }
+  BB1 {
+    assume { Resolve1.resolve old_v_3 };
+    _7 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _7) };
+    assume { Resolve2.resolve _8 };
+    _8 <- e_2;
+    _6 <- Push0.push _7 _8;
+    goto BB2
+  }
+  BB2 {
+    _10 <- borrow_mut ( * v_1);
+    v_1 <- { v_1 with current = ( ^ _10) };
+    r_9 <- Pop0.pop _10;
+    goto BB3
+  }
+  BB3 {
+    assume { Resolve3.resolve v_1 };
+    switch (r_9)
+      | Type.Core_Option_Option_None -> goto BB4
+      | Type.Core_Option_Option_Some _ -> goto BB6
+      end
+  }
+  BB4 {
+    _11 <- ();
+    assume { Resolve5.resolve _11 };
+    goto BB8
+  }
+  BB5 {
+    assume { Resolve4.resolve r_9 };
+    absurd
+  }
+  BB6 {
+    assume { Resolve2.resolve v_13 };
+    v_13 <- Type.core_option_option_Some_0 r_9;
+    _11 <- ();
+    assume { Resolve5.resolve _11 };
+    goto BB7
+  }
+  BB7 {
+    assume { Resolve2.resolve v_13 };
+    goto BB8
+  }
+  BB8 {
+    assert { Seq.(==) (Model0.model v_1) (Model0.model (Model1.model old_v_3)) };
+    _14 <- ();
+    assume { Resolve5.resolve _14 };
+    assert { Model0.model v_1 = Model0.model (Model1.model old_v_3) };
+    _15 <- ();
+    assume { Resolve5.resolve _15 };
+    _0 <- ();
+    goto BB9
+  }
+  BB9 {
+    assume { Resolve4.resolve r_9 };
+    goto BB10
+  }
+  BB10 {
+    return _0
+  }
+  
+end


### PR DESCRIPTION
Currently the specification of `Vec::pop` is less than optimal: the encoding of `match` in the logic means that the code in the attached test is not automatically provable without a useless match. This is due to the lack of "triggers" for Why3 to break up the `match` in `pop`'s post-condition in client code. 

An alternative spec can be given in terms of a logical `unwrap` symbol, this effectively corresponds to changing the encoding of `match` in why3 to work in terms of 'accessors' rather than the current 'quantifier' approach. 

Specifically, the spec would be:

```rust
#[ensures((result === None) ==> self.resolve() && (@self).len() === 0)]
#[ensures(!(result === None) ==> (@self) === (@^self).push(unwrap(result)))]
```
Supposing:

```rust
#[logic]
#[requires(!(o === None))]
#[ensures(o === Some(result))]
#[trusted]
fn unwrap<T>(o: Option<T>) -> T {
    std::process::abort()
}
```

Alternatively, user code can provide a trigger by using the value returned by pop, like shown in the attached example, a dummy match suffices.

I'm opening this PR to provide a place to discuss the broader question of handling logical matches in post-conditions. `unwrap` may work well enough for `Result` and `None` but doesn't scale well with larger or custom data-types and this is a dumb thing to trip over.
