### PR TITLE
Update toolchain

### DIFF
--- a/ci/rust-toolchain
+++ b/ci/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-05-14"
+channel = "nightly-2022-05-25"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -7,7 +7,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{
     self,
     subst::{InternalSubsts, Subst, SubstsRef},
-    TyCtxt, TypeFoldable, TypeVisitor,
+    EarlyBinder, TyCtxt, TypeFoldable, TypeVisitor,
 };
 use rustc_middle::ty::{DefIdTree, ProjectionTy, Ty, TyKind};
 use rustc_span::{Symbol, DUMMY_SP};
@@ -429,7 +429,7 @@ impl<'tcx> CloneMap<'tcx> {
         subst: SubstsRef<'tcx>,
         dep: (DefId, SubstsRef<'tcx>),
     ) -> DepNode<'tcx> {
-        let dep = (dep.0, dep.1.subst(self.tcx, subst));
+        let dep = (dep.0, EarlyBinder(dep.1).subst(self.tcx, subst));
 
         let param_env = ctx.param_env(self.self_id);
         let resolved = traits::resolve_opt(ctx.tcx, param_env, dep.0, dep.1).unwrap_or(dep);

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -199,8 +199,8 @@ impl<'tcx, 'sess> TranslationCtx<'sess, 'tcx> {
                     .and_then(|id| self.extern_specs.get(&id))
                 {
                     let i = InternalSubsts::identity_for_item(self.tcx, def_id);
-                    use rustc_middle::ty::subst::Subst;
-                    term.subst(self.tcx, i)
+                    use rustc_middle::ty::{subst::Subst, EarlyBinder};
+                    EarlyBinder(term).subst(self.tcx, i)
                 } else {
                     term
                 }

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -25,6 +25,8 @@ extern crate rustc_target;
 extern crate rustc_trait_selection;
 extern crate rustc_typeck;
 extern crate smallvec;
+extern crate rustc_smir;
+
 #[macro_use]
 extern crate log;
 

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -9,7 +9,7 @@ use rustc_macros::{TyDecodable, TyEncodable};
 use rustc_middle::thir::visit::Visitor;
 use rustc_middle::thir::{self, Expr, ExprKind, Thir};
 use rustc_middle::ty::subst::{InternalSubsts, Subst, SubstsRef};
-use rustc_middle::ty::{Predicate, TyCtxt, TyKind, WithOptConstParam};
+use rustc_middle::ty::{EarlyBinder, Predicate, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::symbol::kw;
 use rustc_span::Symbol;
 use why3::declaration::ValKind;
@@ -92,7 +92,7 @@ impl<'tcx> ExternSpec<'tcx> {
         tcx: TyCtxt<'tcx>,
         sub: SubstsRef<'tcx>,
     ) -> Vec<Predicate<'tcx>> {
-        self.additional_predicates.clone().subst(tcx, sub)
+        EarlyBinder(self.additional_predicates.clone()).subst(tcx, sub)
     }
 }
 

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -59,8 +59,8 @@ impl<'tcx> BodyTranslator<'_, '_, 'tcx> {
             Abort => self.emit_terminator(MlT::Absurd),
             Return => self.emit_terminator(MlT::Return),
             Unreachable => self.emit_terminator(MlT::Absurd),
-            Call { func, args, destination, .. } => {
-                if destination.is_none() {
+            Call { func, args, destination, target, .. } => {
+                if target.is_none() {
                     // If we have no target block after the call, then we cannot move past it.
                     self.emit_terminator(MlT::Absurd);
                     return;
@@ -109,7 +109,7 @@ impl<'tcx> BodyTranslator<'_, '_, 'tcx> {
                     )
                 };
 
-                let (loc, bb) = destination.unwrap();
+                let (loc, bb) = (destination, target.unwrap());
                 self.emit_assignment(&loc, call_exp);
                 self.emit_terminator(MlT::Goto(BlockId(bb.into())));
             }

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -14,7 +14,7 @@ use self::typing::pearlite_stub;
 use super::LocalIdent;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{Body, Location};
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, EarlyBinder, TyCtxt};
 
 mod builtins;
 mod lower;
@@ -47,13 +47,13 @@ impl PreContract {
         use crate::rustc_middle::ty::subst::Subst;
         for req_id in self.requires {
             log::debug!("require clause {:?}", req_id);
-            let term = ctx.term(req_id).unwrap().clone().subst(ctx.tcx, subst);
+            let term = EarlyBinder(ctx.term(req_id).unwrap().clone()).subst(ctx.tcx, subst);
             out.requires.push(lower_pure(ctx, names, req_id, term));
         }
 
         for ens_id in self.ensures {
             log::debug!("ensures clause {:?}", ens_id);
-            let term = ctx.term(ens_id).unwrap().clone().subst(ctx.tcx, subst);
+            let term = EarlyBinder(ctx.term(ens_id).unwrap().clone()).subst(ctx.tcx, subst);
             let exp = lower_pure(ctx, names, ens_id, term);
 
             out.ensures.push(exp);
@@ -61,7 +61,7 @@ impl PreContract {
 
         if let Some(var_id) = self.variant {
             log::debug!("variant clause {:?}", var_id);
-            let term = ctx.term(var_id).unwrap().clone().subst(ctx.tcx, subst);
+            let term = EarlyBinder(ctx.term(var_id).unwrap().clone()).subst(ctx.tcx, subst);
             out.variant = vec![lower_pure(ctx, names, var_id, term)];
         };
 

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -344,7 +344,7 @@ pub(super) fn mk_binders(func: Exp, args: Vec<Exp>) -> Exp {
 
 fn is_identity_from<'tcx>(tcx: TyCtxt<'tcx>, id: DefId, subst: SubstsRef<'tcx>) -> bool {
     if tcx.def_path_str(id) == "std::convert::From::from" && subst.len() == 1 {
-        let out_ty = tcx.fn_sig(id).no_bound_vars().unwrap().output();
+        let out_ty = tcx.bound_fn_sig(id).map_bound(|sig| sig.no_bound_vars().unwrap().output());
         return subst[0].expect_ty() == out_ty.subst(tcx, subst);
     }
     false

--- a/creusot/src/translation/specification/typing.rs
+++ b/creusot/src/translation/specification/typing.rs
@@ -475,7 +475,7 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
                         "non-boolean constant patterns are unsupported",
                     ));
                 }
-                Ok(Pattern::Boolean(value.val().try_to_bool().unwrap()))
+                Ok(Pattern::Boolean(value.try_to_bool().unwrap()))
             }
             ref pk => todo!("lower_pattern: unsupported pattern kind {:?}", pk),
         }

--- a/creusot/src/validate.rs
+++ b/creusot/src/validate.rs
@@ -1,8 +1,9 @@
 use crate::ctx::TranslationCtx;
 use crate::util::is_law;
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::itemlikevisit::ItemLikeVisitor;
+use rustc_hir::intravisit::Visitor;
 use rustc_hir::{ForeignItem, ImplItem, Item, TraitItem};
+use rustc_middle::hir::nested_filter::OnlyBodies;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
@@ -11,22 +12,24 @@ struct LawParams<'tcx> {
     law_violations: Vec<(LocalDefId, Span)>,
 }
 
-impl<'hir, 'tcx> ItemLikeVisitor<'hir> for LawParams<'tcx> {
-    fn visit_item(&mut self, _: &'hir Item<'hir>) {}
-    fn visit_trait_item(&mut self, trait_item: &'hir TraitItem<'hir>) {
+impl<'tcx> Visitor<'tcx> for LawParams<'tcx> {
+    type NestedFilter = OnlyBodies;
+
+    fn visit_item(&mut self, _: &'tcx Item<'tcx>) {}
+    fn visit_trait_item(&mut self, trait_item: &'tcx TraitItem<'tcx>) {
         if is_law(self.tcx, trait_item.def_id.to_def_id()) && !trait_item.generics.params.is_empty()
         {
             self.law_violations.push((trait_item.def_id, trait_item.span))
         }
     }
-    fn visit_impl_item(&mut self, _: &'hir ImplItem<'hir>) {}
-    fn visit_foreign_item(&mut self, _: &'hir ForeignItem<'hir>) {}
+    fn visit_impl_item(&mut self, _: &'tcx ImplItem<'tcx>) {}
+    fn visit_foreign_item(&mut self, _: &'tcx ForeignItem<'tcx>) {}
 }
 
 pub fn validate_traits(ctx: &mut TranslationCtx) {
     let mut law_visitor = LawParams { tcx: ctx.tcx, law_violations: Vec::new() };
 
-    ctx.tcx.hir().visit_all_item_likes(&mut law_visitor);
+    ctx.tcx.hir().deep_visit_all_item_likes(&mut law_visitor);
 
     for (_, sp) in law_visitor.law_violations {
         ctx.error(sp, "Laws cannot have additional generic parameters");


### PR DESCRIPTION
Updates creusot to use the `rustc_smir` crate. However, we still need it to be merged.
