### PR TITLE
Fix #127

### DIFF
--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -600,7 +600,8 @@ fn cloneable_name(tcx: TyCtxt, def_id: DefId, interface: bool) -> QName {
     // TODO: Refactor.
     match util::item_type(tcx, def_id) {
         Logic | Predicate | Impl => {
-            if interface {
+            let is_opaque = util::is_opaque(tcx, def_id);
+            if interface || is_opaque {
                 // TODO: this should directly be a function...
                 QName { module: Vec::new(), name: interface::interface_name(tcx, def_id) }
             } else {

--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -73,6 +73,10 @@ pub(crate) fn is_trusted(tcx: TyCtxt, def_id: DefId) -> bool {
     get_attr(tcx.get_attrs_unchecked(def_id), &["creusot", "decl", "trusted"]).is_some()
 }
 
+pub(crate) fn is_opaque(tcx: TyCtxt, def_id: DefId) -> bool {
+    get_attr(tcx.get_attrs_unchecked(def_id), &["creusot", "decl", "opaque"]).is_some()
+}
+
 pub(crate) fn is_law(tcx: TyCtxt, def_id: DefId) -> bool {
     get_attr(tcx.get_attrs_unchecked(def_id), &["creusot", "decl", "law"]).is_some()
 }

--- a/creusot/tests/should_succeed/opaque.rs
+++ b/creusot/tests/should_succeed/opaque.rs
@@ -1,0 +1,16 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[logic]
+#[creusot::decl::opaque]
+#[ensures(result == 2)]
+fn two() -> Int {
+    pearlite! {
+     1 + 1 - 1 + 1 - 1 + 1 - 1 + 1
+    }
+}
+
+#[ensures(@result == two())]
+fn x() -> u64 {
+    2
+}

--- a/creusot/tests/should_succeed/opaque.stdout
+++ b/creusot/tests/should_succeed/opaque.stdout
@@ -1,0 +1,63 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use prelude.Prelude
+end
+module Opaque_Two_Interface
+  use mach.int.Int
+  use mach.int.Int32
+  function two (_ : ()) : int
+end
+module Opaque_Two
+  use mach.int.Int
+  use mach.int.Int32
+  function two [#"../opaque.rs" 7 0 15] (_ : ()) : int = 
+    [#"../opaque.rs" 7 0 15] 1 + 1 - 1 + 1 - 1 + 1 - 1 + 1
+  axiom two_spec : [#"../opaque.rs" 6 0 23] two () = 2
+end
+module Opaque_Two_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  let rec ghost function two (_ : ()) : int
+    ensures { [#"../opaque.rs" 6 0 23] result = 2 }
+    
+   = 
+    [#"../opaque.rs" 7 0 15] 1 + 1 - 1 + 1 - 1 + 1 - 1 + 1
+end
+module Opaque_X_Interface
+  use mach.int.UInt64
+  use mach.int.Int
+  clone Opaque_Two_Interface as Two0 with axiom .
+  val x [@cfg:stackify] (_ : ()) : uint64
+    ensures { [#"../opaque.rs" 13 0 28] UInt64.to_int result = Two0.two () }
+    
+end
+module Opaque_X
+  use mach.int.UInt64
+  use mach.int.Int
+  clone Opaque_Two_Interface as Two0 with axiom .
+  let rec cfg x [@cfg:stackify] [#"../opaque.rs" 14 0 13] (_ : ()) : uint64
+    ensures { [#"../opaque.rs" 13 0 28] UInt64.to_int result = Two0.two () }
+    
+   = 
+  var _0 : uint64;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- (2 : uint64);
+    return _0
+  }
+  
+end


### PR DESCRIPTION
Adds a `#[creusot::decl::opaque]` annotation which prevents using the body of a definition in dependencies. 


