### PR TITLE
Emit a nice error when an associated type is used in a declaration

### DIFF
--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -122,7 +122,7 @@ impl Lower<'_, '_, 'tcx> {
                 let args = fields.into_iter().map(|f| self.lower_term(f)).collect();
 
                 let ctor = constructor_qname(self.ctx.tcx, &adt.variants[variant]);
-                crate::ty::translate_tydecl(self.ctx, rustc_span::DUMMY_SP, adt.did);
+                crate::ty::translate_tydecl(self.ctx, self.ctx.def_span(adt.did), adt.did);
                 Exp::Constructor { ctor, args }
             }
             TermKind::Cur { box term } => Exp::Current(box self.lower_term(term)),

--- a/creusot/tests/should_fail/assoc_type.rs
+++ b/creusot/tests/should_fail/assoc_type.rs
@@ -1,0 +1,9 @@
+trait Tr {
+    type A;
+}
+
+struct Assoc<T: Tr> {
+    item: T::A,
+}
+
+fn uses<T: Tr>(x: Assoc<T>) {}


### PR DESCRIPTION
Makes creusot error rather than why3
