### PR TITLE
'Maintains' macro

### DIFF
--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -56,3 +56,8 @@ pub fn trusted(_: TS1, tokens: TS1) -> TS1 {
 pub fn extern_spec(_: TS1) -> TS1 {
     TS1::new()
 }
+
+#[proc_macro_attribute]
+pub fn maintains(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -12,6 +12,7 @@ use syn::{
     *,
 };
 
+mod maintains;
 mod pretyping;
 
 trait FilterAttrs<'a> {
@@ -582,4 +583,14 @@ pub fn extern_spec(tokens: TS1) -> TS1 {
           #specs
         )*
     })
+}
+
+#[proc_macro_attribute]
+pub fn maintains(attr: TS1, body: TS1) -> TS1 {
+    let tokens = maintains::maintains_impl(attr, body);
+
+    match tokens {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }

--- a/creusot-contracts-proc/src/maintains.rs
+++ b/creusot-contracts-proc/src/maintains.rs
@@ -1,0 +1,111 @@
+// Implementation of the `maintains` macro.
+
+use pearlite_syn::*;
+use proc_macro::TokenStream as TS1;
+use proc_macro2::Span;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens, TokenStreamExt};
+use std::iter;
+use syn::{
+    parse::{Parse, Result},
+    punctuated::{Pair, Punctuated},
+    token::{Brace, Comma, Paren},
+    *,
+};
+
+type PearliteExpr = Term;
+
+struct Maintains {
+    receiver: Option<MaintainsArg>,
+    invariant: Path,
+    args: Punctuated<MaintainsArg, Comma>,
+}
+
+enum MaintainsArg {
+    Mut(PearliteExpr),
+    Immut(PearliteExpr),
+}
+
+impl Parse for MaintainsArg {
+    fn parse(input: parse::ParseStream) -> Result<Self> {
+        if input.peek(Token![mut]) {
+            let _: Token![mut] = input.parse()?;
+
+            return Ok(Self::Mut(input.parse()?));
+        } else {
+            return Ok(Self::Immut(input.parse()?));
+        }
+    }
+}
+
+impl Parse for Maintains {
+    fn parse(input: parse::ParseStream) -> Result<Self> {
+        let receiver = if input.peek(token::Paren) {
+            let content;
+            let _ = parenthesized!(content in input);
+            let _: Token![.] = input.parse()?;
+            Some(content.parse()?)
+        } else if input.peek2(Token![.]) {
+            let arg: TermPath = input.parse()?;
+            let _: Token![.] = input.parse()?;
+            Some(MaintainsArg::Immut(Term::Path(arg)))
+        } else {
+            None
+        };
+
+        let property: Path = input.parse()?;
+
+        let content;
+        let _ = parenthesized!(content in input);
+        let args = Punctuated::parse_terminated(&content)?;
+
+        Ok(Maintains { receiver, invariant: property, args })
+    }
+}
+
+fn maintains_tokens(mntn: &Maintains, pre: bool) -> TokenStream {
+    let mut args = Vec::new();
+    for a in &mntn.args {
+        match a {
+            MaintainsArg::Mut(a) => {
+                if pre {
+                    args.push(quote! { * (#a) })
+                } else {
+                    args.push(quote! { ^ (#a) })
+                }
+            }
+            MaintainsArg::Immut(a) => args.push(quote! { #a }),
+        }
+    }
+
+    let inv = &mntn.invariant;
+    if mntn.receiver.is_some() {
+        let recv = &mntn.receiver.as_ref().unwrap();
+        let recv = match recv {
+            MaintainsArg::Mut(a) if pre => quote! { * (#a) },
+            MaintainsArg::Mut(a) => quote! { ^ (#a) },
+            MaintainsArg::Immut(a) => quote! { #a },
+        };
+        quote! {
+          (#recv) . #inv (#(#args),*)
+        }
+    } else {
+        quote! {
+          #inv (#(#args),*)
+        }
+    }
+}
+
+pub fn maintains_impl(attr: TS1, body: TS1) -> Result<TS1> {
+    let maintains: Maintains = parse(attr)?;
+
+    let pre_toks = maintains_tokens(&maintains, true);
+    let post_toks = maintains_tokens(&maintains, false);
+    let body = TokenStream::from(body);
+    Ok(quote! {
+      #[requires(#pre_toks)]
+      #[ensures(#post_toks)]
+      #body
+    }
+    .into())
+}

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -51,6 +51,14 @@ mod macros {
     /// Allows specifications to be attached to functions coming from external crates
     /// TODO: Document syntax
     pub use creusot_contracts_proc::extern_spec;
+
+    /// Allows specifying both a pre- and post-condition in a single statement.
+    /// Expects an expression in either the form of a method or function call
+    /// Arguments to the call can be prefixed with `mut` to indicate that they are mutable borrows.
+    ///
+    /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
+    /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
+    pub use creusot_contracts_proc::maintains;
 }
 
 #[cfg(not(feature = "contracts"))]
@@ -94,11 +102,19 @@ mod macros {
     pub use creusot_contracts_dummy::variant;
 
     /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
-    pub use creusot_contracts_proc::pearlite;
+    pub use creusot_contracts_dummy::pearlite;
 
     /// Allows specifications to be attached to functions coming from external crates
     /// TODO: Document syntax
-    pub use creusot_contracts_proc::extern_spec;
+    pub use creusot_contracts_dummy::extern_spec;
+
+    /// Allows specifying both a pre- and post-condition in a single statement.
+    /// Expects an expression in either the form of a method or function call
+    /// Arguments to the call can be prefixed with `mut` to indicate that they are mutable borrows.
+    ///
+    /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
+    /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
+    pub use creusot_contracts_dummy::maintains;
 }
 
 pub use macros::*;

--- a/creusot/tests/should_succeed/syntax/09_maintains.rs
+++ b/creusot/tests/should_succeed/syntax/09_maintains.rs
@@ -1,0 +1,39 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+// Tests that we can use field access syntax in pearlite.
+
+struct A {}
+
+impl A {
+    #[predicate]
+    fn invariant(self, b: bool, c: u64) -> bool {
+        true
+    }
+
+    #[predicate]
+    fn inv2(self, b: Int) -> bool {
+        true
+    }
+}
+
+#[predicate]
+fn other_inv(a: A, b: bool) -> bool {
+    true
+}
+
+#[maintains(a.invariant(b, c))]
+fn test_1(a: A, b: bool, c: u64) {}
+
+#[maintains((mut a).invariant(b, c))]
+fn test_2(a: &mut A, b: bool, c: u64) {}
+
+#[maintains((mut a).invariant(mut b, c))]
+fn test_3(a: &mut A, b: &mut bool, c: u64) {}
+
+#[maintains(a.inv2(@b + 0))]
+fn test_5(a: A, b: usize) {}
+
+#[maintains(other_inv(a, b))]
+fn test_6(a: A, b: bool) {}

--- a/creusot/tests/should_succeed/syntax/09_maintains.stdout
+++ b/creusot/tests/should_succeed/syntax/09_maintains.stdout
@@ -1,0 +1,299 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type c09maintains_a  = 
+    | C09Maintains_A
+    
+end
+module C09Maintains_Impl0_Invariant_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  predicate invariant' (self : Type.c09maintains_a) (b : bool) (c : uint64)
+end
+module C09Maintains_Impl0_Invariant
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  predicate invariant' (self : Type.c09maintains_a) (b : bool) (c : uint64) = 
+    true
+end
+module C09Maintains_Impl0_Inv2_Interface
+  use Type
+  use mach.int.Int
+  predicate inv2 (self : Type.c09maintains_a) (b : int)
+end
+module C09Maintains_Impl0_Inv2
+  use Type
+  use mach.int.Int
+  predicate inv2 (self : Type.c09maintains_a) (b : int) = 
+    true
+end
+module C09Maintains_OtherInv_Interface
+  use Type
+  predicate other_inv (a : Type.c09maintains_a) (b : bool)
+end
+module C09Maintains_OtherInv
+  use Type
+  predicate other_inv (a : Type.c09maintains_a) (b : bool) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t   
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t   
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self   
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t   
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
+module C09Maintains_Test1_Interface
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant_Interface as Invariant0
+  val test_1 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) (c : uint64) : ()
+    requires {Invariant0.invariant' a b c}
+    ensures { Invariant0.invariant' a b c }
+    
+end
+module C09Maintains_Test1
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
+  let rec cfg test_1 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) (c : uint64) : ()
+    requires {Invariant0.invariant' a b c}
+    ensures { Invariant0.invariant' a b c }
+    
+   = 
+  var _0 : ();
+  var a_1 : Type.c09maintains_a;
+  var b_2 : bool;
+  var c_3 : uint64;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    c_3 <- c;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve2.resolve c_3 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Logic_Resolve_Impl1_Resolve
+  type t   
+  use prelude.Prelude
+  predicate resolve (self : borrowed t) = 
+     ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Impl1
+  type t   
+  use prelude.Prelude
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
+  predicate resolve = Resolve0.resolve
+end
+module C09Maintains_Test2_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant_Interface as Invariant0
+  val test_2 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : bool) (c : uint64) : ()
+    requires {Invariant0.invariant' ( * a) b c}
+    ensures { Invariant0.invariant' ( ^ a) b c }
+    
+end
+module C09Maintains_Test2
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.c09maintains_a
+  let rec cfg test_2 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : bool) (c : uint64) : ()
+    requires {Invariant0.invariant' ( * a) b c}
+    ensures { Invariant0.invariant' ( ^ a) b c }
+    
+   = 
+  var _0 : ();
+  var a_1 : borrowed (Type.c09maintains_a);
+  var b_2 : bool;
+  var c_3 : uint64;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    c_3 <- c;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve2.resolve c_3 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C09Maintains_Test3_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant_Interface as Invariant0
+  val test_3 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : borrowed bool) (c : uint64) : ()
+    requires {Invariant0.invariant' ( * a) ( * b) c}
+    ensures { Invariant0.invariant' ( ^ a) ( ^ b) c }
+    
+end
+module C09Maintains_Test3
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  clone C09Maintains_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.c09maintains_a
+  let rec cfg test_3 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : borrowed bool) (c : uint64) : ()
+    requires {Invariant0.invariant' ( * a) ( * b) c}
+    ensures { Invariant0.invariant' ( ^ a) ( ^ b) c }
+    
+   = 
+  var _0 : ();
+  var a_1 : borrowed (Type.c09maintains_a);
+  var b_2 : borrowed bool;
+  var c_3 : uint64;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    c_3 <- c;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    assume { Resolve2.resolve c_3 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C09Maintains_Test5_Interface
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  use prelude.Prelude
+  clone C09Maintains_Impl0_Inv2_Interface as Inv20
+  val test_5 [@cfg:stackify] (a : Type.c09maintains_a) (b : usize) : ()
+    requires {Inv20.inv2 a (UInt64.to_int b + 0)}
+    ensures { Inv20.inv2 a (UInt64.to_int b + 0) }
+    
+end
+module C09Maintains_Test5
+  use mach.int.UInt64
+  use mach.int.Int
+  use mach.int.Int32
+  use Type
+  use prelude.Prelude
+  clone C09Maintains_Impl0_Inv2 as Inv20
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
+  let rec cfg test_5 [@cfg:stackify] (a : Type.c09maintains_a) (b : usize) : ()
+    requires {Inv20.inv2 a (UInt64.to_int b + 0)}
+    ensures { Inv20.inv2 a (UInt64.to_int b + 0) }
+    
+   = 
+  var _0 : ();
+  var a_1 : Type.c09maintains_a;
+  var b_2 : usize;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C09Maintains_Test6_Interface
+  use Type
+  clone C09Maintains_OtherInv_Interface as OtherInv0
+  val test_6 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) : ()
+    requires {OtherInv0.other_inv a b}
+    ensures { OtherInv0.other_inv a b }
+    
+end
+module C09Maintains_Test6
+  use Type
+  clone C09Maintains_OtherInv as OtherInv0
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
+  let rec cfg test_6 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) : ()
+    requires {OtherInv0.other_inv a b}
+    ensures { OtherInv0.other_inv a b }
+    
+   = 
+  var _0 : ();
+  var a_1 : Type.c09maintains_a;
+  var b_2 : bool;
+  {
+    a_1 <- a;
+    b_2 <- b;
+    goto BB0
+  }
+  BB0 {
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve1.resolve b_2 };
+    _0 <- ();
+    return _0
+  }
+  
+end


### PR DESCRIPTION
Because we don't yet have type invariants, it is common to repeat a contract in the `requires` and `ensures` of a function. To remedy this, this PR adds `maintains` which allieviates this by generating both of these from a single expression. 

It takes a single method / function call in which function arguments can be annotated as `mut`.

In the generated `requires` all `mut` are replaced by `*` while in the `ensures` they are replaced by `^`. This limited expressivity both helps ensure the implementation is simple and yet captures the usecases which will be covered by type invariants.

cc @sarsko
