### PR TITLE
Don't suppress resolve statements of closures

### DIFF
--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -640,6 +640,7 @@ fn resolve_predicate_of<'tcx>(
         Some(method) => {
             if !ty.still_further_specializable()
                 && ctx.is_diagnostic_item(Symbol::intern("creusot_resolve_default"), method.0)
+                && !method.1.type_at(0).is_closure()
             {
                 return ResolveStmt { exp: None };
             }

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.rs
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.rs
@@ -1,3 +1,4 @@
+// WHY3PROVE Z3
 extern crate creusot_contracts;
 use creusot_contracts::*;
 

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.stdout
@@ -54,19 +54,19 @@ module C07MutableCapture_TestFnmut_Closure2_Interface
       end
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = uint32
   predicate precondition [@cfg:stackify] (_1' : c07mutablecapture_testfnmut_closure2) (_2' : ()) = 
-    [#"../07_mutable_capture.rs" 6 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') < 1000000
+    [#"../07_mutable_capture.rs" 7 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') < 1000000
   predicate postcondition_mut [@cfg:stackify] (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) (result : int32)
     
    = 
-    ([#"../07_mutable_capture.rs" 7 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1) &&  ^ c07mutablecapture_testfnmut_closure2_0 ( ^ _1') =  ^ c07mutablecapture_testfnmut_closure2_0 ( * _1') && true
+    ([#"../07_mutable_capture.rs" 8 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1) &&  ^ c07mutablecapture_testfnmut_closure2_0 ( ^ _1') =  ^ c07mutablecapture_testfnmut_closure2_0 ( * _1') && true
   predicate postcondition_once [@cfg:stackify] (_1' : c07mutablecapture_testfnmut_closure2) (_2' : ()) (result : int32)
    = 
-    [#"../07_mutable_capture.rs" 7 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') + 1
+    [#"../07_mutable_capture.rs" 8 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 _1') + 1
   predicate resolve (_1' : c07mutablecapture_testfnmut_closure2) = 
     Resolve0.resolve (c07mutablecapture_testfnmut_closure2_0 _1') && true
   val c07MutableCapture_TestFnmut_Closure2 [@cfg:stackify] (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) : int32
-    requires {[#"../07_mutable_capture.rs" 6 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
-    ensures { [#"../07_mutable_capture.rs" 7 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
+    requires {[#"../07_mutable_capture.rs" 7 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
+    ensures { [#"../07_mutable_capture.rs" 8 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
     ensures {  ^ c07mutablecapture_testfnmut_closure2_0 ( ^ _1') =  ^ c07mutablecapture_testfnmut_closure2_0 ( * _1') && true }
     
 end
@@ -83,9 +83,9 @@ module C07MutableCapture_TestFnmut_Closure2
       end
   use mach.int.Int32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = c07mutablecapture_testfnmut_closure2
-  let rec cfg c07MutableCapture_TestFnmut_Closure2 [@cfg:stackify] [#"../07_mutable_capture.rs" 8 4 5] (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) : int32
-    requires {[#"../07_mutable_capture.rs" 6 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
-    ensures { [#"../07_mutable_capture.rs" 7 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
+  let rec cfg c07MutableCapture_TestFnmut_Closure2 [@cfg:stackify] [#"../07_mutable_capture.rs" 9 4 5] (_1' : borrowed c07mutablecapture_testfnmut_closure2) (_2' : ()) : int32
+    requires {[#"../07_mutable_capture.rs" 7 17 44] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) < 1000000}
+    ensures { [#"../07_mutable_capture.rs" 8 4 35] UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( ^ _1')) = UInt32.to_int ( * c07mutablecapture_testfnmut_closure2_0 ( * _1')) + 1 }
     
    = 
   var _0 : int32;
@@ -95,12 +95,21 @@ module C07MutableCapture_TestFnmut_Closure2
     goto BB0
   }
   BB0 {
-    _1 <- { _1 with current = (let C07MutableCapture_TestFnmut_Closure2 a =  * _1 in C07MutableCapture_TestFnmut_Closure2 ({ (c07mutablecapture_testfnmut_closure2_0 ( * _1)) with current = ([#"../07_mutable_capture.rs" 9 8 14]  * c07mutablecapture_testfnmut_closure2_0 ( * _1) + (1 : uint32)) })) };
+    _1 <- { _1 with current = (let C07MutableCapture_TestFnmut_Closure2 a =  * _1 in C07MutableCapture_TestFnmut_Closure2 ({ (c07mutablecapture_testfnmut_closure2_0 ( * _1)) with current = ([#"../07_mutable_capture.rs" 10 8 14]  * c07mutablecapture_testfnmut_closure2_0 ( * _1) + (1 : uint32)) })) };
     assume { Resolve0.resolve _1 };
     _0 <- (5 : int32);
     return _0
   }
   
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Logic_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) = 
+    true
 end
 module CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface
   type self
@@ -164,7 +173,7 @@ module C07MutableCapture_TestFnmut_Interface
   use mach.int.Int
   use mach.int.Int32
   val test_fnmut [@cfg:stackify] (x : uint32) : ()
-    requires {[#"../07_mutable_capture.rs" 4 0 26] UInt32.to_int x = 100000}
+    requires {[#"../07_mutable_capture.rs" 5 0 26] UInt32.to_int x = 100000}
     
 end
 module C07MutableCapture_TestFnmut
@@ -175,8 +184,8 @@ module C07MutableCapture_TestFnmut
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = uint32
   clone C07MutableCapture_TestFnmut_Closure2_Interface as Closure20 with predicate Resolve0.resolve = Resolve0.resolve,
   axiom .
-  let rec cfg test_fnmut [@cfg:stackify] [#"../07_mutable_capture.rs" 5 0 25] (x : uint32) : ()
-    requires {[#"../07_mutable_capture.rs" 4 0 26] UInt32.to_int x = 100000}
+  let rec cfg test_fnmut [@cfg:stackify] [#"../07_mutable_capture.rs" 6 0 25] (x : uint32) : ()
+    requires {[#"../07_mutable_capture.rs" 5 0 26] UInt32.to_int x = 100000}
     
    = 
   var _0 : ();
@@ -199,22 +208,24 @@ module C07MutableCapture_TestFnmut
     _4 <- borrow_mut x_1;
     x_1 <-  ^ _4;
     closure_3 <- Closure20.C07MutableCapture_TestFnmut_Closure2 _4;
+    assume { Closure20.resolve c_2 };
     c_2 <- closure_3;
     _6 <- borrow_mut c_2;
     c_2 <-  ^ _6;
     _7 <- ();
-    _5 <- ([#"../07_mutable_capture.rs" 12 4 7] Closure20.c07MutableCapture_TestFnmut_Closure2 _6 _7);
+    _5 <- ([#"../07_mutable_capture.rs" 13 4 7] Closure20.c07MutableCapture_TestFnmut_Closure2 _6 _7);
     goto BB1
   }
   BB1 {
     _9 <- borrow_mut c_2;
     c_2 <-  ^ _9;
+    assume { Closure20.resolve c_2 };
     _10 <- ();
-    _8 <- ([#"../07_mutable_capture.rs" 13 4 7] Closure20.c07MutableCapture_TestFnmut_Closure2 _9 _10);
+    _8 <- ([#"../07_mutable_capture.rs" 14 4 7] Closure20.c07MutableCapture_TestFnmut_Closure2 _9 _10);
     goto BB2
   }
   BB2 {
-    assert { [#"../07_mutable_capture.rs" 15 4 34] UInt32.to_int x_1 = 100002 };
+    assert { [#"../07_mutable_capture.rs" 16 4 34] UInt32.to_int x_1 = 100002 };
     _11 <- ();
     _0 <- ();
     return _0


### PR DESCRIPTION
Clsoures secretely overload the default implementation of `Resolve` with their actual resolution predicate, so we need to preserve those statements even if they might seem 'trivial'. 

The reason that we need to do this hack to handle closures is that `rustc` prohibits us from giving an actual instance to closures: we cannot inject instances into rustc's process nor can we generate syntax to include such an instance.

cc @jhjourdan
