### PR TITLE
Support mutually recursive types

### DIFF
--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -675,10 +675,9 @@ fn generic_decls<'tcx, I: Iterator<Item = &'tcx GenericParamDef> + 'tcx>(
 ) -> impl Iterator<Item = Decl> + 'tcx {
     it.filter_map(|param| {
         if let GenericParamDefKind::Type { .. } = param.kind {
-            Some(Decl::TyDecl(TyDecl {
+            Some(Decl::TyDecl(TyDecl::Opaque {
                 ty_name: (&*param.name.as_str().to_lowercase()).into(),
                 ty_params: vec![],
-                kind: TyDeclKind::Opaque,
             }))
         } else {
             None

--- a/creusot/tests/should_fail/infinite_size.rs
+++ b/creusot/tests/should_fail/infinite_size.rs
@@ -1,0 +1,2 @@
+struct Node2(Tree2);
+struct Tree2(Node2);

--- a/creusot/tests/should_fail/mutual_rec_types.rs
+++ b/creusot/tests/should_fail/mutual_rec_types.rs
@@ -1,6 +1,0 @@
-struct T(Box<U>);
-struct U(Box<T>);
-
-fn test(t: T) {}
-
-fn main() {}

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -13,42 +13,42 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -58,7 +58,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -71,7 +71,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -84,22 +84,22 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -108,7 +108,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -121,7 +121,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -134,13 +134,13 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -149,7 +149,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -163,7 +163,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -177,13 +177,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -191,8 +191,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -200,7 +200,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -215,7 +215,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -230,8 +230,8 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -239,8 +239,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -248,7 +248,7 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -268,7 +268,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -288,31 +288,31 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -323,18 +323,18 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -351,7 +351,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -367,14 +367,14 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -384,13 +384,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -403,13 +403,13 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -80,42 +80,42 @@ module AllZero_Get
       end
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -52,13 +52,13 @@ module BinarySearch_Main
   
 end
 module BinarySearch_Impl0_LenLogic_Interface
-  type t   
+  type t
   use Type
   use mach.int.Int
   function len_logic (self : Type.binarysearch_list t) : int
 end
 module BinarySearch_Impl0_LenLogic
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -69,13 +69,13 @@ module BinarySearch_Impl0_LenLogic
       end
 end
 module BinarySearch_Impl0_Get_Interface
-  type t   
+  type t
   use Type
   use mach.int.Int
   function get (self : Type.binarysearch_list t) (ix : int) : Type.core_option_option t
 end
 module BinarySearch_Impl0_Get
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -86,30 +86,30 @@ module BinarySearch_Impl0_Get
       end
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module BinarySearch_Impl0_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use mach.int.Int
   use Type
@@ -122,7 +122,7 @@ module BinarySearch_Impl0_Index_Interface
     
 end
 module BinarySearch_Impl0_Index
-  type t   
+  type t
   use mach.int.UInt64
   use mach.int.Int
   use Type
@@ -223,7 +223,7 @@ module BinarySearch_Impl0_Index
   
 end
 module BinarySearch_Impl0_Len_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -237,7 +237,7 @@ module BinarySearch_Impl0_Len_Interface
     
 end
 module BinarySearch_Impl0_Len
-  type t   
+  type t
   use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
@@ -309,13 +309,13 @@ module BinarySearch_Impl0_Len
   
 end
 module BinarySearch_Impl0_GetDefault_Interface
-  type t   
+  type t
   use Type
   use mach.int.Int
   function get_default (self : Type.binarysearch_list t) (ix : int) (def : t) : t
 end
 module BinarySearch_Impl0_GetDefault
-  type t   
+  type t
   use Type
   use mach.int.Int
   clone BinarySearch_Impl0_Get_Interface as Get0 with type t = t

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -13,42 +13,42 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -58,7 +58,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_New_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -69,7 +69,7 @@ module CreusotContracts_Std1_Vec_Impl1_New_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_New
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -80,22 +80,22 @@ module CreusotContracts_Std1_Vec_Impl1_New
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -104,7 +104,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -117,7 +117,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -130,20 +130,20 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -154,13 +154,13 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -170,13 +170,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/bug/02_derive.stdout
+++ b/creusot/tests/should_succeed/bug/02_derive.stdout
@@ -40,28 +40,28 @@ module C02Derive_Impl0_Clone
   
 end
 module Core_Clone_Clone_Clone_Interface
-  type self   
+  type self
   use prelude.Prelude
   val clone' [@cfg:stackify] (self : self) : self
     requires {false}
     
 end
 module Core_Clone_Clone_Clone
-  type self   
+  type self
   use prelude.Prelude
   val clone' [@cfg:stackify] (self : self) : self
     requires {false}
     
 end
 module Core_Clone_Clone_CloneFrom_Interface
-  type self   
+  type self
   use prelude.Prelude
   val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
     requires {false}
     
 end
 module Core_Clone_Clone_CloneFrom
-  type self   
+  type self
   use prelude.Prelude
   val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
     requires {false}

--- a/creusot/tests/should_succeed/bug/173.stdout
+++ b/creusot/tests/should_succeed/bug/173.stdout
@@ -15,24 +15,24 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -71,7 +71,7 @@ module C173_Test233
   
 end
 module C173_Knapsack01Dyn_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -81,7 +81,7 @@ module C173_Knapsack01Dyn_Interface
     
 end
 module C173_Knapsack01Dyn
-  type name   
+  type name
   use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/bug/195.stdout
+++ b/creusot/tests/should_succeed/bug/195.stdout
@@ -15,24 +15,24 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -13,7 +13,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type c206_a  = 
     | C206_A (creusotcontracts_std1_vec_vec usize)
     
@@ -24,39 +24,39 @@ module Type
   axiom c206_a_A_0_acc : forall a : creusotcontracts_std1_vec_vec usize . c206_a_A_0 (C206_A a : c206_a) = a
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -110,24 +110,24 @@ module C206_U
     U20.u2 a
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/bug/217.stdout
+++ b/creusot/tests/should_succeed/bug/217.stdout
@@ -15,12 +15,12 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail_Interface
-  type t   
+  type t
   use seq.Seq
   function tail (self : Seq.seq t) : Seq.seq t
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/bug/235.stdout
+++ b/creusot/tests/should_succeed/bug/235.stdout
@@ -15,24 +15,24 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/bug/256.stdout
+++ b/creusot/tests/should_succeed/bug/256.stdout
@@ -33,24 +33,24 @@ module Type
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -13,42 +13,42 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -57,13 +57,13 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -73,13 +73,13 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -92,13 +92,13 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -107,7 +107,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -121,7 +121,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -135,7 +135,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -148,7 +148,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -161,39 +161,39 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -30,18 +30,18 @@ module Type
     
 end
 module C01_Inv_Inv_Interface
-  type self   
-  type t   
+  type self
+  type t
   predicate inv (x : t)
 end
 module C01_Inv_Inv
-  type self   
-  type t   
+  type self
+  type t
   predicate inv (x : t)
 end
 module C01_Impl0_Get_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C01_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -50,8 +50,8 @@ module C01_Impl0_Get_Interface
     
 end
 module C01_Impl0_Get
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C01_Inv_Inv as Inv0 with type self = i, type t = t
@@ -60,17 +60,17 @@ module C01_Impl0_Get
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module C01_Impl0_Set_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C01_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -79,8 +79,8 @@ module C01_Impl0_Set_Interface
     
 end
 module C01_Impl0_Set
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C01_Inv_Inv as Inv0 with type self = i, type t = t
@@ -89,15 +89,15 @@ module C01_Impl0_Set
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -44,23 +44,23 @@ module Type
     ensures { result = core_option_option_Some_0 self }
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module C02_Inv_Inv_Interface
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module C02_Inv_Inv
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module C02_Impl0_Get_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C02_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -69,8 +69,8 @@ module C02_Impl0_Get_Interface
     
 end
 module C02_Impl0_Get
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C02_Inv_Inv as Inv0 with type self = i, type t = t
@@ -79,8 +79,8 @@ module C02_Impl0_Get
     
 end
 module C02_Impl0_Set_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C02_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -89,8 +89,8 @@ module C02_Impl0_Set_Interface
     
 end
 module C02_Impl0_Set
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C02_Inv_Inv as Inv0 with type self = i, type t = t
@@ -188,13 +188,13 @@ module C02_Impl1_Inv
       end
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
@@ -220,27 +220,27 @@ module C02_FibCell
     forall i : (int) . UInt64.to_int (Type.c02_fib_Fib_ix (Type.c02_cell_Cell_ghost_inv (Seq.get (Model0.model v) i))) = i
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -249,19 +249,19 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -273,7 +273,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -283,22 +283,22 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -306,8 +306,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -315,7 +315,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -330,7 +330,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -345,26 +345,26 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -44,23 +44,23 @@ module Type
     ensures { result = core_option_option_Some_0 self }
     
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module C03FibUnbounded_Inv_Inv_Interface
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module C03FibUnbounded_Inv_Inv
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module C03FibUnbounded_Impl0_Get_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C03FibUnbounded_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -69,8 +69,8 @@ module C03FibUnbounded_Impl0_Get_Interface
     
 end
 module C03FibUnbounded_Impl0_Get
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C03FibUnbounded_Inv_Inv as Inv0 with type self = i, type t = t
@@ -79,8 +79,8 @@ module C03FibUnbounded_Impl0_Get
     
 end
 module C03FibUnbounded_Impl0_Set_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C03FibUnbounded_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -89,8 +89,8 @@ module C03FibUnbounded_Impl0_Set_Interface
     
 end
 module C03FibUnbounded_Impl0_Set
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone C03FibUnbounded_Inv_Inv as Inv0 with type self = i, type t = t
@@ -134,13 +134,13 @@ module C03FibUnbounded_Impl1_Inv
       end
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
@@ -162,27 +162,27 @@ module C03FibUnbounded_FibCell
     forall i : (int) . Type.c03fibunbounded_fib_Fib_ix (Type.c03fibunbounded_cell_Cell_ghost_inv (Seq.get (Model0.model v) i)) = i
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -191,19 +191,19 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -215,7 +215,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -225,22 +225,22 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -248,8 +248,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -257,7 +257,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use prelude.Prelude
@@ -271,7 +271,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use prelude.Prelude
@@ -285,26 +285,26 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = t

--- a/creusot/tests/should_succeed/clones/03.stdout
+++ b/creusot/tests/should_succeed/clones/03.stdout
@@ -15,31 +15,31 @@ module Type
   use prelude.Prelude
 end
 module C03_Omg_Interface
-  type t   
+  type t
   function omg (x : t) : bool
 end
 module C03_Omg
-  type t   
+  type t
   function omg (x : t) : bool = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C03_Prog_Interface
-  type t   
+  type t
   clone C03_Omg_Interface as Omg0 with type t = t
   val prog [@cfg:stackify] (x : t) : ()
     ensures { Omg0.omg x }
     
 end
 module C03_Prog
-  type t   
+  type t
   clone C03_Omg as Omg0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg prog [@cfg:stackify] (x : t) : ()

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -50,24 +50,24 @@ module C04_C
     x < (50 : uint32) && B0.b x
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/closures/01_basic.stdout
+++ b/creusot/tests/should_succeed/closures/01_basic.stdout
@@ -62,13 +62,13 @@ module C01Basic_UsesClosure_Closure0
   
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module Core_Ops_Function_Fn_Call_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -76,8 +76,8 @@ module Core_Ops_Function_Fn_Call_Interface
     
 end
 module Core_Ops_Function_Fn_Call
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output

--- a/creusot/tests/should_succeed/closures/02_nested.stdout
+++ b/creusot/tests/should_succeed/closures/02_nested.stdout
@@ -64,13 +64,13 @@ module C02Nested_NestedClosure_Closure0_Closure0
   
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module Core_Ops_Function_Fn_Call_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -78,8 +78,8 @@ module Core_Ops_Function_Fn_Call_Interface
     
 end
 module Core_Ops_Function_Fn_Call
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output

--- a/creusot/tests/should_succeed/closures/03_generic_bound.stdout
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.stdout
@@ -15,13 +15,13 @@ module Type
   use prelude.Prelude
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module Core_Ops_Function_Fn_Call_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -29,8 +29,8 @@ module Core_Ops_Function_Fn_Call_Interface
     
 end
 module Core_Ops_Function_Fn_Call
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -38,11 +38,11 @@ module Core_Ops_Function_Fn_Call
     
 end
 module C03GenericBound_ClosureParam_Interface
-  type f   
+  type f
   val closure_param [@cfg:stackify] (f : f) : ()
 end
 module C03GenericBound_ClosureParam
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude

--- a/creusot/tests/should_succeed/closures/04_generic_closure.stdout
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.stdout
@@ -15,13 +15,13 @@ module Type
   use prelude.Prelude
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module Core_Ops_Function_Fn_Call_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -29,8 +29,8 @@ module Core_Ops_Function_Fn_Call_Interface
     
 end
 module Core_Ops_Function_Fn_Call
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -38,15 +38,15 @@ module Core_Ops_Function_Fn_Call
     
 end
 module C04GenericClosure_GenericClosure_Interface
-  type a   
-  type b   
-  type f   
+  type a
+  type b
+  type f
   val generic_closure [@cfg:stackify] (f : f) (a : a) : b
 end
 module C04GenericClosure_GenericClosure
-  type a   
-  type b   
-  type f   
+  type a
+  type b
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (a), type Output0.output = b
   let rec cfg generic_closure [@cfg:stackify] (f : f) (a : a) : b = 
@@ -85,7 +85,7 @@ module C04GenericClosure_GenericClosure
   
 end
 module C04GenericClosure_Mapper_Closure0_Interface
-  type a   
+  type a
   use prelude.Prelude
   type c04genericclosure_mapper_closure0  = 
     | C04GenericClosure_Mapper_Closure0
@@ -103,7 +103,7 @@ module C04GenericClosure_Mapper_Closure0_Interface
   val c04GenericClosure_Mapper_Closure0 (_1' : c04genericclosure_mapper_closure0) (a : (a)) : ()
 end
 module C04GenericClosure_Mapper_Closure0
-  type a   
+  type a
   type c04genericclosure_mapper_closure0  = 
     | C04GenericClosure_Mapper_Closure0
     
@@ -129,11 +129,11 @@ module C04GenericClosure_Mapper_Closure0
   
 end
 module C04GenericClosure_Mapper_Interface
-  type a   
+  type a
   val mapper [@cfg:stackify] (x : a) : ()
 end
 module C04GenericClosure_Mapper
-  type a   
+  type a
   clone C04GenericClosure_Mapper_Closure0_Interface as Closure00 with type a = a, axiom .
   clone C04GenericClosure_GenericClosure_Interface as GenericClosure0 with type a = a, type b = (),
   type f = Closure00.c04genericclosure_mapper_closure0

--- a/creusot/tests/should_succeed/closures/05_map.stdout
+++ b/creusot/tests/should_succeed/closures/05_map.stdout
@@ -37,31 +37,31 @@ module Type
   axiom c05map_map_Map_func_acc : forall a : 'i, b : 'f . c05map_map_Map_func (C05Map_Map a b : c05map_map 'i 'f) = b
 end
 module C05Map_FakeIterator_Item
-  type self   
-  type item   
+  type self
+  type item
 end
 module C05Map_FakeIterator_Next_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone C05Map_FakeIterator_Item as Item0 with type self = self
   val next [@cfg:stackify] (self : borrowed self) : Type.core_option_option Item0.item
 end
 module C05Map_FakeIterator_Next
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone C05Map_FakeIterator_Item as Item0 with type self = self
   val next [@cfg:stackify] (self : borrowed self) : Type.core_option_option Item0.item
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module Core_Ops_Function_Fn_Call_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -69,8 +69,8 @@ module Core_Ops_Function_Fn_Call_Interface
     
 end
 module Core_Ops_Function_Fn_Call
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   val call [@cfg:stackify] (self : self) (args : args) : Output0.output
@@ -78,19 +78,19 @@ module Core_Ops_Function_Fn_Call
     
 end
 module C05Map_Impl0_Next_Interface
-  type a   
-  type b   
-  type f   
-  type i   
+  type a
+  type b
+  type f
+  type i
   use prelude.Prelude
   use Type
   val next [@cfg:stackify] (self : borrowed (Type.c05map_map i f)) : Type.core_option_option b
 end
 module C05Map_Impl0_Next
-  type a   
-  type b   
-  type f   
-  type i   
+  type a
+  type b
+  type f
+  type i
   use prelude.Prelude
   use Type
   use mach.int.Int
@@ -168,18 +168,18 @@ module C05Map_Impl0_Next
   
 end
 module C05Map_Impl0_Item
-  type a   
-  type b   
-  type f   
-  type i   
+  type a
+  type b
+  type f
+  type i
   type item  = 
     b
 end
 module C05Map_Impl0
-  type a   
-  type b   
-  type f   
-  type i   
+  type a
+  type b
+  type f
+  type i
   use Type
   clone C05Map_Impl0_Next_Interface as Next0 with type a = a, type b = b, type f = f, type i = i
   clone C05Map_Impl0_Item as Item0 with type a = a, type b = b, type f = f, type i = i

--- a/creusot/tests/should_succeed/closures/06_fn_specs.stdout
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.stdout
@@ -15,71 +15,71 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition (self : self) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnSpec_Postcondition
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition (self : self) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_once (self : self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_once (self : self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnSpec_FnMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = self,
@@ -90,8 +90,8 @@ module CreusotContracts_Std1_Fun_FnSpec_FnMut_Interface
   function fn_mut (self : self) (args : args) (res : Output0.output) : ()
 end
 module CreusotContracts_Std1_Fun_FnSpec_FnMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = self,
@@ -103,8 +103,8 @@ module CreusotContracts_Std1_Fun_FnSpec_FnMut
   axiom fn_mut_spec : forall self : self, args : args, res : Output0.output . (Postcondition0.postcondition self args res -> (exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res)) && ((exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res) -> Postcondition0.postcondition self args res)
 end
 module Core_Ops_Function_FnOnce_CallOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
@@ -116,8 +116,8 @@ module Core_Ops_Function_FnOnce_CallOnce_Interface
     
 end
 module Core_Ops_Function_FnOnce_CallOnce
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
@@ -129,8 +129,8 @@ module Core_Ops_Function_FnOnce_CallOnce
     
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
@@ -141,8 +141,8 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
   function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
@@ -154,8 +154,8 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
   axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
 end
 module C06FnSpecs_Weaken3_Interface
-  type a   
-  type f   
+  type a
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = f,
   type args = a, type Output0.output = Output0.output
@@ -166,8 +166,8 @@ module C06FnSpecs_Weaken3_Interface
     
 end
 module C06FnSpecs_Weaken3
-  type a   
-  type f   
+  type a
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,
   type Output0.output = Output0.output
@@ -219,8 +219,8 @@ module C06FnSpecs_Weaken3
   
 end
 module C06FnSpecs_Weaken2_Interface
-  type a   
-  type f   
+  type a
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = f,
@@ -234,8 +234,8 @@ module C06FnSpecs_Weaken2_Interface
     
 end
 module C06FnSpecs_Weaken2
-  type a   
-  type f   
+  type a
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,
@@ -298,8 +298,8 @@ module C06FnSpecs_Weaken2
   
 end
 module C06FnSpecs_Weaken_Interface
-  type a   
-  type f   
+  type a
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnSpec_Postcondition_Interface as Postcondition0 with type self = f, type args = a,
   type Output0.output = Output0.output
@@ -310,8 +310,8 @@ module C06FnSpecs_Weaken_Interface
     
 end
 module C06FnSpecs_Weaken
-  type a   
-  type f   
+  type a
+  type f
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = a
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce as PostconditionOnce0 with type self = f, type args = a,

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
@@ -15,26 +15,26 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
@@ -102,46 +102,46 @@ module C07MutableCapture_TestFnmut_Closure2
   
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module Core_Ops_Function_FnMut_CallMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
@@ -154,8 +154,8 @@ module Core_Ops_Function_FnMut_CallMut_Interface
     
 end
 module Core_Ops_Function_FnMut_CallMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
@@ -168,7 +168,7 @@ module Core_Ops_Function_FnMut_CallMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
@@ -15,15 +15,15 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C08MultipleCalls_MultiUse_Closure1_Interface
-  type t   
+  type t
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
@@ -51,7 +51,7 @@ module C08MultipleCalls_MultiUse_Closure1_Interface
     
 end
 module C08MultipleCalls_MultiUse_Closure1
-  type t   
+  type t
   use prelude.Prelude
   type c08multiplecalls_multiuse_closure1  = 
     | C08MultipleCalls_MultiUse_Closure1 t
@@ -87,36 +87,36 @@ module C08MultipleCalls_MultiUse_Closure1
   
 end
 module CreusotContracts_Std1_Fun_Impl0_Precondition_Interface
-  type args   
-  type f   
+  type args
+  type f
   predicate precondition (self : f) (_2' : args)
 end
 module CreusotContracts_Std1_Fun_Impl0_Precondition
-  type args   
-  type f   
+  type args
+  type f
   predicate precondition (self : f) (_2' : args)
 end
 module Core_Ops_Function_FnOnce_Output
-  type self   
-  type args   
-  type output   
+  type self
+  type args
+  type output
 end
 module CreusotContracts_Std1_Fun_Impl2_Postcondition_Interface
-  type args   
-  type f   
+  type args
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition (self : f) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_Impl2_Postcondition
-  type args   
-  type f   
+  type args
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition (self : f) (_2' : args) (_3' : Output0.output)
 end
 module C08MultipleCalls_UsesFn_Interface
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
@@ -129,7 +129,7 @@ module C08MultipleCalls_UsesFn_Interface
     
 end
 module C08MultipleCalls_UsesFn
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
@@ -142,56 +142,56 @@ module C08MultipleCalls_UsesFn
     
 end
 module CreusotContracts_Std1_Fun_Impl1_PostconditionMut_Interface
-  type args   
-  type f   
+  type args
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition_mut (self : borrowed f) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_Impl1_PostconditionMut
-  type args   
-  type f   
+  type args
+  type f
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition_mut (self : borrowed f) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition
-  type self   
-  type args   
+  type self
+  type args
   predicate precondition (self : self) (a : args)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_once (self : self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_once (self : self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_Impl0_PostconditionOnce_Interface
-  type args   
-  type f   
+  type args
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition_once (self : f) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_Impl0_PostconditionOnce
-  type args   
-  type f   
+  type args
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   predicate postcondition_once (self : f) (_2' : args) (_3' : Output0.output)
 end
 module CreusotContracts_Std1_Fun_Impl0
-  type args   
-  type f   
+  type args
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = args, type f = f,
   type Output0.output = Output0.output
@@ -203,22 +203,22 @@ module CreusotContracts_Std1_Fun_Impl0
   predicate precondition = Precondition0.precondition
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   predicate postcondition_mut (self : borrowed self) (a : args) (res : Output0.output)
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
@@ -229,8 +229,8 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
   function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
@@ -242,21 +242,21 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
   axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
 end
 module CreusotContracts_Std1_Fun_Impl1_FnMutOnce_Interface
-  type args   
-  type f   
+  type args
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   function fn_mut_once (self : f) (_2' : args) (_3' : Output0.output) : ()
 end
 module CreusotContracts_Std1_Fun_Impl1_FnMutOnce
-  type args   
-  type f   
+  type args
+  type f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   function fn_mut_once (self : f) (_2' : args) (_3' : Output0.output) : () = 
     ()
 end
 module CreusotContracts_Std1_Fun_Impl1
-  type args   
-  type f   
+  type args
+  type f
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = f, type args = args
   clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = args, type f = f,
@@ -274,8 +274,8 @@ module CreusotContracts_Std1_Fun_Impl1
   predicate postcondition_mut = PostconditionMut0.postcondition_mut, type Output0.output = Output0.output
 end
 module Core_Ops_Function_FnMut_CallMut_Interface
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
@@ -288,8 +288,8 @@ module Core_Ops_Function_FnMut_CallMut_Interface
     
 end
 module Core_Ops_Function_FnMut_CallMut
-  type self   
-  type args   
+  type self
+  type args
   use prelude.Prelude
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnMutSpec_PostconditionMut_Interface as PostconditionMut0 with type self = self,
@@ -302,7 +302,7 @@ module Core_Ops_Function_FnMut_CallMut
     
 end
 module C08MultipleCalls_UsesFnmut_Interface
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
@@ -315,7 +315,7 @@ module C08MultipleCalls_UsesFnmut_Interface
     
 end
 module C08MultipleCalls_UsesFnmut
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
@@ -366,8 +366,8 @@ module C08MultipleCalls_UsesFnmut
   
 end
 module Core_Ops_Function_FnOnce_CallOnce_Interface
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
@@ -379,8 +379,8 @@ module Core_Ops_Function_FnOnce_CallOnce_Interface
     
 end
 module Core_Ops_Function_FnOnce_CallOnce
-  type self   
-  type args   
+  type self
+  type args
   clone Core_Ops_Function_FnOnce_Output as Output0 with type self = self, type args = args
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
@@ -392,7 +392,7 @@ module Core_Ops_Function_FnOnce_CallOnce
     
 end
 module C08MultipleCalls_UsesFnonce_Interface
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce_Interface as PostconditionOnce0 with type args = (),
@@ -404,7 +404,7 @@ module C08MultipleCalls_UsesFnonce_Interface
     
 end
 module C08MultipleCalls_UsesFnonce
-  type f   
+  type f
   use mach.int.Int
   use mach.int.UInt32
   clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = (), type f = f,
@@ -451,12 +451,12 @@ module C08MultipleCalls_UsesFnonce
   
 end
 module C08MultipleCalls_MultiUse_Interface
-  type t   
+  type t
   use prelude.Prelude
   val multi_use [@cfg:stackify] (x : t) : ()
 end
 module C08MultipleCalls_MultiUse
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone C08MultipleCalls_MultiUse_Closure1_Interface as Closure10 with type t = t,

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -24,8 +24,8 @@ module Type
     
 end
 module Core_Cmp_PartialOrd_PartialCmp_Interface
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   use Type
   val partial_cmp [@cfg:stackify] (self : self) (other : rhs) : Type.core_option_option (Type.core_cmp_ordering)
@@ -33,8 +33,8 @@ module Core_Cmp_PartialOrd_PartialCmp_Interface
     
 end
 module Core_Cmp_PartialOrd_PartialCmp
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   use Type
   val partial_cmp [@cfg:stackify] (self : self) (other : rhs) : Type.core_option_option (Type.core_cmp_ordering)
@@ -42,88 +42,88 @@ module Core_Cmp_PartialOrd_PartialCmp
     
 end
 module Core_Cmp_PartialOrd_Lt_Interface
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val lt [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Lt
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val lt [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Le_Interface
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val le [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Le
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val le [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Gt_Interface
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val gt [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Gt
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val gt [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Ge_Interface
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val ge [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Cmp_PartialOrd_Ge
-  type self   
-  type rhs   
+  type self
+  type rhs
   use prelude.Prelude
   val ge [@cfg:stackify] (self : self) (other : rhs) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Lt_Interface
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val lt [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Lt
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val lt [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_PartialCmp_Interface
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   use Type
   val partial_cmp [@cfg:stackify] (self : (k, l)) (other : (k, l)) : Type.core_option_option (Type.core_cmp_ordering)
@@ -131,8 +131,8 @@ module Core_Tuple_Impl7_PartialCmp_Interface
     
 end
 module Core_Tuple_Impl7_PartialCmp
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   use Type
   val partial_cmp [@cfg:stackify] (self : (k, l)) (other : (k, l)) : Type.core_option_option (Type.core_cmp_ordering)
@@ -140,56 +140,56 @@ module Core_Tuple_Impl7_PartialCmp
     
 end
 module Core_Tuple_Impl7_Le_Interface
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val le [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Le
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val le [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Ge_Interface
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val ge [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Ge
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val ge [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Gt_Interface
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val gt [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7_Gt
-  type k   
-  type l   
+  type k
+  type l
   use prelude.Prelude
   val gt [@cfg:stackify] (self : (k, l)) (other : (k, l)) : bool
     requires {false}
     
 end
 module Core_Tuple_Impl7
-  type k   
-  type l   
+  type k
+  type l
   clone Core_Tuple_Impl7_Gt_Interface as Gt0 with type k = k, type l = l
   clone Core_Cmp_PartialOrd_Gt_Interface as Gt1 with type self = (k, l), type rhs = (k, l), val gt = Gt0.gt
   clone Core_Tuple_Impl7_Ge_Interface as Ge0 with type k = k, type l = l

--- a/creusot/tests/should_succeed/drop_pair.stdout
+++ b/creusot/tests/should_succeed/drop_pair.stdout
@@ -30,29 +30,29 @@ module DropPair_Main
   
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   predicate resolve (self : (t1, t2))
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
 module CreusotContracts_Logic_Resolve_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,
@@ -61,18 +61,18 @@ module CreusotContracts_Logic_Resolve_Impl0
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -13,16 +13,16 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
@@ -122,27 +122,27 @@ module FilterPositive_LemmaNumOfPosIncreasing_Impl
     if j < k then lemma_num_of_pos_increasing i (j + 1) k t else ()
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -152,22 +152,22 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -176,7 +176,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -190,7 +190,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -204,13 +204,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -218,8 +218,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -227,7 +227,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -242,7 +242,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -257,7 +257,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -271,7 +271,7 @@ module CreusotContracts_Std1_Vec_FromElem_Interface
     
 end
 module CreusotContracts_Std1_Vec_FromElem
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -285,8 +285,8 @@ module CreusotContracts_Std1_Vec_FromElem
     
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -294,8 +294,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -303,13 +303,13 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -318,7 +318,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -338,7 +338,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -358,31 +358,31 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -393,18 +393,18 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -421,7 +421,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -437,14 +437,14 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -454,13 +454,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -472,13 +472,13 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/heapsort_generic.stdout
+++ b/creusot/tests/should_succeed/heapsort_generic.stdout
@@ -18,7 +18,7 @@ module Type
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
@@ -34,34 +34,34 @@ module HeapsortGeneric_Parent
     div (i + 1) 2 - 1
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
-  type self   
+  type self
   predicate le_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
 end
 module HeapsortGeneric_HeapFrag_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate heap_frag (s : Seq.seq t) (start : int) (end' : int)
 end
 module HeapsortGeneric_HeapFrag
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
@@ -70,14 +70,14 @@ module HeapsortGeneric_HeapFrag
     forall i : (int) . start <= Parent0.parent i && i < end' -> LeLog0.le_log (Seq.get s i) (Seq.get s (Parent0.parent i))
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
@@ -85,25 +85,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
+  type self
   predicate lt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
@@ -111,25 +111,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
+  type self
   predicate ge_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
@@ -137,25 +137,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
+  type self
   predicate gt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
@@ -163,74 +163,74 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
   axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
   axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -238,61 +238,61 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module HeapsortGeneric_HeapFragMax_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -301,7 +301,7 @@ module HeapsortGeneric_HeapFragMax_Interface
   function heap_frag_max (s : Seq.seq t) (i : int) (end' : int) : ()
 end
 module HeapsortGeneric_HeapFragMax
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -317,7 +317,7 @@ module HeapsortGeneric_HeapFragMax
   axiom heap_frag_max_spec : forall s : Seq.seq t, i : int, end' : int . 0 <= i && i < end' -> HeapFrag0.heap_frag s 0 end' -> LeLog0.le_log (Seq.get s i) (Seq.get s 0)
 end
 module HeapsortGeneric_HeapFragMax_Impl
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -371,27 +371,27 @@ module HeapsortGeneric_HeapFragMax_Impl
     if i > 0 then let b' = Parent0.parent i in heap_frag_max s b' end' else ()
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -400,24 +400,24 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
+  type t
   use seq.Seq
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -426,28 +426,28 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
     Permut.permut self o 0 (Seq.length self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -457,13 +457,13 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -476,7 +476,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -486,15 +486,15 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -503,7 +503,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -512,33 +512,33 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -546,8 +546,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -555,13 +555,13 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -570,7 +570,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -585,7 +585,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -600,7 +600,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -609,7 +609,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -618,7 +618,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -626,7 +626,7 @@ module CreusotContracts_Std1_Ord_Ord_Le_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -634,7 +634,7 @@ module CreusotContracts_Std1_Ord_Ord_Le
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -642,7 +642,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -650,7 +650,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -658,7 +658,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -666,7 +666,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -674,7 +674,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -682,7 +682,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -700,7 +700,7 @@ module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -718,25 +718,25 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -753,13 +753,13 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -771,7 +771,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module HeapsortGeneric_SiftDown_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -796,7 +796,7 @@ module HeapsortGeneric_SiftDown_Interface
     
 end
 module HeapsortGeneric_SiftDown
-  type t   
+  type t
   use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
@@ -1117,13 +1117,13 @@ module HeapsortGeneric_SiftDown
   
 end
 module HeapsortGeneric_SortedRange_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
 end
 module HeapsortGeneric_SortedRange
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
@@ -1131,12 +1131,12 @@ module HeapsortGeneric_SortedRange
     forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module HeapsortGeneric_Sorted_Interface
-  type t   
+  type t
   use seq.Seq
   predicate sorted (s : Seq.seq t)
 end
 module HeapsortGeneric_Sorted
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -1145,7 +1145,7 @@ module HeapsortGeneric_Sorted
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -1159,7 +1159,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -1173,7 +1173,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module HeapsortGeneric_HeapSort_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use prelude.Prelude
@@ -1193,7 +1193,7 @@ module HeapsortGeneric_HeapSort_Interface
     
 end
 module HeapsortGeneric_HeapSort
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -15,41 +15,41 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -31,41 +31,41 @@ module IncMax3_Swap
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -15,41 +15,41 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -15,41 +15,41 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -82,24 +82,24 @@ module IncSome2List_Impl1_LemmaSumNonneg_Impl
       end
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -182,27 +182,27 @@ module IncSome2List_Impl1_SumX
   
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -216,13 +216,13 @@ module CreusotContracts_Logic_Int_Impl5_ModelTy
     int
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -255,30 +255,30 @@ module CreusotContracts_Logic_Int_Impl5
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Rand_Random_Interface
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module Rand_Random
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
@@ -402,21 +402,21 @@ module IncSome2List_Impl1_TakeSomeRest
   
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   predicate resolve (self : (t1, t2))
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
 module CreusotContracts_Logic_Resolve_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -87,24 +87,24 @@ module IncSome2Tree_Impl1_LemmaSumNonneg_Impl
       end
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -205,27 +205,27 @@ module IncSome2Tree_Impl1_SumX
   
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -239,13 +239,13 @@ module CreusotContracts_Logic_Int_Impl5_ModelTy
     int
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -278,30 +278,30 @@ module CreusotContracts_Logic_Int_Impl5
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Rand_Random_Interface
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module Rand_Random
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
@@ -485,21 +485,21 @@ module IncSome2Tree_Impl1_TakeSomeRest
   
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   predicate resolve (self : (t1, t2))
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
 module CreusotContracts_Logic_Resolve_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -88,24 +88,24 @@ module IncSomeList_Impl1_LemmaSumNonneg_Impl
       end
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -188,27 +188,27 @@ module IncSomeList_Impl1_SumX
   
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -222,13 +222,13 @@ module CreusotContracts_Logic_Int_Impl5_ModelTy
     int
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -261,18 +261,18 @@ module CreusotContracts_Logic_Int_Impl5
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -87,24 +87,24 @@ module IncSomeTree_Impl1_LemmaSumNonneg_Impl
       end
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -205,27 +205,27 @@ module IncSomeTree_Impl1_SumX
   
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -239,13 +239,13 @@ module CreusotContracts_Logic_Int_Impl5_ModelTy
     int
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -278,30 +278,30 @@ module CreusotContracts_Logic_Int_Impl5
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Rand_Random_Interface
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module Rand_Random
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/inplace_list_reversal.stdout
+++ b/creusot/tests/should_succeed/inplace_list_reversal.stdout
@@ -27,13 +27,13 @@ module Type
     
 end
 module InplaceListReversal_RevAppend_Interface
-  type t   
+  type t
   use Type
   function rev_append (n : Type.inplacelistreversal_list t) (o : Type.inplacelistreversal_list t) : Type.inplacelistreversal_list t
     
 end
 module InplaceListReversal_RevAppend
-  type t   
+  type t
   use Type
   function rev_append (n : Type.inplacelistreversal_list t) (o : Type.inplacelistreversal_list t) : Type.inplacelistreversal_list t
     
@@ -44,36 +44,36 @@ module InplaceListReversal_RevAppend
       end
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -83,15 +83,15 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -100,7 +100,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -109,7 +109,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Std1_Mem_Replace_Interface
-  type t   
+  type t
   use prelude.Prelude
   val replace [@cfg:stackify] (dest : borrowed t) (src : t) : t
     ensures { result =  * dest }
@@ -117,7 +117,7 @@ module CreusotContracts_Std1_Mem_Replace_Interface
     
 end
 module CreusotContracts_Std1_Mem_Replace
-  type t   
+  type t
   use prelude.Prelude
   val replace [@cfg:stackify] (dest : borrowed t) (src : t) : t
     ensures { result =  * dest }
@@ -125,40 +125,40 @@ module CreusotContracts_Std1_Mem_Replace
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module InplaceListReversal_Rev_Interface
-  type t   
+  type t
   use Type
   use prelude.Prelude
   clone InplaceListReversal_RevAppend_Interface as RevAppend0 with type t = t
@@ -167,7 +167,7 @@ module InplaceListReversal_Rev_Interface
     
 end
 module InplaceListReversal_Rev
-  type t   
+  type t
   use Type
   use prelude.Prelude
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = Type.inplacelistreversal_list t

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -39,8 +39,8 @@ module Type
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
 end
 module Alloc_Vec_Impl1_Pop_Interface
-  type t   
-  type a   
+  type t
+  type a
   use prelude.Prelude
   use Type
   val pop [@cfg:stackify] (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
@@ -48,8 +48,8 @@ module Alloc_Vec_Impl1_Pop_Interface
     
 end
 module Alloc_Vec_Impl1_Pop
-  type t   
-  type a   
+  type t
+  type a
   use prelude.Prelude
   use Type
   val pop [@cfg:stackify] (self : borrowed (Type.alloc_vec_vec t a)) : Type.core_option_option t
@@ -57,42 +57,42 @@ module Alloc_Vec_Impl1_Pop
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -54,33 +54,33 @@ module Type
     
 end
 module IterMut_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.itermut_vec t) : Seq.seq t
 end
 module IterMut_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.itermut_vec t) : Seq.seq t
 end
 module IterMut_Impl2_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   use prelude.Prelude
   function model (self : Type.itermut_itermut t) : Seq.seq (borrowed t)
 end
 module IterMut_Impl2_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   use prelude.Prelude
   function model (self : Type.itermut_itermut t) : Seq.seq (borrowed t)
 end
 module IterMut_Impl1_IterMut_Interface
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use prelude.Prelude
@@ -94,7 +94,7 @@ module IterMut_Impl1_IterMut_Interface
     
 end
 module IterMut_Impl1_IterMut
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use prelude.Prelude
@@ -108,7 +108,7 @@ module IterMut_Impl1_IterMut
     
 end
 module IterMut_Impl1_Len_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -119,7 +119,7 @@ module IterMut_Impl1_Len_Interface
     
 end
 module IterMut_Impl1_Len
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -130,12 +130,12 @@ module IterMut_Impl1_Len
     
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail_Interface
-  type t   
+  type t
   use seq.Seq
   function tail (self : Seq.seq t) : Seq.seq t
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use seq_ext.SeqExt
@@ -143,14 +143,14 @@ module CreusotContracts_Logic_Seq_Impl1_Tail
     SeqExt.subsequence self 1 (Seq.length self)
 end
 module CreusotContracts_Logic_Seq_Impl1_Get_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use Type
   function get (self : Seq.seq t) (ix : int) : Type.core_option_option t
 end
 module CreusotContracts_Logic_Seq_Impl1_Get
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use Type
@@ -158,7 +158,7 @@ module CreusotContracts_Logic_Seq_Impl1_Get
     if ix < Seq.length self then Type.Core_Option_Option_Some (Seq.get self ix) else Type.Core_Option_Option_None
 end
 module IterMut_Impl3_Next_Interface
-  type t   
+  type t
   use mach.int.Int
   use prelude.Prelude
   use Type
@@ -171,7 +171,7 @@ module IterMut_Impl3_Next_Interface
     
 end
 module IterMut_Impl3_Next
-  type t   
+  type t
   use mach.int.Int
   use prelude.Prelude
   use Type
@@ -184,27 +184,27 @@ module IterMut_Impl3_Next
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -213,28 +213,28 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module IterMut_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -244,7 +244,7 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module IterMut_Impl0
-  type t   
+  type t
   use Type
   clone IterMut_Impl0_Model as Model0 with type t = t
   clone IterMut_Impl0_ModelTy as ModelTy0 with type t = t
@@ -254,13 +254,13 @@ module IterMut_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -273,14 +273,14 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module IterMut_Impl2_ModelTy
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   type modelTy  = 
     Seq.seq (borrowed t)
 end
 module IterMut_Impl2
-  type t   
+  type t
   use Type
   clone IterMut_Impl2_Model as Model0 with type t = t
   clone IterMut_Impl2_ModelTy as ModelTy0 with type t = t
@@ -290,16 +290,16 @@ module IterMut_Impl2
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -308,7 +308,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -317,32 +317,32 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -26,7 +26,7 @@ module Type
     ensures { result = knapsack_item_Item_value self }
     
   axiom knapsack_item_Item_value_acc : forall a : 'name, b : usize, c : usize . knapsack_item_Item_value (Knapsack_Item a b c : knapsack_item 'name) = c
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module Knapsack_MaxLog_Interface
   use mach.int.Int
@@ -38,24 +38,24 @@ module Knapsack_MaxLog
     if a < b then b else a
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -123,7 +123,7 @@ module Knapsack_Max
   
 end
 module Knapsack_M_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -131,7 +131,7 @@ module Knapsack_M_Interface
   function m (items : Seq.seq (Type.knapsack_item name)) (i : int) (w : int) : int
 end
 module Knapsack_M
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -151,7 +151,7 @@ module Knapsack_M
   axiom m_spec : forall items : Seq.seq (Type.knapsack_item name), i : int, w : int . 0 <= w -> 0 <= i && i <= Seq.length items -> m items i w >= 0
 end
 module Knapsack_M_Impl
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -176,27 +176,27 @@ module Knapsack_M_Impl
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -205,31 +205,31 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -241,7 +241,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -251,7 +251,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -265,7 +265,7 @@ module CreusotContracts_Std1_Vec_FromElem_Interface
     
 end
 module CreusotContracts_Std1_Vec_FromElem
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -279,7 +279,7 @@ module CreusotContracts_Std1_Vec_FromElem
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -293,7 +293,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -307,13 +307,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -321,8 +321,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -330,7 +330,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -345,7 +345,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -360,8 +360,8 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -369,8 +369,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -378,13 +378,13 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -393,7 +393,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -413,7 +413,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -433,18 +433,18 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -457,7 +457,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -470,7 +470,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -483,7 +483,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -496,12 +496,12 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -512,12 +512,12 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -534,7 +534,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -550,14 +550,14 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -567,13 +567,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -586,7 +586,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module Knapsack_Knapsack01Dyn_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -603,7 +603,7 @@ module Knapsack_Knapsack01Dyn_Interface
     
 end
 module Knapsack_Knapsack01Dyn
-  type name   
+  type name
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -26,7 +26,7 @@ module Type
     ensures { result = knapsackfull_item_Item_value self }
     
   axiom knapsackfull_item_Item_value_acc : forall a : 'name, b : usize, c : usize . knapsackfull_item_Item_value (KnapsackFull_Item a b c : knapsackfull_item 'name) = c
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module KnapsackFull_MaxLog_Interface
   use mach.int.Int
@@ -38,24 +38,24 @@ module KnapsackFull_MaxLog
     if a < b then b else a
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -121,7 +121,7 @@ module KnapsackFull_Max
   
 end
 module KnapsackFull_SumWeights_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -130,7 +130,7 @@ module KnapsackFull_SumWeights_Interface
   function sum_weights (s : Seq.seq (Type.knapsackfull_item name)) (i : int) : int
 end
 module KnapsackFull_SumWeights
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -146,7 +146,7 @@ module KnapsackFull_SumWeights
   axiom sum_weights_spec : forall s : Seq.seq (Type.knapsackfull_item name), i : int . 0 <= i && i <= Seq.length s -> sum_weights s i >= 0
 end
 module KnapsackFull_SumWeights_Impl
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -166,7 +166,7 @@ module KnapsackFull_SumWeights_Impl
     
 end
 module KnapsackFull_SumValues_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -175,7 +175,7 @@ module KnapsackFull_SumValues_Interface
   function sum_values (s : Seq.seq (Type.knapsackfull_item name)) (i : int) : int
 end
 module KnapsackFull_SumValues
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -191,7 +191,7 @@ module KnapsackFull_SumValues
   axiom sum_values_spec : forall s : Seq.seq (Type.knapsackfull_item name), i : int . i >= 0 && i <= Seq.length s -> true
 end
 module KnapsackFull_SumValues_Impl
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -210,7 +210,7 @@ module KnapsackFull_SumValues_Impl
     
 end
 module KnapsackFull_SubseqRev_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -218,7 +218,7 @@ module KnapsackFull_SubseqRev_Interface
   predicate subseq_rev (s1 : Seq.seq t) (i1 : int) (s2 : Seq.seq t) (i2 : int)
 end
 module KnapsackFull_SubseqRev
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -232,7 +232,7 @@ module KnapsackFull_SubseqRev
   axiom subseq_rev_spec : forall s1 : Seq.seq t, i1 : int, s2 : Seq.seq t, i2 : int . 0 <= i2 && i2 <= Seq.length s2 -> 0 <= i1 && i1 <= Seq.length s1 -> true
 end
 module KnapsackFull_SubseqRev_Impl
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -250,7 +250,7 @@ module KnapsackFull_SubseqRev_Impl
     
 end
 module KnapsackFull_M_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -262,7 +262,7 @@ module KnapsackFull_M_Interface
   function m (items : Seq.seq (Type.knapsackfull_item name)) (i : int) (w : int) : int
 end
 module KnapsackFull_M
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -286,7 +286,7 @@ module KnapsackFull_M
   axiom m_spec : forall items : Seq.seq (Type.knapsackfull_item name), i : int, w : int . 0 <= w -> 0 <= i && i <= Seq.length items -> m items i w >= 0 && (forall j : (int) . forall s : (Seq.seq (Type.knapsackfull_item name)) . 0 <= j && j <= Seq.length s && SubseqRev0.subseq_rev s j items i && SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= m items i w)
 end
 module KnapsackFull_M_Impl
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -316,27 +316,27 @@ module KnapsackFull_M_Impl
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -345,31 +345,31 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -381,7 +381,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -391,7 +391,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -405,7 +405,7 @@ module CreusotContracts_Std1_Vec_FromElem_Interface
     
 end
 module CreusotContracts_Std1_Vec_FromElem
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -419,7 +419,7 @@ module CreusotContracts_Std1_Vec_FromElem
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -433,7 +433,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -447,13 +447,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -461,8 +461,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -470,7 +470,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -485,7 +485,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -500,8 +500,8 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -509,8 +509,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -518,13 +518,13 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -533,7 +533,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -553,7 +553,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -573,18 +573,18 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -597,7 +597,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -610,7 +610,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -623,7 +623,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -636,12 +636,12 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -652,12 +652,12 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -674,7 +674,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -690,14 +690,14 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -707,13 +707,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -726,7 +726,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module KnapsackFull_Knapsack01Dyn_Interface
-  type name   
+  type name
   use mach.int.Int
   use mach.int.Int32
   use seq.Seq
@@ -750,7 +750,7 @@ module KnapsackFull_Knapsack01Dyn_Interface
     
 end
 module KnapsackFull_Knapsack01Dyn
-  type name   
+  type name
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -73,42 +73,42 @@ module ListIndexMut_Get
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/mapping_test.stdout
+++ b/creusot/tests/should_succeed/mapping_test.stdout
@@ -45,16 +45,16 @@ module MappingTest_Impl0_Model
   )
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
@@ -74,31 +74,31 @@ module MappingTest_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -108,7 +108,7 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -117,7 +117,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -126,32 +126,32 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -30,24 +30,24 @@ module Mc91_Main
   
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/model.stdout
+++ b/creusot/tests/should_succeed/model.stdout
@@ -49,20 +49,20 @@ module Model_Seven
     
 end
 module Model_Impl1_Model_Interface
-  type t   
-  type u   
+  type t
+  type u
   use Type
   function model (self : Type.model_pair t u) : (t, u)
 end
 module Model_Impl1_Model
-  type t   
-  type u   
+  type t
+  type u
   use Type
   function model (self : Type.model_pair t u) : (t, u)
 end
 module Model_Pair_Interface
-  type t   
-  type u   
+  type t
+  type u
   use Type
   clone Model_Impl1_Model_Interface as Model0 with type t = t, type u = u
   val pair [@cfg:stackify] (a : t) (b : u) : Type.model_pair t u
@@ -70,8 +70,8 @@ module Model_Pair_Interface
     
 end
 module Model_Pair
-  type t   
-  type u   
+  type t
+  type u
   use Type
   clone Model_Impl1_Model as Model0 with type t = t, type u = u
   val pair [@cfg:stackify] (a : t) (b : u) : Type.model_pair t u
@@ -79,16 +79,16 @@ module Model_Pair
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
@@ -107,14 +107,14 @@ module Model_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module Model_Impl1_ModelTy
-  type t   
-  type u   
+  type t
+  type u
   type modelTy  = 
     (t, u)
 end
 module Model_Impl1
-  type t   
-  type u   
+  type t
+  type u
   use Type
   clone Model_Impl1_Model as Model0 with type t = t, type u = u
   clone Model_Impl1_ModelTy as ModelTy0 with type t = t, type u = u

--- a/creusot/tests/should_succeed/modules.stdout
+++ b/creusot/tests/should_succeed/modules.stdout
@@ -42,11 +42,11 @@ module Modules_Nested_Impl0_Resolve
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module Modules_Nested_Impl0

--- a/creusot/tests/should_succeed/mutex.stdout
+++ b/creusot/tests/should_succeed/mutex.stdout
@@ -13,7 +13,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type mutex_mutexinner 't  
+  type mutex_mutexinner 't
   type mutex_mutex 't 'i = 
     | Mutex_Mutex (mutex_mutexinner 't) 'i
     
@@ -33,7 +33,7 @@ module Type
     ensures { result = mutex_addstwo_AddsTwo_mutex self }
     
   axiom mutex_addstwo_AddsTwo_mutex_acc : forall a : mutex_mutex uint32 (mutex_even) . mutex_addstwo_AddsTwo_mutex (Mutex_AddsTwo a : mutex_addstwo) = a
-  type mutex_guardinner 't  
+  type mutex_guardinner 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
@@ -45,7 +45,7 @@ module Type
     ensures { result = mutex_mutexguard_MutexGuard_1 self }
     
   axiom mutex_mutexguard_MutexGuard_1_acc : forall a : mutex_guardinner 't, b : creusotcontracts_logic_ghost_ghost 'i . mutex_mutexguard_MutexGuard_1 (Mutex_MutexGuard a b : mutex_mutexguard 't 'i) = b
-  type mutex_joinhandleinner 't  
+  type mutex_joinhandleinner 't
   type mutex_joinhandle 't 'i = 
     | Mutex_JoinHandle (mutex_joinhandleinner 't) (creusotcontracts_logic_ghost_ghost 'i)
     
@@ -68,29 +68,29 @@ module Type
     
 end
 module Mutex_FakeFnOnce_Return
-  type self   
-  type return'   
+  type self
+  type return'
 end
 module Mutex_FakeFnOnce_Precondition_Interface
-  type self   
+  type self
   predicate precondition (self : self)
 end
 module Mutex_FakeFnOnce_Precondition
-  type self   
+  type self
   predicate precondition (self : self)
 end
 module Mutex_FakeFnOnce_Postcondition_Interface
-  type self   
+  type self
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
   predicate postcondition (self : self) (_2' : Return0.return')
 end
 module Mutex_FakeFnOnce_Postcondition
-  type self   
+  type self
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
   predicate postcondition (self : self) (_2' : Return0.return')
 end
 module Mutex_FakeFnOnce_Call_Interface
-  type self   
+  type self
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
   clone Mutex_FakeFnOnce_Postcondition_Interface as Postcondition0 with type self = self,
   type Return0.return' = Return0.return'
@@ -101,7 +101,7 @@ module Mutex_FakeFnOnce_Call_Interface
     
 end
 module Mutex_FakeFnOnce_Call
-  type self   
+  type self
   clone Mutex_FakeFnOnce_Return as Return0 with type self = self
   clone Mutex_FakeFnOnce_Postcondition as Postcondition0 with type self = self, type Return0.return' = Return0.return'
   clone Mutex_FakeFnOnce_Precondition as Precondition0 with type self = self
@@ -111,39 +111,39 @@ module Mutex_FakeFnOnce_Call
     
 end
 module Mutex_Inv_Inv_Interface
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module Mutex_Inv_Inv
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module Mutex_Impl0_Lock_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = i
@@ -152,8 +152,8 @@ module Mutex_Impl0_Lock_Interface
     
 end
 module Mutex_Impl0_Lock
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = i
@@ -162,8 +162,8 @@ module Mutex_Impl0_Lock
     
 end
 module Mutex_Impl1_Deref_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -173,8 +173,8 @@ module Mutex_Impl1_Deref_Interface
     
 end
 module Mutex_Impl1_Deref
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
@@ -184,8 +184,8 @@ module Mutex_Impl1_Deref
     
 end
 module Mutex_Impl1_Set_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -195,8 +195,8 @@ module Mutex_Impl1_Set_Interface
     
 end
 module Mutex_Impl1_Set
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
@@ -206,40 +206,40 @@ module Mutex_Impl1_Set
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -369,8 +369,8 @@ module Mutex_Impl3_Call
   
 end
 module Mutex_Impl0_New_Interface
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
   val new [@cfg:stackify] (val' : t) (i : i) : Type.mutex_mutex t i
@@ -378,8 +378,8 @@ module Mutex_Impl0_New_Interface
     
 end
 module Mutex_Impl0_New
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
   val new [@cfg:stackify] (val' : t) (i : i) : Type.mutex_mutex t i
@@ -387,33 +387,33 @@ module Mutex_Impl0_New
     
 end
 module Mutex_Leak_Interface
-  type t   
+  type t
   use prelude.Prelude
   val leak [@cfg:stackify] (b : t) : borrowed t
     ensures {  * result = b }
     
 end
 module Mutex_Leak
-  type t   
+  type t
   use prelude.Prelude
   val leak [@cfg:stackify] (b : t) : borrowed t
     ensures {  * result = b }
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Mutex_Spawn_Interface
-  type t   
-  type f   
+  type t
+  type f
   use Type
   clone Mutex_FakeFnOnce_Precondition_Interface as Precondition0 with type self = f
   val spawn [@cfg:stackify] (f : f) : Type.mutex_joinhandle t (Type.mutex_spawnpostcond f)
@@ -421,8 +421,8 @@ module Mutex_Spawn_Interface
     
 end
 module Mutex_Spawn
-  type t   
-  type f   
+  type t
+  type f
   use Type
   clone Mutex_FakeFnOnce_Precondition as Precondition0 with type self = f
   val spawn [@cfg:stackify] (f : f) : Type.mutex_joinhandle t (Type.mutex_spawnpostcond f)
@@ -430,8 +430,8 @@ module Mutex_Spawn
     
 end
 module Mutex_Impl4_Join_Interface
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = i
@@ -443,8 +443,8 @@ module Mutex_Impl4_Join_Interface
     
 end
 module Mutex_Impl4_Join
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = i
@@ -456,7 +456,7 @@ module Mutex_Impl4_Join
     
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
@@ -500,14 +500,14 @@ module Mutex_Impl3
   clone Mutex_FakeFnOnce_Return as Return1 with type self = Type.mutex_addstwo, type return' = Return0.return'
 end
 module Mutex_Impl5_Inv_Interface
-  type f   
+  type f
   use prelude.Prelude
   use Type
   clone Mutex_FakeFnOnce_Return as Return0 with type self = f
   predicate inv (self : Type.mutex_spawnpostcond f) (v : Return0.return')
 end
 module Mutex_Impl5_Inv
-  type f   
+  type f
   use prelude.Prelude
   use Type
   clone Mutex_FakeFnOnce_Return as Return0 with type self = f
@@ -517,7 +517,7 @@ module Mutex_Impl5_Inv
     Postcondition0.postcondition (Type.mutex_spawnpostcond_SpawnPostCond_f self) v
 end
 module Mutex_Impl5
-  type f   
+  type f
   use Type
   clone Mutex_FakeFnOnce_Return as Return0 with type self = f
   clone Mutex_FakeFnOnce_Postcondition as Postcondition0 with type self = f, type Return0.return' = Return0.return'
@@ -637,8 +637,8 @@ module Mutex_Concurrent
   
 end
 module Mutex_Impl0_IntoInner_Interface
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
   val into_inner [@cfg:stackify] (self : Type.mutex_mutex t i) : t
@@ -646,8 +646,8 @@ module Mutex_Impl0_IntoInner_Interface
     
 end
 module Mutex_Impl0_IntoInner
-  type t   
-  type i   
+  type t
+  type i
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
   val into_inner [@cfg:stackify] (self : Type.mutex_mutex t i) : t
@@ -655,8 +655,8 @@ module Mutex_Impl0_IntoInner
     
 end
 module Mutex_Impl0_GetMut_Interface
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
@@ -666,8 +666,8 @@ module Mutex_Impl0_GetMut_Interface
     
 end
 module Mutex_Impl0_GetMut
-  type t   
-  type i   
+  type t
+  type i
   use prelude.Prelude
   use Type
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -20,25 +20,25 @@ module Type
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -47,7 +47,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -56,18 +56,18 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
-  type self   
+  type self
   predicate le_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -75,7 +75,7 @@ module CreusotContracts_Std1_Ord_Ord_Le_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -83,18 +83,18 @@ module CreusotContracts_Std1_Ord_Ord_Le
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
+  type self
   predicate ge_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -102,7 +102,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -110,18 +110,18 @@ module CreusotContracts_Std1_Ord_Ord_Ge
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
+  type self
   predicate gt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -129,7 +129,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -137,18 +137,18 @@ module CreusotContracts_Std1_Ord_Ord_Gt
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
+  type self
   predicate lt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -156,7 +156,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -164,14 +164,14 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
@@ -179,14 +179,14 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
@@ -194,14 +194,14 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
@@ -209,14 +209,14 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
@@ -224,74 +224,74 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
   axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
   axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -299,68 +299,68 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module OrdTrait_X_Interface
-  type t   
+  type t
   use prelude.Prelude
   val x [@cfg:stackify] (x : t) : bool
     ensures { result = true }
     
 end
 module OrdTrait_X
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
@@ -426,7 +426,7 @@ module OrdTrait_X
   
 end
 module OrdTrait_GtOrLe_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   val gt_or_le [@cfg:stackify] (x : t) (y : t) : bool
@@ -434,7 +434,7 @@ module OrdTrait_GtOrLe_Interface
     
 end
 module OrdTrait_GtOrLe
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
@@ -503,16 +503,16 @@ module OrdTrait_GtOrLe
   
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -15,55 +15,55 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module ProjectionToggle_ProjToggle_Interface
-  type t   
+  type t
   use prelude.Prelude
   val proj_toggle [@cfg:stackify] (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { if toggle then result = a &&  ^ b =  * b else result = b &&  ^ a =  * a }
     
 end
 module ProjectionToggle_ProjToggle
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool

--- a/creusot/tests/should_succeed/rand.stdout
+++ b/creusot/tests/should_succeed/rand.stdout
@@ -15,13 +15,13 @@ module Type
   use prelude.Prelude
 end
 module Rand_Random_Interface
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     
 end
 module Rand_Random
-  type t   
+  type t
   val random [@cfg:stackify] () : t
     requires {false}
     

--- a/creusot/tests/should_succeed/selection_sort_generic.stdout
+++ b/creusot/tests/should_succeed/selection_sort_generic.stdout
@@ -18,40 +18,40 @@ module Type
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
-  type self   
+  type self
   predicate le_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
 end
 module SelectionSortGeneric_SortedRange_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
 end
 module SelectionSortGeneric_SortedRange
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
@@ -59,12 +59,12 @@ module SelectionSortGeneric_SortedRange
     forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module SelectionSortGeneric_Sorted_Interface
-  type t   
+  type t
   use seq.Seq
   predicate sorted (s : Seq.seq t)
 end
 module SelectionSortGeneric_Sorted
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -73,13 +73,13 @@ module SelectionSortGeneric_Sorted
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
 module SelectionSortGeneric_Partition_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate partition (v : Seq.seq t) (i : int)
 end
 module SelectionSortGeneric_Partition
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -88,39 +88,39 @@ module SelectionSortGeneric_Partition
     forall k2 : (int) . forall k1 : (int) . 0 <= k1 && k1 < i && i <= k2 && k2 < Seq.length v -> LeLog0.le_log (Seq.get v k1) (Seq.get v k2)
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -129,12 +129,12 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
+  type t
   use seq.Seq
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -143,28 +143,28 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
     Permut.permut self o 0 (Seq.length self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -174,13 +174,13 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -193,7 +193,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -203,14 +203,14 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
@@ -218,25 +218,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
+  type self
   predicate lt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
@@ -244,25 +244,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
+  type self
   predicate ge_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
@@ -270,25 +270,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
+  type self
   predicate gt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
@@ -296,74 +296,74 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
   axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
   axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -371,69 +371,69 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -442,7 +442,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -451,22 +451,22 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -475,7 +475,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -489,7 +489,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -503,13 +503,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -517,8 +517,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -526,7 +526,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -541,7 +541,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -556,7 +556,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -565,7 +565,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -574,7 +574,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -582,7 +582,7 @@ module CreusotContracts_Std1_Ord_Ord_Le_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -590,7 +590,7 @@ module CreusotContracts_Std1_Ord_Ord_Le
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -598,7 +598,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -606,7 +606,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -614,7 +614,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -622,7 +622,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -630,7 +630,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -638,7 +638,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -656,7 +656,7 @@ module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -674,29 +674,29 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -713,20 +713,20 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -738,7 +738,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module SelectionSortGeneric_SelectionSort_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone SelectionSortGeneric_Sorted_Interface as Sorted0 with type t = t
@@ -753,7 +753,7 @@ module SelectionSortGeneric_SelectionSort_Interface
     
 end
 module SelectionSortGeneric_SelectionSort
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int

--- a/creusot/tests/should_succeed/slices/01.stdout
+++ b/creusot/tests/should_succeed/slices/01.stdout
@@ -19,27 +19,27 @@ module Type
     
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -48,13 +48,13 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Logic_Model_Impl2_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module Core_Slice_Impl0_Len_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.UInt64
   use prelude.Prelude
@@ -67,7 +67,7 @@ module Core_Slice_Impl0_Len_Interface
     
 end
 module Core_Slice_Impl0_Len
-  type t   
+  type t
   use seq.Seq
   use mach.int.UInt64
   use prelude.Prelude
@@ -80,36 +80,36 @@ module Core_Slice_Impl0_Len
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -121,20 +121,20 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl2_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   function model (self : seq t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl2_Model
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   function model (self : seq t) : Seq.seq t = 
     Prelude.id self
 end
 module CreusotContracts_Logic_Model_Impl2
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   clone CreusotContracts_Logic_Model_Impl2_Model as Model0 with type t = t
@@ -144,14 +144,14 @@ module CreusotContracts_Logic_Model_Impl2
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = seq t, type modelTy = ModelTy0.modelTy
 end
 module C01_SliceFirst_Interface
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   use Type
   val slice_first [@cfg:stackify] (a : seq t) : Type.core_option_option t
 end
 module C01_SliceFirst
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   use Type

--- a/creusot/tests/should_succeed/sparse_array.stdout
+++ b/creusot/tests/should_succeed/sparse_array.stdout
@@ -17,7 +17,7 @@ module Type
     | Core_Option_Option_None
     | Core_Option_Option_Some 't
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type sparsearray_sparse 't = 
     | SparseArray_Sparse usize usize (creusotcontracts_std1_vec_vec 't) (creusotcontracts_std1_vec_vec usize) (creusotcontracts_std1_vec_vec usize)
     
@@ -48,27 +48,27 @@ module Type
   axiom sparsearray_sparse_Sparse_values_acc : forall a : usize, b : usize, c : creusotcontracts_std1_vec_vec 't, d : creusotcontracts_std1_vec_vec usize, e : creusotcontracts_std1_vec_vec usize . sparsearray_sparse_Sparse_values (SparseArray_Sparse a b c d e : sparsearray_sparse 't) = c
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -77,13 +77,13 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -120,35 +120,35 @@ module CreusotContracts_Logic_Int_Impl7
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = int32, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module SparseArray_Impl1_IsElt_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   use mach.int.Int
   predicate is_elt (self : Type.sparsearray_sparse t) (i : int)
 end
 module SparseArray_Impl1_IsElt
-  type t   
+  type t
   use prelude.Prelude
   use Type
   use mach.int.Int
@@ -160,7 +160,7 @@ module SparseArray_Impl1_IsElt
     0 <= i && i < UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) && UInt64.to_int (Seq.get (Model0.model (Type.sparsearray_sparse_Sparse_idx self)) i) < UInt64.to_int (Type.sparsearray_sparse_Sparse_n self) && UInt64.to_int (Seq.get (Model0.model (Type.sparsearray_sparse_Sparse_back self)) (UInt64.to_int (Seq.get (Model0.model (Type.sparsearray_sparse_Sparse_idx self)) i))) = i
 end
 module SparseArray_Impl0_Model_Interface
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use Type
@@ -170,7 +170,7 @@ module SparseArray_Impl0_Model_Interface
   function model (self : Type.sparsearray_sparse t) : Seq.seq (Type.core_option_option t)
 end
 module SparseArray_Impl0_Model
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use Type
@@ -185,20 +185,20 @@ module SparseArray_Impl0_Model
   ))
 end
 module SparseArray_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   use Type
   type modelTy  = 
     Seq.seq (Type.core_option_option t)
 end
 module SparseArray_Impl1_SparseInv_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   predicate sparse_inv (self : Type.sparsearray_sparse t)
 end
 module SparseArray_Impl1_SparseInv
-  type t   
+  type t
   use prelude.Prelude
   use Type
   use mach.int.UInt64
@@ -216,7 +216,7 @@ module SparseArray_Impl1_SparseInv
       end)
 end
 module SparseArray_Impl0
-  type t   
+  type t
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
@@ -233,13 +233,13 @@ module SparseArray_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -249,15 +249,15 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -271,7 +271,7 @@ module CreusotContracts_Std1_Vec_FromElem_Interface
     
 end
 module CreusotContracts_Std1_Vec_FromElem
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -285,13 +285,13 @@ module CreusotContracts_Std1_Vec_FromElem
     
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module SparseArray_Create_Interface
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use Type
@@ -309,7 +309,7 @@ module SparseArray_Create_Interface
     
 end
 module SparseArray_Create
-  type t   
+  type t
   use mach.int.Int
   use seq.Seq
   use Type
@@ -392,13 +392,13 @@ module SparseArray_Create
   
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -406,8 +406,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -415,7 +415,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -430,7 +430,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -445,12 +445,12 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -467,7 +467,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module SparseArray_Impl1_Get_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -491,7 +491,7 @@ module SparseArray_Impl1_Get_Interface
     
 end
 module SparseArray_Impl1_Get
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -641,7 +641,7 @@ module SparseArray_Impl1_Get
   
 end
 module SparseArray_Impl1_LemmaPermutation_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -651,7 +651,7 @@ module SparseArray_Impl1_LemmaPermutation_Interface
   function lemma_permutation (self : Type.sparsearray_sparse t) (i : int) : ()
 end
 module SparseArray_Impl1_LemmaPermutation
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -663,7 +663,7 @@ module SparseArray_Impl1_LemmaPermutation
   axiom lemma_permutation_spec : forall self : Type.sparsearray_sparse t, i : int . 0 <= i && i < UInt64.to_int (Type.sparsearray_sparse_Sparse_size self) -> Type.sparsearray_sparse_Sparse_n self = Type.sparsearray_sparse_Sparse_size self -> SparseInv0.sparse_inv self -> IsElt0.is_elt self i
 end
 module SparseArray_Impl1_LemmaPermutation_Impl
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -689,8 +689,8 @@ module SparseArray_Impl1_LemmaPermutation_Impl
     ()
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -698,8 +698,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -707,13 +707,13 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -722,7 +722,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -742,7 +742,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -762,18 +762,18 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -789,20 +789,20 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -815,7 +815,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module SparseArray_Impl1_Set_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -836,7 +836,7 @@ module SparseArray_Impl1_Set_Interface
     
 end
 module SparseArray_Impl1_Set
-  type t   
+  type t
   use mach.int.UInt64
   use mach.int.Int
   use seq.Seq

--- a/creusot/tests/should_succeed/specification/division.stdout
+++ b/creusot/tests/should_succeed/specification/division.stdout
@@ -15,24 +15,24 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/specification/logic_call.stdout
+++ b/creusot/tests/should_succeed/specification/logic_call.stdout
@@ -15,11 +15,11 @@ module Type
   use prelude.Prelude
 end
 module LogicCall_Reflexive_Interface
-  type t   
+  type t
   function reflexive (x : t) : bool
 end
 module LogicCall_Reflexive
-  type t   
+  type t
   function reflexive (x : t) : bool = 
     x = x
 end

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -30,24 +30,24 @@ module Sum_Main
   
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/sum_of_odds.stdout
+++ b/creusot/tests/should_succeed/sum_of_odds.stdout
@@ -83,24 +83,24 @@ module SumOfOdds_SumOfOddIsSqr_Impl
     if x > 0 then sum_of_odd_is_sqr (x - 1) else ()
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/syntax/02_operators.stdout
+++ b/creusot/tests/should_succeed/syntax/02_operators.stdout
@@ -23,24 +23,24 @@ module Type
   axiom c02operators_x_X_a_acc : forall a : usize . c02operators_x_X_a (C02Operators_X a : c02operators_x) = a
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/syntax/03_unbounded.stdout
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.stdout
@@ -15,24 +15,24 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.stdout
@@ -15,29 +15,29 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   predicate resolve (self : (t1, t2))
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
 module CreusotContracts_Logic_Resolve_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,
@@ -46,16 +46,16 @@ module CreusotContracts_Logic_Resolve_Impl0
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/syntax/05_annotations.stdout
+++ b/creusot/tests/should_succeed/syntax/05_annotations.stdout
@@ -15,34 +15,34 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module C05Annotations_Assertion_Interface
-  type t   
+  type t
   val assertion [@cfg:stackify] (x : t) : ()
 end
 module C05Annotations_Assertion
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg assertion [@cfg:stackify] (x : t) : () = 

--- a/creusot/tests/should_succeed/syntax/06_logic_function_contracts.stdout
+++ b/creusot/tests/should_succeed/syntax/06_logic_function_contracts.stdout
@@ -81,12 +81,12 @@ module C06LogicFunctionContracts_AllZero_Impl
     
 end
 module C06LogicFunctionContracts_Stupid_Interface
-  type t   
+  type t
   use mach.int.Int
   predicate stupid (x : t) (i : int)
 end
 module C06LogicFunctionContracts_Stupid
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   predicate stupid (x : t) (i : int)
@@ -94,7 +94,7 @@ module C06LogicFunctionContracts_Stupid
   axiom stupid_spec : forall x : t, i : int . true
 end
 module C06LogicFunctionContracts_Stupid_Impl
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   let rec ghost function stupid (x : t) (i : int) : bool

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
@@ -30,38 +30,38 @@ module Type
     
 end
 module Alloc_Vec_Impl0_New_Interface
-  type t   
+  type t
   use Type
   val new [@cfg:stackify] () : Type.alloc_vec_vec t (Type.alloc_alloc_global)
     requires {true = true}
     
 end
 module Alloc_Vec_Impl0_New
-  type t   
+  type t
   use Type
   val new [@cfg:stackify] () : Type.alloc_vec_vec t (Type.alloc_alloc_global)
     requires {true = true}
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -94,15 +94,15 @@ module C07ExternSpec_Main
   
 end
 module C07ExternSpec_HasParams_Interface
-  type v   
-  type u   
-  type x   
+  type v
+  type u
+  type x
   val has_params [@cfg:stackify] (a : v) (b : u) (c : x) : ()
 end
 module C07ExternSpec_HasParams
-  type v   
-  type u   
-  type x   
+  type v
+  type u
+  type x
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = v
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = u
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = x
@@ -136,11 +136,11 @@ module C07ExternSpec_HasParams
   
 end
 module C07ExternSpec_UsesA_Interface
-  type t   
+  type t
   val uses_a [@cfg:stackify] (x : t) : ()
 end
 module C07ExternSpec_UsesA
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg uses_a [@cfg:stackify] (x : t) : () = 
   var _0 : ();
@@ -160,11 +160,11 @@ module C07ExternSpec_UsesA
   
 end
 module C07ExternSpec_Client_Interface
-  type t   
+  type t
   val client [@cfg:stackify] (y : t) : ()
 end
 module C07ExternSpec_Client
-  type t   
+  type t
   clone C07ExternSpec_UsesA_Interface as UsesA0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg client [@cfg:stackify] (y : t) : () = 
@@ -190,27 +190,27 @@ module C07ExternSpec_Client
   
 end
 module C07ExternSpec_Id_Interface
-  type t   
+  type t
   function id (x : t) : t
 end
 module C07ExternSpec_Id
-  type t   
+  type t
   function id (x : t) : t = 
     x
 end
 module C07ExternSpec_RenamedParams_Interface
-  type a   
-  type b   
-  type c   
+  type a
+  type b
+  type c
   clone C07ExternSpec_Id_Interface as Id0 with type t = a
   val renamed_params [@cfg:stackify] (a : a) (b : b) (c : c) : ()
     ensures { Id0.id a = a }
     
 end
 module C07ExternSpec_RenamedParams
-  type a   
-  type b   
-  type c   
+  type a
+  type b
+  type c
   clone C07ExternSpec_Id as Id0 with type t = a
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = a
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = b

--- a/creusot/tests/should_succeed/syntax/08_const.stdout
+++ b/creusot/tests/should_succeed/syntax/08_const.stdout
@@ -15,12 +15,12 @@ module Type
   use prelude.Prelude
 end
 module C08Const_Omg_Interface
-  type t   
+  type t
   use seq.Seq
   function omg () : Seq.seq t
 end
 module C08Const_Omg
-  type t   
+  type t
   use seq.Seq
   function omg () : Seq.seq t = 
     Seq.empty 

--- a/creusot/tests/should_succeed/syntax/09_maintains.stdout
+++ b/creusot/tests/should_succeed/syntax/09_maintains.stdout
@@ -51,24 +51,24 @@ module C09Maintains_OtherInv
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -116,18 +116,18 @@ module C09Maintains_Test1
   
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/syntax/10_mutual_rec_types.rs
+++ b/creusot/tests/should_succeed/syntax/10_mutual_rec_types.rs
@@ -1,0 +1,19 @@
+struct Tree(Option<Box<Node>>);
+
+struct Node {
+    left: Tree,
+    val: u32,
+    right: Tree,
+}
+
+// To force the translation of `Tree`
+fn use_tree(t: &Tree) {}
+
+impl Tree {
+    fn height(&self) -> u64 {
+        match self {
+            Tree(None) => 0,
+            Tree(Some(n)) => n.left.height().max(n.right.height()) + 1,
+        }
+    }
+}

--- a/creusot/tests/should_succeed/syntax/10_mutual_rec_types.stdout
+++ b/creusot/tests/should_succeed/syntax/10_mutual_rec_types.stdout
@@ -1,0 +1,193 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type core_option_option 't = 
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
+    
+  function core_option_option_Some_0 (self : core_option_option 't) : 't
+  val core_option_option_Some_0 (self : core_option_option 't) : 't
+    ensures { result = core_option_option_Some_0 self }
+    
+  axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
+  type c10mutualrectypes_node  = 
+    | C10MutualRecTypes_Node (c10mutualrectypes_tree) uint32 (c10mutualrectypes_tree)
+    with c10mutualrectypes_tree  = 
+    | C10MutualRecTypes_Tree (core_option_option (c10mutualrectypes_node))
+    
+  function c10mutualrectypes_tree_Tree_0 (self : c10mutualrectypes_tree) : core_option_option (c10mutualrectypes_node)
+  val c10mutualrectypes_tree_Tree_0 (self : c10mutualrectypes_tree) : core_option_option (c10mutualrectypes_node)
+    ensures { result = c10mutualrectypes_tree_Tree_0 self }
+    
+  axiom c10mutualrectypes_tree_Tree_0_acc : forall a : core_option_option (c10mutualrectypes_node) . c10mutualrectypes_tree_Tree_0 (C10MutualRecTypes_Tree a : c10mutualrectypes_tree) = a
+  function c10mutualrectypes_node_Node_left (self : c10mutualrectypes_node) : c10mutualrectypes_tree
+  val c10mutualrectypes_node_Node_left (self : c10mutualrectypes_node) : c10mutualrectypes_tree
+    ensures { result = c10mutualrectypes_node_Node_left self }
+    
+  axiom c10mutualrectypes_node_Node_left_acc : forall a : c10mutualrectypes_tree, b : uint32, c : c10mutualrectypes_tree . c10mutualrectypes_node_Node_left (C10MutualRecTypes_Node a b c : c10mutualrectypes_node) = a
+  function c10mutualrectypes_node_Node_right (self : c10mutualrectypes_node) : c10mutualrectypes_tree
+  val c10mutualrectypes_node_Node_right (self : c10mutualrectypes_node) : c10mutualrectypes_tree
+    ensures { result = c10mutualrectypes_node_Node_right self }
+    
+  axiom c10mutualrectypes_node_Node_right_acc : forall a : c10mutualrectypes_tree, b : uint32, c : c10mutualrectypes_tree . c10mutualrectypes_node_Node_right (C10MutualRecTypes_Node a b c : c10mutualrectypes_node) = c
+  type core_cmp_ordering  = 
+    | Core_Cmp_Ordering_Less
+    | Core_Cmp_Ordering_Equal
+    | Core_Cmp_Ordering_Greater
+    
+end
+module C10MutualRecTypes_UseTree_Interface
+  use prelude.Prelude
+  use Type
+  val use_tree [@cfg:stackify] (t : Type.c10mutualrectypes_tree) : ()
+end
+module C10MutualRecTypes_UseTree
+  use prelude.Prelude
+  use Type
+  let rec cfg use_tree [@cfg:stackify] (t : Type.c10mutualrectypes_tree) : () = 
+  var _0 : ();
+  var t_1 : Type.c10mutualrectypes_tree;
+  {
+    t_1 <- t;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    assume { (fun x -> true) t_1 };
+    return _0
+  }
+  
+end
+module Core_Cmp_Ord_Cmp_Interface
+  type self
+  use prelude.Prelude
+  use Type
+  val cmp [@cfg:stackify] (self : self) (other : self) : Type.core_cmp_ordering
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Cmp
+  type self
+  use prelude.Prelude
+  use Type
+  val cmp [@cfg:stackify] (self : self) (other : self) : Type.core_cmp_ordering
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Max_Interface
+  type self
+  val max [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Max
+  type self
+  val max [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Min_Interface
+  type self
+  val min [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Min
+  type self
+  val min [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Clamp_Interface
+  type self
+  val clamp [@cfg:stackify] (self : self) (min : self) (max : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Clamp
+  type self
+  val clamp [@cfg:stackify] (self : self) (min : self) (max : self) : self
+    requires {false}
+    
+end
+module C10MutualRecTypes_Impl0_Height_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  val height [@cfg:stackify] (self : Type.c10mutualrectypes_tree) : uint64
+end
+module C10MutualRecTypes_Impl0_Height
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  use mach.int.Int64
+  clone Core_Cmp_Ord_Max_Interface as Max0 with type self = uint64
+  let rec cfg height [@cfg:stackify] (self : Type.c10mutualrectypes_tree) : uint64 = 
+  var _0 : uint64;
+  var self_1 : Type.c10mutualrectypes_tree;
+  var _2 : isize;
+  var n_3 : Type.c10mutualrectypes_node;
+  var _4 : uint64;
+  var _5 : uint64;
+  var _6 : Type.c10mutualrectypes_tree;
+  var _7 : uint64;
+  var _8 : Type.c10mutualrectypes_tree;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    switch (Type.c10mutualrectypes_tree_Tree_0 self_1)
+      | Type.Core_Option_Option_None -> goto BB3
+      | Type.Core_Option_Option_Some _ -> goto BB1
+      end
+  }
+  BB1 {
+    n_3 <- Type.core_option_option_Some_0 (Type.c10mutualrectypes_tree_Tree_0 self_1);
+    assume { (fun x -> true) self_1 };
+    _6 <- Type.c10mutualrectypes_node_Node_left n_3;
+    _5 <- height _6;
+    goto BB4
+  }
+  BB2 {
+    assume { (fun x -> true) self_1 };
+    absurd
+  }
+  BB3 {
+    assume { (fun x -> true) self_1 };
+    _0 <- (0 : uint64);
+    goto BB7
+  }
+  BB4 {
+    _8 <- Type.c10mutualrectypes_node_Node_right n_3;
+    assume { (fun x -> true) n_3 };
+    _7 <- height _8;
+    goto BB5
+  }
+  BB5 {
+    _4 <- Max0.max _5 _7;
+    goto BB6
+  }
+  BB6 {
+    _0 <- _4 + (1 : uint64);
+    goto BB7
+  }
+  BB7 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/take_first_mut.stdout
+++ b/creusot/tests/should_succeed/take_first_mut.stdout
@@ -24,35 +24,35 @@ module Type
   axiom core_option_option_Some_0_acc : forall a : 't . core_option_option_Some_0 (Core_Option_Option_Some a : core_option_option 't) = a
 end
 module TakeFirstMut_DefaultSpec_DefaultLog_Interface
-  type self   
+  type self
   function default_log () : self
 end
 module TakeFirstMut_DefaultSpec_DefaultLog
-  type self   
+  type self
   function default_log () : self
 end
 module CreusotContracts_Logic_Model_Impl2_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   function model (self : seq t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl2_Model
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   function model (self : seq t) : Seq.seq t = 
     Prelude.id self
 end
 module TakeFirstMut_Impl0_DefaultLog_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Impl2_Model_Interface as Model0 with type t = t
   function default_log () : borrowed (seq t)
 end
 module TakeFirstMut_Impl0_DefaultLog
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Impl2_Model_Interface as Model0 with type t = t
@@ -60,12 +60,12 @@ module TakeFirstMut_Impl0_DefaultLog
   axiom default_log_spec : Model0.model ( * default_log ()) = Seq.empty  && Model0.model ( ^ default_log ()) = Seq.empty 
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail_Interface
-  type t   
+  type t
   use seq.Seq
   function tail (self : Seq.seq t) : Seq.seq t
 end
 module CreusotContracts_Logic_Seq_Impl1_Tail
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -74,27 +74,27 @@ module CreusotContracts_Logic_Seq_Impl1_Tail
     SeqExt.subsequence self 1 (Seq.length self)
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl2_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl2
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   clone CreusotContracts_Logic_Model_Impl2_Model as Model0 with type t = t
@@ -104,7 +104,7 @@ module CreusotContracts_Logic_Model_Impl2
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = seq t, type modelTy = ModelTy0.modelTy
 end
 module Core_Mem_Take_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone TakeFirstMut_DefaultSpec_DefaultLog_Interface as DefaultLog0 with type self = t
   val take [@cfg:stackify] (dest : borrowed t) : t
@@ -113,7 +113,7 @@ module Core_Mem_Take_Interface
     
 end
 module Core_Mem_Take
-  type t   
+  type t
   use prelude.Prelude
   clone TakeFirstMut_DefaultSpec_DefaultLog_Interface as DefaultLog0 with type self = t
   val take [@cfg:stackify] (dest : borrowed t) : t
@@ -122,13 +122,13 @@ module Core_Mem_Take
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -137,7 +137,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module Core_Slice_Impl0_SplitFirstMut_Interface
-  type t   
+  type t
   use Type
   use prelude.Prelude
   use seq.Seq
@@ -156,7 +156,7 @@ module Core_Slice_Impl0_SplitFirstMut_Interface
     
 end
 module Core_Slice_Impl0_SplitFirstMut
-  type t   
+  type t
   use Type
   use prelude.Prelude
   use seq.Seq
@@ -175,33 +175,33 @@ module Core_Slice_Impl0_SplitFirstMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module TakeFirstMut_Impl0
-  type t   
+  type t
   use prelude.Prelude
   use seq.Seq
   clone CreusotContracts_Logic_Model_Impl2_Model as Model0 with type t = t
@@ -210,13 +210,13 @@ module TakeFirstMut_Impl0
   function default_log = DefaultLog0.default_log
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -229,7 +229,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module TakeFirstMut_TakeFirstMut_Interface
-  type t   
+  type t
   use Type
   use prelude.Prelude
   use mach.int.Int
@@ -245,7 +245,7 @@ module TakeFirstMut_TakeFirstMut_Interface
     
 end
 module TakeFirstMut_TakeFirstMut
-  type t   
+  type t
   use Type
   use prelude.Prelude
   use mach.int.Int

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -15,15 +15,15 @@ module Type
   use prelude.Prelude
 end
 module Trait_UsesCustom_Interface
-  type a   
-  type b   
-  type t   
+  type a
+  type b
+  type t
   val uses_custom [@cfg:stackify] (t : t) : ()
 end
 module Trait_UsesCustom
-  type a   
-  type b   
-  type t   
+  type a
+  type b
+  type t
   let rec cfg uses_custom [@cfg:stackify] (t : t) : () = 
   var _0 : ();
   var t_1 : t;
@@ -42,15 +42,15 @@ module Trait_UsesCustom
   
 end
 module Trait_UsesCustom2_Interface
-  type a   
-  type b   
-  type t   
+  type a
+  type b
+  type t
   val uses_custom2 [@cfg:stackify] (t : t) : ()
 end
 module Trait_UsesCustom2
-  type a   
-  type b   
-  type t   
+  type a
+  type b
+  type t
   let rec cfg uses_custom2 [@cfg:stackify] (t : t) : () = 
   var _0 : ();
   var t_1 : t;

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -15,13 +15,13 @@ module Type
   use prelude.Prelude
 end
 module TraitImpl_T_X_Interface
-  type self   
-  type b   
+  type self
+  type b
   val x [@cfg:stackify] (self : self) : ()
 end
 module TraitImpl_T_X
-  type self   
-  type b   
+  type self
+  type b
   val x [@cfg:stackify] (self : self) : ()
 end
 module TraitImpl_Main_Interface
@@ -40,15 +40,15 @@ module TraitImpl_Main
   
 end
 module TraitImpl_Impl0_X_Interface
-  type b   
-  type t2   
-  type t1   
+  type b
+  type t2
+  type t1
   val x [@cfg:stackify] (self : (t1, t2)) : ()
 end
 module TraitImpl_Impl0_X
-  type b   
-  type t2   
-  type t1   
+  type b
+  type t2
+  type t1
   let rec cfg x [@cfg:stackify] (self : (t1, t2)) : () = 
   var _0 : ();
   var self_1 : (t1, t2);
@@ -67,13 +67,13 @@ module TraitImpl_Impl0_X
   
 end
 module TraitImpl_Impl1_X_Interface
-  type b   
+  type b
   use mach.int.Int
   use mach.int.UInt32
   val x [@cfg:stackify] (self : uint32) : ()
 end
 module TraitImpl_Impl1_X
-  type b   
+  type b
   use mach.int.Int
   use mach.int.UInt32
   let rec cfg x [@cfg:stackify] (self : uint32) : () = 
@@ -91,14 +91,14 @@ module TraitImpl_Impl1_X
   
 end
 module TraitImpl_Impl0
-  type b   
-  type t2   
-  type t1   
+  type b
+  type t2
+  type t1
   clone TraitImpl_Impl0_X_Interface as X0 with type b = b, type t2 = t2, type t1 = t1
   clone TraitImpl_T_X_Interface as X1 with type self = (t1, t2), type b = b, val x = X0.x
 end
 module TraitImpl_Impl1
-  type b   
+  type b
   use mach.int.Int
   use mach.int.UInt32
   clone TraitImpl_Impl1_X_Interface as X0 with type b = b

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -15,23 +15,23 @@ module Type
   use prelude.Prelude
 end
 module C01_A_FromB_Interface
-  type self   
-  type b   
+  type self
+  type b
   val from_b [@cfg:stackify] (x : self) : b
 end
 module C01_A_FromB
-  type self   
-  type b   
+  type self
+  type b
   val from_b [@cfg:stackify] (x : self) : b
 end
 module C01_UsesGeneric_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.UInt32
   val uses_generic [@cfg:stackify] (b : t) : uint32
 end
 module C01_UsesGeneric
-  type t   
+  type t
   use mach.int.Int
   use mach.int.UInt32
   clone C01_A_FromB_Interface as FromB0 with type self = t, type b = uint32

--- a/creusot/tests/should_succeed/traits/02.stdout
+++ b/creusot/tests/should_succeed/traits/02.stdout
@@ -15,35 +15,35 @@ module Type
   use prelude.Prelude
 end
 module C02_A_IsTrue_Interface
-  type self   
+  type self
   use prelude.Prelude
   val is_true [@cfg:stackify] (self : self) : bool
     ensures { result = true }
     
 end
 module C02_A_IsTrue
-  type self   
+  type self
   use prelude.Prelude
   val is_true [@cfg:stackify] (self : self) : bool
     ensures { result = true }
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C02_Omg_Interface
-  type t   
+  type t
   val omg [@cfg:stackify] (a : t) : bool
     ensures { result = true }
     
 end
 module C02_Omg
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone C02_A_IsTrue_Interface as IsTrue0 with type self = t

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -15,60 +15,60 @@ module Type
   use prelude.Prelude
 end
 module C03_B_G_Interface
-  type self   
+  type self
   use prelude.Prelude
   val g [@cfg:stackify] (self : self) : self
     ensures { result = result }
     
 end
 module C03_B_G
-  type self   
+  type self
   use prelude.Prelude
   val g [@cfg:stackify] (self : self) : self
     ensures { result = result }
     
 end
 module C03_A_F_Interface
-  type self   
+  type self
   use prelude.Prelude
   val f [@cfg:stackify] (self : self) : self
 end
 module C03_A_F
-  type self   
+  type self
   use prelude.Prelude
   val f [@cfg:stackify] (self : self) : self
 end
 module C03_C_H_Interface
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   val h [@cfg:stackify] (x : t) : t
 end
 module C03_C_H
-  type self   
-  type t   
+  type self
+  type t
   use prelude.Prelude
   val h [@cfg:stackify] (x : t) : t
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
@@ -124,12 +124,12 @@ module C03_Impl1_G
   
 end
 module C03_Impl2_H_Interface
-  type g   
+  type g
   use prelude.Prelude
   val h [@cfg:stackify] (y : g) : g
 end
 module C03_Impl2_H
-  type g   
+  type g
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = g
   let rec cfg h [@cfg:stackify] (y : g) : g = 
@@ -160,7 +160,7 @@ module C03_Impl1
   clone C03_B_G_Interface as G1 with type self = uint32, val g = G0.g
 end
 module C03_Impl2
-  type g   
+  type g
   use mach.int.Int
   use mach.int.UInt32
   clone C03_Impl2_H_Interface as H0 with type g = g

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -15,67 +15,67 @@ module Type
   use prelude.Prelude
 end
 module C04_A_Func1_Interface
-  type self   
+  type self
   use prelude.Prelude
   val func1 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module C04_A_Func1
-  type self   
+  type self
   use prelude.Prelude
   val func1 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module C04_A_Func2_Interface
-  type self   
+  type self
   use prelude.Prelude
   val func2 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module C04_A_Func2
-  type self   
+  type self
   use prelude.Prelude
   val func2 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module C04_A_Func3_Interface
-  type self   
+  type self
   use prelude.Prelude
   val func3 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module C04_A_Func3
-  type self   
+  type self
   use prelude.Prelude
   val func3 [@cfg:stackify] (self : self) (o : self) : bool
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module C04_User_Interface
-  type t   
+  type t
   use prelude.Prelude
   val user [@cfg:stackify] (a : t) (b : t) : bool
     ensures { result = false }
     
 end
 module C04_User
-  type t   
+  type t
   use prelude.Prelude
   clone C04_A_Func3_Interface as Func30 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -15,11 +15,11 @@ module Type
   use prelude.Prelude
 end
 module C06_Ix_Tgt
-  type self   
-  type tgt   
+  type self
+  type tgt
 end
 module C06_Ix_Ix_Interface
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
@@ -27,7 +27,7 @@ module C06_Ix_Ix_Interface
   val ix [@cfg:stackify] (self : self) (ix : usize) : Tgt0.tgt
 end
 module C06_Ix_Ix
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt64
@@ -35,13 +35,13 @@ module C06_Ix_Ix
   val ix [@cfg:stackify] (self : self) (ix : usize) : Tgt0.tgt
 end
 module C06_Test_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone C06_Ix_Tgt as Tgt0 with type self = t
   val test [@cfg:stackify] (a : t) : Tgt0.tgt
 end
 module C06_Test
-  type t   
+  type t
   use prelude.Prelude
   clone C06_Ix_Tgt as Tgt0 with type self = t
   use mach.int.Int

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -15,17 +15,17 @@ module Type
   use prelude.Prelude
 end
 module C07_Ix_Tgt
-  type self   
-  type tgt   
+  type self
+  type tgt
 end
 module C07_Ix_Ix_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone C07_Ix_Tgt as Tgt0 with type self = self
   val ix [@cfg:stackify] (self : self) : Tgt0.tgt
 end
 module C07_Ix_Ix
-  type self   
+  type self
   use prelude.Prelude
   clone C07_Ix_Tgt as Tgt0 with type self = self
   val ix [@cfg:stackify] (self : self) : Tgt0.tgt
@@ -55,8 +55,8 @@ module C07_Impl0_Ix
   
 end
 module C07_Test_Interface
-  type g   
-  type t   
+  type g
+  type t
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
@@ -64,8 +64,8 @@ module C07_Test_Interface
   val test [@cfg:stackify] (a : uint32) (b : uint64) : bool
 end
 module C07_Test
-  type g   
-  type t   
+  type g
+  type t
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32

--- a/creusot/tests/should_succeed/traits/08.stdout
+++ b/creusot/tests/should_succeed/traits/08.stdout
@@ -15,42 +15,42 @@ module Type
   use prelude.Prelude
 end
 module C08_Tr_Logical_Interface
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   function logical (self : self) : int
 end
 module C08_Tr_Logical
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   function logical (self : self) : int
 end
 module C08_Tr_Predicate_Interface
-  type self   
+  type self
   use prelude.Prelude
   predicate predicate' (self : self)
 end
 module C08_Tr_Predicate
-  type self   
+  type self
   use prelude.Prelude
   predicate predicate' (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C08_Tr_Program_Interface
-  type self   
+  type self
   use prelude.Prelude
   val program [@cfg:stackify] (self : self) : ()
 end
 module C08_Tr_Program
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = self
   let rec cfg program [@cfg:stackify] (self : self) : () = 
@@ -68,11 +68,11 @@ module C08_Tr_Program
   
 end
 module C08_Test_Interface
-  type t   
+  type t
   val test [@cfg:stackify] (_1' : t) : ()
 end
 module C08_Test
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg test [@cfg:stackify] (_1' : t) : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -15,17 +15,17 @@ module Type
   use prelude.Prelude
 end
 module C09_Tr_X
-  type self   
-  type x   
+  type self
+  type x
 end
 module C09_Test_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.UInt32
   val test [@cfg:stackify] (t : uint32) : uint32
 end
 module C09_Test
-  type t   
+  type t
   use mach.int.Int
   use mach.int.UInt32
   let rec cfg test [@cfg:stackify] (t : uint32) : uint32 = 
@@ -46,14 +46,14 @@ module C09_Test
   
 end
 module C09_Test2_Interface
-  type t   
-  type u   
+  type t
+  type u
   clone C09_Tr_X as X0 with type self = t
   val test2 [@cfg:stackify] (t : X0.x) : X0.x
 end
 module C09_Test2
-  type t   
-  type u   
+  type t
+  type u
   clone C09_Tr_X as X0 with type self = t
   let rec cfg test2 [@cfg:stackify] (t : X0.x) : X0.x = 
   var _0 : X0.x;

--- a/creusot/tests/should_succeed/traits/10.stdout
+++ b/creusot/tests/should_succeed/traits/10.stdout
@@ -28,22 +28,22 @@ module Type
   axiom c10_pair_Pair_1_acc : forall a : 't, b : 'u . c10_pair_Pair_1 (C10_Pair a b : c10_pair 't 'u) = b
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C10_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   use Type
   predicate resolve (self : Type.c10_pair t1 t2)
 end
 module C10_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
@@ -51,8 +51,8 @@ module C10_Impl0_Resolve
     Resolve0.resolve (Type.c10_pair_Pair_0 self) && Resolve1.resolve (Type.c10_pair_Pair_1 self)
 end
 module C10_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1

--- a/creusot/tests/should_succeed/traits/11.stdout
+++ b/creusot/tests/should_succeed/traits/11.stdout
@@ -15,20 +15,20 @@ module Type
   use prelude.Prelude
 end
 module C11_A_T
-  type self   
-  type t   
+  type self
+  type t
 end
 module C11_Id_Interface
-  type t   
+  type t
   function id (x : t) : t
 end
 module C11_Id
-  type t   
+  type t
   function id (x : t) : t = 
     x
 end
 module C11_A_F_Interface
-  type self   
+  type self
   clone C11_A_T as T0 with type self = self
   clone C11_Id_Interface as Id0 with type t = T0.t
   val f [@cfg:stackify] (x : T0.t) : ()
@@ -36,7 +36,7 @@ module C11_A_F_Interface
     
 end
 module C11_A_F
-  type self   
+  type self
   clone C11_A_T as T0 with type self = self
   clone C11_Id as Id0 with type t = T0.t
   val f [@cfg:stackify] (x : T0.t) : ()
@@ -44,19 +44,19 @@ module C11_A_F
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C11_Test_Interface
-  type t   
+  type t
   val test [@cfg:stackify] (_1' : t) : ()
 end
 module C11_Test
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg test [@cfg:stackify] (_1' : t) : () = 
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -15,22 +15,22 @@ module Type
   use prelude.Prelude
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C12DefaultMethod_T_Default_Interface
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
   val default [@cfg:stackify] (self : self) : uint32
 end
 module C12DefaultMethod_T_Default
-  type self   
+  type self
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
@@ -50,25 +50,25 @@ module C12DefaultMethod_T_Default
   
 end
 module C12DefaultMethod_T_LogicDefault_Interface
-  type self   
+  type self
   function logic_default (self : self) : bool
 end
 module C12DefaultMethod_T_LogicDefault
-  type self   
+  type self
   function logic_default (self : self) : bool = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/traits/13_assoc_types.stdout
+++ b/creusot/tests/should_succeed/traits/13_assoc_types.stdout
@@ -15,35 +15,35 @@ module Type
   use prelude.Prelude
 end
 module C13AssocTypes_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module C13AssocTypes_Model_Model_Interface
-  type self   
+  type self
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = self
   val model [@cfg:stackify] (self : self) : ModelTy0.modelTy
 end
 module C13AssocTypes_Model_Model
-  type self   
+  type self
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = self
   val model [@cfg:stackify] (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module C13AssocTypes_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
   val model [@cfg:stackify] (self : t) : ModelTy0.modelTy
 end
 module C13AssocTypes_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
@@ -67,13 +67,13 @@ module C13AssocTypes_Impl0_Model
   
 end
 module C13AssocTypes_Impl0_ModelTy
-  type t   
+  type t
   clone C13AssocTypes_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module C13AssocTypes_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone C13AssocTypes_Model_ModelTy as ModelTy2 with type self = t
   clone C13AssocTypes_Impl0_Model_Interface as Model0 with type t = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/traits/14_assoc_in_logic.stdout
+++ b/creusot/tests/should_succeed/traits/14_assoc_in_logic.stdout
@@ -15,31 +15,31 @@ module Type
   use prelude.Prelude
 end
 module C14AssocInLogic_Assoc_Ty
-  type self   
-  type ty   
+  type self
+  type ty
 end
 module C14AssocInLogic_FromTy_Interface
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   function from_ty (x : Ty0.ty) : t
 end
 module C14AssocInLogic_FromTy
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   function from_ty (x : Ty0.ty) : t
 end
 module C14AssocInLogic_ToTy_Interface
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   function to_ty (x : t) : Ty0.ty
 end
 module C14AssocInLogic_ToTy
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   function to_ty (x : t) : Ty0.ty
 end
 module C14AssocInLogic_Test_Interface
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   clone C14AssocInLogic_FromTy_Interface as FromTy0 with type t = t, type Ty0.ty = Ty0.ty
   clone C14AssocInLogic_ToTy_Interface as ToTy0 with type t = t, type Ty0.ty = Ty0.ty
@@ -48,7 +48,7 @@ module C14AssocInLogic_Test_Interface
     
 end
 module C14AssocInLogic_Test
-  type t   
+  type t
   clone C14AssocInLogic_Assoc_Ty as Ty0 with type self = t
   clone C14AssocInLogic_FromTy as FromTy0 with type t = t, type Ty0.ty = Ty0.ty
   clone C14AssocInLogic_ToTy as ToTy0 with type t = t, type Ty0.ty = Ty0.ty

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -15,16 +15,16 @@ module Type
   use prelude.Prelude
 end
 module C15ImplInterfaces_Tr_A
-  type self   
-  type a   
+  type self
+  type a
 end
 module C15ImplInterfaces_X_Interface
-  type t   
+  type t
   clone C15ImplInterfaces_Tr_A as A0 with type self = t
   function x (x : t) : A0.a
 end
 module C15ImplInterfaces_X
-  type t   
+  type t
   clone C15ImplInterfaces_Tr_A as A0 with type self = t
   function x (x : t) : A0.a
 end
@@ -37,24 +37,24 @@ module C15ImplInterfaces_Impl0
   clone C15ImplInterfaces_Tr_A as A1 with type self = (), type a = A0.a
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.stdout
@@ -33,39 +33,39 @@ module Type
     
 end
 module C16ImplCloning_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.c16implcloning_vec t) : Seq.seq t
 end
 module C16ImplCloning_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.c16implcloning_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -74,19 +74,19 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module C16ImplCloning_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -99,7 +99,7 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module C16ImplCloning_Impl0
-  type t   
+  type t
   use Type
   clone C16ImplCloning_Impl0_Model as Model0 with type t = t
   clone C16ImplCloning_Impl0_ModelTy as ModelTy0 with type t = t
@@ -109,33 +109,33 @@ module C16ImplCloning_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module C16ImplCloning_Test_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone C16ImplCloning_Impl0_Model_Interface as Model1 with type t = t
@@ -147,7 +147,7 @@ module C16ImplCloning_Test_Interface
     
 end
 module C16ImplCloning_Test
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone C16ImplCloning_Impl0_Model as Model1 with type t = t

--- a/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
+++ b/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
@@ -15,7 +15,7 @@ module Type
   use prelude.Prelude
 end
 module C17ImplRefinement_Tr_MyFunction_Interface
-  type self   
+  type self
   use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
@@ -25,7 +25,7 @@ module C17ImplRefinement_Tr_MyFunction_Interface
     
 end
 module C17ImplRefinement_Tr_MyFunction
-  type self   
+  type self
   use mach.int.UInt64
   use mach.int.Int
   use mach.int.Int32
@@ -35,24 +35,24 @@ module C17ImplRefinement_Tr_MyFunction
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/traits/18_trait_laws.stdout
+++ b/creusot/tests/should_succeed/traits/18_trait_laws.stdout
@@ -15,37 +15,37 @@ module Type
   use prelude.Prelude
 end
 module C18TraitLaws_Symmetric_Op_Interface
-  type self   
+  type self
   function op (self : self) (_2' : self) : self
 end
 module C18TraitLaws_Symmetric_Op
-  type self   
+  type self
   function op (self : self) (_2' : self) : self
 end
 module C18TraitLaws_Symmetric_Reflexive_Interface
-  type self   
+  type self
   clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = self
   function reflexive (a : self) (b : self) : ()
 end
 module C18TraitLaws_Symmetric_Reflexive
-  type self   
+  type self
   clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = self
   function reflexive (a : self) (b : self) : ()
   axiom reflexive_spec : forall a : self, b : self . Op0.op a b = Op0.op b a
 end
 module C18TraitLaws_UsesOp_Interface
-  type t   
+  type t
   function uses_op (x : t) (y : t) : bool
 end
 module C18TraitLaws_UsesOp
-  type t   
+  type t
   clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = t
   function uses_op (x : t) (y : t) : bool = 
     Op0.op x y = Op0.op y x
   axiom uses_op_spec : forall x : t, y : t . uses_op x y = true
 end
 module C18TraitLaws_UsesOp_Impl
-  type t   
+  type t
   clone C18TraitLaws_Symmetric_Op as Op0 with type self = t
   clone C18TraitLaws_Symmetric_Reflexive as Reflexive0 with type self = t, function Op0.op = Op0.op, axiom .
   let rec ghost function uses_op (x : t) (y : t) : bool

--- a/creusot/tests/should_succeed/unnest.stdout
+++ b/creusot/tests/should_succeed/unnest.stdout
@@ -30,26 +30,26 @@ module Unnest_Main
   
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -30,24 +30,24 @@ module UnusedInLoop_Main
   
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -13,7 +13,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
@@ -34,48 +34,48 @@ module C01_Main
   
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -85,13 +85,13 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -101,16 +101,16 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -119,7 +119,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -128,13 +128,13 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -143,7 +143,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -157,7 +157,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -171,13 +171,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -185,8 +185,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -194,13 +194,13 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -209,7 +209,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -229,7 +229,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -249,37 +249,37 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -295,20 +295,20 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -320,13 +320,13 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -18,40 +18,40 @@ module Type
     | Core_Cmp_Ordering_Equal
     | Core_Cmp_Ordering_Greater
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
-  type self   
+  type self
   predicate le_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
 end
 module C02Gnome_SortedRange_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
 end
 module C02Gnome_SortedRange
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
@@ -59,12 +59,12 @@ module C02Gnome_SortedRange
     forall j : (int) . forall i : (int) . l <= i && i < j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module C02Gnome_Sorted_Interface
-  type t   
+  type t
   use seq.Seq
   predicate sorted (s : Seq.seq t)
 end
 module C02Gnome_Sorted
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -73,24 +73,24 @@ module C02Gnome_Sorted
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
+  type t
   use seq.Seq
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -99,27 +99,27 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
     Permut.permut self o 0 (Seq.length self)
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -128,23 +128,23 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -157,12 +157,12 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -172,13 +172,13 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -188,14 +188,14 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
@@ -203,25 +203,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
+  type self
   predicate lt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
@@ -229,25 +229,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
+  type self
   predicate ge_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
@@ -255,25 +255,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
+  type self
   predicate gt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
@@ -281,74 +281,74 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
   axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
   axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -356,69 +356,69 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -427,7 +427,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -436,22 +436,22 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -460,7 +460,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -474,7 +474,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -488,7 +488,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -506,7 +506,7 @@ module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -524,13 +524,13 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -538,8 +538,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -547,7 +547,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -562,7 +562,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -577,7 +577,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -586,7 +586,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -595,7 +595,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -603,7 +603,7 @@ module CreusotContracts_Std1_Ord_Ord_Le_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -611,7 +611,7 @@ module CreusotContracts_Std1_Ord_Ord_Le
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -619,7 +619,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -627,7 +627,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -635,7 +635,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -643,7 +643,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -651,7 +651,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -659,29 +659,29 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -698,20 +698,20 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -723,7 +723,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module C02Gnome_GnomeSort_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone C02Gnome_Sorted_Interface as Sorted0 with type t = t
@@ -735,7 +735,7 @@ module C02Gnome_GnomeSort_Interface
     
 end
 module C02Gnome_GnomeSort
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -13,7 +13,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type creusotcontracts_logic_ghost_ghost 't = 
     | CreusotContracts_Logic_Ghost_Ghost opaque_ptr
     
@@ -37,39 +37,39 @@ module C03KnuthShuffle_RandInRange
     
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -78,12 +78,12 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface
-  type t   
+  type t
   use seq.Seq
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t)
 end
 module CreusotContracts_Logic_Seq_Impl1_PermutationOf
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -92,29 +92,29 @@ module CreusotContracts_Logic_Seq_Impl1_PermutationOf
     Permut.permut self o 0 (Seq.length self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Ghost_Impl0_Model
-  type t   
+  type t
   use Type
   function model (self : Type.creusotcontracts_logic_ghost_ghost t) : t
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -127,12 +127,12 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ghost_Impl0_ModelTy
-  type t   
+  type t
   type modelTy  = 
     t
 end
 module CreusotContracts_Logic_Ghost_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Logic_Ghost_Impl0_ModelTy as ModelTy0 with type t = t
@@ -142,7 +142,7 @@ module CreusotContracts_Logic_Ghost_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -152,15 +152,15 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -169,7 +169,7 @@ module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
     
 end
 module CreusotContracts_Logic_Ghost_Impl1_Record
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model_Interface as Model0 with type t = t
@@ -178,22 +178,22 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -202,7 +202,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -216,7 +216,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -230,7 +230,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -248,7 +248,7 @@ module CreusotContracts_Std1_Vec_Impl1_Swap_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Swap
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -266,37 +266,37 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -308,7 +308,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module C03KnuthShuffle_KnuthShuffle_Interface
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Seq_Impl1_PermutationOf_Interface as PermutationOf0 with type t = t
@@ -321,7 +321,7 @@ module C03KnuthShuffle_KnuthShuffle_Interface
     
 end
 module C03KnuthShuffle_KnuthShuffle
-  type t   
+  type t
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Seq_Impl1_PermutationOf as PermutationOf0 with type t = t

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -17,7 +17,7 @@ module Type
     | Core_Result_Result_Ok 't
     | Core_Result_Result_Err 'e
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module C04BinarySearch_SortedRange_Interface
   use seq.Seq
@@ -48,27 +48,27 @@ module C04BinarySearch_Sorted
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -77,19 +77,19 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -101,19 +101,19 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -123,7 +123,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -137,7 +137,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -151,22 +151,22 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -174,8 +174,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -183,7 +183,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -198,7 +198,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -213,26 +213,26 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -22,37 +22,37 @@ module Type
     | Core_Result_Result_Ok 't
     | Core_Result_Result_Err 'e
     
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
-  type self   
+  type self
   use Type
   function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
-  type self   
+  type self
   predicate le_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater)
 end
 module C05BinarySearchGeneric_SortedRange_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   predicate sorted_range (s : Seq.seq t) (l : int) (u : int)
 end
 module C05BinarySearchGeneric_SortedRange
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
@@ -60,12 +60,12 @@ module C05BinarySearchGeneric_SortedRange
     forall j : (int) . forall i : (int) . l <= i && i <= j && j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module C05BinarySearchGeneric_Sorted_Interface
-  type t   
+  type t
   use seq.Seq
   predicate sorted (s : Seq.seq t)
 end
 module C05BinarySearchGeneric_Sorted
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -74,27 +74,27 @@ module C05BinarySearchGeneric_Sorted
     SortedRange0.sorted_range s 0 (Seq.length s)
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -103,38 +103,38 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
-  type self   
+  type self
   predicate lt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -146,14 +146,14 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
@@ -161,14 +161,14 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
@@ -176,25 +176,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
-  type self   
+  type self
   predicate ge_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) = 
     not (CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
@@ -202,25 +202,25 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = not (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
-  type self   
+  type self
   predicate gt_log (self : self) (o : self)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) = 
     CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
@@ -228,66 +228,66 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
   axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
   axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
   axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
-  type self   
+  type self
   use Type
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -295,73 +295,73 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   axiom eq_cmp_spec : forall x : self, y : self . (LogEq0.log_eq x y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> LogEq0.log_eq x y)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -371,7 +371,7 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -385,7 +385,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -399,30 +399,30 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -430,8 +430,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -439,7 +439,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -454,7 +454,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -469,7 +469,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -478,7 +478,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Cmp
-  type self   
+  type self
   use prelude.Prelude
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
@@ -487,7 +487,7 @@ module CreusotContracts_Std1_Ord_Ord_Cmp
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -495,7 +495,7 @@ module CreusotContracts_Std1_Ord_Ord_Le_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Le
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   val le [@cfg:stackify] (self : self) (o : self) : bool
@@ -503,7 +503,7 @@ module CreusotContracts_Std1_Ord_Ord_Le
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -511,7 +511,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Ge
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   val ge [@cfg:stackify] (self : self) (o : self) : bool
@@ -519,7 +519,7 @@ module CreusotContracts_Std1_Ord_Ord_Ge
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -527,7 +527,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Gt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   val gt [@cfg:stackify] (self : self) (o : self) : bool
@@ -535,7 +535,7 @@ module CreusotContracts_Std1_Ord_Ord_Gt
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -543,7 +543,7 @@ module CreusotContracts_Std1_Ord_Ord_Lt_Interface
     
 end
 module CreusotContracts_Std1_Ord_Ord_Lt
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   val lt [@cfg:stackify] (self : self) (o : self) : bool
@@ -551,18 +551,18 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -579,7 +579,7 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module C05BinarySearchGeneric_BinarySearch_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use prelude.Prelude
@@ -601,7 +601,7 @@ module C05BinarySearchGeneric_BinarySearch_Interface
     
 end
 module C05BinarySearchGeneric_BinarySearch
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -13,7 +13,7 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
   type c06knightstour_point  = 
     | C06KnightsTour_Point isize isize
     
@@ -52,36 +52,36 @@ module Type
   axiom c06knightstour_board_Board_field_acc : forall a : usize, b : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize) . c06knightstour_board_Board_field (C06KnightsTour_Board a b : c06knightstour_board) = b
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -90,13 +90,13 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -110,7 +110,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -124,13 +124,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -138,8 +138,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -147,7 +147,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -162,7 +162,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -177,38 +177,38 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -225,13 +225,13 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -243,7 +243,7 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -543,7 +543,7 @@ module C06KnightsTour_Impl1_Wf
     UInt64.to_int (Type.c06knightstour_board_Board_size self) <= 1000 && Seq.length (Model0.model (Type.c06knightstour_board_Board_field self)) = UInt64.to_int (Type.c06knightstour_board_Board_size self) && (forall i : (int) . 0 <= i && i < UInt64.to_int (Type.c06knightstour_board_Board_size self) -> Seq.length (Model1.model (Seq.get (Model0.model (Type.c06knightstour_board_Board_field self)) i)) = UInt64.to_int (Type.c06knightstour_board_Board_size self))
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -556,7 +556,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_WithCapacity
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -569,7 +569,7 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     
 end
 module CreusotContracts_Std1_Vec_FromElem_Interface
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -583,7 +583,7 @@ module CreusotContracts_Std1_Vec_FromElem_Interface
     
 end
 module CreusotContracts_Std1_Vec_FromElem
-  type t   
+  type t
   use mach.int.Int
   use mach.int.Int32
   use mach.int.UInt64
@@ -597,13 +597,13 @@ module CreusotContracts_Std1_Vec_FromElem
     
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -612,7 +612,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl1_Push_Interface
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -625,7 +625,7 @@ module CreusotContracts_Std1_Vec_Impl1_Push_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Push
-  type t   
+  type t
   use seq.Seq
   use prelude.Prelude
   use Type
@@ -638,12 +638,12 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
-  type t   
+  type t
   use Type
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t)
 end
 module CreusotContracts_Std1_Vec_Impl5_Resolve
-  type t   
+  type t
   use Type
   use mach.int.Int
   use mach.int.Int32
@@ -654,7 +654,7 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl5
-  type t   
+  type t
   use Type
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
@@ -664,13 +664,13 @@ module CreusotContracts_Std1_Vec_Impl5
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -1040,21 +1040,21 @@ module C06KnightsTour_Moves
     
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
-  type t1   
-  type t2   
+  type t1
+  type t2
   predicate resolve (self : (t1, t2))
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) = 
     Resolve0.resolve (let (a, _) = self in a) && Resolve1.resolve (let (_, a) = self in a)
 end
 module CreusotContracts_Logic_Resolve_Impl0
-  type t1   
-  type t2   
+  type t1
+  type t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t1
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve0 with type t1 = t1, type t2 = t2,
@@ -1240,19 +1240,19 @@ module C06KnightsTour_Impl1_CountDegree
   
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -1260,8 +1260,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -1269,7 +1269,7 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -1289,7 +1289,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -1309,14 +1309,14 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -1459,7 +1459,7 @@ module C06KnightsTour_DumbNonlinearArith_Impl
     ()
 end
 module CreusotContracts_Std1_Vec_Impl1_New_Interface
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -1470,7 +1470,7 @@ module CreusotContracts_Std1_Vec_Impl1_New_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_New
-  type t   
+  type t
   use seq.Seq
   use mach.int.Int
   use mach.int.Int32
@@ -1889,28 +1889,28 @@ module C06KnightsTour_Impl2
   
 end
 module Core_Clone_Clone_Clone_Interface
-  type self   
+  type self
   use prelude.Prelude
   val clone' [@cfg:stackify] (self : self) : self
     requires {false}
     
 end
 module Core_Clone_Clone_Clone
-  type self   
+  type self
   use prelude.Prelude
   val clone' [@cfg:stackify] (self : self) : self
     requires {false}
     
 end
 module Core_Clone_Clone_CloneFrom_Interface
-  type self   
+  type self
   use prelude.Prelude
   val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
     requires {false}
     
 end
 module Core_Clone_Clone_CloneFrom
-  type self   
+  type self
   use prelude.Prelude
   val clone_from [@cfg:stackify] (self : borrowed self) (source : self) : ()
     requires {false}

--- a/creusot/tests/should_succeed/vector/07_read_write.stdout
+++ b/creusot/tests/should_succeed/vector/07_read_write.stdout
@@ -13,30 +13,30 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : borrowed t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -45,19 +45,19 @@ module CreusotContracts_Logic_Model_Impl1_Model
     Model0.model ( * self)
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
 end
 module CreusotContracts_Logic_Model_Impl1_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -70,19 +70,19 @@ module CreusotContracts_Logic_Model_Impl1
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -92,30 +92,30 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -123,8 +123,8 @@ module Core_Ops_Index_IndexMut_IndexMut_Interface
     
 end
 module Core_Ops_Index_IndexMut_IndexMut
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index_mut [@cfg:stackify] (self : borrowed self) (index : idx) : borrowed Output0.output
@@ -132,7 +132,7 @@ module Core_Ops_Index_IndexMut_IndexMut
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -152,7 +152,7 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl2_IndexMut
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -172,19 +172,19 @@ module CreusotContracts_Std1_Vec_Impl2_IndexMut
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -192,8 +192,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -201,13 +201,13 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -216,7 +216,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -231,7 +231,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -246,15 +246,15 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogEq
-  type self   
+  type self
   predicate log_eq (self : self) (_2' : self)
 end
 module CreusotContracts_Std1_Eq_Eq_Eq_Interface
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   val eq [@cfg:stackify] (self : self) (o : self) : bool
@@ -262,7 +262,7 @@ module CreusotContracts_Std1_Eq_Eq_Eq_Interface
     
 end
 module CreusotContracts_Std1_Eq_Eq_Eq
-  type self   
+  type self
   use prelude.Prelude
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   val eq [@cfg:stackify] (self : self) (o : self) : bool
@@ -270,18 +270,18 @@ module CreusotContracts_Std1_Eq_Eq_Eq
     
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl2
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -297,14 +297,14 @@ module CreusotContracts_Std1_Vec_Impl2
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude
@@ -321,13 +321,13 @@ module CreusotContracts_Std1_Vec_Impl3
   type output = Output0.output
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -339,61 +339,61 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_LogNe
-  type self   
+  type self
   predicate log_ne (self : self) (_2' : self)
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_EqNe
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe_Interface as LogNe0 with type self = self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function eq_ne (a : self) (b : self) : ()
   axiom eq_ne_spec : forall a : self, b : self . not (LogEq0.log_eq a b = LogNe0.log_ne a b)
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Refl
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function refl (x : self) : ()
   axiom refl_spec : forall x : self . LogEq0.log_eq x x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Symmetry
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function symmetry (x : self) (y : self) : ()
   axiom symmetry_spec : forall x : self, y : self . LogEq0.log_eq x y -> LogEq0.log_eq y x
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
 end
 module CreusotContracts_Logic_Eq_EqLogic_Transitivity
-  type self   
+  type self
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq_Interface as LogEq0 with type self = self
   function transitivity (x : self) (y : self) (z : self) : ()
   axiom transitivity_spec : forall x : self, y : self, z : self . LogEq0.log_eq y z -> LogEq0.log_eq x y -> LogEq0.log_eq x z
 end
 module C07ReadWrite_ReadWrite_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -407,7 +407,7 @@ module C07ReadWrite_ReadWrite_Interface
     
 end
 module C07ReadWrite_ReadWrite
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int

--- a/creusot/tests/should_succeed/vector/08_haystack.stdout
+++ b/creusot/tests/should_succeed/vector/08_haystack.stdout
@@ -13,30 +13,30 @@ module Type
   use floating_point.Single
   use floating_point.Double
   use prelude.Prelude
-  type creusotcontracts_std1_vec_vec 't  
+  type creusotcontracts_std1_vec_vec 't
 end
 module CreusotContracts_Logic_Model_Model_ModelTy
-  type self   
-  type modelTy   
+  type self
+  type modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model_Interface
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Model_Model
-  type self   
+  type self
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
   function model (self : self) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   function model (self : t) : ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0_Model
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
@@ -45,7 +45,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
     Model0.model self
 end
 module CreusotContracts_Std1_Vec_Impl0_ModelTy
-  type t   
+  type t
   use seq.Seq
   type modelTy  = 
     Seq.seq t
@@ -74,13 +74,13 @@ module C08Haystack_MatchAt
     len <= Seq.length (Model0.model needle) && pos <= Seq.length (Model0.model haystack) - len && (forall i : (int) . 0 <= i && i < len -> Seq.get (Model0.model needle) i = Seq.get (Model0.model haystack) (pos + i))
 end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
-  type t   
+  type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
   type modelTy  = 
     ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Model_Impl0
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy2 with type self = t
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = t, type ModelTy0.modelTy = ModelTy2.modelTy
@@ -92,19 +92,19 @@ module CreusotContracts_Logic_Model_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
-  type t   
+  type t
   use Type
   use seq.Seq
   function model (self : Type.creusotcontracts_std1_vec_vec t) : Seq.seq t
 end
 module CreusotContracts_Std1_Vec_Impl0
-  type t   
+  type t
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
@@ -114,16 +114,16 @@ module CreusotContracts_Std1_Vec_Impl0
   type modelTy = ModelTy0.modelTy
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -137,7 +137,7 @@ module CreusotContracts_Std1_Vec_Impl1_Len_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl1_Len
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use prelude.Prelude
@@ -151,13 +151,13 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     
 end
 module Core_Ops_Index_Index_Output
-  type self   
-  type idx   
-  type output   
+  type self
+  type idx
+  type output
 end
 module Core_Ops_Index_Index_Index_Interface
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -165,8 +165,8 @@ module Core_Ops_Index_Index_Index_Interface
     
 end
 module Core_Ops_Index_Index_Index
-  type self   
-  type idx   
+  type self
+  type idx
   use prelude.Prelude
   clone Core_Ops_Index_Index_Output as Output0 with type self = self, type idx = idx
   val index [@cfg:stackify] (self : self) (index : idx) : Output0.output
@@ -174,7 +174,7 @@ module Core_Ops_Index_Index_Index
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index_Interface
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -189,7 +189,7 @@ module CreusotContracts_Std1_Vec_Impl3_Index_Interface
     
 end
 module CreusotContracts_Std1_Vec_Impl3_Index
-  type t   
+  type t
   use mach.int.UInt64
   use seq.Seq
   use mach.int.Int
@@ -204,26 +204,26 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
-  type t   
+  type t
   type output  = 
     t
 end
 module CreusotContracts_Std1_Vec_Impl3
-  type t   
+  type t
   use Type
   use mach.int.Int
   use prelude.Prelude

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -19,41 +19,41 @@ module Type
     
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t   
+  type t
   predicate resolve (self : t)
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t   
+  type t
   predicate resolve (self : t) = 
     true
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t)
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve
-  type t   
+  type t
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self   
+  type self
   predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl2
-  type t   
+  type t
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
-  type t   
+  type t
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -924,23 +924,79 @@ impl Print for TyDecl {
     where
         A::Doc: Clone,
     {
-        let mut ty_decl =
-            alloc.text("type ").append(self.ty_name.pretty(alloc, env)).append(" ").append(
-                alloc.intersperse(
-                    self.ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+        let ty_decl = match self {
+            TyDecl::Opaque { ty_name, ty_params } => {
+                let mut decl = alloc.text("type ").append(ty_name.pretty(alloc, env));
+
+                if !ty_params.is_empty() {
+                    decl = decl.append(" ").append(alloc.intersperse(
+                        ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+                        alloc.space(),
+                    ));
+                }
+                decl
+            }
+            TyDecl::Alias { ty_name, ty_params, alias } => alloc
+                .text("type ")
+                .append(ty_name.pretty(alloc, env))
+                .append(" ")
+                .append(alloc.intersperse(
+                    ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
                     alloc.space(),
-                ),
-            );
+                ))
+                .append(alloc.text(" = ").append(alloc.hardline()))
+                .append(alias.pretty(alloc, env).indent(2)),
+            TyDecl::Adt { tys } => {
+                use std::iter::*;
+                let header = once("type").chain(repeat("with"));
+                let mut decl = alloc.nil();
 
-        if !matches!(self.kind, TyDeclKind::Opaque) {
-            ty_decl = ty_decl.append(alloc.text(" = ").append(alloc.hardline()));
-        }
+                for (hdr, ty_decl) in header.zip(tys.iter()) {
+                    decl = decl
+                        .append(hdr)
+                        .append(" ")
+                        .append(ty_decl.ty_name.pretty(alloc, env))
+                        .append(" ")
+                        .append(
+                            alloc.intersperse(
+                                ty_decl
+                                    .ty_params
+                                    .iter()
+                                    .map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+                                alloc.space(),
+                            ),
+                        );
 
-        ty_decl.append(self.kind.pretty(alloc, env).indent(2))
+                    let mut inner_doc = alloc.nil();
+                    for cons in &ty_decl.constrs {
+                        let ty_cons = alloc.text("| ").append(cons.pretty(alloc, env));
+                        inner_doc = inner_doc.append(ty_cons.append(alloc.hardline()))
+                    }
+                    decl = decl
+                        .append(alloc.text(" = ").append(alloc.hardline()))
+                        .append(inner_doc.indent(2))
+                }
+                decl
+            }
+        };
+
+        // let mut ty_decl =
+        //     alloc.text("type ").append(self.ty_name.pretty(alloc, env)).append(" ").append(
+        //         alloc.intersperse(
+        //             self.ty_params.iter().map(|p| alloc.text("'").append(p.pretty(alloc, env))),
+        //             alloc.space(),
+        //         ),
+        //     );
+
+        // if !matches!(self, TyDecl::Opaque { .. }) {
+        //     ty_decl = ty_decl.append(alloc.text(" = ").append(alloc.hardline()));
+        // }
+        ty_decl
+        // ty_decl.append(self.kind.pretty(alloc, env).indent(2))
     }
 }
 
-impl Print for TyDeclKind {
+impl Print for ConstructorDecl {
     fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
         &'a self,
         alloc: &'a A,
@@ -949,35 +1005,63 @@ impl Print for TyDeclKind {
     where
         A::Doc: Clone,
     {
-        match self {
-            TyDeclKind::Adt(cons) => {
-                let mut inner_doc = alloc.nil();
-                for (cons, args) in cons {
-                    let mut ty_cons = alloc.text("| ").append(alloc.text(cons));
+        let mut cons_doc = self.name.pretty(alloc, env);
 
-                    if !args.is_empty() {
-                        ty_cons = ty_cons.append(alloc.space()).append(alloc.intersperse(
-                            args.iter().map(|ty_arg| {
-                                if !ty_arg.complex() {
-                                    ty_arg.pretty(alloc, env)
-                                } else {
-                                    ty_arg.pretty(alloc, env).parens()
-                                }
-                            }),
-                            alloc.text(" "),
-                        ))
+        if !self.fields.is_empty() {
+            cons_doc = cons_doc.append(alloc.space()).append(alloc.intersperse(
+                self.fields.iter().map(|ty_arg| {
+                    if !ty_arg.complex() {
+                        ty_arg.pretty(alloc, env)
+                    } else {
+                        ty_arg.pretty(alloc, env).parens()
                     }
-
-                    inner_doc = inner_doc.append(ty_cons.append(alloc.hardline()))
-                }
-
-                inner_doc
-            }
-            TyDeclKind::Alias(t) => t.pretty(alloc, env),
-            TyDeclKind::Opaque => alloc.nil(),
+                }),
+                alloc.text(" "),
+            ));
         }
+
+        cons_doc
     }
 }
+
+// impl Print for TyDeclKind {
+//     fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(
+//         &'a self,
+//         alloc: &'a A,
+//         env: &mut PrintEnv,
+//     ) -> DocBuilder<'a, A>
+//     where
+//         A::Doc: Clone,
+//     {
+//         match self {
+//             TyDeclKind::Adt(cons) => {
+//                 let mut inner_doc = alloc.nil();
+//                 for (cons, args) in cons {
+//                     let mut ty_cons = alloc.text("| ").append(alloc.text(cons));
+
+//                     if !args.is_empty() {
+//                         ty_cons = ty_cons.append(alloc.space()).append(alloc.intersperse(
+//                             args.iter().map(|ty_arg| {
+//                                 if !ty_arg.complex() {
+//                                     ty_arg.pretty(alloc, env)
+//                                 } else {
+//                                     ty_arg.pretty(alloc, env).parens()
+//                                 }
+//                             }),
+//                             alloc.text(" "),
+//                         ))
+//                     }
+
+//                     inner_doc = inner_doc.append(ty_cons.append(alloc.hardline()))
+//                 }
+
+//                 inner_doc
+//             }
+//             TyDeclKind::Alias(t) => t.pretty(alloc, env),
+//             TyDeclKind::Opaque => alloc.nil(),
+//         }
+//     }
+// }
 
 impl Print for Ident {
     fn pretty<'b, 'a: 'b, A: DocAllocator<'a>>(


### PR DESCRIPTION
I figured it was time to actually do the Red-Black Tree proof I said I would do.
The natural definition in Rust involves using a mutually recursive pointer and node type, which doesn't pose any intrinsic difficulty.

This PR removes the restriction on using mutually recursive types in Creusot, translating them to mutually recursive types in Why3.
When we eventually split up the `Types` module, we'll just have to make sure to handle importing any of the mutually recursive components correctly, but this doesn't seem especially challenging. 
