### PR TITLE
Remove contracts from logical interfaces

### DIFF
--- a/creusot/src/translation/interface.rs
+++ b/creusot/src/translation/interface.rs
@@ -52,23 +52,13 @@ pub fn interface_for<'tcx>(
 
     match util::item_type(ctx.tcx, def_id) {
         ItemType::Predicate => {
-            let sig_ = sig.clone();
             sig.retty = None;
             sig.contract = Contract::new();
             decls.push(Decl::ValDecl(ValKind::Predicate { sig }));
-            let has_axioms = !sig_.contract.is_empty();
-            if has_axioms {
-                decls.push(Decl::Axiom(spec_axiom(&sig_)));
-            }
         }
         ItemType::Logic => {
-            let sig_ = sig.clone();
             sig.contract = Contract::new();
             decls.push(Decl::ValDecl(ValKind::Function { sig }));
-            let has_axioms = !sig_.contract.is_empty();
-            if has_axioms {
-                decls.push(Decl::Axiom(spec_axiom(&sig_)));
-            }
         }
         _ => {
             if !def_id.is_local()

--- a/creusot/tests/should_succeed/100doors.stdout
+++ b/creusot/tests/should_succeed/100doors.stdout
@@ -44,7 +44,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/binary_search.stdout
+++ b/creusot/tests/should_succeed/binary_search.stdout
@@ -57,7 +57,6 @@ module BinarySearch_Impl0_LenLogic_Interface
   use mach.int.Int32
   use Type
   function len_logic (self : Type.binarysearch_list t) : int
-  axiom len_logic_spec : forall self : Type.binarysearch_list t . [#"../binary_search.rs" 21 4 27] len_logic self >= 0
 end
 module BinarySearch_Impl0_LenLogic
   type t

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.stdout
@@ -40,7 +40,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/bug/206.stdout
+++ b/creusot/tests/should_succeed/bug/206.stdout
@@ -47,7 +47,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -100,7 +99,6 @@ module C206_U2_Interface
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = usize, type a = Type.alloc_alloc_global,
   axiom .
   function u2 (a : Type.c206_a) : ()
-  axiom u2_spec : forall a : Type.c206_a . [#"../206.rs" 8 0 24] Model0.model (Type.c206_a_A_0 a) = Model0.model (Type.c206_a_A_0 a)
 end
 module C206_U2
   use Type

--- a/creusot/tests/should_succeed/bug/222.stdout
+++ b/creusot/tests/should_succeed/bug/222.stdout
@@ -32,7 +32,6 @@ module C222_A_IsTrue_Interface
   use mach.int.Int32
   clone C222_A_Mktrue_Interface as Mktrue0 with type self = self
   function is_true (_ : ()) : ()
-  axiom is_true_spec : [#"../222.rs" 12 4 36] Mktrue0.mktrue () <= 10
 end
 module C222_A_IsTrue
   type self

--- a/creusot/tests/should_succeed/bug/two_phase.stdout
+++ b/creusot/tests/should_succeed/bug/two_phase.stdout
@@ -40,7 +40,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/cell/02.stdout
+++ b/creusot/tests/should_succeed/cell/02.stdout
@@ -142,7 +142,6 @@ module C02_LemmaFibBound_Interface
   use int.Power
   clone C02_Fib_Interface as Fib0 with axiom .
   function lemma_fib_bound (i : int) : ()
-  axiom lemma_fib_bound_spec : forall i : int . ([#"../02.rs" 49 0 19] 0 <= i) -> ([#"../02.rs" 50 0 30] Fib0.fib i <= Power.power 2 i)
 end
 module C02_LemmaFibBound
   use mach.int.Int
@@ -181,7 +180,6 @@ module C02_LemmaMaxInt_Interface
   use prelude.Prelude
   use mach.int.UInt64
   function lemma_max_int (_ : ()) : ()
-  axiom lemma_max_int_spec : [#"../02.rs" 65 0 51] Power.power 2 63 < 18446744073709551615
 end
 module C02_LemmaMaxInt
   use mach.int.Int
@@ -220,7 +218,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.stdout
@@ -159,7 +159,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.Int
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/closures/06_fn_specs.stdout
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.stdout
@@ -88,7 +88,6 @@ module CreusotContracts_Std1_Fun_FnSpec_FnMut_Interface
   type args = args, type Output0.output = Output0.output
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = self
   function fn_mut (self : self) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : self, args : args, res : Output0.output . (Postcondition0.postcondition self args res -> (exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res)) && ((exists s : (borrowed self) .  * s = self && Resolve0.resolve ( * s) && PostconditionMut0.postcondition_mut s args res) -> Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Fun_FnSpec_FnMut
   type self
@@ -140,7 +139,6 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
   function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
   type self

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.stdout
@@ -228,7 +228,6 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce_Interface
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
   function fn_mut_once (self : self) (a : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : self, a : args, res : Output0.output . ((exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)) -> PostconditionOnce0.postcondition_once self a res) && (PostconditionOnce0.postcondition_once self a res -> (exists s : (borrowed self) .  * s = self && PostconditionMut0.postcondition_mut s a res && Resolve0.resolve ( ^ s)))
 end
 module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
   type self

--- a/creusot/tests/should_succeed/eq_extern.stdout
+++ b/creusot/tests/should_succeed/eq_extern.stdout
@@ -165,7 +165,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -192,7 +191,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -219,7 +217,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -246,7 +243,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -261,7 +257,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -275,7 +270,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -289,7 +283,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -303,7 +296,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -317,7 +309,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self

--- a/creusot/tests/should_succeed/filter_positive.stdout
+++ b/creusot/tests/should_succeed/filter_positive.stdout
@@ -44,7 +44,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -95,7 +94,6 @@ module FilterPositive_LemmaNumOfPosStrictlyIncreasing_Interface
   use mach.int.Int
   clone FilterPositive_NumOfPos_Interface as NumOfPos0 with axiom .
   function lemma_num_of_pos_strictly_increasing (i : int) (t : Seq.seq int32) : ()
-  axiom lemma_num_of_pos_strictly_increasing_spec : forall i : int, t : Seq.seq int32 . ([#"../filter_positive.rs" 74 0 22] Int32.to_int (Seq.get t i) > 0) -> ([#"../filter_positive.rs" 73 0 34] 0 <= i && i < Seq.length t) -> ([#"../filter_positive.rs" 75 0 51] NumOfPos0.num_of_pos 0 i t < NumOfPos0.num_of_pos 0 (i + 1) t)
 end
 module FilterPositive_LemmaNumOfPosStrictlyIncreasing
   use seq.Seq
@@ -125,7 +123,6 @@ module FilterPositive_LemmaNumOfPosIncreasing_Interface
   use mach.int.Int32
   clone FilterPositive_NumOfPos_Interface as NumOfPos0 with axiom .
   function lemma_num_of_pos_increasing (i : int) (j : int) (k : int) (t : Seq.seq int32) : ()
-  axiom lemma_num_of_pos_increasing_spec : forall i : int, j : int, k : int, t : Seq.seq int32 . ([#"../filter_positive.rs" 59 0 19] j <= k) -> ([#"../filter_positive.rs" 60 0 50] NumOfPos0.num_of_pos i j t <= NumOfPos0.num_of_pos i k t)
 end
 module FilterPositive_LemmaNumOfPosIncreasing
   use mach.int.Int

--- a/creusot/tests/should_succeed/hashmap.stdout
+++ b/creusot/tests/should_succeed/hashmap.stdout
@@ -66,7 +66,6 @@ module Hashmap_Hash_HashLog_Interface
   use mach.int.Int
   use mach.int.Int32
   function hash_log (self : self) : int
-  axiom hash_log_spec : forall self : self . [#"../hashmap.rs" 49 4 27] hash_log self >= 0
 end
 module Hashmap_Hash_HashLog
   type self
@@ -116,7 +115,6 @@ module Hashmap_Hash_HashLogEqModel_Interface
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = self,
   type ModelTy0.modelTy = ModelTy0.modelTy
   function hash_log_eq_model (x : self) (y : self) : ()
-  axiom hash_log_eq_model_spec : forall x : self, y : self . ([#"../hashmap.rs" 53 4 25] Model0.model x = Model0.model y) -> ([#"../hashmap.rs" 54 4 44] HashLog0.hash_log x = HashLog0.hash_log y)
 end
 module Hashmap_Hash_HashLogEqModel
   type self
@@ -136,7 +134,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -222,7 +219,6 @@ module Hashmap_Impl3_Model_Interface
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = k,
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : Type.hashmap_myhashmap k v) : Map.map ModelTy0.modelTy (Type.core_option_option v)
-  axiom model_spec : forall self : Type.hashmap_myhashmap k v . [#"../hashmap.rs" 84 4 70] forall k : (k) . Map.get (model self) (Model0.model k) = Get0.get (Bucket0.bucket self k) (Model0.model k)
 end
 module Hashmap_Impl3_Model
   type k
@@ -1834,7 +1830,6 @@ module Hashmap_Impl2_HashLogEqModel_Interface
   use prelude.Prelude
   clone Hashmap_Impl2_HashLog_Interface as HashLog0
   function hash_log_eq_model (x : usize) (y : usize) : ()
-  axiom hash_log_eq_model_spec : forall x : usize, y : usize . ([#"../hashmap.rs" 70 4 25] UInt64.to_int x = UInt64.to_int y) -> ([#"../hashmap.rs" 71 4 44] HashLog0.hash_log x = HashLog0.hash_log y)
 end
 module Hashmap_Impl2_HashLogEqModel
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/heapsort_generic.stdout
+++ b/creusot/tests/should_succeed/heapsort_generic.stdout
@@ -95,7 +95,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -122,7 +121,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -149,7 +147,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -176,7 +173,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -191,7 +187,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -205,7 +200,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -219,7 +213,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -233,7 +226,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -247,7 +239,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -264,7 +255,6 @@ module HeapsortGeneric_HeapFragMax_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   clone HeapsortGeneric_HeapFrag_Interface as HeapFrag0 with type t = t
   function heap_frag_max (s : Seq.seq t) (i : int) (end' : int) : ()
-  axiom heap_frag_max_spec : forall s : Seq.seq t, i : int, end' : int . ([#"../heapsort_generic.rs" 22 0 30] 0 <= i && i < end') -> ([#"../heapsort_generic.rs" 21 0 33] HeapFrag0.heap_frag s 0 end') -> ([#"../heapsort_generic.rs" 23 0 24] LeLog0.le_log (Seq.get s i) (Seq.get s 0))
 end
 module HeapsortGeneric_HeapFragMax
   type t
@@ -335,7 +325,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/inc_some_2_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_list.stdout
@@ -51,7 +51,6 @@ module IncSome2List_Impl1_LemmaSumNonneg_Interface
   use Type
   clone IncSome2List_Impl1_Sum_Interface as Sum0
   function lemma_sum_nonneg (self : Type.incsome2list_list) : ()
-  axiom lemma_sum_nonneg_spec : forall self : Type.incsome2list_list . [#"../inc_some_2_list.rs" 23 4 31] Sum0.sum self >= 0
 end
 module IncSome2List_Impl1_LemmaSumNonneg
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_2_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_2_tree.stdout
@@ -56,7 +56,6 @@ module IncSome2Tree_Impl1_LemmaSumNonneg_Interface
   use Type
   clone IncSome2Tree_Impl1_Sum_Interface as Sum0
   function lemma_sum_nonneg (self : Type.incsome2tree_tree) : ()
-  axiom lemma_sum_nonneg_spec : forall self : Type.incsome2tree_tree . [#"../inc_some_2_tree.rs" 23 4 31] Sum0.sum self >= 0
 end
 module IncSome2Tree_Impl1_LemmaSumNonneg
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_list.stdout
+++ b/creusot/tests/should_succeed/inc_some_list.stdout
@@ -57,7 +57,6 @@ module IncSomeList_Impl1_LemmaSumNonneg_Interface
   use Type
   clone IncSomeList_Impl1_Sum_Interface as Sum0
   function lemma_sum_nonneg (self : Type.incsomelist_list) : ()
-  axiom lemma_sum_nonneg_spec : forall self : Type.incsomelist_list . [#"../inc_some_list.rs" 28 4 31] Sum0.sum self >= 0
 end
 module IncSomeList_Impl1_LemmaSumNonneg
   use mach.int.Int

--- a/creusot/tests/should_succeed/inc_some_tree.stdout
+++ b/creusot/tests/should_succeed/inc_some_tree.stdout
@@ -56,7 +56,6 @@ module IncSomeTree_Impl1_LemmaSumNonneg_Interface
   use Type
   clone IncSomeTree_Impl1_Sum_Interface as Sum0
   function lemma_sum_nonneg (self : Type.incsometree_tree) : ()
-  axiom lemma_sum_nonneg_spec : forall self : Type.incsometree_tree . [#"../inc_some_tree.rs" 23 4 31] Sum0.sum self >= 0
 end
 module IncSomeTree_Impl1_LemmaSumNonneg
   use mach.int.Int

--- a/creusot/tests/should_succeed/invariant_moves.stdout
+++ b/creusot/tests/should_succeed/invariant_moves.stdout
@@ -78,7 +78,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/knapsack.stdout
+++ b/creusot/tests/should_succeed/knapsack.stdout
@@ -115,7 +115,6 @@ module Knapsack_M_Interface
   use seq.Seq
   use Type
   function m (items : Seq.seq (Type.knapsack_item name)) (i : int) (w : int) : int
-  axiom m_spec : forall items : Seq.seq (Type.knapsack_item name), i : int, w : int . ([#"../knapsack.rs" 39 0 19] 0 <= w) -> ([#"../knapsack.rs" 38 0 39] 0 <= i && i <= Seq.length items) -> ([#"../knapsack.rs" 40 0 23] m items i w >= 0)
 end
 module Knapsack_M
   type name
@@ -207,7 +206,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/knapsack_full.stdout
+++ b/creusot/tests/should_succeed/knapsack_full.stdout
@@ -114,7 +114,6 @@ module KnapsackFull_SumWeights_Interface
   use prelude.Prelude
   use Type
   function sum_weights (s : Seq.seq (Type.knapsackfull_item name)) (i : int) : int
-  axiom sum_weights_spec : forall s : Seq.seq (Type.knapsackfull_item name), i : int . ([#"../knapsack_full.rs" 30 0 35] 0 <= i && i <= Seq.length s) -> ([#"../knapsack_full.rs" 31 0 23] sum_weights s i >= 0)
 end
 module KnapsackFull_SumWeights
   type name
@@ -160,7 +159,6 @@ module KnapsackFull_SumValues_Interface
   use prelude.Prelude
   use Type
   function sum_values (s : Seq.seq (Type.knapsackfull_item name)) (i : int) : int
-  axiom sum_values_spec : forall s : Seq.seq (Type.knapsackfull_item name), i : int . ([#"../knapsack_full.rs" 41 0 35] i >= 0 && i <= Seq.length s) -> true
 end
 module KnapsackFull_SumValues
   type name
@@ -204,7 +202,6 @@ module KnapsackFull_SubseqRev_Interface
   use seq.Seq
   use prelude.Prelude
   predicate subseq_rev (s1 : Seq.seq t) (i1 : int) (s2 : Seq.seq t) (i2 : int)
-  axiom subseq_rev_spec : forall s1 : Seq.seq t, i1 : int, s2 : Seq.seq t, i2 : int . ([#"../knapsack_full.rs" 52 0 38] 0 <= i2 && i2 <= Seq.length s2) -> ([#"../knapsack_full.rs" 51 0 38] 0 <= i1 && i1 <= Seq.length s1) -> true
 end
 module KnapsackFull_SubseqRev
   type t
@@ -249,7 +246,6 @@ module KnapsackFull_M_Interface
   clone KnapsackFull_SumWeights_Interface as SumWeights0 with type name = name, axiom .
   clone KnapsackFull_SubseqRev_Interface as SubseqRev0 with type t = Type.knapsackfull_item name, axiom .
   function m (items : Seq.seq (Type.knapsackfull_item name)) (i : int) (w : int) : int
-  axiom m_spec : forall items : Seq.seq (Type.knapsackfull_item name), i : int, w : int . ([#"../knapsack_full.rs" 66 0 19] 0 <= w) -> ([#"../knapsack_full.rs" 65 0 39] 0 <= i && i <= Seq.length items) -> ([#"../knapsack_full.rs" 67 0 23] m items i w >= 0) && ([#"../knapsack_full.rs" 68 0 2] forall j : (int) . forall s : (Seq.seq (Type.knapsackfull_item name)) . 0 <= j && j <= Seq.length s && SubseqRev0.subseq_rev s j items i && SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= m items i w)
 end
 module KnapsackFull_M
   type name
@@ -343,7 +339,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/mapping_test.stdout
+++ b/creusot/tests/should_succeed/mapping_test.stdout
@@ -30,11 +30,6 @@ module MappingTest_Impl0_Model_Interface
   use mach.int.Int32
   use Type
   function model (self : Type.mappingtest_t) : Map.map int int
-  axiom model_spec : forall self : Type.mappingtest_t . [#"../mapping_test.rs" 15 4 76] forall i : (int) . Map.get (model self) i = (if 0 <= i && i < Int32.to_int (Type.mappingtest_t_T_a self) then
-    1
-  else
-    0
-  )
 end
 module MappingTest_Impl0_Model
   use mach.int.Int

--- a/creusot/tests/should_succeed/ord_trait.stdout
+++ b/creusot/tests/should_succeed/ord_trait.stdout
@@ -169,7 +169,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -185,7 +184,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -201,7 +199,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -217,7 +214,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -232,7 +228,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -246,7 +241,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -260,7 +254,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -274,7 +267,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -288,7 +280,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self

--- a/creusot/tests/should_succeed/red_black_tree.stdout
+++ b/creusot/tests/should_succeed/red_black_tree.stdout
@@ -335,7 +335,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -351,7 +350,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -378,7 +376,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -405,7 +402,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -420,7 +416,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -434,7 +429,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -448,7 +442,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -462,7 +455,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -476,7 +468,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -2152,7 +2143,6 @@ module RedBlackTree_Impl4_ModelAccHasBinding_Interface
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model_acc_has_binding (self : Type.redblacktree_tree k v) (accu : Map.map ModelTy0.modelTy (Type.core_option_option v)) (k : ModelTy0.modelTy) : ()
     
-  axiom model_acc_has_binding_spec : forall self : Type.redblacktree_tree k v, accu : Map.map ModelTy0.modelTy (Type.core_option_option v), k : ModelTy0.modelTy . [#"../red_black_tree.rs" 447 4 93] Map.get (ModelAcc0.model_acc self accu) k = Map.get accu k || (exists v : (v) . Map.get (ModelAcc0.model_acc self accu) k = Type.Core_Option_Option_Some v && HasMapping0.has_mapping self k v)
 end
 module RedBlackTree_Impl4_ModelAccHasBinding
   type k
@@ -2208,7 +2198,6 @@ module RedBlackTree_Impl4_HasBindingModelAcc_Interface
   clone RedBlackTree_Impl1_OrdInvariant_Interface as OrdInvariant0 with type k = k, type v = v
   function has_binding_model_acc (self : Type.redblacktree_tree k v) (accu : Map.map ModelTy0.modelTy (Type.core_option_option v)) (k : ModelTy0.modelTy) : ()
     
-  axiom has_binding_model_acc_spec : forall self : Type.redblacktree_tree k v, accu : Map.map ModelTy0.modelTy (Type.core_option_option v), k : ModelTy0.modelTy . ([#"../red_black_tree.rs" 464 4 37] OrdInvariant0.ord_invariant self) -> ([#"../red_black_tree.rs" 465 4 94] forall v : (v) . HasMapping0.has_mapping self k v -> Map.get (ModelAcc0.model_acc self accu) k = Type.Core_Option_Option_Some v)
 end
 module RedBlackTree_Impl4_HasBindingModelAcc
   type k
@@ -2303,7 +2292,6 @@ module RedBlackTree_Impl4_HasBindingModel_Interface
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone RedBlackTree_Impl1_OrdInvariant_Interface as OrdInvariant0 with type k = k, type v = v
   function has_binding_model (self : Type.redblacktree_tree k v) (k : ModelTy0.modelTy) (v : v) : ()
-  axiom has_binding_model_spec : forall self : Type.redblacktree_tree k v, k : ModelTy0.modelTy, v : v . ([#"../red_black_tree.rs" 485 4 37] OrdInvariant0.ord_invariant self) -> ([#"../red_black_tree.rs" 486 4 69] HasMapping0.has_mapping self k v = (Map.get (Model0.model self) k = Type.Core_Option_Option_Some v))
 end
 module RedBlackTree_Impl4_HasBindingModel
   type k

--- a/creusot/tests/should_succeed/selection_sort_generic.stdout
+++ b/creusot/tests/should_succeed/selection_sort_generic.stdout
@@ -116,7 +116,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -240,7 +239,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -267,7 +265,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -294,7 +291,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -321,7 +317,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -336,7 +331,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -350,7 +344,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -364,7 +357,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -378,7 +370,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -392,7 +383,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self

--- a/creusot/tests/should_succeed/sparse_array.stdout
+++ b/creusot/tests/should_succeed/sparse_array.stdout
@@ -142,7 +142,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -185,11 +184,6 @@ module SparseArray_Impl0_Model_Interface
   axiom .
   clone SparseArray_Impl1_IsElt_Interface as IsElt0 with type t = t
   function model (self : Type.sparsearray_sparse t) : Seq.seq (Type.core_option_option t)
-  axiom model_spec : forall self : Type.sparsearray_sparse t . ([#"../sparse_array.rs" 34 4 44] Seq.length (model self) = UInt64.to_int (Type.sparsearray_sparse_Sparse_size self)) && ([#"../sparse_array.rs" 35 4 6] forall i : (int) . Seq.get (model self) i = (if IsElt0.is_elt self i then
-    Type.Core_Option_Option_Some (Seq.get (Model0.model (Type.sparsearray_sparse_Sparse_values self)) i)
-  else
-    Type.Core_Option_Option_None
-  ))
 end
 module SparseArray_Impl0_Model
   type t
@@ -1079,7 +1073,6 @@ module SparseArray_Impl1_LemmaPermutation_Interface
   clone SparseArray_Impl1_IsElt_Interface as IsElt0 with type t = t
   clone SparseArray_Impl1_SparseInv_Interface as SparseInv0 with type t = t
   function lemma_permutation (self : Type.sparsearray_sparse t) (i : int) : ()
-  axiom lemma_permutation_spec : forall self : Type.sparsearray_sparse t, i : int . ([#"../sparse_array.rs" 103 4 43] 0 <= i && i < UInt64.to_int (Type.sparsearray_sparse_Sparse_size self)) -> ([#"../sparse_array.rs" 102 4 36] Type.sparsearray_sparse_Sparse_n self = Type.sparsearray_sparse_Sparse_size self) -> ([#"../sparse_array.rs" 101 4 34] SparseInv0.sparse_inv self) -> ([#"../sparse_array.rs" 104 4 30] IsElt0.is_elt self i)
 end
 module SparseArray_Impl1_LemmaPermutation
   type t

--- a/creusot/tests/should_succeed/sum_of_odds.stdout
+++ b/creusot/tests/should_succeed/sum_of_odds.stdout
@@ -63,7 +63,6 @@ module SumOfOdds_SumOfOddIsSqr_Interface
   clone SumOfOdds_Sqr_Interface as Sqr0
   clone SumOfOdds_SumOfOdd_Interface as SumOfOdd0 with axiom .
   function sum_of_odd_is_sqr (x : int) : ()
-  axiom sum_of_odd_is_sqr_spec : forall x : int . ([#"../sum_of_odds.rs" 27 0 19] x >= 0) -> ([#"../sum_of_odds.rs" 28 0 35] SumOfOdd0.sum_of_odd x = Sqr0.sqr x)
 end
 module SumOfOdds_SumOfOddIsSqr
   use mach.int.Int

--- a/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
+++ b/creusot/tests/should_succeed/syntax/07_extern_spec.stdout
@@ -40,7 +40,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/take_first_mut.stdout
+++ b/creusot/tests/should_succeed/take_first_mut.stdout
@@ -50,7 +50,6 @@ module TakeFirstMut_Impl0_DefaultLog_Interface
   use prelude.Prelude
   clone CreusotContracts_Logic_Model_Impl2_Model_Interface as Model0 with type t = t
   function default_log (_ : ()) : borrowed (seq t)
-  axiom default_log_spec : ([#"../take_first_mut.rs" 32 4 38] Model0.model ( * default_log ()) = Seq.empty ) && ([#"../take_first_mut.rs" 33 4 38] Model0.model ( ^ default_log ()) = Seq.empty )
 end
 module TakeFirstMut_Impl0_DefaultLog
   type t

--- a/creusot/tests/should_succeed/traits/18_trait_laws.stdout
+++ b/creusot/tests/should_succeed/traits/18_trait_laws.stdout
@@ -26,7 +26,6 @@ module C18TraitLaws_Symmetric_Reflexive_Interface
   type self
   clone C18TraitLaws_Symmetric_Op_Interface as Op0 with type self = self
   function reflexive (a : self) (b : self) : ()
-  axiom reflexive_spec : forall a : self, b : self . [#"../18_trait_laws.rs" 10 4 34] Op0.op a b = Op0.op b a
 end
 module C18TraitLaws_Symmetric_Reflexive
   type self
@@ -37,7 +36,6 @@ end
 module C18TraitLaws_UsesOp_Interface
   type t
   function uses_op (x : t) (y : t) : bool
-  axiom uses_op_spec : forall x : t, y : t . [#"../18_trait_laws.rs" 15 0 26] uses_op x y = true
 end
 module C18TraitLaws_UsesOp
   type t
@@ -79,7 +77,6 @@ module C18TraitLaws_Impl0
 end
 module C18TraitLaws_ImplLaws_Interface
   function impl_laws (_ : ()) : bool
-  axiom impl_laws_spec : [#"../18_trait_laws.rs" 31 0 26] impl_laws () = true
 end
 module C18TraitLaws_ImplLaws
   clone C18TraitLaws_Impl0_Op_Interface as Op0

--- a/creusot/tests/should_succeed/vector/01.stdout
+++ b/creusot/tests/should_succeed/vector/01.stdout
@@ -62,7 +62,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/vector/02_gnome.stdout
+++ b/creusot/tests/should_succeed/vector/02_gnome.stdout
@@ -101,7 +101,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -225,7 +224,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -252,7 +250,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -279,7 +276,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -306,7 +302,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -321,7 +316,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -335,7 +329,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -349,7 +342,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -363,7 +355,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -377,7 +368,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.stdout
@@ -61,7 +61,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/vector/04_binary_search.stdout
+++ b/creusot/tests/should_succeed/vector/04_binary_search.stdout
@@ -130,7 +130,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.stdout
@@ -164,7 +164,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -180,7 +179,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -207,7 +205,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -234,7 +231,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -249,7 +245,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -263,7 +258,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -277,7 +271,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -291,7 +284,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -305,7 +297,6 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   use Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -323,7 +314,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/vector/06_knights_tour.stdout
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.stdout
@@ -73,7 +73,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t
@@ -1754,7 +1753,6 @@ module C06KnightsTour_DumbNonlinearArith_Interface
   use mach.int.Int32
   use prelude.Prelude
   function dumb_nonlinear_arith (a : usize) : ()
-  axiom dumb_nonlinear_arith_spec : forall a : usize . ([#"../06_knights_tour.rs" 137 0 24] UInt64.to_int a <= 1000) -> ([#"../06_knights_tour.rs" 138 0 32] UInt64.to_int a * UInt64.to_int a <= 1000000)
 end
 module C06KnightsTour_DumbNonlinearArith
   use mach.int.UInt64

--- a/creusot/tests/should_succeed/vector/07_read_write.stdout
+++ b/creusot/tests/should_succeed/vector/07_read_write.stdout
@@ -99,7 +99,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t

--- a/creusot/tests/should_succeed/vector/08_haystack.stdout
+++ b/creusot/tests/should_succeed/vector/08_haystack.stdout
@@ -121,7 +121,6 @@ module CreusotContracts_Std1_Vec_Impl0_Model_Interface
   use mach.int.UInt64
   use Type
   function model (self : Type.alloc_vec_vec t a) : Seq.seq t
-  axiom model_spec : forall self : Type.alloc_vec_vec t a . Seq.length (model self) <= 18446744073709551615
 end
 module CreusotContracts_Std1_Vec_Impl0_Model
   type t


### PR DESCRIPTION
Removes contracts from logical function interfaces because they generate bogus proof obligations.
I would still like this change to happen in the future, but I will do it properly using actual function contracts instead.
