### PR TITLE
Remove unnecessary resolve statements

### DIFF
--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -64,8 +64,7 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                     // TODO: should this be done for *any* form of assignment?
                     let ty = place.ty(self.body, self.tcx).ty;
                     let pl_exp = self.translate_rplace(place);
-                    let assumption: Exp = self.resolve_ty(ty).app_to(pl_exp);
-                    self.emit_statement(Assume(assumption));
+                    self.resolve_ty(ty).emit(pl_exp, self);
                     self.translate_rplace(pl)
                 }
                 Constant(box c) => crate::constant::from_mir_constant(

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -128,8 +128,7 @@ impl<'tcx> FunctionTranslator<'_, '_, 'tcx> {
                 // Drop
                 let ty = place.ty(self.body, self.tcx).ty;
                 let pl_exp = self.translate_rplace(place);
-                let assumption: Exp = self.resolve_ty(ty).app_to(pl_exp);
-                self.emit_statement(Statement::Assume(assumption));
+                self.resolve_ty(ty).emit(pl_exp, self);
 
                 // Assign
                 let rhs = match value {

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -83,15 +83,6 @@ module CreusotContracts_Std1_Vec_Impl1_WithCapacity
     ensures { Seq.length (Model0.model result) = 0 }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t
   use prelude.Prelude
@@ -322,12 +313,6 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -420,6 +405,21 @@ module CreusotContracts_Logic_Model_Impl0
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = t, type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C100doors_Main_Interface
   val main [@cfg:stackify] () : ()
 end
@@ -431,12 +431,9 @@ module C100doors_Main
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = bool
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = bool
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec bool,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = bool,
@@ -448,7 +445,7 @@ module C100doors_Main
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = bool,
   function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = bool, function Model0.model = Model0.model,
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = bool, function Model0.model = Model0.model,
   predicate Resolve0.resolve = Resolve2.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = bool,
   function Model0.model = Model0.model
@@ -511,7 +508,6 @@ module C100doors_Main
   BB3 {
     invariant loop_bounds { 1 <= UInt64.to_int i_2 && UInt64.to_int i_2 <= 101 };
     invariant door_size { Seq.length (Model0.model door_open_1) = UInt64.to_int i_2 - 1 };
-    assume { Resolve0.resolve _6 };
     _6 <- i_2;
     _5 <- _6 < (101 : usize);
     switch (_5)
@@ -528,13 +524,10 @@ module C100doors_Main
   BB5 {
     i_2 <- i_2 + (1 : usize);
     _4 <- ();
-    assume { Resolve1.resolve _4 };
     goto BB3
   }
   BB6 {
-    assume { Resolve0.resolve i_2 };
     _3 <- ();
-    assume { Resolve1.resolve _3 };
     _16 <- door_open_1;
     _15 <- Len0.len _16;
     goto BB7
@@ -552,7 +545,6 @@ module C100doors_Main
   }
   BB9 {
     _12 <- ();
-    assume { Resolve1.resolve _12 };
     pass_18 <- (1 : usize);
     goto BB10
   }
@@ -562,7 +554,6 @@ module C100doors_Main
   BB11 {
     invariant loop_bounds { 1 <= UInt64.to_int pass_18 && UInt64.to_int pass_18 <= 101 };
     invariant door_size { Seq.length (Model0.model door_open_1) = 100 };
-    assume { Resolve0.resolve _20 };
     _20 <- pass_18;
     _19 <- _20 < (101 : usize);
     switch (_19)
@@ -571,7 +562,6 @@ module C100doors_Main
       end
   }
   BB12 {
-    assume { Resolve0.resolve door_21 };
     door_21 <- pass_18;
     goto BB13
   }
@@ -581,7 +571,6 @@ module C100doors_Main
   BB14 {
     invariant loop_bounds { 1 <= UInt64.to_int door_21 && UInt64.to_int door_21 <= 100 + UInt64.to_int pass_18 };
     invariant door_size { Seq.length (Model0.model door_open_1) = 100 };
-    assume { Resolve0.resolve _24 };
     _24 <- door_21;
     _23 <- _24 <= (100 : usize);
     switch (_23)
@@ -591,19 +580,15 @@ module C100doors_Main
   }
   BB15 {
     _27 <- door_open_1;
-    assume { Resolve0.resolve _29 };
     _29 <- door_21;
     _28 <- _29 - (1 : usize);
     _26 <- Index0.index _27 _28;
     goto BB16
   }
   BB16 {
-    assume { Resolve2.resolve _25 };
     _25 <- _26;
-    assume { Resolve3.resolve _26 };
     _31 <- borrow_mut door_open_1;
     door_open_1 <-  ^ _31;
-    assume { Resolve0.resolve _33 };
     _33 <- door_21;
     _32 <- _33 - (1 : usize);
     _30 <- IndexMut0.index_mut _31 _32;
@@ -611,30 +596,24 @@ module C100doors_Main
   }
   BB17 {
     _30 <- { _30 with current = not _25 };
-    assume { Resolve4.resolve _30 };
-    assume { Resolve0.resolve _34 };
+    assume { Resolve0.resolve _30 };
     _34 <- pass_18;
     door_21 <- door_21 + _34;
     _4 <- ();
-    assume { Resolve1.resolve _4 };
     goto BB14
   }
   BB18 {
-    assume { Resolve0.resolve door_21 };
     _22 <- ();
-    assume { Resolve1.resolve _22 };
     pass_18 <- pass_18 + (1 : usize);
     _4 <- ();
-    assume { Resolve1.resolve _4 };
     goto BB11
   }
   BB19 {
-    assume { Resolve0.resolve pass_18 };
     _0 <- ();
     goto BB20
   }
   BB20 {
-    assume { Resolve5.resolve door_open_1 };
+    assume { Resolve1.resolve door_open_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/all_zero.stdout
+++ b/creusot/tests/should_succeed/all_zero.stdout
@@ -90,15 +90,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self
   predicate resolve (self : self)
@@ -112,12 +103,6 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module AllZero_AllZero_Interface
@@ -142,7 +127,6 @@ module AllZero_AllZero
   clone AllZero_Get as Get0
   clone AllZero_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.allzero_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.allzero_list
@@ -193,7 +177,6 @@ module AllZero_AllZero
     assume { Resolve0.resolve loop_l_2 };
     loop_l_2 <- _7;
     _3 <- ();
-    assume { Resolve3.resolve _3 };
     goto BB1
   }
   BB3 {

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -85,15 +85,6 @@ module BinarySearch_Impl0_Get
       | Type.BinarySearch_List_Nil -> Type.Core_Option_Option_None
       end
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self
   predicate resolve (self : self)
@@ -101,12 +92,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module BinarySearch_Impl0_Index_Interface
   type t
@@ -130,11 +115,9 @@ module BinarySearch_Impl0_Index
   clone BinarySearch_Impl0_Get as Get0 with type t = t
   clone BinarySearch_Impl0_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.binarysearch_list t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.binarysearch_list t
   let rec cfg index [@cfg:stackify] (self : Type.binarysearch_list t) (ix : usize) : t
     requires {UInt64.to_int ix < LenLogic0.len_logic self}
     ensures { Type.Core_Option_Option_Some result = Get0.get self (UInt64.to_int ix) }
@@ -165,12 +148,10 @@ module BinarySearch_Impl0_Index
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve orig_ix_3 };
     orig_ix_3 <- ix_2;
-    assume { Resolve0.resolve orig_ix_3 };
-    assume { Resolve1.resolve l_4 };
+    assume { Resolve0.resolve l_4 };
     l_4 <- self_1;
-    assume { Resolve1.resolve self_1 };
+    assume { Resolve0.resolve self_1 };
     goto BB1
   }
   BB1 {
@@ -184,8 +165,7 @@ module BinarySearch_Impl0_Index
   BB2 {
     t_8 <- Type.binarysearch_list_Cons_0 l_4;
     ls_9 <- Type.binarysearch_list_Cons_1 l_4;
-    assume { Resolve1.resolve l_4 };
-    assume { Resolve0.resolve _11 };
+    assume { Resolve0.resolve l_4 };
     _11 <- ix_2;
     _10 <- _11 > (0 : usize);
     switch (_10)
@@ -194,30 +174,26 @@ module BinarySearch_Impl0_Index
       end
   }
   BB3 {
-    assume { Resolve3.resolve t_8 };
+    assume { Resolve1.resolve t_8 };
     _13 <- ls_9;
-    assume { Resolve4.resolve ls_9 };
+    assume { Resolve2.resolve ls_9 };
     _12 <- _13;
-    assume { Resolve4.resolve _13 };
-    assume { Resolve1.resolve l_4 };
+    assume { Resolve2.resolve _13 };
+    assume { Resolve0.resolve l_4 };
     l_4 <- _12;
     ix_2 <- ix_2 - (1 : usize);
     _6 <- ();
-    assume { Resolve2.resolve _6 };
     goto BB1
   }
   BB4 {
-    assume { Resolve0.resolve ix_2 };
-    assume { Resolve4.resolve ls_9 };
+    assume { Resolve2.resolve ls_9 };
     _0 <- t_8;
-    assume { Resolve3.resolve t_8 };
+    assume { Resolve1.resolve t_8 };
     return _0
   }
   BB5 {
-    assume { Resolve0.resolve ix_2 };
-    assume { Resolve1.resolve l_4 };
+    assume { Resolve0.resolve l_4 };
     _5 <- ();
-    assume { Resolve2.resolve _5 };
     absurd
   }
   
@@ -245,9 +221,7 @@ module BinarySearch_Impl0_Len
   use Type
   clone BinarySearch_Impl0_LenLogic as LenLogic0 with type t = t
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.binarysearch_list t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.binarysearch_list t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.binarysearch_list t
   let rec cfg len [@cfg:stackify] (self : Type.binarysearch_list t) : usize
     requires {LenLogic0.len_logic self <= 1000000}
@@ -290,20 +264,16 @@ module BinarySearch_Impl0_Len
     assume { Resolve0.resolve l_3 };
     len_2 <- len_2 + (1 : usize);
     _8 <- ls_7;
-    assume { Resolve3.resolve ls_7 };
+    assume { Resolve1.resolve ls_7 };
     assume { Resolve0.resolve l_3 };
     l_3 <- _8;
     _5 <- ();
-    assume { Resolve1.resolve _5 };
     goto BB1
   }
   BB3 {
     assume { Resolve0.resolve l_3 };
     _4 <- ();
-    assume { Resolve1.resolve _4 };
-    assume { Resolve2.resolve _0 };
     _0 <- len_2;
-    assume { Resolve2.resolve len_2 };
     return _0
   }
   
@@ -373,11 +343,6 @@ module BinarySearch_BinarySearch
   clone BinarySearch_Impl1_IsSorted as IsSorted0 with function Get0.get = Get0.get
   clone BinarySearch_Impl0_GetDefault as GetDefault0 with type t = uint32, function Get0.get = Get0.get
   clone BinarySearch_Impl0_LenLogic as LenLogic0 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.binarysearch_list uint32
   clone BinarySearch_Impl0_Index_Interface as Index0 with type t = uint32,
   function LenLogic0.len_logic = LenLogic0.len_logic, function Get0.get = Get0.get
   clone BinarySearch_Impl0_Len_Interface as Len0 with type t = uint32,
@@ -454,14 +419,11 @@ module BinarySearch_BinarySearch
       end
   }
   BB2 {
-    assume { Resolve0.resolve arr_1 };
-    assume { Resolve1.resolve elem_2 };
     _0 <- Type.Core_Result_Result_Err (0 : usize);
     goto BB20
   }
   BB3 {
     _3 <- ();
-    assume { Resolve2.resolve _3 };
     _9 <- arr_1;
     size_8 <- Len0.len _9;
     goto BB4
@@ -474,7 +436,6 @@ module BinarySearch_BinarySearch
     invariant size_valid { UInt64.to_int size_8 + UInt64.to_int base_10 <= LenLogic0.len_logic arr_1 };
     invariant in_interval { GetDefault0.get_default arr_1 (UInt64.to_int base_10) (0 : uint32) <= elem_2 && elem_2 <= GetDefault0.get_default arr_1 (UInt64.to_int base_10 + UInt64.to_int size_8) (0 : uint32) };
     invariant size_pos { size_8 > (0 : usize) };
-    assume { Resolve3.resolve _14 };
     _14 <- size_8;
     _13 <- _14 > (1 : usize);
     switch (_13)
@@ -483,7 +444,6 @@ module BinarySearch_BinarySearch
       end
   }
   BB6 {
-    assume { Resolve3.resolve _16 };
     _16 <- size_8;
     _17 <- (2 : usize) = (0 : usize);
     assert { not _17 };
@@ -491,22 +451,16 @@ module BinarySearch_BinarySearch
   }
   BB7 {
     half_15 <- _16 / (2 : usize);
-    assume { Resolve3.resolve _19 };
     _19 <- base_10;
-    assume { Resolve3.resolve _20 };
     _20 <- half_15;
     mid_18 <- _19 + _20;
     _25 <- arr_1;
-    assume { Resolve3.resolve _26 };
     _26 <- mid_18;
     _24 <- Index0.index _25 _26;
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _23 };
     _23 <- _24;
-    assume { Resolve4.resolve _24 };
-    assume { Resolve1.resolve _27 };
     _27 <- elem_2;
     _22 <- _23 > _27;
     switch (_22)
@@ -515,48 +469,30 @@ module BinarySearch_BinarySearch
       end
   }
   BB9 {
-    assume { Resolve3.resolve mid_18 };
-    assume { Resolve3.resolve _21 };
     _21 <- base_10;
-    assume { Resolve3.resolve base_10 };
     goto BB11
   }
   BB10 {
-    assume { Resolve3.resolve base_10 };
-    assume { Resolve3.resolve _21 };
     _21 <- mid_18;
-    assume { Resolve3.resolve mid_18 };
     goto BB11
   }
   BB11 {
-    assume { Resolve3.resolve base_10 };
     base_10 <- _21;
-    assume { Resolve3.resolve _28 };
     _28 <- half_15;
-    assume { Resolve3.resolve half_15 };
     size_8 <- size_8 - _28;
     _12 <- ();
-    assume { Resolve2.resolve _12 };
     goto BB5
   }
   BB12 {
-    assume { Resolve3.resolve size_8 };
     _11 <- ();
-    assume { Resolve2.resolve _11 };
     _34 <- arr_1;
-    assume { Resolve0.resolve arr_1 };
-    assume { Resolve3.resolve _35 };
     _35 <- base_10;
     _33 <- Index0.index _34 _35;
     goto BB13
   }
   BB13 {
-    assume { Resolve1.resolve cmp_32 };
     cmp_32 <- _33;
-    assume { Resolve4.resolve _33 };
-    assume { Resolve1.resolve _37 };
     _37 <- cmp_32;
-    assume { Resolve1.resolve _38 };
     _38 <- elem_2;
     _36 <- _37 = _38;
     switch (_36)
@@ -565,21 +501,13 @@ module BinarySearch_BinarySearch
       end
   }
   BB14 {
-    assume { Resolve1.resolve elem_2 };
-    assume { Resolve1.resolve cmp_32 };
-    assume { Resolve3.resolve _39 };
     _39 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Ok _39;
     goto BB19
   }
   BB15 {
-    assume { Resolve1.resolve _41 };
     _41 <- cmp_32;
-    assume { Resolve1.resolve cmp_32 };
-    assume { Resolve1.resolve _42 };
     _42 <- elem_2;
-    assume { Resolve1.resolve elem_2 };
     _40 <- _41 < _42;
     switch (_40)
       | False -> goto BB17
@@ -587,17 +515,13 @@ module BinarySearch_BinarySearch
       end
   }
   BB16 {
-    assume { Resolve3.resolve _44 };
     _44 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _43 <- _44 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err _43;
     goto BB18
   }
   BB17 {
-    assume { Resolve3.resolve _45 };
     _45 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Err _45;
     goto BB18
   }

--- a/creusot/tests/should_succeed/branch_borrow_2.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_2.stdout
@@ -49,10 +49,8 @@ module BranchBorrow2_Main
     c_3 <- (10 : int32);
     x_4 <- borrow_mut a_1;
     a_1 <-  ^ x_4;
-    assume { (fun x -> true) a_1 };
     y_5 <- borrow_mut b_2;
     b_2 <-  ^ y_5;
-    assume { (fun x -> true) b_2 };
     z_6 <- borrow_mut c_3;
     c_3 <-  ^ z_6;
     _9 <- (3 : int32);
@@ -65,52 +63,31 @@ module BranchBorrow2_Main
       end
   }
   BB1 {
-    assume { (fun x -> true) x_4 };
-    assume { (fun x -> true) y_5 };
-    assume { (fun x -> true) _9 };
     z_6 <- { z_6 with current = (8 : int32) };
     _12 <- borrow_mut ( * z_6);
     z_6 <- { z_6 with current = ( ^ _12) };
-    assume { (fun x -> true) z_6 };
-    assume { (fun x -> true) w_7 };
     w_7 <- _12;
     _8 <- ();
-    assume { (fun x -> true) _8 };
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) y_5 };
-    assume { (fun x -> true) z_6 };
-    assume { (fun x -> true) _9 };
     x_4 <- { x_4 with current = (6 : int32) };
-    assume { (fun x -> true) _10 };
     _10 <- x_4;
-    assume { (fun x -> true) w_7 };
     w_7 <- _10;
     _8 <- ();
-    assume { (fun x -> true) _8 };
     goto BB4
   }
   BB3 {
-    assume { (fun x -> true) x_4 };
-    assume { (fun x -> true) z_6 };
-    assume { (fun x -> true) _9 };
     y_5 <- { y_5 with current = (7 : int32) };
     _11 <- borrow_mut ( * y_5);
     y_5 <- { y_5 with current = ( ^ _11) };
-    assume { (fun x -> true) y_5 };
-    assume { (fun x -> true) w_7 };
     w_7 <- _11;
     _8 <- ();
-    assume { (fun x -> true) _8 };
     goto BB4
   }
   BB4 {
     w_7 <- { w_7 with current = (5 : int32) };
-    assume { (fun x -> true) w_7 };
-    assume { (fun x -> true) _16 };
     _16 <- c_3;
-    assume { (fun x -> true) c_3 };
     _15 <- _16 = (5 : int32);
     _14 <- not _15;
     switch (_14)
@@ -123,7 +100,6 @@ module BranchBorrow2_Main
   }
   BB6 {
     _13 <- ();
-    assume { (fun x -> true) _13 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/branch_borrow_3.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_3.stdout
@@ -50,20 +50,13 @@ module BranchBorrow3_Main
     a_1 <- (_2, _3);
     b_4 <- borrow_mut a_1;
     a_1 <-  ^ b_4;
-    assume { (fun x -> true) a_1 };
     c_5 <- borrow_mut (let (_, a) =  * b_4 in a);
     b_4 <- { b_4 with current = (let (a, b) =  * b_4 in (a,  ^ c_5)) };
     d_6 <- borrow_mut (let (a, _) =  * b_4 in a);
     b_4 <- { b_4 with current = (let (a, b) =  * b_4 in ( ^ d_6, b)) };
-    assume { (fun x -> true) b_4 };
-    assume { (fun x -> true) _8 };
     _8 <- Type.branchborrow3_myint_MyInt_0 ( * c_5);
-    assume { (fun x -> true) c_5 };
-    assume { (fun x -> true) _9 };
     _9 <- Type.branchborrow3_myint_MyInt_0 ( * d_6);
-    assume { (fun x -> true) d_6 };
     _7 <- _8 <> _9;
-    assume { (fun x -> true) _7 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/branch_borrow_4.stdout
+++ b/creusot/tests/should_succeed/branch_borrow_4.stdout
@@ -41,10 +41,8 @@ module BranchBorrow4_Main
     b_2 <- (10 : int32);
     x_3 <- borrow_mut a_1;
     a_1 <-  ^ x_3;
-    assume { (fun x -> true) a_1 };
     y_4 <- borrow_mut b_2;
     b_2 <-  ^ y_4;
-    assume { (fun x -> true) b_2 };
     _7 <- true;
     switch (_7)
       | False -> goto BB2
@@ -52,33 +50,22 @@ module BranchBorrow4_Main
       end
   }
   BB1 {
-    assume { (fun x -> true) y_4 };
     x_3 <- { x_3 with current = (5 : int32) };
-    assume { (fun x -> true) _8 };
     _8 <- x_3;
-    assume { (fun x -> true) w_5 };
     w_5 <- _8;
     _6 <- ();
-    assume { (fun x -> true) _6 };
     goto BB3
   }
   BB2 {
-    assume { (fun x -> true) x_3 };
     y_4 <- { y_4 with current = (6 : int32) };
     _9 <- borrow_mut ( * y_4);
     y_4 <- { y_4 with current = ( ^ _9) };
-    assume { (fun x -> true) y_4 };
-    assume { (fun x -> true) w_5 };
     w_5 <- _9;
     _6 <- ();
-    assume { (fun x -> true) _6 };
     goto BB3
   }
   BB3 {
-    assume { (fun x -> true) _10 };
     _10 <-  * w_5;
-    assume { (fun x -> true) w_5 };
-    assume { (fun x -> true) _10 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -79,15 +79,6 @@ module CreusotContracts_Std1_Vec_Impl1_New
     ensures { Seq.length (Model0.model result) = 0 }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl1_Model_Interface
   type t
   use prelude.Prelude
@@ -153,12 +144,6 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl5
   type t
   use Type
@@ -188,6 +173,21 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C01ResolveUnsoundness_MakeVecOfSize_Interface
   use seq.Seq
   use mach.int.UInt64
@@ -206,16 +206,14 @@ module C01ResolveUnsoundness_MakeVecOfSize
   use seq.Seq
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec bool,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = bool,
   function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve2 with type t = bool, function Model0.model = Model0.model,
-  predicate Resolve0.resolve = Resolve3.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = bool, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve1.resolve
   clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New0 with type t = bool, function Model0.model = Model0.model
   let rec cfg make_vec_of_size [@cfg:stackify] (n : usize) : Type.creusotcontracts_std1_vec_vec bool
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
@@ -250,9 +248,7 @@ module C01ResolveUnsoundness_MakeVecOfSize
   }
   BB2 {
     invariant loop_invariant { (0 : usize) <= i_4 && i_4 <= n_1 };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
-    assume { Resolve0.resolve _9 };
     _9 <- n_1;
     _7 <- _8 <= _9;
     switch (_7)
@@ -269,15 +265,11 @@ module C01ResolveUnsoundness_MakeVecOfSize
   BB4 {
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     goto BB2
   }
   BB5 {
-    assume { Resolve0.resolve n_1 };
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve1.resolve _5 };
-    assume { Resolve2.resolve _0 };
+    assume { Resolve0.resolve _0 };
     _0 <- out_3;
     goto BB6
   }

--- a/creusot/tests/should_succeed/bug/02_derive.stdout
+++ b/creusot/tests/should_succeed/bug/02_derive.stdout
@@ -33,7 +33,6 @@ module C02Derive_Impl0_Clone
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) self_1 };
     _0 <- Type.C02Derive_Lit;
     return _0
   }

--- a/creusot/tests/should_succeed/bug/173.stdout
+++ b/creusot/tests/should_succeed/bug/173.stdout
@@ -14,37 +14,12 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C173_Test233_Interface
   val test_233 [@cfg:stackify] () : ()
 end
 module C173_Test233
   use mach.int.Int32
   use mach.int.Int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg test_233 [@cfg:stackify] () : () = 
   var _0 : ();
   var x_1 : int32;
@@ -56,15 +31,11 @@ module C173_Test233
   }
   BB0 {
     x_1 <- (17 : int32);
-    assume { Resolve0.resolve x_1 };
     assert { Int32.to_int x_1 = 17 };
     _2 <- ();
-    assume { Resolve1.resolve _2 };
     x_3 <- (42 : int32);
-    assume { Resolve0.resolve x_3 };
     assert { Int32.to_int x_3 = 42 };
     _4 <- ();
-    assume { Resolve1.resolve _4 };
     _0 <- ();
     return _0
   }
@@ -86,8 +57,6 @@ module C173_Knapsack01Dyn
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg knapsack01_dyn [@cfg:stackify] (n : usize) : ()
     requires {0 < UInt64.to_int n && UInt64.to_int n < 10000}
     
@@ -111,15 +80,12 @@ module C173_Knapsack01Dyn
   }
   BB0 {
     i_2 <- (0 : usize);
-    assume { Resolve0.resolve i_2 };
     w_3 <- (1 : usize);
     goto BB1
   }
   BB1 {
     invariant i_items_len { UInt64.to_int i_2 < UInt64.to_int n_1 };
-    assume { Resolve0.resolve _7 };
     _7 <- w_3;
-    assume { Resolve0.resolve _8 };
     _8 <- n_1;
     _6 <- _7 <= _8;
     switch (_6)
@@ -130,17 +96,11 @@ module C173_Knapsack01Dyn
   BB2 {
     w_3 <- w_3 + (1 : usize);
     _5 <- ();
-    assume { Resolve1.resolve _5 };
     goto BB1
   }
   BB3 {
-    assume { Resolve0.resolve w_3 };
     _4 <- ();
-    assume { Resolve1.resolve _4 };
-    assume { Resolve0.resolve i_12 };
     i_12 <- n_1;
-    assume { Resolve0.resolve n_1 };
-    assume { Resolve0.resolve i_12 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/bug/195.stdout
+++ b/creusot/tests/should_succeed/bug/195.stdout
@@ -14,36 +14,12 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C195_Example_Interface
   val example [@cfg:stackify] (exampleParameter : bool) : ()
     requires {exampleParameter = exampleParameter}
     
 end
 module C195_Example
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg example [@cfg:stackify] (exampleParameter : bool) : ()
     requires {exampleParameter = exampleParameter}
     
@@ -55,7 +31,6 @@ module C195_Example
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve exampleParameter_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -109,29 +109,6 @@ module C206_U
   function u (a : Type.c206_a) : () = 
     U20.u2 a
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C206_Ex_Interface
   use prelude.Prelude
   use Type
@@ -148,7 +125,6 @@ module C206_Ex
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = usize
   clone C206_U2 as U20 with function Model0.model = Model0.model, axiom .
   clone C206_U as U0 with function U20.u2 = U20.u2, function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c206_a
   let rec cfg ex [@cfg:stackify] (a : Type.c206_a) : ()
     ensures { U0.u a = U0.u a }
     
@@ -160,7 +136,6 @@ module C206_Ex
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve a_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/bug/235.stdout
+++ b/creusot/tests/should_succeed/bug/235.stdout
@@ -14,36 +14,12 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C235_Main_Interface
   val main [@cfg:stackify] () : ()
 end
 module C235_Main
   use mach.int.Int
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var _1 : ();
@@ -67,7 +43,6 @@ module C235_Main
   }
   BB2 {
     _1 <- ();
-    assume { Resolve0.resolve _1 };
     goto BB1
   }
   BB3 {

--- a/creusot/tests/should_succeed/bug/256.stdout
+++ b/creusot/tests/should_succeed/bug/256.stdout
@@ -32,29 +32,6 @@ module Type
     | Alloc_String_String (alloc_vec_vec uint8 (alloc_alloc_global))
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C256_U8Safe_Interface
   use mach.int.Int
   use prelude.Prelude
@@ -65,7 +42,6 @@ module C256_U8Safe
   use mach.int.Int
   use prelude.Prelude
   use prelude.UInt8
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint8
   let rec cfg u8_safe [@cfg:stackify] (u : uint8) : () = 
   var _0 : ();
   var u_1 : uint8;
@@ -76,11 +52,8 @@ module C256_U8Safe
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- u_1;
-    assume { Resolve0.resolve u_1 };
     _2 <- _3 + (0 : uint8);
-    assume { Resolve0.resolve _2 };
     _0 <- ();
     return _0
   }
@@ -92,7 +65,6 @@ module C256_Bug256_Interface
 end
 module C256_Bug256
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.alloc_string_string
   let rec cfg bug_256 [@cfg:stackify] (x : Type.alloc_string_string) : () = 
   var _0 : ();
   var x_1 : Type.alloc_string_string;
@@ -105,7 +77,6 @@ module C256_Bug256
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/bug/258.stdout
+++ b/creusot/tests/should_succeed/bug/258.stdout
@@ -33,7 +33,6 @@ module C258_Err
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) to'_1 };
     return _0
   }
   
@@ -57,7 +56,6 @@ module C258_Err2
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) bBB'_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/bug/271.stdout
+++ b/creusot/tests/should_succeed/bug/271.stdout
@@ -28,7 +28,6 @@ module C271_Ex
   }
   BB0 {
     a_1 <- (0 : int32);
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     return _0
   }
@@ -57,12 +56,10 @@ module C271_Ex2
       end
   }
   BB1 {
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     goto BB3
   }
   BB2 {
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     goto BB3
   }
@@ -97,17 +94,14 @@ module C271_Ex3
       end
   }
   BB1 {
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     goto BB4
   }
   BB3 {
-    assume { (fun x -> true) a_1 };
     _0 <- ();
     goto BB4
   }

--- a/creusot/tests/should_succeed/cell/01.stdout
+++ b/creusot/tests/should_succeed/cell/01.stdout
@@ -59,15 +59,6 @@ module C01_Impl0_Get
     ensures { Inv0.inv result }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module C01_Impl0_Set_Interface
   type t
   type i
@@ -87,20 +78,6 @@ module C01_Impl0_Set
   val set [@cfg:stackify] (self : Type.c01_cell t i) (v : t) : ()
     requires {Inv0.inv v}
     
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module C01_Impl1_Inv_Interface
   use mach.int.Int
@@ -132,8 +109,6 @@ module C01_AddsTwo
   use Type
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c01_cell uint32 (Type.c01_even)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone C01_Impl1_Inv as Inv0
   clone C01_Impl0_Set_Interface as Set0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv
   clone C01_Impl0_Get_Interface as Get0 with type t = uint32, type i = Type.c01_even, predicate Inv0.inv = Inv0.inv
@@ -160,7 +135,6 @@ module C01_AddsTwo
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _5 };
     _5 <- v_2;
     _4 <- _5 < (100000 : uint32);
     switch (_4)
@@ -170,10 +144,7 @@ module C01_AddsTwo
   }
   BB2 {
     _7 <- c_1;
-    assume { Resolve1.resolve c_1 };
-    assume { Resolve0.resolve _9 };
     _9 <- v_2;
-    assume { Resolve0.resolve v_2 };
     _8 <- _9 + (2 : uint32);
     _6 <- Set0.set _7 _8;
     goto BB3
@@ -183,9 +154,7 @@ module C01_AddsTwo
     goto BB6
   }
   BB4 {
-    assume { Resolve0.resolve v_2 };
     _11 <- c_1;
-    assume { Resolve1.resolve c_1 };
     _10 <- Set0.set _11 (0 : uint32);
     goto BB5
   }

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -282,15 +282,6 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module Core_Ops_Index_Index_Output
   type self
   type idx
@@ -343,20 +334,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
@@ -425,11 +402,6 @@ module C02_FibMemo
   clone C02_LemmaFibBound as LemmaFibBound0 with function Fib0.fib = Fib0.fib, axiom .
   clone C02_LemmaMaxInt as LemmaMaxInt0 with axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.core_option_option usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec (Type.c02_cell (Type.core_option_option usize) (Type.c02_fib))
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.c02_cell (Type.core_option_option usize) (Type.c02_fib),
   function Model0.model = Model0.model
   clone C02_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
@@ -484,14 +456,12 @@ module C02_FibMemo
   }
   BB0 {
     _6 <- mem_1;
-    assume { Resolve0.resolve _7 };
     _7 <- i_2;
     _5 <- Index0.index _6 _7;
     goto BB1
   }
   BB1 {
     _4 <- _5;
-    assume { Resolve1.resolve _5 };
     _3 <- Get0.get _4;
     goto BB2
   }
@@ -502,8 +472,6 @@ module C02_FibMemo
       end
   }
   BB3 {
-    assume { Resolve3.resolve _3 };
-    assume { Resolve0.resolve _12 };
     _12 <- i_2;
     _11 <- _12 = (0 : usize);
     switch (_11)
@@ -512,20 +480,11 @@ module C02_FibMemo
       end
   }
   BB4 {
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve i_2 };
-    assume { Resolve3.resolve _3 };
     absurd
   }
   BB5 {
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve i_2 };
-    assume { Resolve0.resolve v_9 };
     v_9 <- Type.core_option_option_Some_0 _3;
-    assume { Resolve3.resolve _3 };
-    assume { Resolve0.resolve _0 };
     _0 <- v_9;
-    assume { Resolve0.resolve v_9 };
     goto BB16
   }
   BB6 {
@@ -533,7 +492,6 @@ module C02_FibMemo
     goto BB13
   }
   BB7 {
-    assume { Resolve0.resolve _14 };
     _14 <- i_2;
     _13 <- _14 = (1 : usize);
     switch (_13)
@@ -548,12 +506,9 @@ module C02_FibMemo
   BB9 {
     assert { let _ = LemmaMaxInt0.lemma_max_int () in true };
     _15 <- ();
-    assume { Resolve4.resolve _15 };
     assert { let _ = LemmaFibBound0.lemma_fib_bound 0 in true };
     _16 <- ();
-    assume { Resolve4.resolve _16 };
     _18 <- mem_1;
-    assume { Resolve0.resolve _20 };
     _20 <- i_2;
     _19 <- _20 - (1 : usize);
     _17 <- fib_memo _18 _19;
@@ -561,7 +516,6 @@ module C02_FibMemo
   }
   BB10 {
     _22 <- mem_1;
-    assume { Resolve0.resolve _24 };
     _24 <- i_2;
     _23 <- _24 - (2 : usize);
     _21 <- fib_memo _22 _23;
@@ -577,28 +531,20 @@ module C02_FibMemo
   BB13 {
     assert { UInt64.to_int fib_i_10 = Fib0.fib (UInt64.to_int i_2) };
     _25 <- ();
-    assume { Resolve4.resolve _25 };
     _29 <- mem_1;
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve _30 };
     _30 <- i_2;
-    assume { Resolve0.resolve i_2 };
     _28 <- Index0.index _29 _30;
     goto BB14
   }
   BB14 {
     _27 <- _28;
-    assume { Resolve1.resolve _28 };
-    assume { Resolve0.resolve _32 };
     _32 <- fib_i_10;
     _31 <- Type.Core_Option_Option_Some _32;
     _26 <- Set0.set _27 _31;
     goto BB15
   }
   BB15 {
-    assume { Resolve0.resolve _0 };
     _0 <- fib_i_10;
-    assume { Resolve0.resolve fib_i_10 };
     goto BB16
   }
   BB16 {

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -224,15 +224,6 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module Core_Ops_Index_Index_Output
   type self
   type idx
@@ -283,20 +274,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) ix }
     
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
@@ -354,11 +331,6 @@ module C03FibUnbounded_FibMemo
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone C03FibUnbounded_Fib as Fib0 with axiom .
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.core_option_option int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec (Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib))
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.c03fibunbounded_cell (Type.core_option_option int) (Type.c03fibunbounded_fib),
   function Model0.model = Model0.model
   clone C03FibUnbounded_Impl1_Inv as Inv0 with function Fib0.fib = Fib0.fib
@@ -411,14 +383,12 @@ module C03FibUnbounded_FibMemo
   }
   BB0 {
     _6 <- mem_1;
-    assume { Resolve0.resolve _7 };
     _7 <- i_2;
     _5 <- Index0.index _6 _7;
     goto BB1
   }
   BB1 {
     _4 <- _5;
-    assume { Resolve1.resolve _5 };
     _3 <- Get0.get _4;
     goto BB2
   }
@@ -429,8 +399,6 @@ module C03FibUnbounded_FibMemo
       end
   }
   BB3 {
-    assume { Resolve3.resolve _3 };
-    assume { Resolve0.resolve _12 };
     _12 <- i_2;
     _11 <- _12 = (0 : int);
     switch (_11)
@@ -439,20 +407,11 @@ module C03FibUnbounded_FibMemo
       end
   }
   BB4 {
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve i_2 };
-    assume { Resolve3.resolve _3 };
     absurd
   }
   BB5 {
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve i_2 };
-    assume { Resolve0.resolve v_9 };
     v_9 <- Type.core_option_option_Some_0 _3;
-    assume { Resolve3.resolve _3 };
-    assume { Resolve0.resolve _0 };
     _0 <- v_9;
-    assume { Resolve0.resolve v_9 };
     goto BB16
   }
   BB6 {
@@ -460,7 +419,6 @@ module C03FibUnbounded_FibMemo
     goto BB13
   }
   BB7 {
-    assume { Resolve0.resolve _14 };
     _14 <- i_2;
     _13 <- _14 = (1 : int);
     switch (_13)
@@ -474,7 +432,6 @@ module C03FibUnbounded_FibMemo
   }
   BB9 {
     _16 <- mem_1;
-    assume { Resolve0.resolve _18 };
     _18 <- i_2;
     _17 <- _18 - (1 : int);
     _15 <- fib_memo _16 _17;
@@ -482,7 +439,6 @@ module C03FibUnbounded_FibMemo
   }
   BB10 {
     _20 <- mem_1;
-    assume { Resolve0.resolve _22 };
     _22 <- i_2;
     _21 <- _22 - (2 : int);
     _19 <- fib_memo _20 _21;
@@ -498,28 +454,20 @@ module C03FibUnbounded_FibMemo
   BB13 {
     assert { fib_i_10 = Fib0.fib i_2 };
     _23 <- ();
-    assume { Resolve4.resolve _23 };
     _27 <- mem_1;
-    assume { Resolve2.resolve mem_1 };
-    assume { Resolve0.resolve _28 };
     _28 <- i_2;
-    assume { Resolve0.resolve i_2 };
     _26 <- Index0.index _27 _28;
     goto BB14
   }
   BB14 {
     _25 <- _26;
-    assume { Resolve1.resolve _26 };
-    assume { Resolve0.resolve _30 };
     _30 <- fib_i_10;
     _29 <- Type.Core_Option_Option_Some _30;
     _24 <- Set0.set _25 _29;
     goto BB15
   }
   BB15 {
-    assume { Resolve0.resolve _0 };
     _0 <- fib_i_10;
-    assume { Resolve0.resolve fib_i_10 };
     goto BB16
   }
   BB16 {

--- a/creusot/tests/should_succeed/clones/04.stdout
+++ b/creusot/tests/should_succeed/clones/04.stdout
@@ -49,29 +49,6 @@ module C04_C
   function c (x : uint32) : bool = 
     x < (50 : uint32) && B0.b x
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C04_F_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -86,7 +63,6 @@ module C04_F
   clone C04_A as A0
   clone C04_B as B0 with function A0.a = A0.a
   clone C04_C as C0 with function B0.b = B0.b
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg f [@cfg:stackify] (x : uint32) : ()
     requires {C0.c x}
     
@@ -98,7 +74,6 @@ module C04_F
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve x_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/closures/01_basic.stdout
+++ b/creusot/tests/should_succeed/closures/01_basic.stdout
@@ -34,7 +34,7 @@ module C01Basic_UsesClosure_Closure0_Interface
   predicate postcondition_once [@cfg:stackify] (_1' : c01basic_usesclosure_closure0) (_2' : ()) (result : bool) = 
     true
   predicate resolve (_1' : c01basic_usesclosure_closure0) = 
-    (fun x -> true) (c01basic_usesclosure_closure0_0 _1') && true
+    true && true
   val c01Basic_UsesClosure_Closure0 [@cfg:stackify] (_1' : c01basic_usesclosure_closure0) (_2' : ()) : bool
 end
 module C01Basic_UsesClosure_Closure0
@@ -55,9 +55,7 @@ module C01Basic_UsesClosure_Closure0
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _0 };
     _0 <- c01basic_usesclosure_closure0_0 _1;
-    assume { (fun x -> true) _1 };
     return _0
   }
   
@@ -105,16 +103,13 @@ module C01Basic_UsesClosure
   BB0 {
     y_1 <- true;
     _5 <- y_1;
-    assume { (fun x -> true) y_1 };
     _4 <- Closure00.C01Basic_UsesClosure_Closure0 _5;
     _3 <- _4;
-    assume { (fun x -> true) _4 };
     _6 <- ();
     x_2 <- Closure00.c01Basic_UsesClosure_Closure0 _3 _6;
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) x_2 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/closures/02_nested.stdout
+++ b/creusot/tests/should_succeed/closures/02_nested.stdout
@@ -38,7 +38,7 @@ module C02Nested_NestedClosure_Closure0_Closure0_Interface
    = 
     true
   predicate resolve (_1' : c02nested_nestedclosure_closure0_closure0) = 
-    (fun x -> true) (c02nested_nestedclosure_closure0_closure0_0 _1') && true
+    true && true
   val c02Nested_NestedClosure_Closure0_Closure0 [@cfg:stackify] (_1' : c02nested_nestedclosure_closure0_closure0) (_2' : ()) : bool
     
 end
@@ -62,9 +62,7 @@ module C02Nested_NestedClosure_Closure0_Closure0
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _0 };
     _0 <- c02nested_nestedclosure_closure0_closure0_0 _1;
-    assume { (fun x -> true) _1 };
     return _0
   }
   
@@ -113,7 +111,7 @@ module C02Nested_NestedClosure_Closure0_Interface
   predicate postcondition_once [@cfg:stackify] (_1' : c02nested_nestedclosure_closure0) (_2' : ()) (result : bool) = 
     true
   predicate resolve (_1' : c02nested_nestedclosure_closure0) = 
-    (fun x -> true) (c02nested_nestedclosure_closure0_0 _1') && true
+    true && true
   val c02Nested_NestedClosure_Closure0 [@cfg:stackify] (_1' : c02nested_nestedclosure_closure0) (_2' : ()) : bool
 end
 module C02Nested_NestedClosure_Closure0
@@ -142,10 +140,8 @@ module C02Nested_NestedClosure_Closure0
   }
   BB0 {
     _3 <- c02nested_nestedclosure_closure0_0 _1;
-    assume { (fun x -> true) _1 };
     omg_2 <- Closure00.C02Nested_NestedClosure_Closure0_Closure0 _3;
     _4 <- omg_2;
-    assume { (fun x -> true) omg_2 };
     _5 <- ();
     _0 <- Closure00.c02Nested_NestedClosure_Closure0_Closure0 _4 _5;
     goto BB1
@@ -175,16 +171,13 @@ module C02Nested_NestedClosure
   BB0 {
     a_1 <- true;
     _5 <- a_1;
-    assume { (fun x -> true) a_1 };
     _4 <- Closure00.C02Nested_NestedClosure_Closure0 _5;
     _3 <- _4;
-    assume { (fun x -> true) _4 };
     _6 <- ();
     a_2 <- Closure00.c02Nested_NestedClosure_Closure0 _3 _6;
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) a_2 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/closures/03_generic_bound.stdout
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.stdout
@@ -66,7 +66,6 @@ module C03GenericBound_ClosureParam
     goto BB2
   }
   BB2 {
-    assume { (fun x -> true) f_1 };
     return _0
   }
   
@@ -112,8 +111,6 @@ module C03GenericBound_Caller_Closure0
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) _1 };
-    assume { (fun x -> true) x_2 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/closures/04_generic_closure.stdout
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.stdout
@@ -63,7 +63,6 @@ module C04GenericClosure_GenericClosure
   }
   BB0 {
     _3 <- f_1;
-    assume { (fun x -> true) _5 };
     _5 <- a_2;
     _4 <- (_5);
     _0 <- Call0.call _3 _4;
@@ -79,7 +78,6 @@ module C04GenericClosure_GenericClosure
     goto BB4
   }
   BB4 {
-    assume { (fun x -> true) f_1 };
     return _0
   }
   
@@ -121,11 +119,9 @@ module C04GenericClosure_Mapper_Closure0
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) _1 };
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) a_2 };
     return _0
   }
   
@@ -150,7 +146,6 @@ module C04GenericClosure_Mapper
   }
   BB0 {
     _2 <- Closure00.C04GenericClosure_Mapper_Closure0;
-    assume { (fun x -> true) _3 };
     _3 <- x_1;
     _0 <- GenericClosure0.generic_closure _2 _3;
     goto BB1

--- a/creusot/tests/should_succeed/closures/05_map.stdout
+++ b/creusot/tests/should_succeed/closures/05_map.stdout
@@ -125,23 +125,17 @@ module C05Map_Impl0_Next
       end
   }
   BB2 {
-    assume { (fun x -> true) e_5 };
     e_5 <- Type.core_option_option_Some_0 _2;
     _7 <- Type.c05map_map_Map_func ( * self_1);
-    assume { (fun x -> true) self_1 };
-    assume { (fun x -> true) _9 };
     _9 <- e_5;
     _8 <- (_9);
     _6 <- Call0.call _7 _8;
     goto BB5
   }
   BB3 {
-    assume { (fun x -> true) self_1 };
-    assume { (fun x -> true) _2 };
     absurd
   }
   BB4 {
-    assume { (fun x -> true) self_1 };
     _0 <- Type.Core_Option_Option_None;
     goto BB9
   }
@@ -162,7 +156,6 @@ module C05Map_Impl0_Next
     goto BB10
   }
   BB10 {
-    assume { (fun x -> true) _2 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
@@ -104,15 +104,6 @@ module C07MutableCapture_TestFnmut_Closure2
   }
   
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
   type self
   type args
@@ -170,12 +161,6 @@ module Core_Ops_Function_FnMut_CallMut
     ensures { PostconditionMut0.postcondition_mut self args result }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C07MutableCapture_TestFnmut_Interface
   use mach.int.UInt32
   use mach.int.Int
@@ -189,11 +174,9 @@ module C07MutableCapture_TestFnmut
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
-  clone C07MutableCapture_TestFnmut_Closure2_Interface as Closure20 with predicate Resolve0.resolve = Resolve2.resolve,
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
+  clone C07MutableCapture_TestFnmut_Closure2_Interface as Closure20 with predicate Resolve0.resolve = Resolve0.resolve,
   axiom .
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg test_fnmut [@cfg:stackify] (x : uint32) : ()
     requires {UInt32.to_int x = 100000}
     
@@ -217,9 +200,7 @@ module C07MutableCapture_TestFnmut
   BB0 {
     _4 <- borrow_mut x_1;
     x_1 <-  ^ _4;
-    assume { Resolve0.resolve x_1 };
     closure_3 <- Closure20.C07MutableCapture_TestFnmut_Closure2 _4;
-    assume { Closure20.resolve c_2 };
     c_2 <- closure_3;
     _6 <- borrow_mut c_2;
     c_2 <-  ^ _6;
@@ -230,7 +211,6 @@ module C07MutableCapture_TestFnmut
   BB1 {
     _9 <- borrow_mut c_2;
     c_2 <-  ^ _9;
-    assume { Closure20.resolve c_2 };
     _10 <- ();
     _8 <- Closure20.c07MutableCapture_TestFnmut_Closure2 _9 _10;
     goto BB2
@@ -238,7 +218,6 @@ module C07MutableCapture_TestFnmut
   BB2 {
     assert { UInt32.to_int x_1 = 100002 };
     _11 <- ();
-    assume { Resolve1.resolve _11 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/constrained_types.stdout
+++ b/creusot/tests/should_succeed/constrained_types.stdout
@@ -225,9 +225,7 @@ module ConstrainedTypes_UsesConcreteInstance
   }
   BB0 {
     _3 <- x_1;
-    assume { (fun x -> true) x_1 };
     _4 <- y_2;
-    assume { (fun x -> true) y_2 };
     _0 <- Lt0.lt _3 _4;
     goto BB1
   }

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -151,15 +151,6 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t
   use prelude.Prelude
@@ -392,12 +383,6 @@ module CreusotContracts_Std1_Vec_Impl5_Resolve
   predicate resolve (self : Type.creusotcontracts_std1_vec_vec t) = 
     forall i : (int) . 0 <= i && i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -490,6 +475,21 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module FilterPositive_M_Interface
   use Type
   use mach.int.Int
@@ -509,12 +509,9 @@ module FilterPositive_M
   axiom .
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = int32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = int32
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec int32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = int32,
@@ -524,8 +521,8 @@ module FilterPositive_M
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = int32,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = int32, function Model0.model = Model1.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = int32, function Model0.model = Model0.model,
-  predicate Resolve0.resolve = Resolve1.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = int32, function Model0.model = Model0.model,
+  predicate Resolve0.resolve = Resolve2.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = int32,
   function Model0.model = Model0.model
   let rec cfg m [@cfg:stackify] (t : Type.creusotcontracts_std1_vec_vec int32) : Type.creusotcontracts_std1_vec_vec int32
@@ -595,7 +592,6 @@ module FilterPositive_M
     invariant loop_bound { UInt64.to_int i_4 <= Seq.length (Model0.model t_1) };
     invariant count_bound { UInt64.to_int count_3 <= UInt64.to_int i_4 };
     invariant num { UInt64.to_int count_3 = NumOfPos0.num_of_pos 0 (UInt64.to_int i_4) (Model0.model t_1) };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
     _10 <- t_1;
     _9 <- Len0.len _10;
@@ -610,15 +606,12 @@ module FilterPositive_M
   }
   BB5 {
     _15 <- t_1;
-    assume { Resolve0.resolve _16 };
     _16 <- i_4;
     _14 <- Index0.index _15 _16;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _13 };
     _13 <- _14;
-    assume { Resolve2.resolve _14 };
     _12 <- _13 > (0 : int32);
     switch (_12)
       | False -> goto BB8
@@ -628,27 +621,20 @@ module FilterPositive_M
   BB7 {
     count_3 <- count_3 + (1 : usize);
     _11 <- ();
-    assume { Resolve3.resolve _11 };
     goto BB9
   }
   BB8 {
     _11 <- ();
-    assume { Resolve3.resolve _11 };
     goto BB9
   }
   BB9 {
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     goto BB3
   }
   BB10 {
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve3.resolve _5 };
-    assume { Resolve0.resolve _21 };
     _21 <- count_3;
-    assume { Resolve0.resolve count_3 };
     u_20 <- FromElem0.from_elem (0 : int32) _21;
     goto BB11
   }
@@ -666,7 +652,6 @@ module FilterPositive_M
   BB14 {
     invariant num { UInt64.to_int count_3 = NumOfPos0.num_of_pos 0 (UInt64.to_int i_4) (Model0.model t_1) };
     invariant ulength { Seq.length (Model0.model u_20) = NumOfPos0.num_of_pos 0 (Seq.length (Model0.model t_1)) (Model0.model t_1) };
-    assume { Resolve0.resolve _24 };
     _24 <- i_4;
     _26 <- t_1;
     _25 <- Len0.len _26;
@@ -681,15 +666,12 @@ module FilterPositive_M
   }
   BB16 {
     _31 <- t_1;
-    assume { Resolve0.resolve _32 };
     _32 <- i_4;
     _30 <- Index0.index _31 _32;
     goto BB17
   }
   BB17 {
-    assume { Resolve1.resolve _29 };
     _29 <- _30;
-    assume { Resolve2.resolve _30 };
     _28 <- _29 > (0 : int32);
     switch (_28)
       | False -> goto BB23
@@ -702,56 +684,43 @@ module FilterPositive_M
   }
   BB19 {
     _33 <- ();
-    assume { Resolve3.resolve _33 };
     assert { let _ = LemmaNumOfPosIncreasing0.lemma_num_of_pos_increasing 0 (UInt64.to_int i_4 + 1) (Seq.length (Model0.model t_1)) (Model0.model t_1) in UInt64.to_int count_3 < Seq.length (Model0.model u_20) };
     goto BB20
   }
   BB20 {
     _34 <- ();
-    assume { Resolve3.resolve _34 };
     _37 <- t_1;
-    assume { Resolve0.resolve _38 };
     _38 <- i_4;
     _36 <- Index0.index _37 _38;
     goto BB21
   }
   BB21 {
-    assume { Resolve1.resolve _35 };
     _35 <- _36;
-    assume { Resolve2.resolve _36 };
     _40 <- borrow_mut u_20;
     u_20 <-  ^ _40;
-    assume { Resolve0.resolve _41 };
     _41 <- count_3;
     _39 <- IndexMut0.index_mut _40 _41;
     goto BB22
   }
   BB22 {
-    assume { Resolve1.resolve ( * _39) };
     _39 <- { _39 with current = _35 };
-    assume { Resolve4.resolve _39 };
+    assume { Resolve0.resolve _39 };
     count_3 <- count_3 + (1 : usize);
     _27 <- ();
-    assume { Resolve3.resolve _27 };
     goto BB24
   }
   BB23 {
     _27 <- ();
-    assume { Resolve3.resolve _27 };
     goto BB24
   }
   BB24 {
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     goto BB14
   }
   BB25 {
-    assume { Resolve0.resolve count_3 };
-    assume { Resolve0.resolve i_4 };
     _22 <- ();
-    assume { Resolve3.resolve _22 };
-    assume { Resolve5.resolve _0 };
+    assume { Resolve1.resolve _0 };
     _0 <- u_20;
     goto BB26
   }
@@ -759,7 +728,7 @@ module FilterPositive_M
     goto BB27
   }
   BB27 {
-    assume { Resolve5.resolve t_1 };
+    assume { Resolve1.resolve t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/heapsort_generic.stdout
+++ b/creusot/tests/should_succeed/heapsort_generic.stdout
@@ -511,15 +511,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -717,12 +708,6 @@ module CreusotContracts_Std1_Vec_Impl1_Swap
     ensures { Permut.exchange (Model1.model ( ^ self)) (Model1.model ( * self)) (UInt64.to_int i) (UInt64.to_int j) }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -849,11 +834,8 @@ module HeapsortGeneric_SiftDown
   clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Lt_Interface as Lt0 with type self = t, predicate LtLog0.lt_log = LtLog0.lt_log
@@ -944,9 +926,7 @@ module HeapsortGeneric_SiftDown
   }
   BB1 {
     assume { Resolve1.resolve old_v_4 };
-    assume { Resolve2.resolve i_7 };
     i_7 <- start_2;
-    assume { Resolve2.resolve start_2 };
     goto BB2
   }
   BB2 {
@@ -958,9 +938,7 @@ module HeapsortGeneric_SiftDown
     invariant heap { forall j : (int) . UInt64.to_int start_2 <= Parent0.parent j && j < UInt64.to_int end'_3 && not (UInt64.to_int i_7 = Parent0.parent j) -> LeLog0.le_log (Seq.get (Model1.model v_1) j) (Seq.get (Model1.model v_1) (Parent0.parent j)) };
     invariant hole_left { let c = 2 * UInt64.to_int i_7 + 1 in c < UInt64.to_int end'_3 && UInt64.to_int start_2 <= Parent0.parent (UInt64.to_int i_7) -> LeLog0.le_log (Seq.get (Model1.model v_1) c) (Seq.get (Model1.model v_1) (Parent0.parent (Parent0.parent c))) };
     invariant hole_right { let c = 2 * UInt64.to_int i_7 + 2 in c < UInt64.to_int end'_3 && UInt64.to_int start_2 <= Parent0.parent (UInt64.to_int i_7) -> LeLog0.le_log (Seq.get (Model1.model v_1) c) (Seq.get (Model1.model v_1) (Parent0.parent (Parent0.parent c))) };
-    assume { Resolve2.resolve _12 };
     _12 <- i_7;
-    assume { Resolve2.resolve _14 };
     _14 <- end'_3;
     _15 <- (2 : usize) = (0 : usize);
     assert { not _15 };
@@ -975,23 +953,17 @@ module HeapsortGeneric_SiftDown
       end
   }
   BB4 {
-    assume { Resolve3.resolve v_1 };
-    assume { Resolve2.resolve end'_3 };
-    assume { Resolve2.resolve i_7 };
+    assume { Resolve2.resolve v_1 };
     _0 <- ();
     goto BB21
   }
   BB5 {
     _10 <- ();
-    assume { Resolve4.resolve _10 };
-    assume { Resolve2.resolve _19 };
     _19 <- i_7;
     _18 <- (2 : usize) * _19;
     child_17 <- _18 + (1 : usize);
-    assume { Resolve2.resolve _24 };
     _24 <- child_17;
     _23 <- _24 + (1 : usize);
-    assume { Resolve2.resolve _25 };
     _25 <- end'_3;
     _22 <- _23 < _25;
     switch (_22)
@@ -1005,7 +977,6 @@ module HeapsortGeneric_SiftDown
   }
   BB7 {
     _29 <-  * v_1;
-    assume { Resolve2.resolve _30 };
     _30 <- child_17;
     _28 <- Index0.index _29 _30;
     goto BB9
@@ -1018,9 +989,8 @@ module HeapsortGeneric_SiftDown
   }
   BB9 {
     _27 <- _28;
-    assume { Resolve5.resolve _28 };
+    assume { Resolve3.resolve _28 };
     _34 <-  * v_1;
-    assume { Resolve2.resolve _36 };
     _36 <- child_17;
     _35 <- _36 + (1 : usize);
     _33 <- Index0.index _34 _35;
@@ -1028,49 +998,44 @@ module HeapsortGeneric_SiftDown
   }
   BB10 {
     _32 <- _33;
-    assume { Resolve5.resolve _33 };
+    assume { Resolve3.resolve _33 };
     _31 <- _32;
-    assume { Resolve5.resolve _32 };
+    assume { Resolve3.resolve _32 };
     _26 <- Lt0.lt _27 _31;
     goto BB11
   }
   BB11 {
-    assume { Resolve6.resolve _21 };
     _21 <- _26;
     goto BB8
   }
   BB12 {
     child_17 <- child_17 + (1 : usize);
     _20 <- ();
-    assume { Resolve4.resolve _20 };
     goto BB14
   }
   BB13 {
     _20 <- ();
-    assume { Resolve4.resolve _20 };
     goto BB14
   }
   BB14 {
     _41 <-  * v_1;
-    assume { Resolve2.resolve _42 };
     _42 <- child_17;
     _40 <- Index0.index _41 _42;
     goto BB15
   }
   BB15 {
     _39 <- _40;
-    assume { Resolve5.resolve _40 };
+    assume { Resolve3.resolve _40 };
     _46 <-  * v_1;
-    assume { Resolve2.resolve _47 };
     _47 <- i_7;
     _45 <- Index0.index _46 _47;
     goto BB16
   }
   BB16 {
     _44 <- _45;
-    assume { Resolve5.resolve _45 };
+    assume { Resolve3.resolve _45 };
     _43 <- _44;
-    assume { Resolve5.resolve _44 };
+    assume { Resolve3.resolve _44 };
     _38 <- Le0.le _39 _43;
     goto BB17
   }
@@ -1081,34 +1046,23 @@ module HeapsortGeneric_SiftDown
       end
   }
   BB18 {
-    assume { Resolve3.resolve v_1 };
-    assume { Resolve2.resolve end'_3 };
-    assume { Resolve2.resolve i_7 };
-    assume { Resolve2.resolve child_17 };
+    assume { Resolve2.resolve v_1 };
     _0 <- ();
     goto BB21
   }
   BB19 {
     _37 <- ();
-    assume { Resolve4.resolve _37 };
     _50 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _50) };
-    assume { Resolve2.resolve _51 };
     _51 <- i_7;
-    assume { Resolve2.resolve i_7 };
-    assume { Resolve2.resolve _52 };
     _52 <- child_17;
     _49 <- Swap0.swap _50 _51 _52;
     goto BB20
   }
   BB20 {
-    assume { Resolve2.resolve _53 };
     _53 <- child_17;
-    assume { Resolve2.resolve child_17 };
-    assume { Resolve2.resolve i_7 };
     i_7 <- _53;
     _9 <- ();
-    assume { Resolve4.resolve _9 };
     goto BB2
   }
   BB21 {
@@ -1252,9 +1206,7 @@ module HeapsortGeneric_HeapSort
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
@@ -1339,7 +1291,6 @@ module HeapsortGeneric_HeapSort
     invariant proph_const {  ^ v_1 =  ^ Model1.model old_v_2 };
     invariant heap { HeapFrag0.heap_frag (Model0.model v_1) (UInt64.to_int start_5) (Seq.length (Model0.model v_1)) };
     invariant start_bound { UInt64.to_int start_5 <= div (Seq.length (Model0.model v_1)) 2 };
-    assume { Resolve2.resolve _12 };
     _12 <- start_5;
     _11 <- _12 > (0 : usize);
     switch (_11)
@@ -1351,7 +1302,6 @@ module HeapsortGeneric_HeapSort
     start_5 <- start_5 - (1 : usize);
     _14 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _14) };
-    assume { Resolve2.resolve _15 };
     _15 <- start_5;
     _17 <-  * _14;
     _16 <- Len0.len _17;
@@ -1363,13 +1313,10 @@ module HeapsortGeneric_HeapSort
   }
   BB7 {
     _10 <- ();
-    assume { Resolve3.resolve _10 };
     goto BB4
   }
   BB8 {
-    assume { Resolve2.resolve start_5 };
     _9 <- ();
-    assume { Resolve3.resolve _9 };
     _22 <-  * v_1;
     end'_21 <- Len0.len _22;
     goto BB9
@@ -1384,7 +1331,6 @@ module HeapsortGeneric_HeapSort
     invariant heap { HeapFrag0.heap_frag (Model0.model v_1) 0 (UInt64.to_int end'_21) };
     invariant sorted { SortedRange0.sorted_range (Model0.model v_1) (UInt64.to_int end'_21) (Seq.length (Model0.model v_1)) };
     invariant heap_le { forall j : (int) . forall i : (int) . 0 <= i && i < UInt64.to_int end'_21 && UInt64.to_int end'_21 <= j && j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
-    assume { Resolve2.resolve _24 };
     _24 <- end'_21;
     _23 <- _24 > (1 : usize);
     switch (_23)
@@ -1396,7 +1342,6 @@ module HeapsortGeneric_HeapSort
     end'_21 <- end'_21 - (1 : usize);
     _26 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _26) };
-    assume { Resolve2.resolve _27 };
     _27 <- end'_21;
     _25 <- Swap0.swap _26 (0 : usize) _27;
     goto BB12
@@ -1404,22 +1349,18 @@ module HeapsortGeneric_HeapSort
   BB12 {
     assert { let _ = HeapFragMax0.heap_frag_max (Model0.model v_1) 0 (UInt64.to_int end'_21) in forall j : (int) . forall i : (int) . 0 <= i && i < UInt64.to_int end'_21 && UInt64.to_int end'_21 <= j && j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
     _28 <- ();
-    assume { Resolve3.resolve _28 };
     _30 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _30) };
-    assume { Resolve2.resolve _31 };
     _31 <- end'_21;
     _29 <- SiftDown0.sift_down _30 (0 : usize) _31;
     goto BB13
   }
   BB13 {
     _10 <- ();
-    assume { Resolve3.resolve _10 };
     goto BB10
   }
   BB14 {
-    assume { Resolve4.resolve v_1 };
-    assume { Resolve2.resolve end'_21 };
+    assume { Resolve2.resolve v_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/immut.stdout
+++ b/creusot/tests/should_succeed/immut.stdout
@@ -33,10 +33,7 @@ module Immut_Main
     a_1 <- (10 : uint32);
     b_2 <- borrow_mut a_1;
     a_1 <-  ^ b_2;
-    assume { (fun x -> true) a_1 };
     c_3 <-  * b_2;
-    assume { (fun x -> true) b_2 };
-    assume { (fun x -> true) c_3 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max.stdout
+++ b/creusot/tests/should_succeed/inc_max.stdout
@@ -14,15 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -41,12 +32,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -67,8 +52,7 @@ module IncMax_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -88,9 +72,7 @@ module IncMax_TakeMax
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <-  * ma_1;
-    assume { Resolve0.resolve _7 };
     _7 <-  * mb_2;
     _5 <- _6 >= _7;
     switch (_5)
@@ -99,29 +81,29 @@ module IncMax_TakeMax
       end
   }
   BB1 {
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     _8 <- borrow_mut ( * ma_1);
     ma_1 <- { ma_1 with current = ( ^ _8) };
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _4) };
-    assume { Resolve1.resolve _8 };
+    assume { Resolve0.resolve _8 };
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * mb_2);
     mb_2 <- { mb_2 with current = ( ^ _4) };
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     goto BB3
   }
   BB3 {
     _3 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _3) };
-    assume { Resolve1.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve1.resolve _3 };
+    assume { Resolve0.resolve _3 };
     return _0
   }
   
@@ -137,8 +119,6 @@ module IncMax_IncMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMax_TakeMax_Interface as TakeMax0
   let rec cfg inc_max [@cfg:stackify] (a : uint32) (b : uint32) : ()
@@ -181,12 +161,8 @@ module IncMax_IncMax
     assume { Resolve0.resolve _7 };
     mc_3 <- { mc_3 with current = ( * mc_3 + (1 : uint32)) };
     assume { Resolve0.resolve mc_3 };
-    assume { Resolve1.resolve _11 };
     _11 <- a_1;
-    assume { Resolve1.resolve a_1 };
-    assume { Resolve1.resolve _12 };
     _12 <- b_2;
-    assume { Resolve1.resolve b_2 };
     _10 <- _11 <> _12;
     _9 <- not _10;
     switch (_9)
@@ -199,7 +175,6 @@ module IncMax_IncMax
   }
   BB3 {
     _8 <- ();
-    assume { Resolve2.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_3.stdout
+++ b/creusot/tests/should_succeed/inc_max_3.stdout
@@ -30,15 +30,6 @@ module IncMax3_Swap
     ensures {  ^ mma =  * mmb &&  ^ mmb =  * mma }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -57,12 +48,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -84,11 +69,9 @@ module IncMax3_IncMax3
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = borrowed uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = borrowed uint32
   clone IncMax3_Swap_Interface as Swap0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_3 [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires { * ma <= (1000000 : uint32) &&  * mb <= (1000000 : uint32) &&  * mc <= (1000000 : uint32)}
     ensures {  ^ ma <>  ^ mb &&  ^ mb <>  ^ mc &&  ^ mc <>  ^ ma }
@@ -132,9 +115,7 @@ module IncMax3_IncMax3
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <-  * ma_1;
-    assume { Resolve0.resolve _7 };
     _7 <-  * mb_2;
     _5 <- _6 < _7;
     switch (_5)
@@ -155,21 +136,17 @@ module IncMax3_IncMax3
     goto BB2
   }
   BB2 {
-    assume { Resolve1.resolve _10 };
-    assume { Resolve1.resolve _12 };
+    assume { Resolve0.resolve _10 };
+    assume { Resolve0.resolve _12 };
     _4 <- ();
-    assume { Resolve2.resolve _4 };
     goto BB4
   }
   BB3 {
     _4 <- ();
-    assume { Resolve2.resolve _4 };
     goto BB4
   }
   BB4 {
-    assume { Resolve0.resolve _15 };
     _15 <-  * mb_2;
-    assume { Resolve0.resolve _16 };
     _16 <-  * mc_3;
     _14 <- _15 < _16;
     switch (_14)
@@ -184,29 +161,25 @@ module IncMax3_IncMax3
     _19 <- { _19 with current = ( ^ _18) };
     _21 <- borrow_mut mc_3;
     mc_3 <-  ^ _21;
-    assume { Resolve3.resolve mc_3 };
+    assume { Resolve1.resolve mc_3 };
     _20 <- borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     _17 <- Swap0.swap _18 _20;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _19 };
-    assume { Resolve1.resolve _21 };
+    assume { Resolve0.resolve _19 };
+    assume { Resolve0.resolve _21 };
     _13 <- ();
-    assume { Resolve2.resolve _13 };
     goto BB8
   }
   BB7 {
-    assume { Resolve3.resolve mc_3 };
+    assume { Resolve1.resolve mc_3 };
     _13 <- ();
-    assume { Resolve2.resolve _13 };
     goto BB8
   }
   BB8 {
-    assume { Resolve0.resolve _24 };
     _24 <-  * ma_1;
-    assume { Resolve0.resolve _25 };
     _25 <-  * mb_2;
     _23 <- _24 < _25;
     switch (_23)
@@ -227,22 +200,20 @@ module IncMax3_IncMax3
     goto BB10
   }
   BB10 {
-    assume { Resolve1.resolve _28 };
-    assume { Resolve1.resolve _30 };
+    assume { Resolve0.resolve _28 };
+    assume { Resolve0.resolve _30 };
     _22 <- ();
-    assume { Resolve2.resolve _22 };
     goto BB12
   }
   BB11 {
     _22 <- ();
-    assume { Resolve2.resolve _22 };
     goto BB12
   }
   BB12 {
     ma_1 <- { ma_1 with current = ( * ma_1 + (2 : uint32)) };
-    assume { Resolve3.resolve ma_1 };
+    assume { Resolve1.resolve ma_1 };
     mb_2 <- { mb_2 with current = ( * mb_2 + (1 : uint32)) };
-    assume { Resolve3.resolve mb_2 };
+    assume { Resolve1.resolve mb_2 };
     _0 <- ();
     return _0
   }
@@ -259,9 +230,6 @@ module IncMax3_TestIncMax3
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMax3_IncMax3_Interface as IncMax30
   let rec cfg test_inc_max_3 [@cfg:stackify] (a : uint32) (b : uint32) (c : uint32) : ()
@@ -319,9 +287,7 @@ module IncMax3_TestIncMax3
     assume { Resolve0.resolve _6 };
     assume { Resolve0.resolve _8 };
     assume { Resolve0.resolve _10 };
-    assume { Resolve1.resolve _16 };
     _16 <- a_1;
-    assume { Resolve1.resolve _17 };
     _17 <- b_2;
     _15 <- _16 <> _17;
     switch (_15)
@@ -330,20 +296,13 @@ module IncMax3_TestIncMax3
       end
   }
   BB2 {
-    assume { Resolve1.resolve a_1 };
-    assume { Resolve1.resolve c_3 };
     _13 <- false;
     goto BB4
   }
   BB3 {
-    assume { Resolve1.resolve _22 };
     _22 <- c_3;
-    assume { Resolve1.resolve c_3 };
-    assume { Resolve1.resolve _23 };
     _23 <- a_1;
-    assume { Resolve1.resolve a_1 };
     _21 <- _22 <> _23;
-    assume { Resolve2.resolve _13 };
     _13 <- _21;
     goto BB4
   }
@@ -355,18 +314,13 @@ module IncMax3_TestIncMax3
       end
   }
   BB5 {
-    assume { Resolve1.resolve b_2 };
     _14 <- false;
     goto BB7
   }
   BB6 {
-    assume { Resolve1.resolve _19 };
     _19 <- b_2;
-    assume { Resolve1.resolve b_2 };
-    assume { Resolve1.resolve _20 };
     _20 <- c_3;
     _18 <- _19 <> _20;
-    assume { Resolve2.resolve _14 };
     _14 <- _18;
     goto BB7
   }
@@ -381,7 +335,6 @@ module IncMax3_TestIncMax3
   }
   BB9 {
     _11 <- ();
-    assume { Resolve3.resolve _11 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_many.stdout
+++ b/creusot/tests/should_succeed/inc_max_many.stdout
@@ -14,15 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -41,12 +32,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -67,8 +52,7 @@ module IncMaxMany_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -88,9 +72,7 @@ module IncMaxMany_TakeMax
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <-  * ma_1;
-    assume { Resolve0.resolve _7 };
     _7 <-  * mb_2;
     _5 <- _6 >= _7;
     switch (_5)
@@ -99,29 +81,29 @@ module IncMaxMany_TakeMax
       end
   }
   BB1 {
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     _8 <- borrow_mut ( * ma_1);
     ma_1 <- { ma_1 with current = ( ^ _8) };
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _4) };
-    assume { Resolve1.resolve _8 };
+    assume { Resolve0.resolve _8 };
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * mb_2);
     mb_2 <- { mb_2 with current = ( ^ _4) };
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     goto BB3
   }
   BB3 {
     _3 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _3) };
-    assume { Resolve1.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve1.resolve _3 };
+    assume { Resolve0.resolve _3 };
     return _0
   }
   
@@ -137,9 +119,6 @@ module IncMaxMany_IncMaxMany
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMaxMany_TakeMax_Interface as TakeMax0
   let rec cfg inc_max_many [@cfg:stackify] (a : uint32) (b : uint32) (k : uint32) : ()
@@ -191,15 +170,11 @@ module IncMaxMany_IncMaxMany
   BB1 {
     assume { Resolve0.resolve _6 };
     assume { Resolve0.resolve _8 };
-    assume { Resolve1.resolve _9 };
     _9 <- k_3;
     mc_4 <- { mc_4 with current = ( * mc_4 + _9) };
     assume { Resolve0.resolve mc_4 };
-    assume { Resolve1.resolve _14 };
     _14 <- a_1;
-    assume { Resolve1.resolve _16 };
     _16 <- b_2;
-    assume { Resolve1.resolve _17 };
     _17 <- k_3;
     _15 <- _16 + _17;
     _13 <- _14 >= _15;
@@ -209,25 +184,15 @@ module IncMaxMany_IncMaxMany
       end
   }
   BB2 {
-    assume { Resolve1.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
-    assume { Resolve1.resolve k_3 };
     _12 <- true;
     goto BB4
   }
   BB3 {
-    assume { Resolve1.resolve _19 };
     _19 <- b_2;
-    assume { Resolve1.resolve b_2 };
-    assume { Resolve1.resolve _21 };
     _21 <- a_1;
-    assume { Resolve1.resolve a_1 };
-    assume { Resolve1.resolve _22 };
     _22 <- k_3;
-    assume { Resolve1.resolve k_3 };
     _20 <- _21 + _22;
     _18 <- _19 >= _20;
-    assume { Resolve3.resolve _12 };
     _12 <- _18;
     goto BB4
   }
@@ -243,7 +208,6 @@ module IncMaxMany_IncMaxMany
   }
   BB6 {
     _10 <- ();
-    assume { Resolve2.resolve _10 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_max_repeat.stdout
+++ b/creusot/tests/should_succeed/inc_max_repeat.stdout
@@ -14,15 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -41,12 +32,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -67,8 +52,7 @@ module IncMaxRepeat_TakeMax
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   let rec cfg take_max [@cfg:stackify] (ma : borrowed uint32) (mb : borrowed uint32) : borrowed uint32
     ensures { if  * ma >=  * mb then  * mb =  ^ mb && result = ma else  * ma =  ^ ma && result = mb }
     
@@ -88,9 +72,7 @@ module IncMaxRepeat_TakeMax
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <-  * ma_1;
-    assume { Resolve0.resolve _7 };
     _7 <-  * mb_2;
     _5 <- _6 >= _7;
     switch (_5)
@@ -99,29 +81,29 @@ module IncMaxRepeat_TakeMax
       end
   }
   BB1 {
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     _8 <- borrow_mut ( * ma_1);
     ma_1 <- { ma_1 with current = ( ^ _8) };
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _4) };
-    assume { Resolve1.resolve _8 };
+    assume { Resolve0.resolve _8 };
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve ma_1 };
+    assume { Resolve0.resolve ma_1 };
     _4 <- borrow_mut ( * mb_2);
     mb_2 <- { mb_2 with current = ( ^ _4) };
-    assume { Resolve1.resolve mb_2 };
+    assume { Resolve0.resolve mb_2 };
     goto BB3
   }
   BB3 {
     _3 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _3) };
-    assume { Resolve1.resolve _4 };
+    assume { Resolve0.resolve _4 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve1.resolve _3 };
+    assume { Resolve0.resolve _3 };
     return _0
   }
   
@@ -137,11 +119,8 @@ module IncMaxRepeat_IncMaxRepeat
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone IncMaxRepeat_TakeMax_Interface as TakeMax0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg inc_max_repeat [@cfg:stackify] (a : uint32) (b : uint32) (n : uint32) : ()
     requires {a <= (1000000 : uint32) && b <= (1000000 : uint32) && n <= (1000000 : uint32)}
     
@@ -192,9 +171,7 @@ module IncMaxRepeat_IncMaxRepeat
     invariant cntr_bound { i_4 <= n_3 };
     invariant val_bound { a_1 <= (1000000 : uint32) + i_4 && b_2 <= (1000000 : uint32) + i_4 };
     invariant diff_bound { a_1 >= b_2 + i_4 || b_2 >= a_1 + i_4 };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
-    assume { Resolve0.resolve _9 };
     _9 <- n_3;
     _7 <- _8 < _9;
     switch (_7)
@@ -215,24 +192,18 @@ module IncMaxRepeat_IncMaxRepeat
     goto BB3
   }
   BB3 {
-    assume { Resolve1.resolve _12 };
-    assume { Resolve1.resolve _14 };
+    assume { Resolve0.resolve _12 };
+    assume { Resolve0.resolve _14 };
     mc_10 <- { mc_10 with current = ( * mc_10 + (1 : uint32)) };
-    assume { Resolve1.resolve mc_10 };
+    assume { Resolve0.resolve mc_10 };
     i_4 <- i_4 + (1 : uint32);
     _6 <- ();
-    assume { Resolve2.resolve _6 };
     goto BB1
   }
   BB4 {
-    assume { Resolve0.resolve n_3 };
     _5 <- ();
-    assume { Resolve2.resolve _5 };
-    assume { Resolve0.resolve _22 };
     _22 <- a_1;
-    assume { Resolve0.resolve _24 };
     _24 <- b_2;
-    assume { Resolve0.resolve _25 };
     _25 <- i_4;
     _23 <- _24 + _25;
     _21 <- _22 >= _23;
@@ -242,25 +213,15 @@ module IncMaxRepeat_IncMaxRepeat
       end
   }
   BB5 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve b_2 };
-    assume { Resolve0.resolve i_4 };
     _20 <- true;
     goto BB7
   }
   BB6 {
-    assume { Resolve0.resolve _27 };
     _27 <- b_2;
-    assume { Resolve0.resolve b_2 };
-    assume { Resolve0.resolve _29 };
     _29 <- a_1;
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve _30 };
     _30 <- i_4;
-    assume { Resolve0.resolve i_4 };
     _28 <- _29 + _30;
     _26 <- _27 >= _28;
-    assume { Resolve3.resolve _20 };
     _20 <- _26;
     goto BB7
   }
@@ -276,7 +237,6 @@ module IncMaxRepeat_IncMaxRepeat
   }
   BB9 {
     _18 <- ();
-    assume { Resolve2.resolve _18 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -81,29 +81,6 @@ module IncSome2List_Impl1_LemmaSumNonneg_Impl
       | Type.IncSome2List_List_Nil -> ()
       end
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module IncSome2List_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
@@ -124,10 +101,6 @@ module IncSome2List_Impl1_SumX
   use Type
   clone IncSome2List_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsome2list_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsome2list_list
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsome2list_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -152,23 +125,17 @@ module IncSome2List_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve0.resolve self_1 };
     _0 <- (0 : uint32);
     goto BB5
   }
   BB2 {
-    assume { Resolve0.resolve self_1 };
     absurd
   }
   BB3 {
     a_3 <- Type.incsome2list_list_Cons_0 self_1;
     l_4 <- Type.incsome2list_list_Cons_1 self_1;
-    assume { Resolve0.resolve self_1 };
-    assume { Resolve1.resolve _5 };
     _5 <- a_3;
-    assume { Resolve2.resolve a_3 };
     _7 <- l_4;
-    assume { Resolve3.resolve l_4 };
     _6 <- sum_x _7;
     goto BB4
   }
@@ -277,6 +244,14 @@ module Rand_Random
     requires {false}
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -311,10 +286,9 @@ module IncSome2List_Impl1_TakeSomeRest
   clone IncSome2List_Impl1_Sum as Sum0
   clone IncSome2List_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.incsome2list_list
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsome2list_list
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsome2list_list
   let rec cfg take_some_rest [@cfg:stackify] (self : borrowed (Type.incsome2list_list)) : (borrowed uint32, borrowed (Type.incsome2list_list))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -360,7 +334,6 @@ module IncSome2List_Impl1_TakeSomeRest
     assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * ml_4) in true };
     _5 <- ();
-    assume { Resolve1.resolve _5 };
     _6 <- Random0.random ();
     goto BB4
   }
@@ -373,22 +346,22 @@ module IncSome2List_Impl1_TakeSomeRest
   BB5 {
     _7 <- borrow_mut ( * ma_3);
     ma_3 <- { ma_3 with current = ( ^ _7) };
-    assume { Resolve2.resolve ma_3 };
+    assume { Resolve1.resolve ma_3 };
     _8 <- borrow_mut ( * ml_4);
     ml_4 <- { ml_4 with current = ( ^ _8) };
-    assume { Resolve3.resolve ml_4 };
+    assume { Resolve2.resolve ml_4 };
     _0 <- (_7, _8);
     goto BB8
   }
   BB6 {
-    assume { Resolve2.resolve ma_3 };
+    assume { Resolve1.resolve ma_3 };
     _9 <- borrow_mut ( * ml_4);
     ml_4 <- { ml_4 with current = ( ^ _9) };
     _0 <- take_some_rest _9;
     goto BB7
   }
   BB7 {
-    assume { Resolve3.resolve ml_4 };
+    assume { Resolve2.resolve ml_4 };
     goto BB8
   }
   BB8 {
@@ -396,7 +369,6 @@ module IncSome2List_Impl1_TakeSomeRest
   }
   BB9 {
     _11 <- ();
-    assume { Resolve1.resolve _11 };
     goto BB9
   }
   
@@ -442,9 +414,6 @@ module IncSome2List_IncSome2List
   clone IncSome2List_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl5_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.incsome2list_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsome2list_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,
@@ -522,11 +491,9 @@ module IncSome2List_IncSome2List
     assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
     assume { Resolve2.resolve _11 };
-    assume { Resolve3.resolve _13 };
     _13 <- j_2;
     ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
     assume { Resolve0.resolve ma_6 };
-    assume { Resolve3.resolve _14 };
     _14 <- k_3;
     mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
     assume { Resolve0.resolve mb_10 };
@@ -535,16 +502,10 @@ module IncSome2List_IncSome2List
     goto BB5
   }
   BB5 {
-    assume { Resolve3.resolve _22 };
     _22 <- sum0_4;
-    assume { Resolve3.resolve sum0_4 };
-    assume { Resolve3.resolve _23 };
     _23 <- j_2;
-    assume { Resolve3.resolve j_2 };
     _21 <- _22 + _23;
-    assume { Resolve3.resolve _24 };
     _24 <- k_3;
-    assume { Resolve3.resolve k_3 };
     _20 <- _21 + _24;
     _17 <- _18 = _20;
     _16 <- not _17;
@@ -558,12 +519,10 @@ module IncSome2List_IncSome2List
   }
   BB7 {
     _15 <- ();
-    assume { Resolve4.resolve _15 };
     _0 <- ();
     goto BB8
   }
   BB8 {
-    assume { Resolve5.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -86,29 +86,6 @@ module IncSome2Tree_Impl1_LemmaSumNonneg_Impl
       | Type.IncSome2Tree_Tree_Leaf -> ()
       end
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module IncSome2Tree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
@@ -130,11 +107,6 @@ module IncSome2Tree_Impl1_SumX
   clone IncSome2Tree_Impl1_Sum as Sum0
   clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsome2tree_tree
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsome2tree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -164,34 +136,26 @@ module IncSome2Tree_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve0.resolve self_1 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB2 {
-    assume { Resolve0.resolve self_1 };
     absurd
   }
   BB3 {
     tl_3 <- Type.incsome2tree_tree_Node_0 self_1;
     a_4 <- Type.incsome2tree_tree_Node_1 self_1;
     tr_5 <- Type.incsome2tree_tree_Node_2 self_1;
-    assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg tl_3 in let _ = LemmaSumNonneg0.lemma_sum_nonneg tr_5 in true };
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     _9 <- tl_3;
-    assume { Resolve2.resolve tl_3 };
     _8 <- sum_x _9;
     goto BB4
   }
   BB4 {
-    assume { Resolve3.resolve _10 };
     _10 <- a_4;
-    assume { Resolve4.resolve a_4 };
     _7 <- _8 + _10;
     _12 <- tr_5;
-    assume { Resolve2.resolve tr_5 };
     _11 <- sum_x _12;
     goto BB5
   }
@@ -300,6 +264,14 @@ module Rand_Random
     requires {false}
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -334,10 +306,9 @@ module IncSome2Tree_Impl1_TakeSomeRest
   clone IncSome2Tree_Impl1_Sum as Sum0
   clone IncSome2Tree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsome2tree_tree
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsome2tree_tree
   let rec cfg take_some_rest [@cfg:stackify] (self : borrowed (Type.incsome2tree_tree)) : (borrowed uint32, borrowed (Type.incsome2tree_tree))
     ensures { Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
@@ -391,7 +362,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
     assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtl_3) in let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtr_5) in true };
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     _7 <- Random0.random ();
     goto BB4
   }
@@ -404,7 +374,7 @@ module IncSome2Tree_Impl1_TakeSomeRest
   BB5 {
     _8 <- borrow_mut ( * ma_4);
     ma_4 <- { ma_4 with current = ( ^ _8) };
-    assume { Resolve2.resolve ma_4 };
+    assume { Resolve1.resolve ma_4 };
     _11 <- Random0.random ();
     goto BB6
   }
@@ -415,20 +385,20 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB7 {
-    assume { Resolve3.resolve mtr_5 };
+    assume { Resolve2.resolve mtr_5 };
     _12 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _12) };
-    assume { Resolve3.resolve mtl_3 };
+    assume { Resolve2.resolve mtl_3 };
     _10 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _10) };
     assume { Resolve0.resolve _12 };
     goto BB9
   }
   BB8 {
-    assume { Resolve3.resolve mtl_3 };
+    assume { Resolve2.resolve mtl_3 };
     _10 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _10) };
-    assume { Resolve3.resolve mtr_5 };
+    assume { Resolve2.resolve mtr_5 };
     goto BB9
   }
   BB9 {
@@ -439,7 +409,7 @@ module IncSome2Tree_Impl1_TakeSomeRest
     goto BB17
   }
   BB10 {
-    assume { Resolve2.resolve ma_4 };
+    assume { Resolve1.resolve ma_4 };
     _13 <- Random0.random ();
     goto BB11
   }
@@ -450,25 +420,25 @@ module IncSome2Tree_Impl1_TakeSomeRest
       end
   }
   BB12 {
-    assume { Resolve3.resolve mtr_5 };
+    assume { Resolve2.resolve mtr_5 };
     _14 <- borrow_mut ( * mtl_3);
     mtl_3 <- { mtl_3 with current = ( ^ _14) };
     _0 <- take_some_rest _14;
     goto BB13
   }
   BB13 {
-    assume { Resolve3.resolve mtl_3 };
+    assume { Resolve2.resolve mtl_3 };
     goto BB16
   }
   BB14 {
-    assume { Resolve3.resolve mtl_3 };
+    assume { Resolve2.resolve mtl_3 };
     _15 <- borrow_mut ( * mtr_5);
     mtr_5 <- { mtr_5 with current = ( ^ _15) };
     _0 <- take_some_rest _15;
     goto BB15
   }
   BB15 {
-    assume { Resolve3.resolve mtr_5 };
+    assume { Resolve2.resolve mtr_5 };
     goto BB16
   }
   BB16 {
@@ -479,7 +449,6 @@ module IncSome2Tree_Impl1_TakeSomeRest
   }
   BB18 {
     _17 <- ();
-    assume { Resolve1.resolve _17 };
     goto BB18
   }
   
@@ -525,9 +494,6 @@ module IncSome2Tree_IncSome2Tree
   clone IncSome2Tree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl5_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.incsome2tree_tree
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsome2tree_tree
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve2 with type t1 = borrowed uint32,
@@ -605,11 +571,9 @@ module IncSome2Tree_IncSome2Tree
     assume { Resolve0.resolve mb_10 };
     mb_10 <- (let (a, _) = _11 in a);
     assume { Resolve2.resolve _11 };
-    assume { Resolve3.resolve _13 };
     _13 <- j_2;
     ma_6 <- { ma_6 with current = ( * ma_6 + _13) };
     assume { Resolve0.resolve ma_6 };
-    assume { Resolve3.resolve _14 };
     _14 <- k_3;
     mb_10 <- { mb_10 with current = ( * mb_10 + _14) };
     assume { Resolve0.resolve mb_10 };
@@ -618,16 +582,10 @@ module IncSome2Tree_IncSome2Tree
     goto BB5
   }
   BB5 {
-    assume { Resolve3.resolve _22 };
     _22 <- sum0_4;
-    assume { Resolve3.resolve sum0_4 };
-    assume { Resolve3.resolve _23 };
     _23 <- j_2;
-    assume { Resolve3.resolve j_2 };
     _21 <- _22 + _23;
-    assume { Resolve3.resolve _24 };
     _24 <- k_3;
-    assume { Resolve3.resolve k_3 };
     _20 <- _21 + _24;
     _17 <- _18 = _20;
     _16 <- not _17;
@@ -641,12 +599,10 @@ module IncSome2Tree_IncSome2Tree
   }
   BB7 {
     _15 <- ();
-    assume { Resolve4.resolve _15 };
     _0 <- ();
     goto BB8
   }
   BB8 {
-    assume { Resolve5.resolve t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -87,29 +87,6 @@ module IncSomeList_Impl1_LemmaSumNonneg_Impl
       | Type.IncSomeList_List_Nil -> ()
       end
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module IncSomeList_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
@@ -130,10 +107,6 @@ module IncSomeList_Impl1_SumX
   use Type
   clone IncSomeList_Impl1_Sum as Sum0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsomelist_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsomelist_list
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsomelist_list) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -158,23 +131,17 @@ module IncSomeList_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve0.resolve self_1 };
     _0 <- (0 : uint32);
     goto BB5
   }
   BB2 {
-    assume { Resolve0.resolve self_1 };
     absurd
   }
   BB3 {
     a_3 <- Type.incsomelist_list_Cons_0 self_1;
     l_4 <- Type.incsomelist_list_Cons_1 self_1;
-    assume { Resolve0.resolve self_1 };
-    assume { Resolve1.resolve _5 };
     _5 <- a_3;
-    assume { Resolve2.resolve a_3 };
     _7 <- l_4;
-    assume { Resolve3.resolve l_4 };
     _6 <- sum_x _7;
     goto BB4
   }
@@ -271,6 +238,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -304,10 +279,9 @@ module IncSomeList_Impl1_TakeSome
   clone IncSomeList_Impl1_Sum as Sum0
   clone IncSomeList_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsomelist_list
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsomelist_list
   clone IncSomeList_Random_Interface as Random0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsomelist_list
   let rec cfg take_some [@cfg:stackify] (self : borrowed (Type.incsomelist_list)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
@@ -356,7 +330,6 @@ module IncSomeList_Impl1_TakeSome
     assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * ml_6) in true };
     _8 <- ();
-    assume { Resolve1.resolve _8 };
     _10 <- Random0.random ();
     goto BB4
   }
@@ -367,47 +340,46 @@ module IncSomeList_Impl1_TakeSome
       end
   }
   BB5 {
-    assume { Resolve2.resolve ml_6 };
+    assume { Resolve1.resolve ml_6 };
     _11 <- borrow_mut ( * ma_5);
     ma_5 <- { ma_5 with current = ( ^ _11) };
-    assume { Resolve3.resolve ma_5 };
+    assume { Resolve2.resolve ma_5 };
     _9 <- borrow_mut ( * _11);
     _11 <- { _11 with current = ( ^ _9) };
-    assume { Resolve3.resolve _11 };
+    assume { Resolve2.resolve _11 };
     goto BB8
   }
   BB6 {
-    assume { Resolve3.resolve ma_5 };
+    assume { Resolve2.resolve ma_5 };
     _13 <- borrow_mut ( * ml_6);
     ml_6 <- { ml_6 with current = ( ^ _13) };
     _12 <- take_some _13;
     goto BB7
   }
   BB7 {
-    assume { Resolve2.resolve ml_6 };
+    assume { Resolve1.resolve ml_6 };
     _9 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _9) };
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     goto BB8
   }
   BB8 {
     _7 <- borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _7) };
-    assume { Resolve3.resolve _9 };
+    assume { Resolve2.resolve _9 };
     _3 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _3) };
-    assume { Resolve3.resolve _7 };
+    assume { Resolve2.resolve _7 };
     _2 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _2) };
-    assume { Resolve3.resolve _3 };
+    assume { Resolve2.resolve _3 };
     _0 <- borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve3.resolve _2 };
+    assume { Resolve2.resolve _2 };
     return _0
   }
   BB9 {
     _15 <- ();
-    assume { Resolve1.resolve _15 };
     goto BB9
   }
   
@@ -430,10 +402,7 @@ module IncSomeList_IncSomeList
   clone IncSomeList_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl5_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsomelist_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Int_Impl5_ModelTy as ModelTy0
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -481,21 +450,16 @@ module IncSomeList_IncSomeList
     goto BB3
   }
   BB3 {
-    assume { Resolve0.resolve _7 };
     _7 <- k_2;
     ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
-    assume { Resolve1.resolve ma_5 };
+    assume { Resolve0.resolve ma_5 };
     _12 <- l_1;
     _11 <- SumX0.sum_x _12;
     goto BB4
   }
   BB4 {
-    assume { Resolve0.resolve _14 };
     _14 <- sum0_3;
-    assume { Resolve0.resolve sum0_3 };
-    assume { Resolve0.resolve _15 };
     _15 <- k_2;
-    assume { Resolve0.resolve k_2 };
     _13 <- _14 + _15;
     _10 <- _11 = _13;
     _9 <- not _10;
@@ -509,12 +473,10 @@ module IncSomeList_IncSomeList
   }
   BB6 {
     _8 <- ();
-    assume { Resolve2.resolve _8 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve3.resolve l_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -86,29 +86,6 @@ module IncSomeTree_Impl1_LemmaSumNonneg_Impl
       | Type.IncSomeTree_Tree_Leaf -> ()
       end
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module IncSomeTree_Impl1_SumX_Interface
   use mach.int.Int
   use mach.int.Int32
@@ -130,11 +107,6 @@ module IncSomeTree_Impl1_SumX
   clone IncSomeTree_Impl1_Sum as Sum0
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.incsometree_tree
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.incsometree_tree
   let rec cfg sum_x [@cfg:stackify] (self : Type.incsometree_tree) : uint32
     requires {Sum0.sum self <= 1000000}
     ensures { UInt32.to_int result = Sum0.sum self }
@@ -164,34 +136,26 @@ module IncSomeTree_Impl1_SumX
       end
   }
   BB1 {
-    assume { Resolve0.resolve self_1 };
     _0 <- (0 : uint32);
     goto BB6
   }
   BB2 {
-    assume { Resolve0.resolve self_1 };
     absurd
   }
   BB3 {
     tl_3 <- Type.incsometree_tree_Node_0 self_1;
     a_4 <- Type.incsometree_tree_Node_1 self_1;
     tr_5 <- Type.incsometree_tree_Node_2 self_1;
-    assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg tl_3 in let _ = LemmaSumNonneg0.lemma_sum_nonneg tr_5 in true };
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     _9 <- tl_3;
-    assume { Resolve2.resolve tl_3 };
     _8 <- sum_x _9;
     goto BB4
   }
   BB4 {
-    assume { Resolve3.resolve _10 };
     _10 <- a_4;
-    assume { Resolve4.resolve a_4 };
     _7 <- _8 + _10;
     _12 <- tr_5;
-    assume { Resolve2.resolve tr_5 };
     _11 <- sum_x _12;
     goto BB5
   }
@@ -300,6 +264,14 @@ module Rand_Random
     requires {false}
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -333,10 +305,9 @@ module IncSomeTree_Impl1_TakeSome
   clone IncSomeTree_Impl1_Sum as Sum0
   clone IncSomeTree_Impl1_LemmaSumNonneg as LemmaSumNonneg0 with function Sum0.sum = Sum0.sum, axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.incsometree_tree
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.incsometree_tree
   clone Rand_Random_Interface as Random0 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.incsometree_tree
   let rec cfg take_some [@cfg:stackify] (self : borrowed (Type.incsometree_tree)) : borrowed uint32
     ensures { Model0.model result <= Sum0.sum ( * self) }
@@ -392,7 +363,6 @@ module IncSomeTree_Impl1_TakeSome
     assume { Resolve0.resolve self_1 };
     assert { let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtl_5) in let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtr_7) in true };
     _9 <- ();
-    assume { Resolve1.resolve _9 };
     _11 <- Random0.random ();
     goto BB4
   }
@@ -403,18 +373,18 @@ module IncSomeTree_Impl1_TakeSome
       end
   }
   BB5 {
-    assume { Resolve2.resolve mtl_5 };
-    assume { Resolve2.resolve mtr_7 };
+    assume { Resolve1.resolve mtl_5 };
+    assume { Resolve1.resolve mtr_7 };
     _12 <- borrow_mut ( * ma_6);
     ma_6 <- { ma_6 with current = ( ^ _12) };
-    assume { Resolve3.resolve ma_6 };
+    assume { Resolve2.resolve ma_6 };
     _10 <- borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _10) };
-    assume { Resolve3.resolve _12 };
+    assume { Resolve2.resolve _12 };
     goto BB13
   }
   BB6 {
-    assume { Resolve3.resolve ma_6 };
+    assume { Resolve2.resolve ma_6 };
     _13 <- Random0.random ();
     goto BB7
   }
@@ -425,34 +395,34 @@ module IncSomeTree_Impl1_TakeSome
       end
   }
   BB8 {
-    assume { Resolve2.resolve mtr_7 };
+    assume { Resolve1.resolve mtr_7 };
     _16 <- borrow_mut ( * mtl_5);
     mtl_5 <- { mtl_5 with current = ( ^ _16) };
     _15 <- take_some _16;
     goto BB9
   }
   BB9 {
-    assume { Resolve2.resolve mtl_5 };
+    assume { Resolve1.resolve mtl_5 };
     _14 <- borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _14) };
-    assume { Resolve3.resolve _15 };
+    assume { Resolve2.resolve _15 };
     _10 <- borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _10) };
-    assume { Resolve3.resolve _14 };
+    assume { Resolve2.resolve _14 };
     goto BB12
   }
   BB10 {
-    assume { Resolve2.resolve mtl_5 };
+    assume { Resolve1.resolve mtl_5 };
     _18 <- borrow_mut ( * mtr_7);
     mtr_7 <- { mtr_7 with current = ( ^ _18) };
     _17 <- take_some _18;
     goto BB11
   }
   BB11 {
-    assume { Resolve2.resolve mtr_7 };
+    assume { Resolve1.resolve mtr_7 };
     _10 <- borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _10) };
-    assume { Resolve3.resolve _17 };
+    assume { Resolve2.resolve _17 };
     goto BB12
   }
   BB12 {
@@ -461,21 +431,20 @@ module IncSomeTree_Impl1_TakeSome
   BB13 {
     _8 <- borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _8) };
-    assume { Resolve3.resolve _10 };
+    assume { Resolve2.resolve _10 };
     _3 <- borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _3) };
-    assume { Resolve3.resolve _8 };
+    assume { Resolve2.resolve _8 };
     _2 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _2) };
-    assume { Resolve3.resolve _3 };
+    assume { Resolve2.resolve _3 };
     _0 <- borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve3.resolve _2 };
+    assume { Resolve2.resolve _2 };
     return _0
   }
   BB14 {
     _20 <- ();
-    assume { Resolve1.resolve _20 };
     goto BB14
   }
   
@@ -498,10 +467,7 @@ module IncSomeTree_IncSomeTree
   clone IncSomeTree_Impl1_Sum as Sum0
   use prelude.Prelude
   clone CreusotContracts_Logic_Int_Impl5_Model as Model1
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.incsometree_tree
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Logic_Int_Impl5_ModelTy as ModelTy0
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -549,21 +515,16 @@ module IncSomeTree_IncSomeTree
     goto BB3
   }
   BB3 {
-    assume { Resolve0.resolve _7 };
     _7 <- k_2;
     ma_5 <- { ma_5 with current = ( * ma_5 + _7) };
-    assume { Resolve1.resolve ma_5 };
+    assume { Resolve0.resolve ma_5 };
     _12 <- t_1;
     _11 <- SumX0.sum_x _12;
     goto BB4
   }
   BB4 {
-    assume { Resolve0.resolve _14 };
     _14 <- sum0_3;
-    assume { Resolve0.resolve sum0_3 };
-    assume { Resolve0.resolve _15 };
     _15 <- k_2;
-    assume { Resolve0.resolve k_2 };
     _13 <- _14 + _15;
     _10 <- _11 = _13;
     _9 <- not _10;
@@ -577,12 +538,10 @@ module IncSomeTree_IncSomeTree
   }
   BB6 {
     _8 <- ();
-    assume { Resolve2.resolve _8 };
     _0 <- ();
     goto BB7
   }
   BB7 {
-    assume { Resolve3.resolve t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/inplace_list_reversal.stdout
+++ b/creusot/tests/should_succeed/inplace_list_reversal.stdout
@@ -124,15 +124,6 @@ module CreusotContracts_Std1_Mem_Replace
     ensures {  ^ dest = src }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -143,12 +134,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -174,10 +159,9 @@ module InplaceListReversal_Rev
   clone InplaceListReversal_RevAppend as RevAppend0 with type t = t
   use mach.int.Int
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve5 with type self = (t, Type.inplacelistreversal_list t)
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.inplacelistreversal_list t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.inplacelistreversal_list t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = (t, Type.inplacelistreversal_list t)
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.inplacelistreversal_list t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = Type.inplacelistreversal_list t
   clone CreusotContracts_Std1_Mem_Replace_Interface as Replace0 with type t = Type.inplacelistreversal_list t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (Type.inplacelistreversal_list t)
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.inplacelistreversal_list t
@@ -243,13 +227,13 @@ module InplaceListReversal_Rev
       end
   }
   BB5 {
-    assume { Resolve5.resolve curr_12 };
+    assume { Resolve4.resolve curr_12 };
     curr_12 <- Type.inplacelistreversal_list_Cons_0 head_6;
-    assume { Resolve3.resolve next_13 };
+    assume { Resolve2.resolve next_13 };
     next_13 <- (let (_, a) = curr_12 in a);
-    assume { Resolve3.resolve _14 };
+    assume { Resolve2.resolve _14 };
     _14 <- prev_5;
-    assume { Resolve3.resolve (let (_, a) = curr_12 in a) };
+    assume { Resolve2.resolve (let (_, a) = curr_12 in a) };
     curr_12 <- (let (a, b) = curr_12 in (a, _14));
     goto BB6
   }
@@ -257,13 +241,13 @@ module InplaceListReversal_Rev
     goto BB7
   }
   BB7 {
-    assume { Resolve5.resolve _16 };
+    assume { Resolve4.resolve _16 };
     _16 <- curr_12;
     _15 <- Type.InplaceListReversal_List_Cons _16;
     goto BB8
   }
   BB8 {
-    assume { Resolve3.resolve prev_5 };
+    assume { Resolve2.resolve prev_5 };
     prev_5 <- _15;
     goto BB9
   }
@@ -271,9 +255,9 @@ module InplaceListReversal_Rev
     goto BB10
   }
   BB10 {
-    assume { Resolve3.resolve _17 };
+    assume { Resolve2.resolve _17 };
     _17 <- next_13;
-    assume { Resolve3.resolve head_6 };
+    assume { Resolve2.resolve head_6 };
     head_6 <- _17;
     goto BB11
   }
@@ -282,7 +266,6 @@ module InplaceListReversal_Rev
   }
   BB12 {
     _10 <- ();
-    assume { Resolve2.resolve _10 };
     goto BB13
   }
   BB13 {
@@ -290,10 +273,9 @@ module InplaceListReversal_Rev
   }
   BB14 {
     _9 <- ();
-    assume { Resolve2.resolve _9 };
-    assume { Resolve3.resolve _21 };
+    assume { Resolve2.resolve _21 };
     _21 <- prev_5;
-    assume { Resolve3.resolve ( * l_1) };
+    assume { Resolve2.resolve ( * l_1) };
     l_1 <- { l_1 with current = _21 };
     goto BB16
   }
@@ -301,7 +283,7 @@ module InplaceListReversal_Rev
     goto BB4
   }
   BB16 {
-    assume { Resolve4.resolve l_1 };
+    assume { Resolve3.resolve l_1 };
     goto BB17
   }
   BB17 {
@@ -309,7 +291,7 @@ module InplaceListReversal_Rev
     goto BB18
   }
   BB18 {
-    assume { Resolve3.resolve head_6 };
+    assume { Resolve2.resolve head_6 };
     goto BB19
   }
   BB19 {

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -67,15 +67,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self
   predicate resolve (self : self)
@@ -91,12 +82,6 @@ module CreusotContracts_Logic_Resolve_Impl1
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
   predicate resolve = Resolve0.resolve
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module InvariantMoves_TestInvariantMove_Interface
   use Type
   use mach.int.Int
@@ -109,10 +94,6 @@ module InvariantMoves_TestInvariantMove
   use mach.int.UInt32
   use prelude.Prelude
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.core_option_option uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)
   clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with type t = uint32, type a = Type.alloc_alloc_global
   let rec cfg test_invariant_move [@cfg:stackify] (x : Type.alloc_vec_vec uint32 (Type.alloc_alloc_global)) : () = 
@@ -154,21 +135,15 @@ module InvariantMoves_TestInvariantMove
       end
   }
   BB4 {
-    assume { Resolve3.resolve x_7 };
     x_7 <- Type.core_option_option_Some_0 _3;
-    assume { Resolve1.resolve _3 };
-    assume { Resolve3.resolve x_7 };
     _2 <- ();
-    assume { Resolve4.resolve _2 };
     goto BB2
   }
   BB5 {
-    assume { Resolve1.resolve _3 };
     _0 <- ();
     goto BB6
   }
   BB6 {
-    assume { Resolve2.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/iter_mut.stdout
+++ b/creusot/tests/should_succeed/iter_mut.stdout
@@ -289,15 +289,6 @@ module IterMut_Impl2
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.itermut_itermut t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
   type t
   use prelude.Prelude
@@ -335,12 +326,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -373,16 +358,10 @@ module IterMut_IncVec
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.itermut_vec int,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.itermut_vec int)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.core_option_option (borrowed int)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.itermut_itermut int
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = int
   clone CreusotContracts_Logic_Seq_Impl1_Get as Get0 with type t = borrowed int
   clone CreusotContracts_Logic_Seq_Impl1_Tail as Tail0 with type t = borrowed int
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.itermut_vec int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.itermut_vec int))
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = borrowed (Type.itermut_vec int)
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.itermut_vec int
   clone IterMut_Impl3_Next_Interface as Next0 with type t = int, function Model0.model = Model3.model,
   function Tail0.tail = Tail0.tail, function Get0.get = Get0.get
   clone IterMut_Impl1_IterMut_Interface as IterMut0 with type t = int, function Model0.model = Model1.model,
@@ -417,19 +396,17 @@ module IterMut_IncVec
   BB0 {
     _4 <- v_1;
     _3 <- _4;
-    assume { Resolve0.resolve _4 };
     old_v_2 <- Record0.record _3;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve old_v_2 };
     _6 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _6) };
     it_5 <- IterMut0.iter_mut _6;
     goto BB2
   }
   BB2 {
-    assume { Resolve2.resolve v_1 };
+    assume { Resolve0.resolve v_1 };
     _ghost_seen_7 <- (0 : int);
     goto BB3
   }
@@ -449,20 +426,15 @@ module IterMut_IncVec
       end
   }
   BB5 {
-    assume { Resolve6.resolve r_12 };
+    assume { Resolve1.resolve r_12 };
     r_12 <- Type.core_option_option_Some_0 _9;
-    assume { Resolve5.resolve _9 };
     r_12 <- { r_12 with current = ( * r_12 + (5 : int)) };
-    assume { Resolve6.resolve r_12 };
+    assume { Resolve1.resolve r_12 };
     _ghost_seen_7 <- _ghost_seen_7 + (1 : int);
     _8 <- ();
-    assume { Resolve7.resolve _8 };
     goto BB3
   }
   BB6 {
-    assume { Resolve3.resolve it_5 };
-    assume { Resolve4.resolve _ghost_seen_7 };
-    assume { Resolve5.resolve _9 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -37,29 +37,6 @@ module Knapsack_MaxLog
   function max_log (a : int) (b : int) : int = 
     if a < b then b else a
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module Knapsack_Max_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -75,7 +52,6 @@ module Knapsack_Max
   use mach.int.Int
   use prelude.Prelude
   clone Knapsack_MaxLog as MaxLog0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg max [@cfg:stackify] (a : usize) (b : usize) : usize
     requires {true}
     ensures { UInt64.to_int result = MaxLog0.max_log (UInt64.to_int a) (UInt64.to_int b) }
@@ -93,9 +69,7 @@ module Knapsack_Max
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
     _4 <- a_1;
-    assume { Resolve0.resolve _5 };
     _5 <- b_2;
     _3 <- _4 < _5;
     switch (_3)
@@ -104,17 +78,11 @@ module Knapsack_Max
       end
   }
   BB1 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve _0 };
     _0 <- b_2;
-    assume { Resolve0.resolve b_2 };
     goto BB3
   }
   BB2 {
-    assume { Resolve0.resolve b_2 };
-    assume { Resolve0.resolve _0 };
     _0 <- a_1;
-    assume { Resolve0.resolve a_1 };
     goto BB3
   }
   BB3 {
@@ -359,6 +327,14 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self
   type idx
@@ -585,6 +561,21 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module Knapsack_Knapsack01Dyn_Interface
   type name
   use mach.int.Int
@@ -618,7 +609,8 @@ module Knapsack_Knapsack01Dyn
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.knapsack_item name
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy3 with type t = Type.knapsack_item name
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model8 with type t = Type.knapsack_item name
   clone CreusotContracts_Logic_Model_Impl1_Model as Model9 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsack_item name),
@@ -627,20 +619,16 @@ module Knapsack_Knapsack01Dyn
   function Model0.model = Model8.model, function Model1.model = Model9.model
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.knapsack_item name,
   function Model0.model = Model8.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.knapsack_item name
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve8 with type t = Type.knapsack_item name,
-  function Model0.model = Model8.model, predicate Resolve0.resolve = Resolve1.resolve
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.knapsack_item name
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve4 with type t = Type.knapsack_item name,
+  function Model0.model = Model8.model, predicate Resolve0.resolve = Resolve0.resolve
   clone Knapsack_Max_Interface as Max0 with function MaxLog0.max_log = MaxLog0.max_log
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve10 with type t = usize, function Model0.model = Model2.model,
-  predicate Resolve0.resolve = Resolve0.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve6 with type t = usize, function Model0.model = Model2.model,
+  predicate Resolve0.resolve = Resolve7.resolve
   clone CreusotContracts_Logic_Model_Impl1_Model as Model7 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -659,8 +647,8 @@ module Knapsack_Knapsack01Dyn
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model4.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve9 with type t = Type.creusotcontracts_std1_vec_vec usize,
-  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve10.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve6.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.knapsack_item name,
@@ -782,7 +770,6 @@ module Knapsack_Knapsack01Dyn
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <- max_weight_2;
     _5 <- _6 + (1 : usize);
     _4 <- FromElem0.from_elem (0 : usize) _5;
@@ -819,7 +806,6 @@ module Knapsack_Knapsack01Dyn
     invariant weight_len { forall i : (int) . 0 <= i && i < Seq.length (Model1.model best_value_3) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model2.model (Seq.get (Model1.model best_value_3) i)) };
     invariant best_value { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= UInt64.to_int i_10 && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) = M0.m (Model0.model items_1) ii ww };
     invariant best_value_bounds { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= Seq.length (Model0.model items_1) && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) <= 10000000 * ii };
-    assume { Resolve0.resolve _14 };
     _14 <- i_10;
     _16 <- items_1;
     _15 <- Len0.len _16;
@@ -834,14 +820,13 @@ module Knapsack_Knapsack01Dyn
   }
   BB10 {
     _19 <- items_1;
-    assume { Resolve0.resolve _20 };
     _20 <- i_10;
     _18 <- Index0.index _19 _20;
     goto BB11
   }
   BB11 {
     it_17 <- _18;
-    assume { Resolve1.resolve _18 };
+    assume { Resolve0.resolve _18 };
     w_21 <- (0 : usize);
     goto BB12
   }
@@ -866,9 +851,7 @@ module Knapsack_Knapsack01Dyn
     invariant best_value2 { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= UInt64.to_int i_10 && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) = M0.m (Model0.model items_1) ii ww };
     invariant best_value2 { forall ww : (int) . 0 <= ww && ww <= UInt64.to_int w_21 - 1 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) (UInt64.to_int i_10 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_10 + 1) ww };
     invariant best_value_bounds { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= Seq.length (Model0.model items_1) && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) <= 10000000 * ii };
-    assume { Resolve0.resolve _24 };
     _24 <- w_21;
-    assume { Resolve0.resolve _25 };
     _25 <- max_weight_2;
     _23 <- _24 <= _25;
     switch (_23)
@@ -877,9 +860,7 @@ module Knapsack_Knapsack01Dyn
       end
   }
   BB18 {
-    assume { Resolve0.resolve _28 };
     _28 <- Type.knapsack_item_Item_weight it_17;
-    assume { Resolve0.resolve _29 };
     _29 <- w_21;
     _27 <- _28 > _29;
     switch (_27)
@@ -889,66 +870,49 @@ module Knapsack_Knapsack01Dyn
   }
   BB19 {
     _33 <- best_value_3;
-    assume { Resolve0.resolve _34 };
     _34 <- i_10;
     _32 <- Index1.index _33 _34;
     goto BB20
   }
   BB20 {
     _31 <- _32;
-    assume { Resolve2.resolve _32 };
-    assume { Resolve0.resolve _35 };
     _35 <- w_21;
     _30 <- Index2.index _31 _35;
     goto BB21
   }
   BB21 {
-    assume { Resolve0.resolve _26 };
     _26 <- _30;
-    assume { Resolve3.resolve _30 };
     goto BB28
   }
   BB22 {
     _40 <- best_value_3;
-    assume { Resolve0.resolve _41 };
     _41 <- i_10;
     _39 <- Index1.index _40 _41;
     goto BB23
   }
   BB23 {
     _38 <- _39;
-    assume { Resolve2.resolve _39 };
-    assume { Resolve0.resolve _42 };
     _42 <- w_21;
     _37 <- Index2.index _38 _42;
     goto BB24
   }
   BB24 {
-    assume { Resolve0.resolve _36 };
     _36 <- _37;
-    assume { Resolve3.resolve _37 };
     _48 <- best_value_3;
-    assume { Resolve0.resolve _49 };
     _49 <- i_10;
     _47 <- Index1.index _48 _49;
     goto BB25
   }
   BB25 {
     _46 <- _47;
-    assume { Resolve2.resolve _47 };
-    assume { Resolve0.resolve _51 };
     _51 <- w_21;
-    assume { Resolve0.resolve _52 };
     _52 <- Type.knapsack_item_Item_weight it_17;
     _50 <- _51 - _52;
     _45 <- Index2.index _46 _50;
     goto BB26
   }
   BB26 {
-    assume { Resolve0.resolve _44 };
     _44 <- _45;
-    assume { Resolve3.resolve _45 };
-    assume { Resolve0.resolve _53 };
     _53 <- Type.knapsack_item_Item_value it_17;
     _43 <- _44 + _53;
     _26 <- Max0.max _36 _43;
@@ -960,7 +924,6 @@ module Knapsack_Knapsack01Dyn
   BB28 {
     _57 <- borrow_mut best_value_3;
     best_value_3 <-  ^ _57;
-    assume { Resolve0.resolve _59 };
     _59 <- i_10;
     _58 <- _59 + (1 : usize);
     _56 <- IndexMut0.index_mut _57 _58;
@@ -969,35 +932,27 @@ module Knapsack_Knapsack01Dyn
   BB29 {
     _55 <- borrow_mut ( * _56);
     _56 <- { _56 with current = ( ^ _55) };
-    assume { Resolve4.resolve _56 };
-    assume { Resolve0.resolve _60 };
+    assume { Resolve1.resolve _56 };
     _60 <- w_21;
     _54 <- IndexMut1.index_mut _55 _60;
     goto BB30
   }
   BB30 {
-    assume { Resolve0.resolve ( * _54) };
     _54 <- { _54 with current = _26 };
-    assume { Resolve5.resolve _54 };
+    assume { Resolve2.resolve _54 };
     w_21 <- w_21 + (1 : usize);
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB17
   }
   BB31 {
-    assume { Resolve1.resolve it_17 };
-    assume { Resolve0.resolve w_21 };
+    assume { Resolve0.resolve it_17 };
     _22 <- ();
-    assume { Resolve6.resolve _22 };
     i_10 <- i_10 + (1 : usize);
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB8
   }
   BB32 {
-    assume { Resolve0.resolve i_10 };
     _11 <- ();
-    assume { Resolve6.resolve _11 };
     _69 <- items_1;
     _68 <- Len0.len _69;
     goto BB33
@@ -1007,9 +962,7 @@ module Knapsack_Knapsack01Dyn
     goto BB34
   }
   BB34 {
-    assume { Resolve0.resolve left_weight_70 };
     left_weight_70 <- max_weight_2;
-    assume { Resolve0.resolve max_weight_2 };
     _72 <- items_1;
     j_71 <- Len0.len _72;
     goto BB35
@@ -1020,7 +973,6 @@ module Knapsack_Knapsack01Dyn
   BB36 {
     invariant j_items_len { UInt64.to_int j_71 <= Seq.length (Model0.model items_1) };
     invariant left_weight_le_max { UInt64.to_int left_weight_70 <= UInt64.to_int max_weight_2 };
-    assume { Resolve0.resolve _75 };
     _75 <- j_71;
     _74 <- (0 : usize) < _75;
     switch (_74)
@@ -1031,16 +983,14 @@ module Knapsack_Knapsack01Dyn
   BB37 {
     j_71 <- j_71 - (1 : usize);
     _78 <- items_1;
-    assume { Resolve0.resolve _79 };
     _79 <- j_71;
     _77 <- Index0.index _78 _79;
     goto BB38
   }
   BB38 {
     it_76 <- _77;
-    assume { Resolve1.resolve _77 };
+    assume { Resolve0.resolve _77 };
     _85 <- best_value_3;
-    assume { Resolve0.resolve _87 };
     _87 <- j_71;
     _86 <- _87 + (1 : usize);
     _84 <- Index1.index _85 _86;
@@ -1048,34 +998,25 @@ module Knapsack_Knapsack01Dyn
   }
   BB39 {
     _83 <- _84;
-    assume { Resolve2.resolve _84 };
-    assume { Resolve0.resolve _88 };
     _88 <- left_weight_70;
     _82 <- Index2.index _83 _88;
     goto BB40
   }
   BB40 {
-    assume { Resolve0.resolve _81 };
     _81 <- _82;
-    assume { Resolve3.resolve _82 };
     _93 <- best_value_3;
-    assume { Resolve0.resolve _94 };
     _94 <- j_71;
     _92 <- Index1.index _93 _94;
     goto BB41
   }
   BB41 {
     _91 <- _92;
-    assume { Resolve2.resolve _92 };
-    assume { Resolve0.resolve _95 };
     _95 <- left_weight_70;
     _90 <- Index2.index _91 _95;
     goto BB42
   }
   BB42 {
-    assume { Resolve0.resolve _89 };
     _89 <- _90;
-    assume { Resolve3.resolve _90 };
     _80 <- _81 <> _89;
     switch (_80)
       | False -> goto BB45
@@ -1085,36 +1026,30 @@ module Knapsack_Knapsack01Dyn
   BB43 {
     _97 <- borrow_mut result_67;
     result_67 <-  ^ _97;
-    assume { Resolve1.resolve _98 };
+    assume { Resolve0.resolve _98 };
     _98 <- it_76;
     _96 <- Push0.push _97 _98;
     goto BB44
   }
   BB44 {
-    assume { Resolve0.resolve _99 };
     _99 <- Type.knapsack_item_Item_weight it_76;
-    assume { Resolve1.resolve it_76 };
+    assume { Resolve0.resolve it_76 };
     left_weight_70 <- left_weight_70 - _99;
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB46
   }
   BB45 {
-    assume { Resolve1.resolve it_76 };
+    assume { Resolve0.resolve it_76 };
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB46
   }
   BB46 {
     goto BB36
   }
   BB47 {
-    assume { Resolve7.resolve items_1 };
-    assume { Resolve0.resolve left_weight_70 };
-    assume { Resolve0.resolve j_71 };
+    assume { Resolve3.resolve items_1 };
     _73 <- ();
-    assume { Resolve6.resolve _73 };
-    assume { Resolve8.resolve _0 };
+    assume { Resolve4.resolve _0 };
     _0 <- result_67;
     goto BB48
   }
@@ -1122,7 +1057,7 @@ module Knapsack_Knapsack01Dyn
     goto BB49
   }
   BB49 {
-    assume { Resolve9.resolve best_value_3 };
+    assume { Resolve5.resolve best_value_3 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -37,29 +37,6 @@ module KnapsackFull_MaxLog
   function max_log (a : int) (b : int) : int = 
     if a < b then b else a
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module KnapsackFull_Max_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -74,7 +51,6 @@ module KnapsackFull_Max
   use mach.int.Int
   use prelude.Prelude
   clone KnapsackFull_MaxLog as MaxLog0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg max [@cfg:stackify] (a : usize) (b : usize) : usize
     ensures { UInt64.to_int result = MaxLog0.max_log (UInt64.to_int a) (UInt64.to_int b) }
     
@@ -91,9 +67,7 @@ module KnapsackFull_Max
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
     _4 <- a_1;
-    assume { Resolve0.resolve _5 };
     _5 <- b_2;
     _3 <- _4 < _5;
     switch (_3)
@@ -102,17 +76,11 @@ module KnapsackFull_Max
       end
   }
   BB1 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve _0 };
     _0 <- b_2;
-    assume { Resolve0.resolve b_2 };
     goto BB3
   }
   BB2 {
-    assume { Resolve0.resolve b_2 };
-    assume { Resolve0.resolve _0 };
     _0 <- a_1;
-    assume { Resolve0.resolve a_1 };
     goto BB3
   }
   BB3 {
@@ -499,6 +467,14 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module Core_Ops_Index_IndexMut_IndexMut_Interface
   type self
   type idx
@@ -725,6 +701,21 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module KnapsackFull_Knapsack01Dyn_Interface
   type name
   use mach.int.Int
@@ -771,28 +762,25 @@ module KnapsackFull_Knapsack01Dyn
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.knapsackfull_item name
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model4.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve7 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name)
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy3 with type t = Type.knapsackfull_item name
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.knapsackfull_item name
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.knapsackfull_item name
   clone CreusotContracts_Logic_Model_Impl1_Model as Model9 with type t = Type.creusotcontracts_std1_vec_vec (Type.knapsackfull_item name),
   type ModelTy0.modelTy = ModelTy3.modelTy, function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = Type.knapsackfull_item name,
   function Model0.model = Model3.model, function Model1.model = Model9.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve8 with type t = Type.knapsackfull_item name,
-  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve1.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve4 with type t = Type.knapsackfull_item name,
+  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve0.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.knapsackfull_item name,
   function Model0.model = Model3.model
   clone KnapsackFull_Max_Interface as Max0 with function MaxLog0.max_log = MaxLog0.max_log
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve10 with type t = usize, function Model0.model = Model2.model,
-  predicate Resolve0.resolve = Resolve0.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve6 with type t = usize, function Model0.model = Model2.model,
+  predicate Resolve0.resolve = Resolve7.resolve
   clone CreusotContracts_Logic_Model_Impl1_Model as Model8 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -811,8 +799,8 @@ module KnapsackFull_Knapsack01Dyn
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model5.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve9 with type t = Type.creusotcontracts_std1_vec_vec usize,
-  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve10.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model1.model, predicate Resolve0.resolve = Resolve6.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = Type.knapsackfull_item name,
@@ -937,7 +925,6 @@ module KnapsackFull_Knapsack01Dyn
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <- max_weight_2;
     _5 <- _6 + (1 : usize);
     _4 <- FromElem0.from_elem (0 : usize) _5;
@@ -974,7 +961,6 @@ module KnapsackFull_Knapsack01Dyn
     invariant weight_len { forall i : (int) . 0 <= i && i < Seq.length (Model1.model best_value_3) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model2.model (Seq.get (Model1.model best_value_3) i)) };
     invariant best_value { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= UInt64.to_int i_10 && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) = M0.m (Model0.model items_1) ii ww };
     invariant best_value_bounds { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= Seq.length (Model0.model items_1) && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) <= 10000000 * ii };
-    assume { Resolve0.resolve _14 };
     _14 <- i_10;
     _16 <- items_1;
     _15 <- Len0.len _16;
@@ -989,14 +975,13 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB10 {
     _19 <- items_1;
-    assume { Resolve0.resolve _20 };
     _20 <- i_10;
     _18 <- Index0.index _19 _20;
     goto BB11
   }
   BB11 {
     it_17 <- _18;
-    assume { Resolve1.resolve _18 };
+    assume { Resolve0.resolve _18 };
     w_21 <- (0 : usize);
     goto BB12
   }
@@ -1021,9 +1006,7 @@ module KnapsackFull_Knapsack01Dyn
     invariant best_value2 { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= UInt64.to_int i_10 && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) = M0.m (Model0.model items_1) ii ww };
     invariant best_value2 { forall ww : (int) . 0 <= ww && ww <= UInt64.to_int w_21 - 1 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) (UInt64.to_int i_10 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_10 + 1) ww };
     invariant best_value_bounds { forall ww : (int) . forall ii : (int) . 0 <= ii && ii <= Seq.length (Model0.model items_1) && 0 <= ww && ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model2.model (Seq.get (Model1.model best_value_3) ii)) ww) <= 10000000 * ii };
-    assume { Resolve0.resolve _24 };
     _24 <- w_21;
-    assume { Resolve0.resolve _25 };
     _25 <- max_weight_2;
     _23 <- _24 <= _25;
     switch (_23)
@@ -1032,9 +1015,7 @@ module KnapsackFull_Knapsack01Dyn
       end
   }
   BB18 {
-    assume { Resolve0.resolve _28 };
     _28 <- Type.knapsackfull_item_Item_weight it_17;
-    assume { Resolve0.resolve _29 };
     _29 <- w_21;
     _27 <- _28 > _29;
     switch (_27)
@@ -1044,66 +1025,49 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB19 {
     _33 <- best_value_3;
-    assume { Resolve0.resolve _34 };
     _34 <- i_10;
     _32 <- Index1.index _33 _34;
     goto BB20
   }
   BB20 {
     _31 <- _32;
-    assume { Resolve2.resolve _32 };
-    assume { Resolve0.resolve _35 };
     _35 <- w_21;
     _30 <- Index2.index _31 _35;
     goto BB21
   }
   BB21 {
-    assume { Resolve0.resolve _26 };
     _26 <- _30;
-    assume { Resolve3.resolve _30 };
     goto BB28
   }
   BB22 {
     _40 <- best_value_3;
-    assume { Resolve0.resolve _41 };
     _41 <- i_10;
     _39 <- Index1.index _40 _41;
     goto BB23
   }
   BB23 {
     _38 <- _39;
-    assume { Resolve2.resolve _39 };
-    assume { Resolve0.resolve _42 };
     _42 <- w_21;
     _37 <- Index2.index _38 _42;
     goto BB24
   }
   BB24 {
-    assume { Resolve0.resolve _36 };
     _36 <- _37;
-    assume { Resolve3.resolve _37 };
     _48 <- best_value_3;
-    assume { Resolve0.resolve _49 };
     _49 <- i_10;
     _47 <- Index1.index _48 _49;
     goto BB25
   }
   BB25 {
     _46 <- _47;
-    assume { Resolve2.resolve _47 };
-    assume { Resolve0.resolve _51 };
     _51 <- w_21;
-    assume { Resolve0.resolve _52 };
     _52 <- Type.knapsackfull_item_Item_weight it_17;
     _50 <- _51 - _52;
     _45 <- Index2.index _46 _50;
     goto BB26
   }
   BB26 {
-    assume { Resolve0.resolve _44 };
     _44 <- _45;
-    assume { Resolve3.resolve _45 };
-    assume { Resolve0.resolve _53 };
     _53 <- Type.knapsackfull_item_Item_value it_17;
     _43 <- _44 + _53;
     _26 <- Max0.max _36 _43;
@@ -1115,7 +1079,6 @@ module KnapsackFull_Knapsack01Dyn
   BB28 {
     _57 <- borrow_mut best_value_3;
     best_value_3 <-  ^ _57;
-    assume { Resolve0.resolve _59 };
     _59 <- i_10;
     _58 <- _59 + (1 : usize);
     _56 <- IndexMut0.index_mut _57 _58;
@@ -1124,35 +1087,27 @@ module KnapsackFull_Knapsack01Dyn
   BB29 {
     _55 <- borrow_mut ( * _56);
     _56 <- { _56 with current = ( ^ _55) };
-    assume { Resolve4.resolve _56 };
-    assume { Resolve0.resolve _60 };
+    assume { Resolve1.resolve _56 };
     _60 <- w_21;
     _54 <- IndexMut1.index_mut _55 _60;
     goto BB30
   }
   BB30 {
-    assume { Resolve0.resolve ( * _54) };
     _54 <- { _54 with current = _26 };
-    assume { Resolve5.resolve _54 };
+    assume { Resolve2.resolve _54 };
     w_21 <- w_21 + (1 : usize);
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB17
   }
   BB31 {
-    assume { Resolve1.resolve it_17 };
-    assume { Resolve0.resolve w_21 };
+    assume { Resolve0.resolve it_17 };
     _22 <- ();
-    assume { Resolve6.resolve _22 };
     i_10 <- i_10 + (1 : usize);
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB8
   }
   BB32 {
-    assume { Resolve0.resolve i_10 };
     _11 <- ();
-    assume { Resolve6.resolve _11 };
     _69 <- items_1;
     _68 <- Len0.len _69;
     goto BB33
@@ -1162,9 +1117,7 @@ module KnapsackFull_Knapsack01Dyn
     goto BB34
   }
   BB34 {
-    assume { Resolve0.resolve left_weight_70 };
     left_weight_70 <- max_weight_2;
-    assume { Resolve0.resolve max_weight_2 };
     _72 <- items_1;
     j_71 <- Len0.len _72;
     goto BB35
@@ -1187,7 +1140,6 @@ module KnapsackFull_Knapsack01Dyn
     invariant result_weight { forall r : (Seq.seq (Type.knapsackfull_item name)) . Seq.length (Model3.model result_67) <= Seq.length r && (forall i : (int) . 0 <= i && i < Seq.length (Model3.model result_67) -> Seq.get (Model3.model result_67) i = Seq.get r i) && SumWeights0.sum_weights r (Seq.length (Model3.model result_67)) <= UInt64.to_int left_weight_70 -> SumWeights0.sum_weights r 0 <= UInt64.to_int max_weight_2 };
     invariant result_value { forall r : (Seq.seq (Type.knapsackfull_item name)) . Seq.length (Model3.model result_67) <= Seq.length r && (forall i : (int) . 0 <= i && i < Seq.length (Model3.model result_67) -> Seq.get (Model3.model result_67) i = Seq.get r i) && SumValues0.sum_values r (Seq.length (Model3.model result_67)) = M0.m (Model0.model items_1) (UInt64.to_int j_71) (UInt64.to_int left_weight_70) -> SumValues0.sum_values r 0 = M0.m (Model0.model items_1) (Seq.length (Model0.model items_1)) (UInt64.to_int max_weight_2) };
     invariant result_subseq { forall r : (Seq.seq (Type.knapsackfull_item name)) . Seq.length (Model3.model result_67) <= Seq.length r && (forall i : (int) . 0 <= i && i < Seq.length (Model3.model result_67) -> Seq.get (Model3.model result_67) i = Seq.get r i) && SubseqRev0.subseq_rev r (Seq.length (Model3.model result_67)) (Model0.model items_1) (UInt64.to_int j_71) -> SubseqRev0.subseq_rev r 0 (Model0.model items_1) (Seq.length (Model0.model items_1)) };
-    assume { Resolve0.resolve _75 };
     _75 <- j_71;
     _74 <- (0 : usize) < _75;
     switch (_74)
@@ -1198,16 +1150,14 @@ module KnapsackFull_Knapsack01Dyn
   BB40 {
     j_71 <- j_71 - (1 : usize);
     _78 <- items_1;
-    assume { Resolve0.resolve _79 };
     _79 <- j_71;
     _77 <- Index0.index _78 _79;
     goto BB41
   }
   BB41 {
     it_76 <- _77;
-    assume { Resolve1.resolve _77 };
+    assume { Resolve0.resolve _77 };
     _85 <- best_value_3;
-    assume { Resolve0.resolve _87 };
     _87 <- j_71;
     _86 <- _87 + (1 : usize);
     _84 <- Index1.index _85 _86;
@@ -1215,34 +1165,25 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB42 {
     _83 <- _84;
-    assume { Resolve2.resolve _84 };
-    assume { Resolve0.resolve _88 };
     _88 <- left_weight_70;
     _82 <- Index2.index _83 _88;
     goto BB43
   }
   BB43 {
-    assume { Resolve0.resolve _81 };
     _81 <- _82;
-    assume { Resolve3.resolve _82 };
     _93 <- best_value_3;
-    assume { Resolve0.resolve _94 };
     _94 <- j_71;
     _92 <- Index1.index _93 _94;
     goto BB44
   }
   BB44 {
     _91 <- _92;
-    assume { Resolve2.resolve _92 };
-    assume { Resolve0.resolve _95 };
     _95 <- left_weight_70;
     _90 <- Index2.index _91 _95;
     goto BB45
   }
   BB45 {
-    assume { Resolve0.resolve _89 };
     _89 <- _90;
-    assume { Resolve3.resolve _90 };
     _80 <- _81 <> _89;
     switch (_80)
       | False -> goto BB48
@@ -1257,30 +1198,24 @@ module KnapsackFull_Knapsack01Dyn
     goto BB47
   }
   BB47 {
-    assume { Resolve0.resolve _99 };
     _99 <- Type.knapsackfull_item_Item_weight it_76;
-    assume { Resolve1.resolve it_76 };
+    assume { Resolve0.resolve it_76 };
     left_weight_70 <- left_weight_70 - _99;
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB49
   }
   BB48 {
-    assume { Resolve1.resolve it_76 };
+    assume { Resolve0.resolve it_76 };
     _12 <- ();
-    assume { Resolve6.resolve _12 };
     goto BB49
   }
   BB49 {
     goto BB39
   }
   BB50 {
-    assume { Resolve7.resolve items_1 };
-    assume { Resolve0.resolve left_weight_70 };
-    assume { Resolve0.resolve j_71 };
+    assume { Resolve3.resolve items_1 };
     _73 <- ();
-    assume { Resolve6.resolve _73 };
-    assume { Resolve8.resolve _0 };
+    assume { Resolve4.resolve _0 };
     _0 <- result_67;
     goto BB51
   }
@@ -1288,7 +1223,7 @@ module KnapsackFull_Knapsack01Dyn
     goto BB52
   }
   BB52 {
-    assume { Resolve9.resolve best_value_3 };
+    assume { Resolve5.resolve best_value_3 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/list_index_mut.stdout
+++ b/creusot/tests/should_succeed/list_index_mut.stdout
@@ -72,15 +72,6 @@ module ListIndexMut_Get
       Type.ListIndexMut_Option_Some i
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -105,12 +96,6 @@ module CreusotContracts_Logic_Resolve_Impl1
   use prelude.Prelude
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = borrowed t,
-  predicate resolve = Resolve0.resolve
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
   predicate resolve = Resolve0.resolve
 end
 module ListIndexMut_IndexMut_Interface
@@ -140,10 +125,8 @@ module ListIndexMut_IndexMut
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.listindexmut_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.listindexmut_list
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   let rec cfg index_mut [@cfg:stackify] (param_l : borrowed (Type.listindexmut_list)) (param_ix : usize) : borrowed uint32
     requires {UInt64.to_int param_ix < Len0.len ( * param_l)}
@@ -180,9 +163,7 @@ module ListIndexMut_IndexMut
   BB0 {
     assume { Resolve0.resolve l_4 };
     l_4 <- param_l_1;
-    assume { Resolve1.resolve ix_5 };
     ix_5 <- param_ix_2;
-    assume { Resolve1.resolve param_ix_2 };
     goto BB1
   }
   BB1 {
@@ -191,7 +172,6 @@ module ListIndexMut_IndexMut
     invariant get_target_fin { Get0.get ( ^ l_4) (UInt64.to_int ix_5) = Get0.get ( ^ param_l_1) (UInt64.to_int param_ix_2) };
     invariant len { Len0.len ( ^ l_4) = Len0.len ( * l_4) -> Len0.len ( ^ param_l_1) = Len0.len ( * param_l_1) };
     invariant untouched { (forall i : (int) . 0 <= i && i < Len0.len ( * l_4) && i <> UInt64.to_int ix_5 -> Get0.get ( ^ l_4) i = Get0.get ( * l_4) i) -> (forall i : (int) . 0 <= i && i < Len0.len ( * param_l_1) && i <> UInt64.to_int param_ix_2 -> Get0.get ( ^ param_l_1) i = Get0.get ( * param_l_1) i) };
-    assume { Resolve1.resolve _9 };
     _9 <- ix_5;
     _8 <- _9 > (0 : usize);
     switch (_8)
@@ -207,12 +187,10 @@ module ListIndexMut_IndexMut
   }
   BB3 {
     assume { Resolve0.resolve l_4 };
-    assume { Resolve1.resolve ix_5 };
     absurd
   }
   BB4 {
     assume { Resolve0.resolve l_4 };
-    assume { Resolve1.resolve ix_5 };
     absurd
   }
   BB5 {
@@ -221,29 +199,25 @@ module ListIndexMut_IndexMut
     assume { Resolve0.resolve l_4 };
     _13 <- borrow_mut ( * n_12);
     n_12 <- { n_12 with current = ( ^ _13) };
-    assume { Resolve2.resolve n_12 };
+    assume { Resolve1.resolve n_12 };
     assume { Resolve0.resolve l_4 };
     l_4 <- _13;
     _10 <- ();
-    assume { Resolve3.resolve _10 };
     ix_5 <- ix_5 - (1 : usize);
     _7 <- ();
-    assume { Resolve3.resolve _7 };
     goto BB1
   }
   BB6 {
-    assume { Resolve1.resolve ix_5 };
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     _18 <- borrow_mut (Type.listindexmut_list_List_0 ( * l_4));
     l_4 <- { l_4 with current = (let Type.ListIndexMut_List a b =  * l_4 in Type.ListIndexMut_List ( ^ _18) b) };
     assume { Resolve0.resolve l_4 };
     _3 <- borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ _3) };
-    assume { Resolve4.resolve _18 };
+    assume { Resolve2.resolve _18 };
     _0 <- borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve4.resolve _3 };
+    assume { Resolve2.resolve _3 };
     return _0
   }
   
@@ -273,10 +247,8 @@ module ListIndexMut_Write
   use mach.int.UInt32
   clone ListIndexMut_Get as Get0
   clone ListIndexMut_Len as Len0
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.listindexmut_list
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.listindexmut_list
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with function Len0.len = Len0.len, function Get0.get = Get0.get
   let rec cfg write [@cfg:stackify] (l : borrowed (Type.listindexmut_list)) (ix : usize) (v : uint32) : ()
     requires {UInt64.to_int ix < Len0.len ( * l)}
@@ -300,22 +272,17 @@ module ListIndexMut_Write
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
     _4 <- v_3;
-    assume { Resolve0.resolve v_3 };
     _6 <- borrow_mut ( * l_1);
     l_1 <- { l_1 with current = ( ^ _6) };
-    assume { Resolve1.resolve _7 };
     _7 <- ix_2;
-    assume { Resolve1.resolve ix_2 };
     _5 <- IndexMut0.index_mut _6 _7;
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve l_1 };
-    assume { Resolve0.resolve ( * _5) };
+    assume { Resolve0.resolve l_1 };
     _5 <- { _5 with current = _4 };
-    assume { Resolve3.resolve _5 };
+    assume { Resolve1.resolve _5 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/loop.stdout
+++ b/creusot/tests/should_succeed/loop.stdout
@@ -39,7 +39,6 @@ module Loop_Main
     b_2 <- borrow_mut a_1;
     a_1 <-  ^ b_2;
     b_2 <- { b_2 with current = (5 : int32) };
-    assume { (fun x -> true) b_2 };
     goto BB1
   }
   BB1 {
@@ -51,18 +50,13 @@ module Loop_Main
   }
   BB2 {
     _3 <- ();
-    assume { (fun x -> true) _3 };
-    assume { (fun x -> true) _8 };
     _8 <- a_1;
-    assume { (fun x -> true) a_1 };
     _7 <- _8 = (15 : int32);
-    assume { (fun x -> true) _7 };
     _0 <- ();
     return _0
   }
   BB3 {
     _4 <- ();
-    assume { (fun x -> true) _4 };
     goto BB1
   }
   

--- a/creusot/tests/should_succeed/mapping_test.stdout
+++ b/creusot/tests/should_succeed/mapping_test.stdout
@@ -73,15 +73,6 @@ module MappingTest_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.mappingtest_t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t
   use Type
@@ -144,12 +135,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -179,9 +164,7 @@ module MappingTest_Incr
   use Type
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model1 with type t = Type.mappingtest_t
   clone MappingTest_Impl0_Model as Model0 with axiom .
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.creusotcontracts_logic_ghost_ghost (Type.mappingtest_t)
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.mappingtest_t
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = Type.mappingtest_t,
   function Model0.model = Model1.model
   let rec cfg incr [@cfg:stackify] (t : borrowed (Type.mappingtest_t)) : ()
@@ -205,12 +188,10 @@ module MappingTest_Incr
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve old_t_2 };
     t_1 <- { t_1 with current = (let Type.MappingTest_T a =  * t_1 in Type.MappingTest_T (Type.mappingtest_t_T_a ( * t_1) + (1 : int32))) };
-    assume { Resolve1.resolve t_1 };
+    assume { Resolve0.resolve t_1 };
     assert { MapExt.(==) (Model0.model ( ^ t_1)) (Map.set (Model0.model (Model1.model old_t_2)) (Int32.to_int (Type.mappingtest_t_T_a (Model1.model old_t_2))) 1) };
     _4 <- ();
-    assume { Resolve2.resolve _4 };
     _0 <- ();
     return _0
   }
@@ -226,9 +207,7 @@ module MappingTest_Main
   clone MappingTest_Impl0_Model as Model0 with axiom .
   use Type
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.mappingtest_t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.mappingtest_t
   clone MappingTest_Incr_Interface as Incr0 with function Model0.model = Model0.model
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
@@ -247,26 +226,21 @@ module MappingTest_Main
     x_1 <- Type.MappingTest_T (42 : int32);
     assert { Map.get (Model0.model x_1) 13 = 1 };
     _2 <- ();
-    assume { Resolve0.resolve _2 };
     assert { Map.get (Model0.model x_1) 42 = 0 };
     _3 <- ();
-    assume { Resolve0.resolve _3 };
     _6 <- borrow_mut x_1;
     x_1 <-  ^ _6;
-    assume { Resolve1.resolve x_1 };
     _5 <- borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- Incr0.incr _5;
     goto BB1
   }
   BB1 {
-    assume { Resolve2.resolve _6 };
+    assume { Resolve0.resolve _6 };
     assert { Map.get (Model0.model x_1) 13 = 1 };
     _7 <- ();
-    assume { Resolve0.resolve _7 };
     assert { Map.get (Model0.model x_1) 42 = 1 };
     _8 <- ();
-    assume { Resolve0.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/match_int.stdout
+++ b/creusot/tests/should_succeed/match_int.stdout
@@ -59,7 +59,6 @@ module MatchInt_Main
       end
   }
   BB3 {
-    assume { (fun x -> true) _1 };
     _8 <- not false;
     switch (_8)
       | False -> goto BB11
@@ -67,7 +66,6 @@ module MatchInt_Main
       end
   }
   BB4 {
-    assume { (fun x -> true) _1 };
     _4 <- not true;
     switch (_4)
       | False -> goto BB6
@@ -82,7 +80,6 @@ module MatchInt_Main
     goto BB12
   }
   BB7 {
-    assume { (fun x -> true) _1 };
     _6 <- not false;
     switch (_6)
       | False -> goto BB9

--- a/creusot/tests/should_succeed/mc91.stdout
+++ b/creusot/tests/should_succeed/mc91.stdout
@@ -29,29 +29,6 @@ module Mc91_Main
   }
   
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module Mc91_Mc91_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -62,7 +39,6 @@ end
 module Mc91_Mc91
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg mc91 [@cfg:stackify] (x : uint32) : uint32
     ensures { x <= (100 : uint32) -> result = (91 : uint32) && x > (100 : uint32) -> result = x - (10 : uint32) }
     
@@ -80,7 +56,6 @@ module Mc91_Mc91
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
     _2 <- _3 > (100 : uint32);
     switch (_2)
@@ -89,16 +64,12 @@ module Mc91_Mc91
       end
   }
   BB1 {
-    assume { Resolve0.resolve _4 };
     _4 <- x_1;
-    assume { Resolve0.resolve x_1 };
     _0 <- _4 - (10 : uint32);
     goto BB5
   }
   BB2 {
-    assume { Resolve0.resolve _7 };
     _7 <- x_1;
-    assume { Resolve0.resolve x_1 };
     _6 <- _7 + (11 : uint32);
     _5 <- mc91 _6;
     goto BB3

--- a/creusot/tests/should_succeed/module_paths.stdout
+++ b/creusot/tests/should_succeed/module_paths.stdout
@@ -50,10 +50,6 @@ module ModulePaths_Test
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) a_1 };
-    assume { (fun x -> true) b_2 };
-    assume { (fun x -> true) c_3 };
-    assume { (fun x -> true) d_4 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/move_path.stdout
+++ b/creusot/tests/should_succeed/move_path.stdout
@@ -36,17 +36,11 @@ module MovePath_Main
     x_1 <- (1 : int32);
     y_2 <- borrow_mut x_1;
     x_1 <-  ^ y_2;
-    assume { (fun x -> true) d_3 };
     d_3 <- y_2;
-    assume { (fun x -> true) z_4 };
     z_4 <- d_3;
     z_4 <- { z_4 with current = (2 : int32) };
-    assume { (fun x -> true) z_4 };
-    assume { (fun x -> true) _6 };
     _6 <- x_1;
-    assume { (fun x -> true) x_1 };
     _5 <- _6 = (2 : int32);
-    assume { (fun x -> true) _5 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/multiple_scopes.stdout
+++ b/creusot/tests/should_succeed/multiple_scopes.stdout
@@ -31,14 +31,9 @@ module MultipleScopes_MultipleScopes
   }
   BB0 {
     x_1 <- (1 : int32);
-    assume { (fun x -> true) x_1 };
     y_2 <- (2 : int32);
-    assume { (fun x -> true) y_2 };
     y_3 <- (3 : int32);
-    assume { (fun x -> true) _4 };
     _4 <- y_3;
-    assume { (fun x -> true) y_3 };
-    assume { (fun x -> true) x_1 };
     x_1 <- _4;
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/mut_call.stdout
+++ b/creusot/tests/should_succeed/mut_call.stdout
@@ -33,7 +33,6 @@ module MutCall_Kill
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) _1 };
     return _0
   }
   
@@ -59,14 +58,12 @@ module MutCall_Test
     a_1 <- (10 : uint32);
     _4 <- borrow_mut a_1;
     a_1 <-  ^ _4;
-    assume { (fun x -> true) a_1 };
     _3 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _3) };
     _2 <- Kill0.kill _3;
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) _4 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/mutex.stdout
+++ b/creusot/tests/should_succeed/mutex.stdout
@@ -122,15 +122,6 @@ module Mutex_Inv_Inv
   use prelude.Prelude
   predicate inv (self : self) (x : t)
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Ghost_Impl0_Model_Interface
   type t
   use Type
@@ -205,20 +196,6 @@ module Mutex_Impl1_Set
     requires {Inv0.inv (Model0.model (Type.mutex_mutexguard_MutexGuard_1 ( * self))) v}
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self
   type modelTy
@@ -279,9 +256,6 @@ module Mutex_Impl3_Call
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.mutex_mutexguard uint32 (Type.mutex_even)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
   clone Mutex_Impl2_Inv as Inv0
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = Type.mutex_even
   clone Mutex_Impl1_Set_Interface as Set0 with type t = uint32, type i = Type.mutex_even,
@@ -290,7 +264,6 @@ module Mutex_Impl3_Call
   function Model0.model = Model0.model, predicate Inv0.inv = Inv0.inv
   clone Mutex_Impl0_Lock_Interface as Lock0 with type t = uint32, type i = Type.mutex_even,
   function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.mutex_addstwo
   let rec cfg call [@cfg:stackify] (self : Type.mutex_addstwo) : () = 
   var _0 : ();
   var self_1 : Type.mutex_addstwo;
@@ -313,7 +286,6 @@ module Mutex_Impl3_Call
   }
   BB0 {
     _3 <- Type.mutex_addstwo_AddsTwo_mutex self_1;
-    assume { Resolve0.resolve self_1 };
     v_2 <- Lock0.lock _3;
     goto BB1
   }
@@ -323,10 +295,7 @@ module Mutex_Impl3_Call
     goto BB2
   }
   BB2 {
-    assume { Resolve1.resolve val'_4 };
     val'_4 <- _5;
-    assume { Resolve2.resolve _5 };
-    assume { Resolve1.resolve _8 };
     _8 <- val'_4;
     _7 <- _8 < (100000 : uint32);
     switch (_7)
@@ -337,9 +306,7 @@ module Mutex_Impl3_Call
   BB3 {
     _10 <- borrow_mut v_2;
     v_2 <-  ^ _10;
-    assume { Resolve1.resolve _12 };
     _12 <- val'_4;
-    assume { Resolve1.resolve val'_4 };
     _11 <- _12 + (2 : uint32);
     _9 <- Set0.set _10 _11;
     goto BB4
@@ -349,7 +316,6 @@ module Mutex_Impl3_Call
     goto BB7
   }
   BB5 {
-    assume { Resolve1.resolve val'_4 };
     _14 <- borrow_mut v_2;
     v_2 <-  ^ _14;
     _13 <- Set0.set _14 (0 : uint32);
@@ -363,7 +329,6 @@ module Mutex_Impl3_Call
     goto BB8
   }
   BB8 {
-    assume { Resolve3.resolve v_2 };
     return _0
   }
   
@@ -455,6 +420,14 @@ module Mutex_Impl4_Join
       end }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -541,13 +514,9 @@ module Mutex_Concurrent
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = Type.mutex_spawnpostcond (Type.mutex_addstwo)
   clone Mutex_Impl4_Join_Interface as Join0 with type t = (), type i = Type.mutex_spawnpostcond (Type.mutex_addstwo),
   function Model0.model = Model0.model, predicate Inv0.inv = Inv1.inv
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.mutex_joinhandle () (Type.mutex_spawnpostcond (Type.mutex_addstwo))
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Impl3_Precondition as Precondition0
   clone Mutex_Spawn_Interface as Spawn0 with type t = (), type f = Type.mutex_addstwo,
   predicate Precondition0.precondition = Precondition0.precondition
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.mutex_addstwo
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Leak_Interface as Leak0 with type t = Type.mutex_mutex uint32 (Type.mutex_even)
   clone Mutex_Impl2_Inv as Inv0
@@ -594,32 +563,25 @@ module Mutex_Concurrent
     assume { Resolve0.resolve _2 };
     _8 <- m_1;
     _7 <- _8;
-    assume { Resolve1.resolve _8 };
     t1_6 <- Type.Mutex_AddsTwo _7;
-    assume { Resolve2.resolve _10 };
     _10 <- t1_6;
     j1_9 <- Spawn0.spawn _10;
     goto BB4
   }
   BB4 {
     _13 <- m_1;
-    assume { Resolve3.resolve m_1 };
     _12 <- _13;
-    assume { Resolve1.resolve _13 };
     t2_11 <- Type.Mutex_AddsTwo _12;
-    assume { Resolve2.resolve _15 };
     _15 <- t2_11;
     j2_14 <- Spawn0.spawn _15;
     goto BB5
   }
   BB5 {
-    assume { Resolve4.resolve _17 };
     _17 <- j1_9;
     _16 <- Join0.join _17;
     goto BB6
   }
   BB6 {
-    assume { Resolve4.resolve _19 };
     _19 <- j2_14;
     _18 <- Join0.join _19;
     goto BB7

--- a/creusot/tests/should_succeed/one_side_update.stdout
+++ b/creusot/tests/should_succeed/one_side_update.stdout
@@ -52,21 +52,14 @@ module OneSideUpdate_Main
       end
   }
   BB1 {
-    assume { (fun x -> true) b_2 };
-    assume { (fun x -> true) _5 };
     _5 <- Type.onesideupdate_myint_MyInt_0 a_1;
-    assume { (fun x -> true) a_1 };
     _4 <- _5 = (10 : usize);
-    assume { (fun x -> true) _4 };
     _0 <- ();
     goto BB3
   }
   BB2 {
-    assume { (fun x -> true) a_1 };
     _6 <- Type.OneSideUpdate_MyInt (5 : usize);
-    assume { (fun x -> true) ( * b_2) };
     b_2 <- { b_2 with current = _6 };
-    assume { (fun x -> true) b_2 };
     _0 <- ();
     goto BB3
   }

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -502,21 +502,6 @@ module OrdTrait_GtOrLe
   }
   
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module OrdTrait_GtOrLeInt_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -529,7 +514,6 @@ module OrdTrait_GtOrLeInt
   use mach.int.UInt64
   use mach.int.Int
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg gt_or_le_int [@cfg:stackify] (x : usize) (y : usize) : bool
     ensures { result = (UInt64.to_int x <= UInt64.to_int y) }
     
@@ -545,12 +529,8 @@ module OrdTrait_GtOrLeInt
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _0 <- _3 <= _4;
     return _0
   }

--- a/creusot/tests/should_succeed/projection_toggle.stdout
+++ b/creusot/tests/should_succeed/projection_toggle.stdout
@@ -14,15 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -42,12 +33,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -65,8 +50,7 @@ end
 module ProjectionToggle_ProjToggle
   type t
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = t
   let rec cfg proj_toggle [@cfg:stackify] (toggle : bool) (a : borrowed t) (b : borrowed t) : borrowed t
     ensures { if toggle then result = a &&  ^ b =  * b else result = b &&  ^ a =  * a }
     
@@ -86,38 +70,36 @@ module ProjectionToggle_ProjToggle
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <- toggle_1;
-    assume { Resolve0.resolve toggle_1 };
     switch (_6)
       | False -> goto BB2
       | _ -> goto BB1
       end
   }
   BB1 {
-    assume { Resolve1.resolve b_3 };
+    assume { Resolve0.resolve b_3 };
     _7 <- borrow_mut ( * a_2);
     a_2 <- { a_2 with current = ( ^ _7) };
-    assume { Resolve1.resolve a_2 };
+    assume { Resolve0.resolve a_2 };
     _5 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _5) };
-    assume { Resolve1.resolve _7 };
+    assume { Resolve0.resolve _7 };
     goto BB3
   }
   BB2 {
-    assume { Resolve1.resolve a_2 };
+    assume { Resolve0.resolve a_2 };
     _5 <- borrow_mut ( * b_3);
     b_3 <- { b_3 with current = ( ^ _5) };
-    assume { Resolve1.resolve b_3 };
+    assume { Resolve0.resolve b_3 };
     goto BB3
   }
   BB3 {
     _4 <- borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    assume { Resolve1.resolve _5 };
+    assume { Resolve0.resolve _5 };
     _0 <- borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _0) };
-    assume { Resolve1.resolve _4 };
+    assume { Resolve0.resolve _4 };
     return _0
   }
   
@@ -129,10 +111,8 @@ module ProjectionToggle_Main
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = int32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = int32
   clone ProjectionToggle_ProjToggle_Interface as ProjToggle0 with type t = int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var a_1 : int32;
@@ -159,20 +139,17 @@ module ProjectionToggle_Main
     _5 <- { _5 with current = ( ^ _4) };
     _7 <- borrow_mut b_2;
     b_2 <-  ^ _7;
-    assume { Resolve0.resolve b_2 };
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     x_3 <- ProjToggle0.proj_toggle true _4 _6;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve _5 };
-    assume { Resolve1.resolve _7 };
+    assume { Resolve0.resolve _5 };
+    assume { Resolve0.resolve _7 };
     x_3 <- { x_3 with current = ( * x_3 + (5 : int32)) };
-    assume { Resolve1.resolve x_3 };
-    assume { Resolve0.resolve _11 };
+    assume { Resolve0.resolve x_3 };
     _11 <- a_1;
-    assume { Resolve0.resolve a_1 };
     _10 <- _11 = (15 : int32);
     _9 <- not _10;
     switch (_9)
@@ -185,7 +162,6 @@ module ProjectionToggle_Main
   }
   BB3 {
     _8 <- ();
-    assume { Resolve2.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/projections.stdout
+++ b/creusot/tests/should_succeed/projections.stdout
@@ -55,9 +55,7 @@ module Projections_CopyOutOfRef
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _0 };
     _0 <- x_1;
-    assume { (fun x -> true) x_1 };
     return _0
   }
   
@@ -93,25 +91,16 @@ module Projections_CopyOutOfSum
       end
   }
   BB1 {
-    assume { (fun x -> true) y_4 };
     y_4 <- Type.core_result_result_Err_0 x_1;
-    assume { (fun x -> true) x_1 };
-    assume { (fun x -> true) _0 };
     _0 <-  * y_4;
-    assume { (fun x -> true) y_4 };
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) x_1 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) x_3 };
     x_3 <- Type.core_result_result_Ok_0 x_1;
-    assume { (fun x -> true) x_1 };
-    assume { (fun x -> true) _0 };
     _0 <-  * x_3;
-    assume { (fun x -> true) x_3 };
     goto BB4
   }
   BB4 {
@@ -148,20 +137,16 @@ module Projections_WriteIntoSum
       end
   }
   BB1 {
-    assume { (fun x -> true) x_1 };
     _0 <- ();
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) x_1 };
     absurd
   }
   BB3 {
     y_3 <- borrow_mut (Type.core_option_option_Some_0 ( * x_1));
     x_1 <- { x_1 with current = (let Type.Core_Option_Option_Some a =  * x_1 in Type.Core_Option_Option_Some ( ^ y_3)) };
-    assume { (fun x -> true) x_1 };
     y_3 <- { y_3 with current = (10 : uint32) };
-    assume { (fun x -> true) y_3 };
     _0 <- ();
     goto BB4
   }
@@ -197,24 +182,16 @@ module Projections_Main
       end
   }
   BB1 {
-    assume { (fun x -> true) _2 };
     _1 <- false;
-    assume { (fun x -> true) _1 };
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) _2 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) x_4 };
     x_4 <- Type.core_option_option_Some_0 _2;
-    assume { (fun x -> true) _2 };
-    assume { (fun x -> true) _5 };
     _5 <- x_4;
-    assume { (fun x -> true) x_4 };
     _1 <- _5 = (0 : int32);
-    assume { (fun x -> true) _1 };
     goto BB4
   }
   BB4 {

--- a/creusot/tests/should_succeed/prophecy.stdout
+++ b/creusot/tests/should_succeed/prophecy.stdout
@@ -32,9 +32,7 @@ module Prophecy_Main
     x_1 <- (0 : int32);
     y_2 <- borrow_mut x_1;
     x_1 <-  ^ y_2;
-    assume { (fun x -> true) x_1 };
     y_2 <- { y_2 with current = (5 : int32) };
-    assume { (fun x -> true) y_2 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/replace.stdout
+++ b/creusot/tests/should_succeed/replace.stdout
@@ -38,9 +38,7 @@ module Replace_Test
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _3 };
     _3 <- b_2;
-    assume { (fun x -> true) a_1 };
     a_1 <- _3;
     goto BB1
   }
@@ -55,7 +53,6 @@ module Replace_Test
     goto BB4
   }
   BB4 {
-    assume { (fun x -> true) a_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/selection_sort_generic.stdout
+++ b/creusot/tests/should_succeed/selection_sort_generic.stdout
@@ -450,15 +450,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t
   use prelude.Prelude
@@ -684,12 +675,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -807,10 +792,8 @@ module SelectionSortGeneric_SelectionSort
   clone CreusotContracts_Logic_Model_Impl1_Model as Model1 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t)
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Lt_Interface as Lt0 with type self = t, predicate LtLog0.lt_log = LtLog0.lt_log
@@ -890,7 +873,6 @@ module SelectionSortGeneric_SelectionSort
     invariant i_bound { UInt64.to_int i_2 <= Seq.length (Model1.model v_1) };
     invariant sorted { SortedRange0.sorted_range (Model1.model v_1) 0 (UInt64.to_int i_2) };
     invariant partition { Partition0.partition (Model1.model v_1) (UInt64.to_int i_2) };
-    assume { Resolve2.resolve _8 };
     _8 <- i_2;
     _10 <-  * v_1;
     _9 <- Len0.len _10;
@@ -904,9 +886,7 @@ module SelectionSortGeneric_SelectionSort
       end
   }
   BB4 {
-    assume { Resolve2.resolve min_11 };
     min_11 <- i_2;
-    assume { Resolve2.resolve _13 };
     _13 <- i_2;
     j_12 <- _13 + (1 : usize);
     goto BB5
@@ -915,7 +895,6 @@ module SelectionSortGeneric_SelectionSort
     invariant min_is_min { forall k : (int) . UInt64.to_int i_2 <= k && k < UInt64.to_int j_12 -> LeLog0.le_log (Seq.get (Model1.model v_1) (UInt64.to_int min_11)) (Seq.get (Model1.model v_1) k) };
     invariant j_bound { UInt64.to_int i_2 <= UInt64.to_int j_12 && UInt64.to_int j_12 <= Seq.length (Model1.model v_1) };
     invariant min_bound { UInt64.to_int i_2 <= UInt64.to_int min_11 && UInt64.to_int min_11 < UInt64.to_int j_12 };
-    assume { Resolve2.resolve _16 };
     _16 <- j_12;
     _18 <-  * v_1;
     _17 <- Len0.len _18;
@@ -930,25 +909,23 @@ module SelectionSortGeneric_SelectionSort
   }
   BB7 {
     _23 <-  * v_1;
-    assume { Resolve2.resolve _24 };
     _24 <- j_12;
     _22 <- Index0.index _23 _24;
     goto BB8
   }
   BB8 {
     _21 <- _22;
-    assume { Resolve3.resolve _22 };
+    assume { Resolve2.resolve _22 };
     _28 <-  * v_1;
-    assume { Resolve2.resolve _29 };
     _29 <- min_11;
     _27 <- Index0.index _28 _29;
     goto BB9
   }
   BB9 {
     _26 <- _27;
-    assume { Resolve3.resolve _27 };
+    assume { Resolve2.resolve _27 };
     _25 <- _26;
-    assume { Resolve3.resolve _26 };
+    assume { Resolve2.resolve _26 };
     _20 <- Lt0.lt _21 _25;
     goto BB10
   }
@@ -959,49 +936,36 @@ module SelectionSortGeneric_SelectionSort
       end
   }
   BB11 {
-    assume { Resolve2.resolve min_11 };
-    assume { Resolve2.resolve _30 };
     _30 <- j_12;
-    assume { Resolve2.resolve min_11 };
     min_11 <- _30;
     _19 <- ();
-    assume { Resolve4.resolve _19 };
     goto BB13
   }
   BB12 {
     _19 <- ();
-    assume { Resolve4.resolve _19 };
     goto BB13
   }
   BB13 {
     j_12 <- j_12 + (1 : usize);
     _6 <- ();
-    assume { Resolve4.resolve _6 };
     goto BB5
   }
   BB14 {
-    assume { Resolve2.resolve j_12 };
     _14 <- ();
-    assume { Resolve4.resolve _14 };
     _35 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _35) };
-    assume { Resolve2.resolve _36 };
     _36 <- i_2;
-    assume { Resolve2.resolve _37 };
     _37 <- min_11;
-    assume { Resolve2.resolve min_11 };
     _34 <- Swap0.swap _35 _36 _37;
     goto BB15
   }
   BB15 {
     i_2 <- i_2 + (1 : usize);
     _6 <- ();
-    assume { Resolve4.resolve _6 };
     goto BB2
   }
   BB16 {
-    assume { Resolve5.resolve v_1 };
-    assume { Resolve2.resolve i_2 };
+    assume { Resolve3.resolve v_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/slices/01.stdout
+++ b/creusot/tests/should_succeed/slices/01.stdout
@@ -87,21 +87,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Model_Impl0_ModelTy
   type t
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = t
@@ -158,8 +143,7 @@ module C01_SliceFirst
   use mach.int.Int
   use mach.int.UInt64
   clone CreusotContracts_Logic_Model_Impl2_Model as Model1 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = seq t
   clone CreusotContracts_Logic_Model_Impl2_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = seq t,
@@ -202,9 +186,8 @@ module C01_SliceFirst
   BB3 {
     _6 <- Seq.get a_1 (UInt64.to_int _7);
     assume { Resolve0.resolve a_1 };
-    assume { Resolve1.resolve _7 };
     _5 <- _6;
-    assume { Resolve2.resolve _6 };
+    assume { Resolve1.resolve _6 };
     _0 <- Type.Core_Option_Option_Some _5;
     goto BB5
   }

--- a/creusot/tests/should_succeed/sparse_array.stdout
+++ b/creusot/tests/should_succeed/sparse_array.stdout
@@ -119,15 +119,6 @@ module CreusotContracts_Logic_Int_Impl7
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = int32, type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   type t
   use Type
@@ -284,12 +275,6 @@ module CreusotContracts_Std1_Vec_FromElem
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module SparseArray_Create_Interface
   type t
   use mach.int.Int
@@ -325,8 +310,7 @@ module SparseArray_Create
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone SparseArray_Impl1_SparseInv as SparseInv0 with type t = t, function Model0.model = Model2.model,
   function Model1.model = Model1.model, function Model2.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem1 with type t = usize,
   function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = t, function Model0.model = Model1.model
@@ -353,26 +337,21 @@ module SparseArray_Create
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- sz_1;
-    assume { Resolve1.resolve _5 };
+    assume { Resolve0.resolve _5 };
     _5 <- dummy_2;
-    assume { Resolve1.resolve dummy_2 };
-    assume { Resolve0.resolve _6 };
+    assume { Resolve0.resolve dummy_2 };
     _6 <- sz_1;
     _4 <- FromElem0.from_elem _5 _6;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _8 };
     _8 <- sz_1;
     _7 <- FromElem1.from_elem (0 : usize) _8;
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve _10 };
     _10 <- sz_1;
-    assume { Resolve0.resolve sz_1 };
     _9 <- FromElem1.from_elem (0 : usize) _10;
     goto BB3
   }
@@ -507,13 +486,10 @@ module SparseArray_Impl1_Get
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone SparseArray_Impl1_SparseInv as SparseInv0 with type t = t, function Model0.model = Model0.model,
   function Model1.model = Model2.model, function Model2.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = Type.sparsearray_sparse t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.sparsearray_sparse t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model4 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = usize,
@@ -563,18 +539,13 @@ module SparseArray_Impl1_Get
   }
   BB0 {
     _5 <- Type.sparsearray_sparse_Sparse_idx self_1;
-    assume { Resolve0.resolve _6 };
     _6 <- i_2;
     _4 <- Index0.index _5 _6;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve index_3 };
     index_3 <- _4;
-    assume { Resolve1.resolve _4 };
-    assume { Resolve0.resolve _9 };
     _9 <- index_3;
-    assume { Resolve0.resolve _10 };
     _10 <- Type.sparsearray_sparse_Sparse_n self_1;
     _8 <- _9 < _10;
     switch (_8)
@@ -583,15 +554,12 @@ module SparseArray_Impl1_Get
       end
   }
   BB2 {
-    assume { Resolve0.resolve index_3 };
     _7 <- false;
     goto BB4
   }
   BB3 {
     _14 <- Type.sparsearray_sparse_Sparse_back self_1;
-    assume { Resolve0.resolve _15 };
     _15 <- index_3;
-    assume { Resolve0.resolve index_3 };
     _13 <- Index0.index _14 _15;
     goto BB5
   }
@@ -602,36 +570,29 @@ module SparseArray_Impl1_Get
       end
   }
   BB5 {
-    assume { Resolve0.resolve _12 };
     _12 <- _13;
-    assume { Resolve1.resolve _13 };
-    assume { Resolve0.resolve _16 };
     _16 <- i_2;
     _11 <- _12 = _16;
-    assume { Resolve2.resolve _7 };
     _7 <- _11;
     goto BB4
   }
   BB6 {
     _20 <- Type.sparsearray_sparse_Sparse_values self_1;
-    assume { Resolve3.resolve self_1 };
-    assume { Resolve0.resolve _21 };
+    assume { Resolve0.resolve self_1 };
     _21 <- i_2;
-    assume { Resolve0.resolve i_2 };
     _19 <- Index1.index _20 _21;
     goto BB7
   }
   BB7 {
     _18 <- _19;
-    assume { Resolve4.resolve _19 };
+    assume { Resolve1.resolve _19 };
     _17 <- _18;
-    assume { Resolve4.resolve _18 };
+    assume { Resolve1.resolve _18 };
     _0 <- Type.Core_Option_Option_Some _17;
     goto BB9
   }
   BB8 {
-    assume { Resolve3.resolve self_1 };
-    assume { Resolve0.resolve i_2 };
+    assume { Resolve0.resolve self_1 };
     _0 <- Type.Core_Option_Option_None;
     goto BB9
   }
@@ -854,15 +815,11 @@ module SparseArray_Impl1_Set
   function Model1.model = Model1.model, function Model2.model = Model3.model
   clone SparseArray_Impl1_LemmaPermutation as LemmaPermutation0 with type t = t,
   predicate SparseInv0.sparse_inv = SparseInv0.sparse_inv, predicate IsElt0.is_elt = IsElt0.is_elt, axiom .
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve7 with type t = Type.sparsearray_sparse t
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.sparsearray_sparse t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = t
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model6 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy2.modelTy, function Model0.model = Model3.model
@@ -932,7 +889,6 @@ module SparseArray_Impl1_Set
     _4 <- v_3;
     _6 <- borrow_mut (Type.sparsearray_sparse_Sparse_values ( * self_1));
     self_1 <- { self_1 with current = (let Type.SparseArray_Sparse a b c d e =  * self_1 in Type.SparseArray_Sparse a b ( ^ _6) d e) };
-    assume { Resolve1.resolve _7 };
     _7 <- i_2;
     _5 <- IndexMut0.index_mut _6 _7;
     goto BB2
@@ -943,23 +899,18 @@ module SparseArray_Impl1_Set
     goto BB3
   }
   BB3 {
-    assume { Resolve2.resolve _5 };
+    assume { Resolve1.resolve _5 };
     goto BB4
   }
   BB4 {
     _10 <- Type.sparsearray_sparse_Sparse_idx ( * self_1);
-    assume { Resolve1.resolve _11 };
     _11 <- i_2;
     _9 <- Index0.index _10 _11;
     goto BB5
   }
   BB5 {
-    assume { Resolve1.resolve index_8 };
     index_8 <- _9;
-    assume { Resolve3.resolve _9 };
-    assume { Resolve1.resolve _15 };
     _15 <- index_8;
-    assume { Resolve1.resolve _16 };
     _16 <- Type.sparsearray_sparse_Sparse_n ( * self_1);
     _14 <- _15 < _16;
     switch (_14)
@@ -968,15 +919,12 @@ module SparseArray_Impl1_Set
       end
   }
   BB6 {
-    assume { Resolve1.resolve index_8 };
     _13 <- false;
     goto BB8
   }
   BB7 {
     _20 <- Type.sparsearray_sparse_Sparse_back ( * self_1);
-    assume { Resolve1.resolve _21 };
     _21 <- index_8;
-    assume { Resolve1.resolve index_8 };
     _19 <- Index0.index _20 _21;
     goto BB9
   }
@@ -988,58 +936,44 @@ module SparseArray_Impl1_Set
       end
   }
   BB9 {
-    assume { Resolve1.resolve _18 };
     _18 <- _19;
-    assume { Resolve3.resolve _19 };
-    assume { Resolve1.resolve _22 };
     _22 <- i_2;
     _17 <- _18 = _22;
-    assume { Resolve4.resolve _13 };
     _13 <- _17;
     goto BB8
   }
   BB10 {
     assert { let _ = LemmaPermutation0.lemma_permutation ( * self_1) (UInt64.to_int i_2) in true };
     _23 <- ();
-    assume { Resolve5.resolve _23 };
     assert { UInt64.to_int (Type.sparsearray_sparse_Sparse_n ( * self_1)) < UInt64.to_int (Type.sparsearray_sparse_Sparse_size ( * self_1)) };
     _24 <- ();
-    assume { Resolve5.resolve _24 };
-    assume { Resolve1.resolve _25 };
     _25 <- Type.sparsearray_sparse_Sparse_n ( * self_1);
     _27 <- borrow_mut (Type.sparsearray_sparse_Sparse_idx ( * self_1));
     self_1 <- { self_1 with current = (let Type.SparseArray_Sparse a b c d e =  * self_1 in Type.SparseArray_Sparse a b c ( ^ _27) e) };
-    assume { Resolve1.resolve _28 };
     _28 <- i_2;
     _26 <- IndexMut1.index_mut _27 _28;
     goto BB11
   }
   BB11 {
-    assume { Resolve1.resolve ( * _26) };
     _26 <- { _26 with current = _25 };
-    assume { Resolve6.resolve _26 };
-    assume { Resolve1.resolve _29 };
+    assume { Resolve2.resolve _26 };
     _29 <- i_2;
-    assume { Resolve1.resolve i_2 };
     _31 <- borrow_mut (Type.sparsearray_sparse_Sparse_back ( * self_1));
     self_1 <- { self_1 with current = (let Type.SparseArray_Sparse a b c d e =  * self_1 in Type.SparseArray_Sparse a b c d ( ^ _31)) };
-    assume { Resolve1.resolve _32 };
     _32 <- Type.sparsearray_sparse_Sparse_n ( * self_1);
     _30 <- IndexMut1.index_mut _31 _32;
     goto BB12
   }
   BB12 {
-    assume { Resolve1.resolve ( * _30) };
     _30 <- { _30 with current = _29 };
-    assume { Resolve6.resolve _30 };
+    assume { Resolve2.resolve _30 };
     self_1 <- { self_1 with current = (let Type.SparseArray_Sparse a b c d e =  * self_1 in Type.SparseArray_Sparse a (Type.sparsearray_sparse_Sparse_n ( * self_1) + (1 : usize)) c d e) };
-    assume { Resolve7.resolve self_1 };
+    assume { Resolve3.resolve self_1 };
     _0 <- ();
     goto BB14
   }
   BB13 {
-    assume { Resolve7.resolve self_1 };
-    assume { Resolve1.resolve i_2 };
+    assume { Resolve3.resolve self_1 };
     _0 <- ();
     goto BB14
   }
@@ -1066,9 +1000,6 @@ module SparseArray_Main
   use mach.int.UInt64
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model5 with type t = usize
   clone SparseArray_Impl1_IsElt as IsElt0 with type t = int32, function Model0.model = Model5.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.sparsearray_sparse int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.core_option_option int32
   clone SparseArray_Impl0_ModelTy as ModelTy1 with type t = int32
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = int32
   clone SparseArray_Impl0_Model as Model2 with type t = int32, predicate IsElt0.is_elt = IsElt0.is_elt,
@@ -1085,7 +1016,6 @@ module SparseArray_Main
   clone SparseArray_Create_Interface as Create0 with type t = int32, function Model0.model = Model2.model,
   predicate SparseInv0.sparse_inv = SparseInv0.sparse_inv, predicate IsElt0.is_elt = IsElt0.is_elt,
   function Model1.model = Model3.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var default_1 : int32;
@@ -1127,15 +1057,12 @@ module SparseArray_Main
   }
   BB0 {
     default_1 <- (0 : int32);
-    assume { Resolve0.resolve _3 };
     _3 <- default_1;
     a_2 <- Create0.create (10 : usize) _3;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _5 };
     _5 <- default_1;
-    assume { Resolve0.resolve default_1 };
     b_4 <- Create0.create (20 : usize) _5;
     goto BB2
   }
@@ -1145,16 +1072,13 @@ module SparseArray_Main
     goto BB3
   }
   BB3 {
-    assume { Resolve1.resolve x_6 };
     _9 <- b_4;
     y_8 <- Get0.get _9 (7 : usize);
     goto BB4
   }
   BB4 {
-    assume { Resolve1.resolve y_8 };
     assert { x_6 = Type.Core_Option_Option_None && y_8 = Type.Core_Option_Option_None };
     _10 <- ();
-    assume { Resolve2.resolve _10 };
     _12 <- borrow_mut a_2;
     a_2 <-  ^ _12;
     _11 <- Set0.set _12 (5 : usize) (1 : int32);
@@ -1172,87 +1096,71 @@ module SparseArray_Main
     goto BB7
   }
   BB7 {
-    assume { Resolve1.resolve x_6 };
     x_6 <- _15;
     _18 <- b_4;
     _17 <- Get0.get _18 (7 : usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve y_8 };
     y_8 <- _17;
-    assume { Resolve1.resolve x_6 };
     assert { match (x_6) with
       | Type.Core_Option_Option_None -> false
       | Type.Core_Option_Option_Some z -> Model0.model z = 1
       end };
     _19 <- ();
-    assume { Resolve2.resolve _19 };
-    assume { Resolve1.resolve y_8 };
     assert { match (y_8) with
       | Type.Core_Option_Option_None -> false
       | Type.Core_Option_Option_Some z -> Model0.model z = 2
       end };
     _20 <- ();
-    assume { Resolve2.resolve _20 };
     _22 <- a_2;
     _21 <- Get0.get _22 (7 : usize);
     goto BB9
   }
   BB9 {
-    assume { Resolve1.resolve x_6 };
     x_6 <- _21;
     _24 <- b_4;
     _23 <- Get0.get _24 (5 : usize);
     goto BB10
   }
   BB10 {
-    assume { Resolve1.resolve y_8 };
     y_8 <- _23;
     assert { x_6 = Type.Core_Option_Option_None && y_8 = Type.Core_Option_Option_None };
     _25 <- ();
-    assume { Resolve2.resolve _25 };
     _27 <- a_2;
     _26 <- Get0.get _27 (0 : usize);
     goto BB11
   }
   BB11 {
-    assume { Resolve1.resolve x_6 };
     x_6 <- _26;
     _29 <- b_4;
     _28 <- Get0.get _29 (0 : usize);
     goto BB12
   }
   BB12 {
-    assume { Resolve1.resolve y_8 };
     y_8 <- _28;
     assert { x_6 = Type.Core_Option_Option_None && y_8 = Type.Core_Option_Option_None };
     _30 <- ();
-    assume { Resolve2.resolve _30 };
     _32 <- a_2;
     _31 <- Get0.get _32 (9 : usize);
     goto BB13
   }
   BB13 {
-    assume { Resolve1.resolve x_6 };
     x_6 <- _31;
     _34 <- b_4;
     _33 <- Get0.get _34 (9 : usize);
     goto BB14
   }
   BB14 {
-    assume { Resolve1.resolve y_8 };
     y_8 <- _33;
     assert { x_6 = Type.Core_Option_Option_None && y_8 = Type.Core_Option_Option_None };
     _0 <- ();
     goto BB15
   }
   BB15 {
-    assume { Resolve3.resolve b_4 };
     goto BB16
   }
   BB16 {
-    assume { Resolve3.resolve a_2 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/specification/division.stdout
+++ b/creusot/tests/should_succeed/specification/division.stdout
@@ -14,29 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module Division_Divide_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -47,7 +24,6 @@ end
 module Division_Divide
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg divide [@cfg:stackify] (y : uint32) (x : uint32) : uint32
     requires {x <> (0 : uint32)}
     
@@ -64,12 +40,8 @@ module Division_Divide
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- y_1;
-    assume { Resolve0.resolve y_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- x_2;
-    assume { Resolve0.resolve x_2 };
     _5 <- _4 = (0 : uint32);
     assert { not _5 };
     goto BB1

--- a/creusot/tests/should_succeed/split_borrow.stdout
+++ b/creusot/tests/should_succeed/split_borrow.stdout
@@ -66,7 +66,6 @@ module SplitBorrow_Main
     x_1 <- (_2, _3);
     y_4 <- borrow_mut x_1;
     x_1 <-  ^ y_4;
-    assume { (fun x -> true) x_1 };
     _6 <- Z0.z ();
     goto BB1
   }
@@ -78,25 +77,18 @@ module SplitBorrow_Main
   }
   BB2 {
     _7 <- Type.SplitBorrow_MyInt (4 : usize);
-    assume { (fun x -> true) (let (_, a) =  * y_4 in a) };
     y_4 <- { y_4 with current = (let (a, b) =  * y_4 in (a, _7)) };
     _5 <- ();
-    assume { (fun x -> true) _5 };
     goto BB4
   }
   BB3 {
     _8 <- Type.SplitBorrow_MyInt (10 : usize);
-    assume { (fun x -> true) (let (a, _) =  * y_4 in a) };
     y_4 <- { y_4 with current = (let (a, b) =  * y_4 in (_8, b)) };
     _5 <- ();
-    assume { (fun x -> true) _5 };
     goto BB4
   }
   BB4 {
-    assume { (fun x -> true) _9 };
     _9 <- Type.splitborrow_myint_MyInt_0 (let (a, _) =  * y_4 in a);
-    assume { (fun x -> true) y_4 };
-    assume { (fun x -> true) _9 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/split_move.stdout
+++ b/creusot/tests/should_succeed/split_move.stdout
@@ -51,16 +51,10 @@ module SplitMove_Main
     a_1 <-  ^ x_4;
     z_5 <- borrow_mut (let (_, a) =  * x_4 in a);
     x_4 <- { x_4 with current = (let (a, b) =  * x_4 in (a,  ^ z_5)) };
-    assume { (fun x -> true) z_5 };
     _6 <- Type.SplitMove_MyInt (3 : usize);
-    assume { (fun x -> true) (let (a, _) =  * x_4 in a) };
     x_4 <- { x_4 with current = (let (a, b) =  * x_4 in (_6, b)) };
-    assume { (fun x -> true) x_4 };
-    assume { (fun x -> true) _8 };
     _8 <- Type.splitmove_myint_MyInt_0 (let (a, _) = a_1 in a);
-    assume { (fun x -> true) a_1 };
     _7 <- _8 = (3 : usize);
-    assume { (fun x -> true) _7 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/std_types.stdout
+++ b/creusot/tests/should_succeed/std_types.stdout
@@ -36,7 +36,6 @@ module StdTypes_X
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/sum.stdout
+++ b/creusot/tests/should_succeed/sum.stdout
@@ -29,29 +29,6 @@ module Sum_Main
   }
   
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module Sum_SumFirstN_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -65,8 +42,6 @@ module Sum_SumFirstN
   use mach.int.Int
   use mach.int.UInt32
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg sum_first_n [@cfg:stackify] (n : uint32) : uint32
     ensures { result = div (n * (n + (1 : uint32))) (2 : uint32) }
     ensures { UInt32.to_int n < 1000 }
@@ -97,9 +72,7 @@ module Sum_SumFirstN
   BB1 {
     invariant bound { i_3 <= n_1 };
     invariant sum_value { sum_2 = div (i_3 * (i_3 + (1 : uint32))) (2 : uint32) };
-    assume { Resolve0.resolve _7 };
     _7 <- i_3;
-    assume { Resolve0.resolve _8 };
     _8 <- n_1;
     _6 <- _7 < _8;
     switch (_6)
@@ -109,21 +82,14 @@ module Sum_SumFirstN
   }
   BB2 {
     i_3 <- i_3 + (1 : uint32);
-    assume { Resolve0.resolve _9 };
     _9 <- i_3;
     sum_2 <- sum_2 + _9;
     _5 <- ();
-    assume { Resolve1.resolve _5 };
     goto BB1
   }
   BB3 {
-    assume { Resolve0.resolve n_1 };
-    assume { Resolve0.resolve i_3 };
     _4 <- ();
-    assume { Resolve1.resolve _4 };
-    assume { Resolve0.resolve _0 };
     _0 <- sum_2;
-    assume { Resolve0.resolve sum_2 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/sum_of_odds.stdout
+++ b/creusot/tests/should_succeed/sum_of_odds.stdout
@@ -82,29 +82,6 @@ module SumOfOdds_SumOfOddIsSqr_Impl
    = 
     if x > 0 then sum_of_odd_is_sqr (x - 1) else ()
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module SumOfOdds_ComputeSumOfOdd_Interface
   use mach.int.UInt32
   use mach.int.Int
@@ -123,8 +100,6 @@ module SumOfOdds_ComputeSumOfOdd
   clone SumOfOdds_SumOfOdd as SumOfOdd0 with axiom .
   clone SumOfOdds_SumOfOddIsSqr as SumOfOddIsSqr0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd,
   function Sqr0.sqr = Sqr0.sqr, axiom .
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg compute_sum_of_odd [@cfg:stackify] (x : uint32) : uint32
     requires {UInt32.to_int x < 65536}
     ensures { UInt32.to_int result = SumOfOdd0.sum_of_odd (UInt32.to_int x) }
@@ -159,9 +134,7 @@ module SumOfOdds_ComputeSumOfOdd
   BB1 {
     invariant i_bound { UInt32.to_int i_4 <= UInt32.to_int x_1 };
     invariant s_is_sum { UInt32.to_int s_3 = SumOfOdd0.sum_of_odd (UInt32.to_int i_4) };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
-    assume { Resolve0.resolve _9 };
     _9 <- x_1;
     _7 <- _8 < _9;
     switch (_7)
@@ -172,25 +145,17 @@ module SumOfOdds_ComputeSumOfOdd
   BB2 {
     assert { let _ = SumOfOddIsSqr0.sum_of_odd_is_sqr (UInt32.to_int i_4) in true };
     _10 <- ();
-    assume { Resolve1.resolve _10 };
-    assume { Resolve0.resolve _13 };
     _13 <- i_4;
     _12 <- (2 : uint32) * _13;
     _11 <- _12 + (1 : uint32);
     s_3 <- s_3 + _11;
     i_4 <- i_4 + (1 : uint32);
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     goto BB1
   }
   BB3 {
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve1.resolve _5 };
-    assume { Resolve0.resolve _0 };
     _0 <- s_3;
-    assume { Resolve0.resolve s_3 };
     return _0
   }
   
@@ -212,7 +177,6 @@ module SumOfOdds_Test
   clone SumOfOdds_SumOfOdd as SumOfOdd0 with axiom .
   clone SumOfOdds_SumOfOddIsSqr as SumOfOddIsSqr0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd,
   function Sqr0.sqr = Sqr0.sqr, axiom .
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   clone SumOfOdds_ComputeSumOfOdd_Interface as ComputeSumOfOdd0 with function SumOfOdd0.sum_of_odd = SumOfOdd0.sum_of_odd
   let rec cfg test [@cfg:stackify] (x : uint32) : ()
     requires {UInt32.to_int x < 65536}
@@ -227,14 +191,11 @@ module SumOfOdds_Test
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
     y_2 <- ComputeSumOfOdd0.compute_sum_of_odd _3;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve y_2 };
     assert { let _ = SumOfOddIsSqr0.sum_of_odd_is_sqr (UInt32.to_int x_1) in IsSquare0.is_square (UInt32.to_int y_2) };
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/switch.stdout
+++ b/creusot/tests/should_succeed/switch.stdout
@@ -52,21 +52,15 @@ module Switch_Test
       end
   }
   BB1 {
-    assume { (fun x -> true) o_1 };
     _0 <- false;
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) o_1 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) x_3 };
     x_3 <- Type.switch_option_Some_0 o_1;
-    assume { (fun x -> true) o_1 };
-    assume { (fun x -> true) _4 };
     _4 <- x_3;
-    assume { (fun x -> true) x_3 };
     _0 <- _4 > (0 : uint32);
     goto BB4
   }
@@ -103,22 +97,15 @@ module Switch_Test2
       end
   }
   BB1 {
-    assume { (fun x -> true) _0 };
     _0 <- (let (_, a) = o_1 in a);
-    assume { (fun x -> true) o_1 };
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) o_1 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) x_3 };
     x_3 <- Type.switch_option_Some_0 (let (a, _) = o_1 in a);
-    assume { (fun x -> true) o_1 };
-    assume { (fun x -> true) _0 };
     _0 <- x_3;
-    assume { (fun x -> true) x_3 };
     goto BB4
   }
   BB4 {

--- a/creusot/tests/should_succeed/switch_struct.stdout
+++ b/creusot/tests/should_succeed/switch_struct.stdout
@@ -59,26 +59,17 @@ module SwitchStruct_Test
       end
   }
   BB1 {
-    assume { (fun x -> true) field2_5 };
     field2_5 <- Type.switchstruct_m_G_field2 o_1;
-    assume { (fun x -> true) o_1 };
-    assume { (fun x -> true) _6 };
     _6 <- field2_5;
-    assume { (fun x -> true) field2_5 };
     _0 <- _6 = (0 : uint32);
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) o_1 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) field1_3 };
     field1_3 <- Type.switchstruct_m_F_field1 o_1;
-    assume { (fun x -> true) o_1 };
-    assume { (fun x -> true) _4 };
     _4 <- field1_3;
-    assume { (fun x -> true) field1_3 };
     _0 <- _4 > (0 : uint32);
     goto BB4
   }

--- a/creusot/tests/should_succeed/syntax/02_operators.stdout
+++ b/creusot/tests/should_succeed/syntax/02_operators.stdout
@@ -22,29 +22,6 @@ module Type
     
   axiom c02operators_x_X_a_acc : forall a : usize . c02operators_x_X_a (C02Operators_X a : c02operators_x) = a
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C02Operators_Division_Interface
   use mach.int.Int
   use prelude.Prelude
@@ -55,7 +32,6 @@ module C02Operators_Division
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg division [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -69,12 +45,8 @@ module C02Operators_Division
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _5 <- _4 = (0 : usize);
     assert { not _5 };
     goto BB1
@@ -95,7 +67,6 @@ module C02Operators_Modulus
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg modulus [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -109,12 +80,8 @@ module C02Operators_Modulus
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _5 <- _4 = (0 : usize);
     assert { not _5 };
     goto BB1
@@ -135,7 +102,6 @@ module C02Operators_Multiply
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg multiply [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -148,12 +114,8 @@ module C02Operators_Multiply
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _0 <- _3 * _4;
     return _0
   }
@@ -169,7 +131,6 @@ module C02Operators_Add
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg add [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -182,12 +143,8 @@ module C02Operators_Add
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _0 <- _3 + _4;
     return _0
   }
@@ -203,7 +160,6 @@ module C02Operators_Sub
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg sub [@cfg:stackify] (x : usize) (y : usize) : usize = 
   var _0 : usize;
   var x_1 : usize;
@@ -216,12 +172,8 @@ module C02Operators_Sub
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _0 <- _3 - _4;
     return _0
   }
@@ -237,7 +189,6 @@ module C02Operators_Expression
   use mach.int.Int
   use prelude.Prelude
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg expression [@cfg:stackify] (x : usize) (y : usize) (z : usize) : bool = 
   var _0 : bool;
   var x_1 : usize;
@@ -262,9 +213,7 @@ module C02Operators_Expression
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _6 };
     _6 <- x_1;
-    assume { Resolve0.resolve _7 };
     _7 <- y_2;
     _8 <- _7 = (0 : usize);
     assert { not _8 };
@@ -272,24 +221,17 @@ module C02Operators_Expression
   }
   BB1 {
     _5 <- _6 / _7;
-    assume { Resolve0.resolve _9 };
     _9 <- z_3;
     _4 <- _5 * _9;
-    assume { Resolve0.resolve _12 };
     _12 <- x_1;
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve _13 };
     _13 <- y_2;
-    assume { Resolve0.resolve y_2 };
     _14 <- _13 = (0 : usize);
     assert { not _14 };
     goto BB2
   }
   BB2 {
     _11 <- _12 / _13;
-    assume { Resolve0.resolve _15 };
     _15 <- z_3;
-    assume { Resolve0.resolve z_3 };
     _10 <- _11 * _15;
     _0 <- _4 = _10;
     return _0
@@ -368,7 +310,6 @@ module C02Operators_PrimitiveComparison
   use prelude.Prelude
   use mach.int.UInt64
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c02operators_x
   let rec cfg primitive_comparison [@cfg:stackify] (x : Type.c02operators_x) : ()
     ensures { Type.c02operators_x_X_a x <= Type.c02operators_x_X_a x }
     
@@ -380,7 +321,6 @@ module C02Operators_PrimitiveComparison
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve x_1 };
     _0 <- ();
     return _0
   }
@@ -393,7 +333,6 @@ module C02Operators_BoolEq_Interface
 end
 module C02Operators_BoolEq
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg bool_eq [@cfg:stackify] (a : bool) (b : bool) : bool
     ensures { result = (a = b) }
     
@@ -409,12 +348,8 @@ module C02Operators_BoolEq
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- a_1;
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve0.resolve _4 };
     _4 <- b_2;
-    assume { Resolve0.resolve b_2 };
     _0 <- Prelude.eqb _3 _4;
     return _0
   }
@@ -426,7 +361,6 @@ module C02Operators_OldTest_Interface
     
 end
 module C02Operators_OldTest
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg old_test [@cfg:stackify] (x : bool) : ()
     ensures { old(x) = x }
     
@@ -438,7 +372,6 @@ module C02Operators_OldTest
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve x_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/syntax/03_unbounded.stdout
+++ b/creusot/tests/should_succeed/syntax/03_unbounded.stdout
@@ -14,29 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C03Unbounded_NoBoundsCheck_Interface
   use mach.int.Int
   val no_bounds_check [@cfg:stackify] (x : int) (y : int) : int
@@ -45,7 +22,6 @@ module C03Unbounded_NoBoundsCheck_Interface
 end
 module C03Unbounded_NoBoundsCheck
   use mach.int.Int
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int
   let rec cfg no_bounds_check [@cfg:stackify] (x : int) (y : int) : int
     ensures { result = (4294967294 : int) }
     
@@ -59,8 +35,6 @@ module C03Unbounded_NoBoundsCheck
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve x_1 };
-    assume { Resolve0.resolve y_2 };
     _0 <- (2147483647 : int) + (2147483647 : int);
     return _0
   }

--- a/creusot/tests/should_succeed/syntax/05_annotations.stdout
+++ b/creusot/tests/should_succeed/syntax/05_annotations.stdout
@@ -14,15 +14,6 @@ module Type
   use floating_point.Double
   use prelude.Prelude
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self
   predicate resolve (self : self)
@@ -31,20 +22,13 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C05Annotations_Assertion_Interface
   type t
   val assertion [@cfg:stackify] (x : t) : ()
 end
 module C05Annotations_Assertion
   type t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   let rec cfg assertion [@cfg:stackify] (x : t) : () = 
   var _0 : ();
   var x_1 : t;
@@ -59,12 +43,11 @@ module C05Annotations_Assertion
   }
   BB1 {
     _2 <- ();
-    assume { Resolve0.resolve _2 };
     _0 <- ();
     goto BB2
   }
   BB2 {
-    assume { Resolve1.resolve x_1 };
+    assume { Resolve0.resolve x_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
@@ -43,35 +43,11 @@ module Alloc_Vec_Impl0_New
     requires {true = true}
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C07ExternSpec_Main_Interface
   val main [@cfg:stackify] () : ()
 end
 module C07ExternSpec_Main
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.alloc_vec_vec bool (Type.alloc_alloc_global)
   clone Alloc_Vec_Impl0_New_Interface as New0 with type t = bool
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
@@ -88,10 +64,17 @@ module C07ExternSpec_Main
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve v_1 };
     return _0
   }
   
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
 end
 module C07ExternSpec_HasParams_Interface
   type v

--- a/creusot/tests/should_succeed/syntax/09_maintains.stdout
+++ b/creusot/tests/should_succeed/syntax/09_maintains.stdout
@@ -50,29 +50,6 @@ module C09Maintains_OtherInv
   predicate other_inv (a : Type.c09maintains_a) (b : bool) = 
     true
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C09Maintains_Test1_Interface
   use Type
   use mach.int.Int
@@ -88,9 +65,6 @@ module C09Maintains_Test1
   use mach.int.Int
   use mach.int.UInt64
   clone C09Maintains_Impl0_Invariant as Invariant0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
   let rec cfg test_1 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) (c : uint64) : ()
     requires {Invariant0.invariant' a b c}
     ensures { Invariant0.invariant' a b c }
@@ -107,9 +81,6 @@ module C09Maintains_Test1
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
-    assume { Resolve2.resolve c_3 };
     _0 <- ();
     return _0
   }
@@ -125,6 +96,14 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   use prelude.Prelude
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -150,8 +129,6 @@ module C09Maintains_Test2
   use mach.int.Int
   use mach.int.UInt64
   clone C09Maintains_Impl0_Invariant as Invariant0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.c09maintains_a
   let rec cfg test_2 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : bool) (c : uint64) : ()
     requires {Invariant0.invariant' ( * a) b c}
@@ -170,8 +147,6 @@ module C09Maintains_Test2
   }
   BB0 {
     assume { Resolve0.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
-    assume { Resolve2.resolve c_3 };
     _0 <- ();
     return _0
   }
@@ -194,7 +169,6 @@ module C09Maintains_Test3
   use mach.int.Int
   use mach.int.UInt64
   clone C09Maintains_Impl0_Invariant as Invariant0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint64
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = bool
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.c09maintains_a
   let rec cfg test_3 [@cfg:stackify] (a : borrowed (Type.c09maintains_a)) (b : borrowed bool) (c : uint64) : ()
@@ -215,7 +189,6 @@ module C09Maintains_Test3
   BB0 {
     assume { Resolve0.resolve a_1 };
     assume { Resolve1.resolve b_2 };
-    assume { Resolve2.resolve c_3 };
     _0 <- ();
     return _0
   }
@@ -240,8 +213,6 @@ module C09Maintains_Test5
   use Type
   use prelude.Prelude
   clone C09Maintains_Impl0_Inv2 as Inv20
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
   let rec cfg test_5 [@cfg:stackify] (a : Type.c09maintains_a) (b : usize) : ()
     requires {Inv20.inv2 a (UInt64.to_int b + 0)}
     ensures { Inv20.inv2 a (UInt64.to_int b + 0) }
@@ -256,8 +227,6 @@ module C09Maintains_Test5
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
     _0 <- ();
     return _0
   }
@@ -274,8 +243,6 @@ end
 module C09Maintains_Test6
   use Type
   clone C09Maintains_OtherInv as OtherInv0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c09maintains_a
   let rec cfg test_6 [@cfg:stackify] (a : Type.c09maintains_a) (b : bool) : ()
     requires {OtherInv0.other_inv a b}
     ensures { OtherInv0.other_inv a b }
@@ -290,8 +257,6 @@ module C09Maintains_Test6
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/syntax/10_mutual_rec_types.stdout
+++ b/creusot/tests/should_succeed/syntax/10_mutual_rec_types.stdout
@@ -65,7 +65,6 @@ module C10MutualRecTypes_UseTree
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) t_1 };
     return _0
   }
   
@@ -158,23 +157,19 @@ module C10MutualRecTypes_Impl0_Height
   }
   BB1 {
     n_3 <- Type.core_option_option_Some_0 (Type.c10mutualrectypes_tree_Tree_0 self_1);
-    assume { (fun x -> true) self_1 };
     _6 <- Type.c10mutualrectypes_node_Node_left n_3;
     _5 <- height _6;
     goto BB4
   }
   BB2 {
-    assume { (fun x -> true) self_1 };
     absurd
   }
   BB3 {
-    assume { (fun x -> true) self_1 };
     _0 <- (0 : uint64);
     goto BB7
   }
   BB4 {
     _8 <- Type.c10mutualrectypes_node_Node_right n_3;
-    assume { (fun x -> true) n_3 };
     _7 <- height _8;
     goto BB5
   }

--- a/creusot/tests/should_succeed/trait.stdout
+++ b/creusot/tests/should_succeed/trait.stdout
@@ -36,7 +36,6 @@ module Trait_UsesCustom
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) t_1 };
     return _0
   }
   
@@ -63,7 +62,6 @@ module Trait_UsesCustom2
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/trait_impl.stdout
+++ b/creusot/tests/should_succeed/trait_impl.stdout
@@ -61,7 +61,6 @@ module TraitImpl_Impl0_X
     goto BB1
   }
   BB1 {
-    assume { (fun x -> true) self_1 };
     return _0
   }
   
@@ -85,7 +84,6 @@ module TraitImpl_Impl1_X
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) self_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/traits/01.stdout
+++ b/creusot/tests/should_succeed/traits/01.stdout
@@ -44,7 +44,6 @@ module C01_UsesGeneric
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _2 };
     _2 <- b_1;
     _0 <- FromB0.from_b _2;
     goto BB1

--- a/creusot/tests/should_succeed/traits/03.stdout
+++ b/creusot/tests/should_succeed/traits/03.stdout
@@ -50,29 +50,6 @@ module C03_C_H
   use prelude.Prelude
   val h [@cfg:stackify] (x : t) : t
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C03_Impl0_F_Interface
   use prelude.Prelude
   use mach.int.Int
@@ -83,7 +60,6 @@ module C03_Impl0_F
   use prelude.Prelude
   use mach.int.Int
   use mach.int.Int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = int32
   let rec cfg f [@cfg:stackify] (self : int32) : int32 = 
   var _0 : int32;
   var self_1 : int32;
@@ -93,7 +69,6 @@ module C03_Impl0_F
   }
   BB0 {
     _0 <- (0 : int32);
-    assume { Resolve0.resolve self_1 };
     return _0
   }
   
@@ -108,7 +83,6 @@ module C03_Impl1_G
   use prelude.Prelude
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg g [@cfg:stackify] (self : uint32) : uint32 = 
   var _0 : uint32;
   var self_1 : uint32;
@@ -118,10 +92,17 @@ module C03_Impl1_G
   }
   BB0 {
     _0 <- (1 : uint32);
-    assume { Resolve0.resolve self_1 };
     return _0
   }
   
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
 end
 module C03_Impl2_H_Interface
   type g

--- a/creusot/tests/should_succeed/traits/04.stdout
+++ b/creusot/tests/should_succeed/traits/04.stdout
@@ -44,15 +44,6 @@ module C04_A_Func3
   use prelude.Prelude
   val func3 [@cfg:stackify] (self : self) (o : self) : bool
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
   type self
   predicate resolve (self : self)
@@ -60,12 +51,6 @@ end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module C04_User_Interface
   type t
@@ -78,8 +63,7 @@ module C04_User
   type t
   use prelude.Prelude
   clone C04_A_Func3_Interface as Func30 with type self = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone C04_A_Func2_Interface as Func20 with type self = t
   clone C04_A_Func1_Interface as Func10 with type self = t
   let rec cfg user [@cfg:stackify] (a : t) (b : t) : bool
@@ -111,16 +95,16 @@ module C04_User
     goto BB7
   }
   BB1 {
-    assume { Resolve1.resolve a_1 };
-    assume { Resolve1.resolve b_2 };
+    assume { Resolve0.resolve a_1 };
+    assume { Resolve0.resolve b_2 };
     _0 <- false;
     goto BB3
   }
   BB2 {
     _11 <- a_1;
-    assume { Resolve1.resolve a_1 };
+    assume { Resolve0.resolve a_1 };
     _12 <- b_2;
-    assume { Resolve1.resolve b_2 };
+    assume { Resolve0.resolve b_2 };
     _10 <- Func30.func3 _11 _12;
     goto BB9
   }
@@ -150,12 +134,10 @@ module C04_User
       end
   }
   BB8 {
-    assume { Resolve0.resolve _3 };
     _3 <- _7;
     goto BB6
   }
   BB9 {
-    assume { Resolve0.resolve _0 };
     _0 <- _10;
     goto BB3
   }

--- a/creusot/tests/should_succeed/traits/06.stdout
+++ b/creusot/tests/should_succeed/traits/06.stdout
@@ -57,7 +57,6 @@ module C06_Test
   }
   BB0 {
     _2 <- a_1;
-    assume { (fun x -> true) a_1 };
     _0 <- Ix0.ix _2 (0 : usize);
     goto BB1
   }

--- a/creusot/tests/should_succeed/traits/07.stdout
+++ b/creusot/tests/should_succeed/traits/07.stdout
@@ -49,7 +49,6 @@ module C07_Impl0_Ix
   }
   BB0 {
     _0 <- ();
-    assume { (fun x -> true) self_1 };
     return _0
   }
   
@@ -81,8 +80,6 @@ module C07_Test
   }
   BB0 {
     _0 <- true;
-    assume { (fun x -> true) a_1 };
-    assume { (fun x -> true) b_2 };
     return _0
   }
   
@@ -120,7 +117,6 @@ module C07_Test2
   }
   BB0 {
     _2 <- a_1;
-    assume { (fun x -> true) a_1 };
     _0 <- Ix0.ix _2;
     goto BB1
   }

--- a/creusot/tests/should_succeed/traits/09.stdout
+++ b/creusot/tests/should_succeed/traits/09.stdout
@@ -37,9 +37,7 @@ module C09_Test
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _2 };
     _2 <- t_1;
-    assume { (fun x -> true) t_1 };
     _0 <- _2 + (0 : uint32);
     return _0
   }
@@ -63,7 +61,6 @@ module C09_Test2
     goto BB0
   }
   BB0 {
-    assume { (fun x -> true) _0 };
     _0 <- t_1;
     goto BB1
   }

--- a/creusot/tests/should_succeed/traits/12_default_method.stdout
+++ b/creusot/tests/should_succeed/traits/12_default_method.stdout
@@ -58,21 +58,6 @@ module C12DefaultMethod_T_LogicDefault
   function logic_default (self : self) : bool = 
     true
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C12DefaultMethod_ShouldUseImpl_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -87,7 +72,6 @@ module C12DefaultMethod_ShouldUseImpl
   clone C12DefaultMethod_T_LogicDefault as LogicDefault0 with type self = uint32
   use prelude.Prelude
   clone C12DefaultMethod_T_Default_Interface as Default0 with type self = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = uint32
   let rec cfg should_use_impl [@cfg:stackify] (x : uint32) : ()
     ensures { LogicDefault0.logic_default x }
     
@@ -102,7 +86,6 @@ module C12DefaultMethod_ShouldUseImpl
   }
   BB0 {
     _3 <- x_1;
-    assume { Resolve0.resolve x_1 };
     _2 <- Default0.default _3;
     goto BB1
   }

--- a/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
+++ b/creusot/tests/should_succeed/traits/15_impl_interfaces.stdout
@@ -36,29 +36,6 @@ module C15ImplInterfaces_Impl0
   clone C15ImplInterfaces_Impl0_A as A0
   clone C15ImplInterfaces_Tr_A as A1 with type self = (), type a = A0.a
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C15ImplInterfaces_Calls_Interface
   clone C15ImplInterfaces_Impl0_A as A0
   clone C15ImplInterfaces_X_Interface as X0 with type t = (), type A0.a = A0.a
@@ -69,7 +46,6 @@ end
 module C15ImplInterfaces_Calls
   clone C15ImplInterfaces_Impl0_A as A0
   clone C15ImplInterfaces_X as X0 with type t = (), type A0.a = A0.a
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg calls [@cfg:stackify] (a : ()) : ()
     requires {X0.x a = ()}
     
@@ -81,7 +57,6 @@ module C15ImplInterfaces_Calls
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve a_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
+++ b/creusot/tests/should_succeed/traits/17_impl_refinement.stdout
@@ -34,29 +34,6 @@ module C17ImplRefinement_Tr_MyFunction
     ensures { UInt64.to_int result >= 10 }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module C17ImplRefinement_Impl0_MyFunction_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -72,7 +49,6 @@ module C17ImplRefinement_Impl0_MyFunction
   use mach.int.Int
   use mach.int.Int32
   use prelude.Prelude
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = ()
   let rec cfg my_function [@cfg:stackify] (self : ()) : usize
     requires {true}
     ensures { UInt64.to_int result >= 15 }
@@ -85,7 +61,6 @@ module C17ImplRefinement_Impl0_MyFunction
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve self_1 };
     _0 <- (20 : usize);
     return _0
   }

--- a/creusot/tests/should_succeed/two_modules.stdout
+++ b/creusot/tests/should_succeed/two_modules.stdout
@@ -34,7 +34,6 @@ module TwoModules_Mod2_X
   }
   BB0 {
     _0 <- true;
-    assume { (fun x -> true) t_1 };
     return _0
   }
   

--- a/creusot/tests/should_succeed/type_constructors.stdout
+++ b/creusot/tests/should_succeed/type_constructors.stdout
@@ -37,10 +37,8 @@ module TypeConstructors_Main
   }
   BB0 {
     _1 <- Type.TypeConstructors_B_X_A;
-    assume { (fun x -> true) _1 };
     _3 <- Type.TypeConstructors_B_X_B;
     _2 <- Type.TypeConstructors_A_Y _3;
-    assume { (fun x -> true) _2 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/unary_op.stdout
+++ b/creusot/tests/should_succeed/unary_op.stdout
@@ -40,7 +40,6 @@ module UnaryOp_Main
   }
   BB2 {
     _1 <- ();
-    assume { (fun x -> true) _1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/unused_in_loop.stdout
+++ b/creusot/tests/should_succeed/unused_in_loop.stdout
@@ -29,29 +29,6 @@ module UnusedInLoop_Main
   }
   
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module UnusedInLoop_UnusedInLoop_Interface
   use mach.int.Int
   use mach.int.UInt32
@@ -62,9 +39,6 @@ end
 module UnusedInLoop_UnusedInLoop
   use mach.int.Int
   use mach.int.UInt32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = bool
   let rec cfg unused_in_loop [@cfg:stackify] (b : bool) : uint32
     ensures { result = (10 : uint32) }
     
@@ -86,7 +60,6 @@ module UnusedInLoop_UnusedInLoop
   }
   BB1 {
     invariant x { true };
-    assume { Resolve0.resolve _5 };
     _5 <- b_1;
     switch (_5)
       | False -> goto BB3
@@ -94,17 +67,12 @@ module UnusedInLoop_UnusedInLoop
       end
   }
   BB2 {
-    assume { Resolve0.resolve b_1 };
     _3 <- ();
-    assume { Resolve1.resolve _3 };
-    assume { Resolve2.resolve _0 };
     _0 <- x_2;
-    assume { Resolve2.resolve x_2 };
     return _0
   }
   BB3 {
     _4 <- ();
-    assume { Resolve1.resolve _4 };
     goto BB1
   }
   

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -100,15 +100,6 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Ghost_Impl1_Record_Interface
   type t
   use prelude.Prelude
@@ -259,20 +250,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -293,6 +270,14 @@ module CreusotContracts_Std1_Vec_Impl2
   function Model0.model = Model0.model, function Model1.model = Model1.model
   clone Core_Ops_Index_IndexMut_IndexMut_Interface as IndexMut1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type idx = usize, val index_mut = IndexMut0.index_mut, type Output0.output = Output0.output
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
@@ -361,13 +346,9 @@ module C01_AllZero
   use Type
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = uint32
   clone CreusotContracts_Logic_Ghost_Impl0_Model as Model0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec uint32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec uint32))
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec uint32)
   clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut0 with type t = uint32,
@@ -407,19 +388,16 @@ module C01_AllZero
     i_2 <- (0 : usize);
     _5 <- v_1;
     _4 <- _5;
-    assume { Resolve0.resolve _5 };
     old_v_3 <- Record0.record _4;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve old_v_3 };
     goto BB2
   }
   BB2 {
     invariant proph_const {  ^ v_1 =  ^ Model0.model old_v_3 };
     invariant in_bounds { Seq.length (Model1.model ( * v_1)) = Seq.length (Model1.model ( * Model0.model old_v_3)) };
     invariant all_zero { forall j : (int) . 0 <= j && j < UInt64.to_int i_2 -> Seq.get (Model1.model ( * v_1)) j = (0 : uint32) };
-    assume { Resolve2.resolve _8 };
     _8 <- i_2;
     _10 <-  * v_1;
     _9 <- Len0.len _10;
@@ -435,22 +413,19 @@ module C01_AllZero
   BB4 {
     _12 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _12) };
-    assume { Resolve2.resolve _13 };
     _13 <- i_2;
     _11 <- IndexMut0.index_mut _12 _13;
     goto BB5
   }
   BB5 {
     _11 <- { _11 with current = (0 : uint32) };
-    assume { Resolve3.resolve _11 };
+    assume { Resolve0.resolve _11 };
     i_2 <- i_2 + (1 : usize);
     _6 <- ();
-    assume { Resolve4.resolve _6 };
     goto BB2
   }
   BB6 {
-    assume { Resolve5.resolve v_1 };
-    assume { Resolve2.resolve i_2 };
+    assume { Resolve1.resolve v_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -435,15 +435,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t
   use prelude.Prelude
@@ -669,12 +660,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -786,11 +771,8 @@ module C02Gnome_GnomeSort
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = t
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve6 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Std1_Ord_Ord_Le_Interface as Le0 with type self = t, predicate LeLog0.le_log = LeLog0.le_log
@@ -860,7 +842,6 @@ module C02Gnome_GnomeSort
     invariant sorted { SortedRange0.sorted_range (Model0.model v_1) 0 (UInt64.to_int i_5) };
     invariant proph_const {  ^ v_1 =  ^ Model1.model old_v_2 };
     invariant permutation { PermutationOf0.permutation_of (Model2.model ( * v_1)) (Model2.model ( * Model1.model old_v_2)) };
-    assume { Resolve2.resolve _8 };
     _8 <- i_5;
     _10 <-  * v_1;
     _9 <- Len0.len _10;
@@ -874,7 +855,6 @@ module C02Gnome_GnomeSort
       end
   }
   BB4 {
-    assume { Resolve2.resolve _13 };
     _13 <- i_5;
     _12 <- _13 = (0 : usize);
     switch (_12)
@@ -888,7 +868,6 @@ module C02Gnome_GnomeSort
   }
   BB6 {
     _17 <-  * v_1;
-    assume { Resolve2.resolve _19 };
     _19 <- i_5;
     _18 <- _19 - (1 : usize);
     _16 <- Index0.index _17 _18;
@@ -902,39 +881,34 @@ module C02Gnome_GnomeSort
   }
   BB8 {
     _15 <- _16;
-    assume { Resolve4.resolve _16 };
+    assume { Resolve2.resolve _16 };
     _23 <-  * v_1;
-    assume { Resolve2.resolve _24 };
     _24 <- i_5;
     _22 <- Index0.index _23 _24;
     goto BB9
   }
   BB9 {
     _21 <- _22;
-    assume { Resolve4.resolve _22 };
+    assume { Resolve2.resolve _22 };
     _20 <- _21;
-    assume { Resolve4.resolve _21 };
+    assume { Resolve2.resolve _21 };
     _14 <- Le0.le _15 _20;
     goto BB10
   }
   BB10 {
-    assume { Resolve5.resolve _11 };
     _11 <- _14;
     goto BB7
   }
   BB11 {
     i_5 <- i_5 + (1 : usize);
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     goto BB14
   }
   BB12 {
     _26 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _26) };
-    assume { Resolve2.resolve _28 };
     _28 <- i_5;
     _27 <- _28 - (1 : usize);
-    assume { Resolve2.resolve _29 };
     _29 <- i_5;
     _25 <- Swap0.swap _26 _27 _29;
     goto BB13
@@ -942,15 +916,13 @@ module C02Gnome_GnomeSort
   BB13 {
     i_5 <- i_5 - (1 : usize);
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     goto BB14
   }
   BB14 {
     goto BB2
   }
   BB15 {
-    assume { Resolve6.resolve v_1 };
-    assume { Resolve2.resolve i_5 };
+    assume { Resolve3.resolve v_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -177,15 +177,6 @@ module CreusotContracts_Logic_Ghost_Impl1_Record
     ensures { Model0.model result = a }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Impl0_Model_Interface
   type t
   use prelude.Prelude
@@ -276,12 +267,6 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   predicate resolve (self : borrowed t) = 
      ^ self =  * self
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -332,10 +317,8 @@ module C03KnuthShuffle_KnuthShuffle
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
   use mach.int.Int
   use mach.int.UInt64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec t
   clone C03KnuthShuffle_RandInRange_Interface as RandInRange0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = Type.creusotcontracts_logic_ghost_ghost (borrowed (Type.creusotcontracts_std1_vec_vec t))
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = borrowed (Type.creusotcontracts_std1_vec_vec t)
   clone CreusotContracts_Logic_Ghost_Impl1_Record_Interface as Record0 with type t = borrowed (Type.creusotcontracts_std1_vec_vec t),
@@ -395,7 +378,6 @@ module C03KnuthShuffle_KnuthShuffle
   BB2 {
     invariant permutation { PermutationOf0.permutation_of (Model0.model v_1) (Model0.model (Model1.model old_v_2)) };
     invariant proph_const {  ^ v_1 =  ^ Model1.model old_v_2 };
-    assume { Resolve2.resolve _8 };
     _8 <- n_5;
     _10 <-  * v_1;
     _9 <- Len0.len _10;
@@ -414,7 +396,6 @@ module C03KnuthShuffle_KnuthShuffle
     goto BB5
   }
   BB5 {
-    assume { Resolve2.resolve _15 };
     _15 <- n_5;
     _12 <- _13 - _15;
     i_11 <- RandInRange0.rand_in_range (0 : usize) _12;
@@ -423,15 +404,12 @@ module C03KnuthShuffle_KnuthShuffle
   BB6 {
     _17 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _17) };
-    assume { Resolve2.resolve _18 };
     _18 <- i_11;
-    assume { Resolve2.resolve i_11 };
     _22 <-  * _17;
     _21 <- Len0.len _22;
     goto BB7
   }
   BB7 {
-    assume { Resolve2.resolve _23 };
     _23 <- n_5;
     _20 <- _21 - _23;
     _19 <- _20 - (1 : usize);
@@ -441,12 +419,10 @@ module C03KnuthShuffle_KnuthShuffle
   BB8 {
     n_5 <- n_5 + (1 : usize);
     _6 <- ();
-    assume { Resolve3.resolve _6 };
     goto BB2
   }
   BB9 {
-    assume { Resolve4.resolve v_1 };
-    assume { Resolve2.resolve n_5 };
+    assume { Resolve2.resolve v_1 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -150,15 +150,6 @@ module CreusotContracts_Std1_Vec_Impl1_Len
     ensures { UInt64.to_int result = Seq.length (Model0.model self) }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module Core_Ops_Index_Index_Output
   type self
   type idx
@@ -211,20 +202,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     requires {UInt64.to_int ix < Seq.length (Model0.model self)}
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
 end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
@@ -281,11 +258,6 @@ module C04BinarySearch_BinarySearch
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = uint32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec uint32,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = uint32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.creusotcontracts_std1_vec_vec uint32
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = uint32,
   function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = uint32, function Model0.model = Model0.model
@@ -361,14 +333,11 @@ module C04BinarySearch_BinarySearch
       end
   }
   BB2 {
-    assume { Resolve0.resolve arr_1 };
-    assume { Resolve1.resolve elem_2 };
     _0 <- Type.Core_Result_Result_Err (0 : usize);
     goto BB20
   }
   BB3 {
     _3 <- ();
-    assume { Resolve2.resolve _3 };
     _9 <- arr_1;
     size_8 <- Len0.len _9;
     goto BB4
@@ -381,7 +350,6 @@ module C04BinarySearch_BinarySearch
     invariant size_valid { 0 < UInt64.to_int size_8 && UInt64.to_int size_8 + UInt64.to_int base_10 <= Seq.length (Model0.model arr_1) };
     invariant lower_b { forall i : (usize) . i < base_10 -> Seq.get (Model0.model arr_1) (UInt64.to_int i) <= elem_2 };
     invariant lower_b { forall i : (usize) . UInt64.to_int base_10 + UInt64.to_int size_8 < UInt64.to_int i && UInt64.to_int i < Seq.length (Model0.model arr_1) -> elem_2 < Seq.get (Model0.model arr_1) (UInt64.to_int i) };
-    assume { Resolve3.resolve _14 };
     _14 <- size_8;
     _13 <- _14 > (1 : usize);
     switch (_13)
@@ -390,7 +358,6 @@ module C04BinarySearch_BinarySearch
       end
   }
   BB6 {
-    assume { Resolve3.resolve _16 };
     _16 <- size_8;
     _17 <- (2 : usize) = (0 : usize);
     assert { not _17 };
@@ -398,22 +365,16 @@ module C04BinarySearch_BinarySearch
   }
   BB7 {
     half_15 <- _16 / (2 : usize);
-    assume { Resolve3.resolve _19 };
     _19 <- base_10;
-    assume { Resolve3.resolve _20 };
     _20 <- half_15;
     mid_18 <- _19 + _20;
     _25 <- arr_1;
-    assume { Resolve3.resolve _26 };
     _26 <- mid_18;
     _24 <- Index0.index _25 _26;
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _23 };
     _23 <- _24;
-    assume { Resolve4.resolve _24 };
-    assume { Resolve1.resolve _27 };
     _27 <- elem_2;
     _22 <- _23 > _27;
     switch (_22)
@@ -422,48 +383,30 @@ module C04BinarySearch_BinarySearch
       end
   }
   BB9 {
-    assume { Resolve3.resolve mid_18 };
-    assume { Resolve3.resolve _21 };
     _21 <- base_10;
-    assume { Resolve3.resolve base_10 };
     goto BB11
   }
   BB10 {
-    assume { Resolve3.resolve base_10 };
-    assume { Resolve3.resolve _21 };
     _21 <- mid_18;
-    assume { Resolve3.resolve mid_18 };
     goto BB11
   }
   BB11 {
-    assume { Resolve3.resolve base_10 };
     base_10 <- _21;
-    assume { Resolve3.resolve _28 };
     _28 <- half_15;
-    assume { Resolve3.resolve half_15 };
     size_8 <- size_8 - _28;
     _12 <- ();
-    assume { Resolve2.resolve _12 };
     goto BB5
   }
   BB12 {
-    assume { Resolve3.resolve size_8 };
     _11 <- ();
-    assume { Resolve2.resolve _11 };
     _34 <- arr_1;
-    assume { Resolve0.resolve arr_1 };
-    assume { Resolve3.resolve _35 };
     _35 <- base_10;
     _33 <- Index0.index _34 _35;
     goto BB13
   }
   BB13 {
-    assume { Resolve1.resolve cmp_32 };
     cmp_32 <- _33;
-    assume { Resolve4.resolve _33 };
-    assume { Resolve1.resolve _37 };
     _37 <- cmp_32;
-    assume { Resolve1.resolve _38 };
     _38 <- elem_2;
     _36 <- _37 = _38;
     switch (_36)
@@ -472,21 +415,13 @@ module C04BinarySearch_BinarySearch
       end
   }
   BB14 {
-    assume { Resolve1.resolve elem_2 };
-    assume { Resolve1.resolve cmp_32 };
-    assume { Resolve3.resolve _39 };
     _39 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Ok _39;
     goto BB19
   }
   BB15 {
-    assume { Resolve1.resolve _41 };
     _41 <- cmp_32;
-    assume { Resolve1.resolve cmp_32 };
-    assume { Resolve1.resolve _42 };
     _42 <- elem_2;
-    assume { Resolve1.resolve elem_2 };
     _40 <- _41 < _42;
     switch (_40)
       | False -> goto BB17
@@ -494,17 +429,13 @@ module C04BinarySearch_BinarySearch
       end
   }
   BB16 {
-    assume { Resolve3.resolve _44 };
     _44 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _43 <- _44 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err _43;
     goto BB18
   }
   BB17 {
-    assume { Resolve3.resolve _45 };
     _45 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Err _45;
     goto BB18
   }

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -406,15 +406,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module Core_Ops_Index_Index_Output
   type self
   type idx
@@ -550,12 +541,6 @@ module CreusotContracts_Std1_Ord_Ord_Lt
     ensures { result = LtLog0.lt_log self o }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -653,10 +638,7 @@ module C05BinarySearchGeneric_BinarySearch
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   use prelude.Int8
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.core_cmp_ordering
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = Type.creusotcontracts_std1_vec_vec t
   clone CreusotContracts_Std1_Ord_Ord_Cmp_Interface as Cmp0 with type self = t,
@@ -752,7 +734,6 @@ module C05BinarySearchGeneric_BinarySearch
   }
   BB6 {
     _3 <- ();
-    assume { Resolve2.resolve _3 };
     _9 <- arr_1;
     size_8 <- Len0.len _9;
     goto BB7
@@ -771,7 +752,6 @@ module C05BinarySearchGeneric_BinarySearch
     invariant size_valid { 0 < UInt64.to_int size_8 && UInt64.to_int size_8 + UInt64.to_int base_10 <= Seq.length (Model0.model arr_1) };
     invariant lower_b { forall i : (usize) . i < base_10 -> LeLog0.le_log (Seq.get (Model0.model arr_1) (UInt64.to_int i)) elem_2 };
     invariant lower_b { forall i : (usize) . UInt64.to_int base_10 + UInt64.to_int size_8 <= UInt64.to_int i && UInt64.to_int i < Seq.length (Model0.model arr_1) -> LtLog0.lt_log elem_2 (Seq.get (Model0.model arr_1) (UInt64.to_int i)) };
-    assume { Resolve3.resolve _14 };
     _14 <- size_8;
     _13 <- _14 > (1 : usize);
     switch (_13)
@@ -780,7 +760,6 @@ module C05BinarySearchGeneric_BinarySearch
       end
   }
   BB11 {
-    assume { Resolve3.resolve _16 };
     _16 <- size_8;
     _17 <- (2 : usize) = (0 : usize);
     assert { not _17 };
@@ -788,25 +767,22 @@ module C05BinarySearchGeneric_BinarySearch
   }
   BB12 {
     half_15 <- _16 / (2 : usize);
-    assume { Resolve3.resolve _19 };
     _19 <- base_10;
-    assume { Resolve3.resolve _20 };
     _20 <- half_15;
     mid_18 <- _19 + _20;
     _23 <- arr_1;
-    assume { Resolve3.resolve _24 };
     _24 <- mid_18;
     _22 <- Index0.index _23 _24;
     goto BB13
   }
   BB13 {
     x_21 <- _22;
-    assume { Resolve4.resolve _22 };
+    assume { Resolve2.resolve _22 };
     _27 <- x_21;
-    assume { Resolve4.resolve x_21 };
+    assume { Resolve2.resolve x_21 };
     _29 <- elem_2;
     _28 <- _29;
-    assume { Resolve4.resolve _29 };
+    assume { Resolve2.resolve _29 };
     _26 <- Gt0.gt _27 _28;
     goto BB14
   }
@@ -817,54 +793,40 @@ module C05BinarySearchGeneric_BinarySearch
       end
   }
   BB15 {
-    assume { Resolve3.resolve mid_18 };
-    assume { Resolve3.resolve _25 };
     _25 <- base_10;
-    assume { Resolve3.resolve base_10 };
     goto BB17
   }
   BB16 {
-    assume { Resolve3.resolve base_10 };
-    assume { Resolve3.resolve _25 };
     _25 <- mid_18;
-    assume { Resolve3.resolve mid_18 };
     goto BB17
   }
   BB17 {
-    assume { Resolve3.resolve base_10 };
     base_10 <- _25;
-    assume { Resolve3.resolve _30 };
     _30 <- half_15;
-    assume { Resolve3.resolve half_15 };
     size_8 <- size_8 - _30;
     _12 <- ();
-    assume { Resolve2.resolve _12 };
     goto BB10
   }
   BB18 {
-    assume { Resolve3.resolve size_8 };
     _11 <- ();
-    assume { Resolve2.resolve _11 };
     _36 <- arr_1;
     assume { Resolve0.resolve arr_1 };
-    assume { Resolve3.resolve _37 };
     _37 <- base_10;
     _35 <- Index0.index _36 _37;
     goto BB19
   }
   BB19 {
     cmp_34 <- _35;
-    assume { Resolve4.resolve _35 };
+    assume { Resolve2.resolve _35 };
     _39 <- cmp_34;
-    assume { Resolve4.resolve cmp_34 };
+    assume { Resolve2.resolve cmp_34 };
     _41 <- elem_2;
     _40 <- _41;
-    assume { Resolve4.resolve _41 };
+    assume { Resolve2.resolve _41 };
     _38 <- Cmp0.cmp _39 _40;
     goto BB20
   }
   BB20 {
-    assume { Resolve5.resolve _38 };
     switch (_38)
       | Type.Core_Cmp_Ordering_Less -> goto BB24
       | Type.Core_Cmp_Ordering_Equal -> goto BB23
@@ -872,28 +834,21 @@ module C05BinarySearchGeneric_BinarySearch
       end
   }
   BB21 {
-    assume { Resolve3.resolve _46 };
     _46 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Err _46;
     goto BB25
   }
   BB22 {
     assume { Resolve1.resolve elem_2 };
-    assume { Resolve3.resolve base_10 };
     absurd
   }
   BB23 {
-    assume { Resolve3.resolve _43 };
     _43 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _0 <- Type.Core_Result_Result_Ok _43;
     goto BB25
   }
   BB24 {
-    assume { Resolve3.resolve _45 };
     _45 <- base_10;
-    assume { Resolve3.resolve base_10 };
     _44 <- _45 + (1 : usize);
     _0 <- Type.Core_Result_Result_Err _44;
     goto BB25

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -51,15 +51,6 @@ module Type
     
   axiom c06knightstour_board_Board_field_acc : forall a : usize, b : creusotcontracts_std1_vec_vec (creusotcontracts_std1_vec_vec usize) . c06knightstour_board_Board_field (C06KnightsTour_Board a b : c06knightstour_board) = b
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Model_Model_ModelTy
   type self
   type modelTy
@@ -176,20 +167,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -267,10 +244,6 @@ module C06KnightsTour_Min
   use mach.int.UInt64
   use mach.int.Int64
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = Type.core_option_option (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (usize, Type.c06knightstour_point)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -278,7 +251,6 @@ module C06KnightsTour_Min
   function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (usize, Type.c06knightstour_point),
   function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   let rec cfg min [@cfg:stackify] (v : Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)) : Type.core_option_option (usize, Type.c06knightstour_point)
     
    = 
@@ -325,7 +297,6 @@ module C06KnightsTour_Min
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _7 };
     _7 <- i_2;
     _9 <- v_1;
     _8 <- Len0.len _9;
@@ -345,45 +316,31 @@ module C06KnightsTour_Min
       end
   }
   BB4 {
-    assume { Resolve3.resolve m_17 };
     m_17 <- Type.core_option_option_Some_0 min_3;
     _21 <- v_1;
-    assume { Resolve0.resolve _22 };
     _22 <- i_2;
     _20 <- Index0.index _21 _22;
     goto BB8
   }
   BB5 {
-    assume { Resolve1.resolve v_1 };
-    assume { Resolve0.resolve i_2 };
-    assume { Resolve2.resolve min_3 };
     absurd
   }
   BB6 {
-    assume { Resolve2.resolve min_3 };
     _15 <- v_1;
-    assume { Resolve0.resolve _16 };
     _16 <- i_2;
     _14 <- Index0.index _15 _16;
     goto BB7
   }
   BB7 {
     _13 <- _14;
-    assume { Resolve3.resolve _14 };
     _12 <- Type.Core_Option_Option_Some _13;
-    assume { Resolve2.resolve min_3 };
     min_3 <- _12;
     _10 <- ();
-    assume { Resolve4.resolve _10 };
     goto BB13
   }
   BB8 {
-    assume { Resolve0.resolve _19 };
     _19 <- (let (a, _) = _20 in a);
-    assume { Resolve3.resolve _20 };
-    assume { Resolve0.resolve _23 };
     _23 <- (let (a, _) = m_17 in a);
-    assume { Resolve3.resolve m_17 };
     _18 <- _19 < _23;
     switch (_18)
       | False -> goto BB11
@@ -391,28 +348,21 @@ module C06KnightsTour_Min
       end
   }
   BB9 {
-    assume { Resolve2.resolve min_3 };
     _28 <- v_1;
-    assume { Resolve0.resolve _29 };
     _29 <- i_2;
     _27 <- Index0.index _28 _29;
     goto BB10
   }
   BB10 {
     _26 <- _27;
-    assume { Resolve3.resolve _27 };
     _25 <- _26;
-    assume { Resolve3.resolve _26 };
     _24 <- Type.Core_Option_Option_Some _25;
-    assume { Resolve2.resolve min_3 };
     min_3 <- _24;
     _10 <- ();
-    assume { Resolve4.resolve _10 };
     goto BB12
   }
   BB11 {
     _10 <- ();
-    assume { Resolve4.resolve _10 };
     goto BB12
   }
   BB12 {
@@ -421,17 +371,11 @@ module C06KnightsTour_Min
   BB13 {
     i_2 <- i_2 + (1 : usize);
     _5 <- ();
-    assume { Resolve4.resolve _5 };
     goto BB1
   }
   BB14 {
-    assume { Resolve1.resolve v_1 };
-    assume { Resolve0.resolve i_2 };
     _4 <- ();
-    assume { Resolve4.resolve _4 };
-    assume { Resolve2.resolve _0 };
     _0 <- min_3;
-    assume { Resolve2.resolve min_3 };
     return _0
   }
   
@@ -444,8 +388,6 @@ end
 module C06KnightsTour_Impl3_Clone
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.c06knightstour_point
   let rec cfg clone' [@cfg:stackify] (self : Type.c06knightstour_point) : Type.c06knightstour_point = 
   var _0 : Type.c06knightstour_point;
   var self_1 : Type.c06knightstour_point;
@@ -454,9 +396,7 @@ module C06KnightsTour_Impl3_Clone
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _0 };
     _0 <- self_1;
-    assume { Resolve1.resolve self_1 };
     return _0
   }
   
@@ -482,9 +422,6 @@ module C06KnightsTour_Impl0_Mov
   use mach.int.Int64
   use prelude.Prelude
   use Type
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = (isize, isize)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = isize
   let rec cfg mov [@cfg:stackify] (self : Type.c06knightstour_point) (p : (isize, isize)) : Type.c06knightstour_point
     requires {- 10000 <= Int64.to_int (let (_, a) = p in a) && Int64.to_int (let (_, a) = p in a) <= 10000}
     requires {- 10000 <= Int64.to_int (let (a, _) = p in a) && Int64.to_int (let (a, _) = p in a) <= 10000}
@@ -509,17 +446,11 @@ module C06KnightsTour_Impl0_Mov
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
     _4 <- Type.c06knightstour_point_Point_x self_1;
-    assume { Resolve0.resolve _5 };
     _5 <- (let (a, _) = p_2 in a);
     _3 <- _4 + _5;
-    assume { Resolve0.resolve _7 };
     _7 <- Type.c06knightstour_point_Point_y self_1;
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve0.resolve _8 };
     _8 <- (let (_, a) = p_2 in a);
-    assume { Resolve2.resolve p_2 };
     _6 <- _7 + _8;
     _0 <- Type.C06KnightsTour_Point _3 _6;
     return _0
@@ -637,6 +568,14 @@ module CreusotContracts_Std1_Vec_Impl1_Push
     ensures { Model0.model ( ^ self) = Seq.snoc (Model1.model self) v }
     
 end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
+  type self
+  predicate resolve (self : self)
+end
+module CreusotContracts_Logic_Resolve_Resolve_Resolve
+  type self
+  predicate resolve (self : self)
+end
 module CreusotContracts_Std1_Vec_Impl5_Resolve_Interface
   type t
   use Type
@@ -682,6 +621,21 @@ module CreusotContracts_Logic_Model_Impl1
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = borrowed t,
   type modelTy = ModelTy0.modelTy
 end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
+end
+module CreusotContracts_Logic_Resolve_Impl2
+  type t
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
+  predicate resolve = Resolve0.resolve
+end
 module C06KnightsTour_Impl1_New_Interface
   use mach.int.UInt64
   use mach.int.Int
@@ -705,19 +659,18 @@ module C06KnightsTour_Impl1_New
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model1 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve3 with type t = usize, function Model0.model = Model1.model,
-  predicate Resolve0.resolve = Resolve0.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = usize, function Model0.model = Model1.model,
+  predicate Resolve0.resolve = Resolve2.resolve
   clone CreusotContracts_Std1_Vec_FromElem_Interface as FromElem0 with type t = usize,
   function Model0.model = Model1.model
   clone CreusotContracts_Logic_Model_Impl1_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec (Type.creusotcontracts_std1_vec_vec usize),
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model0.model, function Model1.model = Model2.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec usize,
-  function Model0.model = Model0.model, predicate Resolve0.resolve = Resolve3.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = Type.creusotcontracts_std1_vec_vec usize,
+  function Model0.model = Model0.model, predicate Resolve0.resolve = Resolve1.resolve
   clone CreusotContracts_Std1_Vec_Impl1_WithCapacity_Interface as WithCapacity0 with type t = Type.creusotcontracts_std1_vec_vec usize,
   function Model0.model = Model0.model
   let rec cfg new [@cfg:stackify] (size : usize) : Type.c06knightstour_board
@@ -750,7 +703,6 @@ module C06KnightsTour_Impl1_New
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _3 };
     _3 <- size_1;
     rows_2 <- WithCapacity0.with_capacity _3;
     goto BB1
@@ -769,9 +721,7 @@ module C06KnightsTour_Impl1_New
     invariant i_size { i_4 <= size_1 };
     invariant rows { forall j : (int) . 0 <= j && j < UInt64.to_int i_4 -> Seq.length (Model1.model (Seq.get (Model0.model rows_2) j)) = UInt64.to_int size_1 };
     invariant row_len { Seq.length (Model0.model rows_2) = UInt64.to_int i_4 };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
-    assume { Resolve0.resolve _9 };
     _9 <- size_1;
     _7 <- _8 < _9;
     switch (_7)
@@ -782,7 +732,6 @@ module C06KnightsTour_Impl1_New
   BB5 {
     _11 <- borrow_mut rows_2;
     rows_2 <-  ^ _11;
-    assume { Resolve0.resolve _13 };
     _13 <- size_1;
     _12 <- FromElem0.from_elem (0 : usize) _13;
     goto BB6
@@ -794,17 +743,12 @@ module C06KnightsTour_Impl1_New
   BB7 {
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     goto BB4
   }
   BB8 {
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve1.resolve _5 };
-    assume { Resolve0.resolve _17 };
     _17 <- size_1;
-    assume { Resolve0.resolve size_1 };
-    assume { Resolve2.resolve _18 };
+    assume { Resolve0.resolve _18 };
     _18 <- rows_2;
     _0 <- Type.C06KnightsTour_Board _17 _18;
     goto BB9
@@ -850,15 +794,8 @@ module C06KnightsTour_Impl1_Available
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = bool
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = isize
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index1 with type t = usize,
@@ -906,7 +843,6 @@ module C06KnightsTour_Impl1_Available
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _7 };
     _7 <- Type.c06knightstour_point_Point_x p_2;
     _6 <- (0 : isize) <= _7;
     switch (_6)
@@ -915,15 +851,11 @@ module C06KnightsTour_Impl1_Available
       end
   }
   BB1 {
-    assume { Resolve3.resolve self_1 };
-    assume { Resolve5.resolve p_2 };
     _0 <- false;
     goto BB3
   }
   BB2 {
     _23 <- Type.c06knightstour_board_Board_field self_1;
-    assume { Resolve3.resolve self_1 };
-    assume { Resolve0.resolve _25 };
     _25 <- Type.c06knightstour_point_Point_x p_2;
     _24 <- UInt64.of_int (Int64.to_int _25);
     _22 <- Index0.index _23 _24;
@@ -937,13 +869,10 @@ module C06KnightsTour_Impl1_Available
     goto BB6
   }
   BB5 {
-    assume { Resolve0.resolve _16 };
     _16 <- Type.c06knightstour_point_Point_y p_2;
     _15 <- UInt64.of_int (Int64.to_int _16);
-    assume { Resolve1.resolve _17 };
     _17 <- Type.c06knightstour_board_Board_size self_1;
     _14 <- _15 < _17;
-    assume { Resolve2.resolve _3 };
     _3 <- _14;
     goto BB6
   }
@@ -958,10 +887,8 @@ module C06KnightsTour_Impl1_Available
     goto BB9
   }
   BB8 {
-    assume { Resolve0.resolve _13 };
     _13 <- Type.c06knightstour_point_Point_y p_2;
     _12 <- (0 : isize) <= _13;
-    assume { Resolve2.resolve _4 };
     _4 <- _12;
     goto BB9
   }
@@ -976,13 +903,10 @@ module C06KnightsTour_Impl1_Available
     goto BB12
   }
   BB11 {
-    assume { Resolve0.resolve _10 };
     _10 <- Type.c06knightstour_point_Point_x p_2;
     _9 <- UInt64.of_int (Int64.to_int _10);
-    assume { Resolve1.resolve _11 };
     _11 <- Type.c06knightstour_board_Board_size self_1;
     _8 <- _9 < _11;
-    assume { Resolve2.resolve _5 };
     _5 <- _8;
     goto BB12
   }
@@ -994,20 +918,14 @@ module C06KnightsTour_Impl1_Available
   }
   BB13 {
     _21 <- _22;
-    assume { Resolve4.resolve _22 };
-    assume { Resolve0.resolve _27 };
     _27 <- Type.c06knightstour_point_Point_y p_2;
-    assume { Resolve5.resolve p_2 };
     _26 <- UInt64.of_int (Int64.to_int _27);
     _20 <- Index1.index _21 _26;
     goto BB14
   }
   BB14 {
-    assume { Resolve1.resolve _19 };
     _19 <- _20;
-    assume { Resolve6.resolve _20 };
     _18 <- _19 = (0 : usize);
-    assume { Resolve2.resolve _0 };
     _0 <- _18;
     goto BB3
   }
@@ -1084,14 +1002,10 @@ module C06KnightsTour_Impl1_CountDegree
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   clone C06KnightsTour_Impl1_InBounds as InBounds0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve7 with type t = isize
-  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve6 with type t1 = isize, type t2 = isize,
-  predicate Resolve0.resolve = Resolve7.resolve, predicate Resolve1.resolve = Resolve7.resolve
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = isize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve1 with type t1 = isize, type t2 = isize,
+  predicate Resolve0.resolve = Resolve2.resolve, predicate Resolve1.resolve = Resolve2.resolve
   clone C06KnightsTour_Impl0_Mov_Interface as Mov0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (isize, isize)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
@@ -1100,10 +1014,9 @@ module C06KnightsTour_Impl1_CountDegree
   function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
   function Model0.model = Model3.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = (isize, isize),
-  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve6.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = (isize, isize),
+  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve1.resolve
   clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,
   predicate InBounds0.in_bounds = InBounds0.in_bounds
   let rec cfg count_degree [@cfg:stackify] (self : Type.c06knightstour_board) (p : Type.c06knightstour_point) : usize
@@ -1150,7 +1063,6 @@ module C06KnightsTour_Impl1_CountDegree
   }
   BB1 {
     invariant count { count_3 <= i_4 };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
     _11 <- Moves0.moves ();
     goto BB2
@@ -1165,7 +1077,7 @@ module C06KnightsTour_Impl1_CountDegree
     goto BB4
   }
   BB4 {
-    assume { Resolve1.resolve _11 };
+    assume { Resolve0.resolve _11 };
     switch (_7)
       | False -> goto BB14
       | _ -> goto BB5
@@ -1178,16 +1090,13 @@ module C06KnightsTour_Impl1_CountDegree
   }
   BB6 {
     _17 <- _18;
-    assume { Resolve0.resolve _19 };
     _19 <- i_4;
     _16 <- Index0.index _17 _19;
     goto BB7
   }
   BB7 {
     _15 <- _16;
-    assume { Resolve2.resolve _16 };
     _14 <- _15;
-    assume { Resolve2.resolve _15 };
     next_12 <- Mov0.mov _13 _14;
     goto BB8
   }
@@ -1195,11 +1104,9 @@ module C06KnightsTour_Impl1_CountDegree
     goto BB9
   }
   BB9 {
-    assume { Resolve1.resolve _18 };
+    assume { Resolve0.resolve _18 };
     _22 <- self_1;
-    assume { Resolve3.resolve _23 };
     _23 <- next_12;
-    assume { Resolve3.resolve next_12 };
     _21 <- Available0.available _22 _23;
     goto BB10
   }
@@ -1212,29 +1119,20 @@ module C06KnightsTour_Impl1_CountDegree
   BB11 {
     count_3 <- count_3 + (1 : usize);
     _20 <- ();
-    assume { Resolve4.resolve _20 };
     goto BB13
   }
   BB12 {
     _20 <- ();
-    assume { Resolve4.resolve _20 };
     goto BB13
   }
   BB13 {
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve4.resolve _6 };
     goto BB1
   }
   BB14 {
-    assume { Resolve5.resolve self_1 };
-    assume { Resolve3.resolve p_2 };
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve4.resolve _5 };
-    assume { Resolve0.resolve _0 };
     _0 <- count_3;
-    assume { Resolve0.resolve count_3 };
     return _0
   }
   
@@ -1355,14 +1253,11 @@ module C06KnightsTour_Impl1_Set
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   clone C06KnightsTour_Impl1_InBounds as InBounds0
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve5 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.creusotcontracts_std1_vec_vec usize
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = Type.creusotcontracts_std1_vec_vec usize
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = isize
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.c06knightstour_board
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.c06knightstour_board
   clone CreusotContracts_Logic_Model_Impl1_Model as Model3 with type t = Type.creusotcontracts_std1_vec_vec usize,
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Std1_Vec_Impl2_IndexMut_Interface as IndexMut1 with type t = usize,
@@ -1398,13 +1293,10 @@ module C06KnightsTour_Impl1_Set
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _4 };
     _4 <- v_3;
-    assume { Resolve0.resolve v_3 };
     _8 <- borrow_mut (Type.c06knightstour_board_Board_field ( * self_1));
     self_1 <- { self_1 with current = (let Type.C06KnightsTour_Board a b =  * self_1 in Type.C06KnightsTour_Board a ( ^ _8)) };
-    assume { Resolve1.resolve self_1 };
-    assume { Resolve2.resolve _10 };
+    assume { Resolve0.resolve self_1 };
     _10 <- Type.c06knightstour_point_Point_x p_2;
     _9 <- UInt64.of_int (Int64.to_int _10);
     _7 <- IndexMut0.index_mut _8 _9;
@@ -1413,18 +1305,15 @@ module C06KnightsTour_Impl1_Set
   BB1 {
     _6 <- borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
-    assume { Resolve3.resolve _7 };
-    assume { Resolve2.resolve _12 };
+    assume { Resolve1.resolve _7 };
     _12 <- Type.c06knightstour_point_Point_y p_2;
-    assume { Resolve4.resolve p_2 };
     _11 <- UInt64.of_int (Int64.to_int _12);
     _5 <- IndexMut1.index_mut _6 _11;
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve ( * _5) };
     _5 <- { _5 with current = _4 };
-    assume { Resolve5.resolve _5 };
+    assume { Resolve2.resolve _5 };
     _0 <- ();
     return _0
   }
@@ -1504,16 +1393,17 @@ module C06KnightsTour_KnightsTour
   clone C06KnightsTour_Impl1_Wf as Wf0 with function Model0.model = Model0.model, function Model1.model = Model1.model
   clone C06KnightsTour_DumbNonlinearArith as DumbNonlinearArith0 with axiom .
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve11 with type t = isize
-  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve9 with type t1 = isize, type t2 = isize,
-  predicate Resolve0.resolve = Resolve11.resolve, predicate Resolve1.resolve = Resolve11.resolve
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve8 with type t = Type.core_option_option (usize, Type.c06knightstour_point)
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = Type.c06knightstour_board
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve6 with type t = Type.c06knightstour_point
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve3 with type t1 = usize,
+  type t2 = Type.c06knightstour_point, predicate Resolve0.resolve = Resolve5.resolve,
+  predicate Resolve1.resolve = Resolve6.resolve
+  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = isize
+  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve2 with type t1 = isize, type t2 = isize,
+  predicate Resolve0.resolve = Resolve4.resolve, predicate Resolve1.resolve = Resolve4.resolve
   clone C06KnightsTour_Min_Interface as Min0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy1 with type t = (usize, Type.c06knightstour_point)
   clone C06KnightsTour_Impl0_Mov_Interface as Mov0
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_ModelTy as ModelTy0 with type t = (isize, isize)
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model3 with type t = (isize, isize)
   clone CreusotContracts_Logic_Model_Impl0_Model as Model4 with type t = Type.creusotcontracts_std1_vec_vec (isize, isize),
@@ -1522,24 +1412,18 @@ module C06KnightsTour_KnightsTour
   function Model0.model = Model4.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = (isize, isize),
   function Model0.model = Model4.model
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve3 with type t = (isize, isize),
-  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve9.resolve
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve0 with type t = (isize, isize),
+  function Model0.model = Model3.model, predicate Resolve0.resolve = Resolve2.resolve
   clone C06KnightsTour_Moves_Interface as Moves0 with function Model0.model = Model3.model
   clone CreusotContracts_Std1_Vec_Impl0_Model as Model2 with type t = (usize, Type.c06knightstour_point)
   clone CreusotContracts_Logic_Model_Impl1_Model as Model5 with type t = Type.creusotcontracts_std1_vec_vec (usize, Type.c06knightstour_point),
   type ModelTy0.modelTy = ModelTy1.modelTy, function Model0.model = Model2.model
   clone CreusotContracts_Std1_Vec_Impl1_Push_Interface as Push0 with type t = (usize, Type.c06knightstour_point),
   function Model0.model = Model2.model, function Model1.model = Model5.model
+  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve1 with type t = (usize, Type.c06knightstour_point),
+  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve3.resolve
   clone CreusotContracts_Std1_Vec_Impl1_New_Interface as New1 with type t = (usize, Type.c06knightstour_point),
   function Model0.model = Model2.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = Type.c06knightstour_point
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
-  clone CreusotContracts_Logic_Resolve_Impl0_Resolve as Resolve10 with type t1 = usize,
-  type t2 = Type.c06knightstour_point, predicate Resolve0.resolve = Resolve0.resolve,
-  predicate Resolve1.resolve = Resolve1.resolve
-  clone CreusotContracts_Std1_Vec_Impl5_Resolve as Resolve7 with type t = (usize, Type.c06knightstour_point),
-  function Model0.model = Model2.model, predicate Resolve0.resolve = Resolve10.resolve
   clone C06KnightsTour_Impl1_CountDegree_Interface as CountDegree0 with predicate InBounds0.in_bounds = InBounds0.in_bounds,
   predicate Wf0.wf = Wf0.wf
   clone C06KnightsTour_Impl1_Available_Interface as Available0 with predicate Wf0.wf = Wf0.wf,
@@ -1631,27 +1515,20 @@ module C06KnightsTour_KnightsTour
     goto BB0
   }
   BB0 {
-    assume { Resolve0.resolve _5 };
     _5 <- size_1;
     board_4 <- New0.new _5;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _8 };
     _8 <- x_2;
-    assume { Resolve0.resolve x_2 };
     _7 <- Int64.of_int (UInt64.to_int _8);
-    assume { Resolve0.resolve _10 };
     _10 <- y_3;
-    assume { Resolve0.resolve y_3 };
     _9 <- Int64.of_int (UInt64.to_int _10);
     p_6 <- Type.C06KnightsTour_Point _7 _9;
     step_11 <- (1 : usize);
     _13 <- borrow_mut board_4;
     board_4 <-  ^ _13;
-    assume { Resolve1.resolve _14 };
     _14 <- p_6;
-    assume { Resolve0.resolve _15 };
     _15 <- step_11;
     _12 <- Set0.set _13 _14 _15;
     goto BB2
@@ -1660,7 +1537,6 @@ module C06KnightsTour_KnightsTour
     step_11 <- step_11 + (1 : usize);
     assert { let _ = DumbNonlinearArith0.dumb_nonlinear_arith size_1 in true };
     _16 <- ();
-    assume { Resolve2.resolve _16 };
     goto BB3
   }
   BB3 {
@@ -1673,11 +1549,8 @@ module C06KnightsTour_KnightsTour
     invariant b { Type.c06knightstour_board_Board_size board_4 = size_1 };
     invariant b { Wf0.wf board_4 };
     invariant p { InBounds0.in_bounds board_4 p_6 };
-    assume { Resolve0.resolve _20 };
     _20 <- step_11;
-    assume { Resolve0.resolve _22 };
     _22 <- size_1;
-    assume { Resolve0.resolve _23 };
     _23 <- size_1;
     _21 <- _22 * _23;
     _19 <- _20 <= _21;
@@ -1695,7 +1568,6 @@ module C06KnightsTour_KnightsTour
     goto BB8
   }
   BB8 {
-    assume { Resolve0.resolve _28 };
     _28 <- i_25;
     _31 <- Moves0.moves ();
     goto BB9
@@ -1710,7 +1582,7 @@ module C06KnightsTour_KnightsTour
     goto BB11
   }
   BB11 {
-    assume { Resolve3.resolve _31 };
+    assume { Resolve0.resolve _31 };
     switch (_27)
       | False -> goto BB24
       | _ -> goto BB12
@@ -1722,23 +1594,19 @@ module C06KnightsTour_KnightsTour
   }
   BB13 {
     _32 <- ();
-    assume { Resolve2.resolve _32 };
     _34 <- p_6;
     _39 <- Moves0.moves ();
     goto BB14
   }
   BB14 {
     _38 <- _39;
-    assume { Resolve0.resolve _40 };
     _40 <- i_25;
     _37 <- Index0.index _38 _40;
     goto BB15
   }
   BB15 {
     _36 <- _37;
-    assume { Resolve4.resolve _37 };
     _35 <- _36;
-    assume { Resolve4.resolve _36 };
     adj_33 <- Mov0.mov _34 _35;
     goto BB16
   }
@@ -1746,9 +1614,8 @@ module C06KnightsTour_KnightsTour
     goto BB17
   }
   BB17 {
-    assume { Resolve3.resolve _39 };
+    assume { Resolve0.resolve _39 };
     _42 <- board_4;
-    assume { Resolve1.resolve _43 };
     _43 <- adj_33;
     _41 <- Available0.available _42 _43;
     goto BB18
@@ -1761,7 +1628,6 @@ module C06KnightsTour_KnightsTour
   }
   BB19 {
     _45 <- board_4;
-    assume { Resolve1.resolve _46 };
     _46 <- adj_33;
     degree_44 <- CountDegree0.count_degree _45 _46;
     goto BB20
@@ -1769,38 +1635,27 @@ module C06KnightsTour_KnightsTour
   BB20 {
     _48 <- borrow_mut candidates_24;
     candidates_24 <-  ^ _48;
-    assume { Resolve0.resolve _50 };
     _50 <- degree_44;
-    assume { Resolve0.resolve degree_44 };
-    assume { Resolve1.resolve _51 };
     _51 <- adj_33;
-    assume { Resolve1.resolve adj_33 };
     _49 <- (_50, _51);
     _47 <- Push0.push _48 _49;
     goto BB21
   }
   BB21 {
     _18 <- ();
-    assume { Resolve2.resolve _18 };
     goto BB23
   }
   BB22 {
-    assume { Resolve1.resolve adj_33 };
     _18 <- ();
-    assume { Resolve2.resolve _18 };
     goto BB23
   }
   BB23 {
     goto BB8
   }
   BB24 {
-    assume { Resolve1.resolve p_6 };
-    assume { Resolve0.resolve i_25 };
     _26 <- ();
-    assume { Resolve2.resolve _26 };
     _58 <- candidates_24;
     _57 <- _58;
-    assume { Resolve5.resolve _58 };
     _56 <- Min0.min _57;
     goto BB25
   }
@@ -1811,36 +1666,21 @@ module C06KnightsTour_KnightsTour
       end
   }
   BB26 {
-    assume { Resolve0.resolve size_1 };
-    assume { Resolve0.resolve step_11 };
-    assume { Resolve8.resolve _56 };
     _0 <- Type.Core_Option_Option_None;
     goto BB34
   }
   BB27 {
-    assume { Resolve0.resolve size_1 };
-    assume { Resolve6.resolve board_4 };
-    assume { Resolve0.resolve step_11 };
-    assume { Resolve7.resolve candidates_24 };
-    assume { Resolve8.resolve _56 };
+    assume { Resolve1.resolve candidates_24 };
     absurd
   }
   BB28 {
-    assume { Resolve1.resolve adj_60 };
     adj_60 <- (let (_, a) = Type.core_option_option_Some_0 _56 in a);
-    assume { Resolve8.resolve _56 };
-    assume { Resolve1.resolve _61 };
     _61 <- adj_60;
-    assume { Resolve1.resolve adj_60 };
-    assume { Resolve1.resolve p_6 };
     p_6 <- _61;
     _55 <- ();
-    assume { Resolve2.resolve _55 };
     _64 <- borrow_mut board_4;
     board_4 <-  ^ _64;
-    assume { Resolve1.resolve _65 };
     _65 <- p_6;
-    assume { Resolve0.resolve _66 };
     _66 <- step_11;
     _63 <- Set0.set _64 _65 _66;
     goto BB29
@@ -1848,20 +1688,14 @@ module C06KnightsTour_KnightsTour
   BB29 {
     step_11 <- step_11 + (1 : usize);
     _18 <- ();
-    assume { Resolve2.resolve _18 };
     goto BB30
   }
   BB30 {
-    assume { Resolve7.resolve candidates_24 };
+    assume { Resolve1.resolve candidates_24 };
     goto BB5
   }
   BB31 {
-    assume { Resolve0.resolve size_1 };
-    assume { Resolve1.resolve p_6 };
-    assume { Resolve0.resolve step_11 };
     _17 <- ();
-    assume { Resolve2.resolve _17 };
-    assume { Resolve6.resolve _70 };
     _70 <- board_4;
     _0 <- Type.Core_Option_Option_Some _70;
     goto BB32
@@ -1873,11 +1707,10 @@ module C06KnightsTour_KnightsTour
     goto BB36
   }
   BB34 {
-    assume { Resolve7.resolve candidates_24 };
+    assume { Resolve1.resolve candidates_24 };
     goto BB35
   }
   BB35 {
-    assume { Resolve6.resolve board_4 };
     goto BB36
   }
   BB36 {

--- a/creusot/tests/should_succeed/vector/07_read_write.stdout
+++ b/creusot/tests/should_succeed/vector/07_read_write.stdout
@@ -99,15 +99,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module Core_Ops_Index_Index_Output
   type self
   type idx
@@ -269,12 +260,6 @@ module CreusotContracts_Std1_Eq_Eq_Eq
     ensures { result = LogEq0.log_eq self o }
     
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -418,7 +403,6 @@ module C07ReadWrite_ReadWrite
   clone CreusotContracts_Logic_Model_Impl1_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone CreusotContracts_Logic_Eq_EqLogic_LogNe as LogNe0 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve5 with type t = ()
   clone CreusotContracts_Logic_Eq_EqLogic_LogEq as LogEq0 with type self = t
   clone CreusotContracts_Logic_Eq_EqLogic_Transitivity as Transitivity0 with type self = t,
   predicate LogEq0.log_eq = LogEq0.log_eq, axiom .
@@ -429,10 +413,9 @@ module C07ReadWrite_ReadWrite
   clone CreusotContracts_Logic_Eq_EqLogic_EqNe as EqNe0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq,
   predicate LogNe0.log_ne = LogNe0.log_ne, axiom .
   clone CreusotContracts_Std1_Eq_Eq_Eq_Interface as Eq0 with type self = t, predicate LogEq0.log_eq = LogEq0.log_eq
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve4 with type self = t
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve3 with type t = Type.creusotcontracts_std1_vec_vec t
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = usize
+  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve3 with type self = t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve2 with type t = Type.creusotcontracts_std1_vec_vec t
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = t
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = t
   clone CreusotContracts_Logic_Model_Impl0_Model as Model2 with type t = Type.creusotcontracts_std1_vec_vec t,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
@@ -472,7 +455,6 @@ module C07ReadWrite_ReadWrite
     _4 <- x_3;
     _6 <- borrow_mut ( * a_1);
     a_1 <- { a_1 with current = ( ^ _6) };
-    assume { Resolve1.resolve _7 };
     _7 <- i_2;
     _5 <- IndexMut0.index_mut _6 _7;
     goto BB1
@@ -480,22 +462,20 @@ module C07ReadWrite_ReadWrite
   BB1 {
     assume { Resolve0.resolve ( * _5) };
     _5 <- { _5 with current = _4 };
-    assume { Resolve2.resolve _5 };
+    assume { Resolve1.resolve _5 };
     _13 <-  * a_1;
-    assume { Resolve3.resolve a_1 };
-    assume { Resolve1.resolve _14 };
+    assume { Resolve2.resolve a_1 };
     _14 <- i_2;
-    assume { Resolve1.resolve i_2 };
     _12 <- Index0.index _13 _14;
     goto BB2
   }
   BB2 {
     _11 <- _12;
-    assume { Resolve4.resolve _12 };
+    assume { Resolve3.resolve _12 };
     _16 <- x_3;
     assume { Resolve0.resolve x_3 };
     _15 <- _16;
-    assume { Resolve4.resolve _16 };
+    assume { Resolve3.resolve _16 };
     _10 <- Eq0.eq _11 _15;
     goto BB3
   }
@@ -511,7 +491,6 @@ module C07ReadWrite_ReadWrite
   }
   BB5 {
     _8 <- ();
-    assume { Resolve5.resolve _8 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/vector/08_haystack.stdout
+++ b/creusot/tests/should_succeed/vector/08_haystack.stdout
@@ -113,15 +113,6 @@ module CreusotContracts_Std1_Vec_Impl0
   clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = Type.creusotcontracts_std1_vec_vec t,
   type modelTy = ModelTy0.modelTy
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Std1_Vec_Impl1_Len_Interface
   type t
   use mach.int.UInt64
@@ -203,20 +194,6 @@ module CreusotContracts_Std1_Vec_Impl3_Index
     ensures { result = Seq.get (Model0.model self) (UInt64.to_int ix) }
     
 end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Resolve_Resolve
-  type self
-  predicate resolve (self : self)
-end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Std1_Vec_Impl3_Output
   type t
   type output  = 
@@ -271,11 +248,6 @@ module C08Haystack_Search
   clone CreusotContracts_Logic_Model_Impl0_Model as Model0 with type t = Type.creusotcontracts_std1_vec_vec uint8,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model1.model
   clone C08Haystack_MatchAt as MatchAt0 with function Model0.model = Model0.model
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve4 with type t = Type.creusotcontracts_std1_vec_vec uint8
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve3 with type t = uint8
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = uint8
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve1 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = usize
   clone CreusotContracts_Std1_Vec_Impl3_Index_Interface as Index0 with type t = uint8,
   function Model0.model = Model0.model
   clone CreusotContracts_Std1_Vec_Impl1_Len_Interface as Len0 with type t = uint8, function Model0.model = Model0.model
@@ -345,7 +317,6 @@ module C08Haystack_Search
   }
   BB1 {
     invariant no_match { forall k : (int) . 0 <= k && k < UInt64.to_int i_4 -> not (MatchAt0.match_at needle_1 haystack_2 k (Seq.length (Model0.model needle_1))) };
-    assume { Resolve0.resolve _8 };
     _8 <- i_4;
     _12 <- haystack_2;
     _11 <- Len0.len _12;
@@ -371,7 +342,6 @@ module C08Haystack_Search
   }
   BB5 {
     invariant partial_match { MatchAt0.match_at needle_1 haystack_2 (UInt64.to_int i_4) (UInt64.to_int j_15) };
-    assume { Resolve0.resolve _18 };
     _18 <- j_15;
     _20 <- needle_1;
     _19 <- Len0.len _20;
@@ -387,30 +357,22 @@ module C08Haystack_Search
   BB7 {
     assert { UInt64.to_int j_15 <= Seq.length (Model0.model needle_1) };
     _21 <- ();
-    assume { Resolve1.resolve _21 };
     _26 <- needle_1;
-    assume { Resolve0.resolve _27 };
     _27 <- j_15;
     _25 <- Index0.index _26 _27;
     goto BB8
   }
   BB8 {
-    assume { Resolve2.resolve _24 };
     _24 <- _25;
-    assume { Resolve3.resolve _25 };
     _30 <- haystack_2;
-    assume { Resolve0.resolve _32 };
     _32 <- i_4;
-    assume { Resolve0.resolve _33 };
     _33 <- j_15;
     _31 <- _32 + _33;
     _29 <- Index0.index _30 _31;
     goto BB9
   }
   BB9 {
-    assume { Resolve2.resolve _28 };
     _28 <- _29;
-    assume { Resolve3.resolve _29 };
     _23 <- _24 <> _28;
     switch (_23)
       | False -> goto BB11
@@ -419,26 +381,20 @@ module C08Haystack_Search
   }
   BB10 {
     _16 <- ();
-    assume { Resolve1.resolve _16 };
     goto BB13
   }
   BB11 {
     _22 <- ();
-    assume { Resolve1.resolve _22 };
     j_15 <- j_15 + (1 : usize);
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     goto BB5
   }
   BB12 {
     _16 <- ();
-    assume { Resolve1.resolve _16 };
     goto BB13
   }
   BB13 {
-    assume { Resolve0.resolve _40 };
     _40 <- j_15;
-    assume { Resolve0.resolve j_15 };
     _42 <- needle_1;
     _41 <- Len0.len _42;
     goto BB14
@@ -451,28 +407,18 @@ module C08Haystack_Search
       end
   }
   BB15 {
-    assume { Resolve4.resolve needle_1 };
-    assume { Resolve4.resolve haystack_2 };
-    assume { Resolve0.resolve _0 };
     _0 <- i_4;
-    assume { Resolve0.resolve i_4 };
     goto BB19
   }
   BB16 {
     _38 <- ();
-    assume { Resolve1.resolve _38 };
     i_4 <- i_4 + (1 : usize);
     _6 <- ();
-    assume { Resolve1.resolve _6 };
     goto BB1
   }
   BB17 {
-    assume { Resolve4.resolve needle_1 };
-    assume { Resolve0.resolve i_4 };
     _5 <- ();
-    assume { Resolve1.resolve _5 };
     _47 <- haystack_2;
-    assume { Resolve4.resolve haystack_2 };
     _0 <- Len0.len _47;
     goto BB18
   }

--- a/creusot/tests/should_succeed/while_let.stdout
+++ b/creusot/tests/should_succeed/while_let.stdout
@@ -18,15 +18,6 @@ module Type
     | WhileLet_Option_None
     
 end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Logic_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) = 
-    true
-end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
   type t
   use prelude.Prelude
@@ -46,12 +37,6 @@ module CreusotContracts_Logic_Resolve_Resolve_Resolve
   type self
   predicate resolve (self : self)
 end
-module CreusotContracts_Logic_Resolve_Impl2
-  type t
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = t
-  clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = t,
-  predicate resolve = Resolve0.resolve
-end
 module CreusotContracts_Logic_Resolve_Impl1
   type t
   use prelude.Prelude
@@ -68,9 +53,7 @@ module WhileLet_Main
   use Type
   use prelude.Prelude
   use mach.int.Int64
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve2 with type t = ()
-  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = Type.whilelet_option int32
-  clone CreusotContracts_Logic_Resolve_Impl2_Resolve as Resolve0 with type t = Type.whilelet_option int32
+  clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Type.whilelet_option int32
   let rec cfg main [@cfg:stackify] () : () = 
   var _0 : ();
   var a_1 : Type.whilelet_option int32;
@@ -88,7 +71,6 @@ module WhileLet_Main
     a_1 <- Type.WhileLet_Option_Some (10 : int32);
     b_2 <- borrow_mut a_1;
     a_1 <-  ^ b_2;
-    assume { Resolve0.resolve a_1 };
     goto BB1
   }
   BB1 {
@@ -100,14 +82,12 @@ module WhileLet_Main
   }
   BB2 {
     _5 <- Type.WhileLet_Option_None;
-    assume { Resolve0.resolve ( * b_2) };
     b_2 <- { b_2 with current = _5 };
     _3 <- ();
-    assume { Resolve2.resolve _3 };
     goto BB1
   }
   BB3 {
-    assume { Resolve1.resolve b_2 };
+    assume { Resolve0.resolve b_2 };
     _0 <- ();
     return _0
   }


### PR DESCRIPTION
Whenever the resolve statement is just `true` and we cannot further specialize it (aka no generic parameters in it), we can just avoid emitting / cloning the resolve entirely. 

In general, this should result in smaller proof contexts, thought its only removing the most trivial hypotheses.
