### PR TITLE
Basic support for array types

### DIFF
--- a/creusot-contracts/src/logic/model.rs
+++ b/creusot-contracts/src/logic/model.rs
@@ -1,3 +1,4 @@
+use crate as creusot_contracts;
 use creusot_contracts_proc::*;
 
 pub trait Model {
@@ -28,6 +29,17 @@ impl<T> Model for [T] {
     #[logic]
     fn model(self) -> Self::ModelTy {
         id(self)
+    }
+}
+
+impl<T, const N: usize> Model for [T; N] {
+    type ModelTy = crate::Seq<T>;
+
+    #[logic]
+    #[trusted]
+    #[creusot::builtins = "prelude.Prelude.id"]
+    fn model(self) -> Self::ModelTy {
+        pearlite! { absurd }
     }
 }
 

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -19,6 +19,7 @@ pub use function::translate_function;
 pub use function::LocalIdent;
 use heck::CamelCase;
 pub use logic::*;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LOCAL_CRATE;
 use std::error::Error;
 use std::io::Write;
@@ -59,6 +60,10 @@ pub fn after_analysis(ctx: &mut TranslationCtx) -> Result<(), Box<dyn Error>> {
 
         if !crate::util::should_translate(ctx.tcx, def_id) {
             info!("Skipping {:?}", def_id);
+            continue;
+        }
+
+        if ctx.def_kind(def_id) == DefKind::AnonConst {
             continue;
         }
 

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -117,10 +117,15 @@ fn translate_ty_inner<'tcx>(
                 vec![translate_ty_inner(trans, ctx, names, span, *ty)],
             )
         }
-        Array(ty, _) => MlT::TApp(
-            box MlT::TConstructor("rust_array".into()),
-            vec![translate_ty_inner(trans, ctx, names, span, *ty)],
-        ),
+        Array(ty, _) => {
+            names.import_prelude_module(PreludeModule::Prelude);
+            names.import_prelude_module(PreludeModule::Seq);
+
+            MlT::TApp(
+                box MlT::TConstructor("rust_array".into()),
+                vec![translate_ty_inner(trans, ctx, names, span, *ty)],
+            )
+        }
         Str => MlT::TConstructor("string".into()),
         // Slice()
         Never => MlT::Tuple(vec![]),

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -265,6 +265,7 @@ pub fn item_type(tcx: TyCtxt<'_>, def_id: DefId) -> ItemType {
         DefKind::Closure => ItemType::Closure,
         DefKind::Struct | DefKind::Enum => ItemType::Type,
         DefKind::AssocTy => ItemType::AssocTy,
+        DefKind::AnonConst => panic!(),
         dk => ItemType::Unsupported(dk),
     }
 }

--- a/creusot/tests/should_succeed/syntax/11_array_types.rs
+++ b/creusot/tests/should_succeed/syntax/11_array_types.rs
@@ -1,0 +1,12 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+struct UsesArray([i64; 5]);
+
+#[requires((@x.0).len() > 0 && (@x.0).len() < @usize::MAX)]
+fn omg(mut x: UsesArray) {
+    x.0[0] = 5;
+
+    proof_assert! { @(@x.0)[0] == 5};
+}

--- a/creusot/tests/should_succeed/syntax/11_array_types.stdout
+++ b/creusot/tests/should_succeed/syntax/11_array_types.stdout
@@ -1,0 +1,73 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+  type c11arraytypes_usesarray  = 
+    | C11ArrayTypes_UsesArray (rust_array int64)
+    
+  let function c11arraytypes_usesarray_UsesArray_0 (self : c11arraytypes_usesarray) : rust_array int64 = 
+    match (self) with
+      | C11ArrayTypes_UsesArray a -> a
+      | _ -> any rust_array int64
+      end
+end
+module C11ArrayTypes_Omg_Interface
+  use prelude.Prelude
+  use seq.Seq
+  use mach.int.Int
+  use mach.int.Int32
+  use mach.int.UInt64
+  use Type
+  val omg [@cfg:stackify] (x : Type.c11arraytypes_usesarray) : ()
+    requires {Seq.length (Prelude.id (Type.c11arraytypes_usesarray_UsesArray_0 x)) > 0 && Seq.length (Prelude.id (Type.c11arraytypes_usesarray_UsesArray_0 x)) < 18446744073709551615}
+    
+end
+module C11ArrayTypes_Omg
+  use prelude.Prelude
+  use mach.int.Int
+  use mach.int.Int32
+  use seq.Seq
+  use mach.int.Int64
+  use mach.int.UInt64
+  use Type
+  let rec cfg omg [@cfg:stackify] (x : Type.c11arraytypes_usesarray) : ()
+    requires {Seq.length (Prelude.id (Type.c11arraytypes_usesarray_UsesArray_0 x)) > 0 && Seq.length (Prelude.id (Type.c11arraytypes_usesarray_UsesArray_0 x)) < 18446744073709551615}
+    
+   = 
+  var _0 : ();
+  var x_1 : Type.c11arraytypes_usesarray;
+  var _2 : usize;
+  var _3 : usize;
+  var _4 : bool;
+  var _5 : ();
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _2 <- (0 : usize);
+    _3 <- UInt64.of_int (Seq.length (Type.c11arraytypes_usesarray_UsesArray_0 x_1));
+    _4 <- _2 < _3;
+    assert { _4 };
+    goto BB1
+  }
+  BB1 {
+    x_1 <- (let Type.C11ArrayTypes_UsesArray a = x_1 in Type.C11ArrayTypes_UsesArray (Seq.set (Type.c11arraytypes_usesarray_UsesArray_0 x_1) (UInt64.to_int _2) (5 : int64)));
+    assert { Int64.to_int (Seq.get (Prelude.id (Type.c11arraytypes_usesarray_UsesArray_0 x_1)) 0) = 5 };
+    _5 <- ();
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/prelude/prelude.mlw
+++ b/prelude/prelude.mlw
@@ -12,8 +12,8 @@ module Prelude
   type usize = uint64
   type isize = int64
   type opaque_ptr
-
-  type slice 'a
+  use seq.Seq
+  type rust_array 'a = seq 'a
 
   type borrowed 'a = { current : 'a ; final : 'a; }
   let function ( *_ ) x = x.current


### PR DESCRIPTION
This fixes the completely broken support for `[T; N]` types in Creusot and provides the absolute _barebones_ support.

In particular we can:

- Define types with values arrays in them, even generic over their length
- Uses array types as parameters
- Index, get the length of etc... of arrays

However cannot:

- Use the static length of arrays in proofs: we support arrays by effectively 'forgetting' the length entirely (for now)
- We must provide an upper bound on array length to do much.. Since arrays are translated to basic why3 sequences (for now), we must ensure that their length is a valid `usize`.

cc @HLasse