### PR TITLE
Emit error when both builtin and contract are used

### DIFF
--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -388,7 +388,7 @@ pub fn load_extern_specs(ctx: &mut TranslationCtx) -> CreusotResult<()> {
 
     // Force extern spec items to get loaded so we export them properly
     let need_to_load: Vec<_> =
-        ctx.extern_specs.values().flat_map(|e| e.contract.iter_items()).collect();
+        ctx.extern_specs.values().flat_map(|e| e.contract.iter_ids()).collect();
 
     for id in need_to_load {
         ctx.term(id);

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -127,14 +127,13 @@ impl<'tcx, 'sess> TranslationCtx<'sess, 'tcx> {
             return;
         }
 
-        let span = self.tcx.hir().span_if_local(def_id).unwrap_or(rustc_span::DUMMY_SP);
         let (interface, deps) = interface_for(self, def_id);
 
         let translated = if util::is_logic(self.tcx, def_id) || util::is_predicate(self.tcx, def_id)
         {
             debug!("translating {:?} as logical", def_id);
             let (modl, proof_modl, has_axioms, deps) =
-                crate::translation::translate_logic_or_predicate(self, def_id, span);
+                crate::translation::translate_logic_or_predicate(self, def_id);
             TranslatedItem::Logic {
                 interface,
                 modl,

--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -245,7 +245,7 @@ fn load_binary_metadata<'tcx>(
     path: &Path,
 ) -> Option<BinaryMetadata<'tcx>> {
     let metadata = MetadataBlob::from_file(&path).and_then(|blob| {
-        let mut decoder = MetadataDecoder::new(tcx, cnum, &blob);
+        let mut decoder = MetadataDecoder::new(tcx, &blob);
         Ok(BinaryMetadata::decode(&mut decoder))
     });
 

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -59,11 +59,10 @@ pub fn extern_module<'tcx>(
 ) {
     match ctx.externs.term(def_id) {
         Some(_) => {
-            let span = ctx.tcx.def_span(def_id);
             match item_type(ctx.tcx, def_id) {
                 // the dependencies should be what was already stored in the metadata...
                 ItemType::Logic | ItemType::Predicate => {
-                    (translate_logic_or_predicate(ctx, def_id, span).0, Err(def_id))
+                    (translate_logic_or_predicate(ctx, def_id).0, Err(def_id))
                 }
                 _ => unreachable!("extern_module: unexpected term for {:?}", def_id),
             }

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use crate::function::all_generic_decls_for;
 use crate::translation::specification;
+use crate::util::get_builtin;
 use crate::{ctx::*, util};
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
@@ -20,6 +21,14 @@ pub fn translate_logic_or_predicate<'tcx>(
     let mut sig = crate::util::signature_of(ctx, &mut names, def_id);
     if util::is_predicate(ctx.tcx, def_id) {
         sig.retty = None;
+    }
+
+    // Check that we don't have both `builtins` and a contract at the same time (which are contradictory)
+    if !sig.contract.is_empty() && get_builtin(ctx.tcx, def_id).is_some() {
+        ctx.crash_and_error(
+            ctx.def_span(def_id),
+            "cannot specify both `creusot::builtins` and a contract on the same definition",
+        );
     }
 
     def_id

--- a/creusot/src/translation/logic.rs
+++ b/creusot/src/translation/logic.rs
@@ -13,7 +13,6 @@ use why3::Ident;
 pub fn translate_logic_or_predicate<'tcx>(
     ctx: &mut TranslationCtx<'_, 'tcx>,
     def_id: DefId,
-    _span: rustc_span::Span,
 ) -> (Module, Option<Module>, bool, CloneMap<'tcx>) {
     let mut names = CloneMap::new(ctx.tcx, def_id, false);
     names.clone_self(def_id);

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -35,14 +35,6 @@ impl PreContract {
         Self { func_id, variant: None, requires: Vec::new(), ensures: Vec::new() }
     }
 
-    pub fn iter_items(&self) -> impl Iterator<Item = DefId> + '_ {
-        self.variant
-            .iter()
-            .cloned()
-            .chain(self.requires.iter().cloned())
-            .chain(self.ensures.iter().cloned())
-    }
-
     pub fn check_and_lower<'tcx>(
         self,
         ctx: &mut TranslationCtx<'_, 'tcx>,

--- a/creusot/tests/should_fail/builtin_with_contract.rs
+++ b/creusot/tests/should_fail/builtin_with_contract.rs
@@ -1,0 +1,7 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[logic]
+#[ensures(true && false)]
+#[creusot::builtins = "dummy_function"]
+fn builtin_with_contract() {}


### PR DESCRIPTION
Emits an error which covers the case described in #367.


