### PR TITLE
Purity checker in specs

### DIFF
--- a/creusot-contracts/src/logic/mapping.rs
+++ b/creusot-contracts/src/logic/mapping.rs
@@ -36,11 +36,13 @@ impl<A, B> EqLogic for Mapping<A, B> {
         std::process::abort()
     }
 
+    #[trusted]
     #[predicate]
     fn log_ne(self, _: Self) -> bool {
         std::process::abort()
     }
 
+    #[trusted]
     #[logic]
     fn eq_ne(_: Self, _: Self) {
         std::process::abort()

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -77,6 +77,10 @@ pub fn translate(tcx: TyCtxt, opts: &Options) -> Result<(), Box<dyn Error>> {
         }
     }
 
+    if tcx.sess.has_errors() {
+        return Err(Box::new(CrErr));
+    }
+
     if ctx.should_export() {
         metadata::dump_exports(&ctx, &ctx.opts.metadata_path);
     }

--- a/creusot/tests/should_fail/impure_functions.rs
+++ b/creusot/tests/should_fail/impure_functions.rs
@@ -1,0 +1,8 @@
+extern crate creusot_contracts;
+use creusot_contracts::std::*;
+use creusot_contracts::*;
+
+#[logic]
+fn x<T>(v: &Vec<T>) -> Int {
+    pearlite! { @v.len() }
+}


### PR DESCRIPTION
Added a basic purity checker in specifications.

It currently allows some builtin functions of rust to pass through (index, add, from/into, etc) as they are needed to power key syntaxes. 
