### PR TITLE
Add a version of Ghost::new for runtime compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,9 @@ dependencies = [
 [[package]]
 name = "creusot-contracts-dummy"
 version = "0.1.0"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "creusot-contracts-proc"

--- a/creusot-contracts-dummy/Cargo.toml
+++ b/creusot-contracts-dummy/Cargo.toml
@@ -9,3 +9,4 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+quote = "*"

--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -28,6 +28,11 @@ pub fn proof_assert(_: TS1) -> TS1 {
 }
 
 #[proc_macro]
+pub fn ghost(_: TS1) -> TS1 {
+    quote::quote! { creusot_contracts::Ghost::new(()) }.into()
+}
+
+#[proc_macro]
 pub fn pearlite(_: TS1) -> TS1 {
     TS1::new()
 }

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -71,7 +71,7 @@ mod macros {
     /// A post-condition of a function or trait item
     pub use creusot_contracts_dummy::ensures;
 
-    pub use creusot_contracts_proc::ghost;
+    pub use creusot_contracts_dummy::ghost;
 
     /// A loop invariant
     /// The first argument should be a name for the invariant
@@ -144,7 +144,7 @@ pub mod logic {
         T: ?Sized;
 
     impl<T> Ghost<T> {
-        pub fn record(_: &T) -> Ghost<T> {
+        pub fn new(_: T) -> Ghost<T> {
             Ghost(std::marker::PhantomData)
         }
     }


### PR DESCRIPTION
I forgot to add this previously, which meant that programs with `ghost!` annotations could not be compiled...

Unfortunately, to avoid ambiguous type errors I had to pick a specific type for the parameter of `Ghost`, which may conflict user type ascriptions... 

I think this should be good for the moment though and allows `CreuSAT` to compile.

cc @sarsko
