### PR TITLE
Fix #387

### DIFF
--- a/creusot/tests/should_succeed/bug/387.mlcfg
+++ b/creusot/tests/should_succeed/bug/387.mlcfg
@@ -1,0 +1,619 @@
+module Type
+  use Ref
+  use mach.int.Int
+  use prelude.Int8
+  use prelude.Int16
+  use mach.int.Int32
+  use mach.int.Int64
+  use prelude.UInt8
+  use prelude.UInt16
+  use mach.int.UInt32
+  use mach.int.UInt64
+  use string.Char
+  use floating_point.Single
+  use floating_point.Double
+  use seq.Seq
+  use prelude.Prelude
+  type core_option_option 't =
+    | Core_Option_Option_None
+    | Core_Option_Option_Some 't
+    
+  let function core_option_option_Some_0 (self : core_option_option 't) : 't =
+    match (self) with
+      | Core_Option_Option_None -> any 't
+      | Core_Option_Option_Some a -> a
+      end
+  type c387_node  =
+    | C387_Node (c387_tree) uint32 (c387_tree)
+    with c387_tree  =
+    | C387_Tree (core_option_option (c387_node))
+    
+  let function c387_tree_Tree_0 (self : c387_tree) : core_option_option (c387_node) =
+    match (self) with
+      | C387_Tree a -> a
+      end
+  let function c387_node_Node_left (self : c387_node) : c387_tree =
+    match (self) with
+      | C387_Node a _ _ -> a
+      end
+  let function c387_node_Node_right (self : c387_node) : c387_tree =
+    match (self) with
+      | C387_Node _ _ a -> a
+      end
+  type core_cmp_ordering  =
+    | Core_Cmp_Ordering_Less
+    | Core_Cmp_Ordering_Equal
+    | Core_Cmp_Ordering_Greater
+    
+end
+module C387_UseTree_Interface
+  use prelude.Prelude
+  use Type
+  val use_tree [@cfg:stackify] (_1' : Type.c387_tree) : ()
+end
+module C387_UseTree
+  use prelude.Prelude
+  use Type
+  let rec cfg use_tree [@cfg:stackify] [#"../387.rs" 15 0 25] (_1' : Type.c387_tree) : () =
+  var _0 : ();
+  var _1 : Type.c387_tree;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module Core_Cmp_Ord_Cmp_Interface
+  type self
+  use prelude.Prelude
+  use Type
+  val cmp [@cfg:stackify] (self : self) (other : self) : Type.core_cmp_ordering
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Cmp
+  type self
+  use prelude.Prelude
+  use Type
+  val cmp [@cfg:stackify] (self : self) (other : self) : Type.core_cmp_ordering
+    requires {false}
+    
+end
+module CreusotContracts_Logic_Model_Model_ModelTy
+  type self
+  type modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model_Interface
+  type self
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Model_Model_Model
+  type self
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  function model (self : self) : ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
+  type self
+  use Type
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
+  type self
+  use Type
+  function cmp_log (self : self) (_2' : self) : Type.core_cmp_ordering
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
+  type self
+  predicate lt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate lt_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Less
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
+  type self
+  predicate le_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LeLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate le_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o <> Type.Core_Cmp_Ordering_Greater
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
+  type self
+  predicate ge_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate ge_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o <> Type.Core_Cmp_Ordering_Less
+end
+module Core_Cmp_Ord_Max_Interface
+  type self
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = self,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val max [@cfg:stackify] (self : self) (other : self) : self
+    ensures { [#"../387.rs" 22 4 47] LtLog0.lt_log (Model0.model other) (Model0.model self) -> result = self }
+    ensures { [#"../387.rs" 21 4 44] LeLog0.le_log (Model0.model self) (Model0.model other) -> result = other }
+    ensures { [#"../387.rs" 20 4 46] result = self || result = other }
+    ensures { [#"../387.rs" 19 4 29] GeLog0.ge_log (Model0.model result) (Model0.model other) }
+    ensures { [#"../387.rs" 18 4 33] GeLog0.ge_log (Model0.model result) (Model0.model self) }
+    
+end
+module Core_Cmp_Ord_Max
+  type self
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = self,
+  type ModelTy0.modelTy = ModelTy0.modelTy
+  val max [@cfg:stackify] (self : self) (other : self) : self
+    ensures { [#"../387.rs" 22 4 47] LtLog0.lt_log (Model0.model other) (Model0.model self) -> result = self }
+    ensures { [#"../387.rs" 21 4 44] LeLog0.le_log (Model0.model self) (Model0.model other) -> result = other }
+    ensures { [#"../387.rs" 20 4 46] result = self || result = other }
+    ensures { [#"../387.rs" 19 4 29] GeLog0.ge_log (Model0.model result) (Model0.model other) }
+    ensures { [#"../387.rs" 18 4 33] GeLog0.ge_log (Model0.model result) (Model0.model self) }
+    
+end
+module Core_Cmp_Ord_Min_Interface
+  type self
+  val min [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Min
+  type self
+  val min [@cfg:stackify] (self : self) (other : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Clamp_Interface
+  type self
+  val clamp [@cfg:stackify] (self : self) (min : self) (max : self) : self
+    requires {false}
+    
+end
+module Core_Cmp_Ord_Clamp
+  type self
+  val clamp [@cfg:stackify] (self : self) (min : self) (max : self) : self
+    requires {false}
+    
+end
+module CreusotContracts_Logic_Int_Impl14_Model_Interface
+  use mach.int.Int
+  use mach.int.UInt64
+  function model (self : uint64) : int
+end
+module CreusotContracts_Logic_Int_Impl14_Model
+  use mach.int.Int
+  use mach.int.UInt64
+  function model (self : uint64) : int =
+    UInt64.to_int self
+end
+module CreusotContracts_Logic_Int_Impl14_ModelTy
+  use mach.int.Int
+  type modelTy  =
+    int
+end
+module CreusotContracts_Logic_Int_Impl14
+  use mach.int.Int
+  use mach.int.UInt64
+  clone CreusotContracts_Logic_Int_Impl14_Model as Model0
+  clone CreusotContracts_Logic_Int_Impl14_ModelTy as ModelTy0
+  clone CreusotContracts_Logic_Model_Model_Model_Interface as Model1 with type self = uint64,
+  function model = Model0.model, type ModelTy0.modelTy = ModelTy0.modelTy
+  clone CreusotContracts_Logic_Model_Model_ModelTy as ModelTy1 with type self = uint64, type modelTy = ModelTy0.modelTy
+end
+module CreusotContracts_Logic_Ord_Impl0_LtLog_Interface
+  use mach.int.Int
+  predicate lt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_LtLog
+  use mach.int.Int
+  predicate lt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  function cmp_le_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
+  function cmp_le_log (x : self) (y : self) : ()
+  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  function cmp_lt_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
+  function cmp_lt_log (x : self) (y : self) : ()
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  function cmp_ge_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
+  function cmp_ge_log (x : self) (y : self) : ()
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Type.Core_Cmp_Ordering_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
+  type self
+  predicate gt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  predicate gt_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o = Type.Core_Cmp_Ordering_Greater
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  function cmp_gt_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
+  function cmp_gt_log (x : self) (y : self) : ()
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function refl (x : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Refl
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function refl (x : self) : ()
+  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Type.Core_Cmp_Ordering_Equal
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Trans
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function trans (x : self) (y : self) (z : self) (o : Type.core_cmp_ordering) : ()
+  axiom trans_spec : forall x : self, y : self, z : self, o : Type.core_cmp_ordering . CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log x z = o
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function antisym1 (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function antisym1 (x : self) (y : self) : ()
+  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Less -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Greater
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function antisym2 (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function antisym2 (x : self) (y : self) : ()
+  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Greater -> CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Less
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self
+  use Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (x = y -> CmpLog0.cmp_log x y = Type.Core_Cmp_Ordering_Equal) && (CmpLog0.cmp_log y x = Type.Core_Cmp_Ordering_Equal -> x = y)
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLog_Interface
+  use mach.int.Int
+  use Type
+  function cmp_log (self : int) (o : int) : Type.core_cmp_ordering
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLog
+  use mach.int.Int
+  use Type
+  function cmp_log (self : int) (o : int) : Type.core_cmp_ordering =
+    if self < o then
+      Type.Core_Cmp_Ordering_Less
+    else
+      if self = o then Type.Core_Cmp_Ordering_Equal else Type.Core_Cmp_Ordering_Greater
+    
+end
+module CreusotContracts_Logic_Ord_Impl0_LeLog_Interface
+  use mach.int.Int
+  predicate le_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_LeLog
+  use mach.int.Int
+  predicate le_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLeLog_Interface
+  use mach.int.Int
+  function cmp_le_log (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLeLog
+  use mach.int.Int
+  function cmp_le_log (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLtLog_Interface
+  use mach.int.Int
+  function cmp_lt_log (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpLtLog
+  use mach.int.Int
+  function cmp_lt_log (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_GeLog_Interface
+  use mach.int.Int
+  predicate ge_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_GeLog
+  use mach.int.Int
+  predicate ge_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpGeLog_Interface
+  use mach.int.Int
+  function cmp_ge_log (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpGeLog
+  use mach.int.Int
+  function cmp_ge_log (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_GtLog_Interface
+  use mach.int.Int
+  predicate gt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_GtLog
+  use mach.int.Int
+  predicate gt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpGtLog_Interface
+  use mach.int.Int
+  function cmp_gt_log (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_CmpGtLog
+  use mach.int.Int
+  function cmp_gt_log (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Refl_Interface
+  use mach.int.Int
+  function refl (_1' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Refl
+  use mach.int.Int
+  function refl (_1' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Trans_Interface
+  use mach.int.Int
+  use Type
+  function trans (_1' : int) (_2' : int) (_3' : int) (_4' : Type.core_cmp_ordering) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Trans
+  use mach.int.Int
+  use Type
+  function trans (_1' : int) (_2' : int) (_3' : int) (_4' : Type.core_cmp_ordering) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Antisym1_Interface
+  use mach.int.Int
+  function antisym1 (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Antisym1
+  use mach.int.Int
+  function antisym1 (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Antisym2_Interface
+  use mach.int.Int
+  function antisym2 (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_Antisym2
+  use mach.int.Int
+  function antisym2 (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0_EqCmp_Interface
+  use mach.int.Int
+  function eq_cmp (_1' : int) (_2' : int) : ()
+end
+module CreusotContracts_Logic_Ord_Impl0_EqCmp
+  use mach.int.Int
+  function eq_cmp (_1' : int) (_2' : int) : () =
+    ()
+end
+module CreusotContracts_Logic_Ord_Impl0
+  use mach.int.Int
+  clone CreusotContracts_Logic_Ord_Impl0_EqCmp as EqCmp0
+  clone CreusotContracts_Logic_Ord_Impl0_Antisym2 as Antisym20
+  clone CreusotContracts_Logic_Ord_Impl0_Antisym1 as Antisym10
+  clone CreusotContracts_Logic_Ord_Impl0_Trans as Trans0
+  clone CreusotContracts_Logic_Ord_Impl0_Refl as Refl0
+  clone CreusotContracts_Logic_Ord_Impl0_CmpGtLog as CmpGtLog0
+  clone CreusotContracts_Logic_Ord_Impl0_GtLog as GtLog0
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog1 with type self = int,
+  predicate gt_log = GtLog0.gt_log
+  clone CreusotContracts_Logic_Ord_Impl0_CmpGeLog as CmpGeLog0
+  clone CreusotContracts_Logic_Ord_Impl0_GeLog as GeLog0
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog1 with type self = int,
+  predicate ge_log = GeLog0.ge_log
+  clone CreusotContracts_Logic_Ord_Impl0_CmpLtLog as CmpLtLog0
+  clone CreusotContracts_Logic_Ord_Impl0_LtLog as LtLog0
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog1 with type self = int,
+  predicate lt_log = LtLog0.lt_log
+  clone CreusotContracts_Logic_Ord_Impl0_CmpLeLog as CmpLeLog0
+  clone CreusotContracts_Logic_Ord_Impl0_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog1 with type self = int,
+  predicate le_log = LeLog0.le_log
+  clone CreusotContracts_Logic_Ord_Impl0_CmpLog as CmpLog0
+  clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp1 with type self = int,
+  function eq_cmp = EqCmp0.eq_cmp, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface as Antisym21 with type self = int,
+  function antisym2 = Antisym20.antisym2, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface as Antisym11 with type self = int,
+  function antisym1 = Antisym10.antisym1, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface as Trans1 with type self = int,
+  function trans = Trans0.trans, function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface as Refl1 with type self = int, function refl = Refl0.refl,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface as CmpGtLog1 with type self = int,
+  function cmp_gt_log = CmpGtLog0.cmp_gt_log, predicate GtLog0.gt_log = GtLog0.gt_log,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface as CmpGeLog1 with type self = int,
+  function cmp_ge_log = CmpGeLog0.cmp_ge_log, predicate GeLog0.ge_log = GeLog0.ge_log,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface as CmpLtLog1 with type self = int,
+  function cmp_lt_log = CmpLtLog0.cmp_lt_log, predicate LtLog0.lt_log = LtLog0.lt_log,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface as CmpLeLog1 with type self = int,
+  function cmp_le_log = CmpLeLog0.cmp_le_log, predicate LeLog0.le_log = LeLog0.le_log,
+  function CmpLog0.cmp_log = CmpLog0.cmp_log, axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog1 with type self = int,
+  function cmp_log = CmpLog0.cmp_log
+end
+module C387_Impl0_Height_Interface
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  val height [@cfg:stackify] (self : Type.c387_tree) : uint64
+end
+module C387_Impl0_Height
+  use prelude.Prelude
+  use Type
+  use mach.int.Int
+  use mach.int.UInt64
+  use mach.int.Int64
+  clone CreusotContracts_Logic_Ord_Impl0_EqCmp as EqCmp0
+  clone CreusotContracts_Logic_Ord_Impl0_Antisym2 as Antisym20
+  clone CreusotContracts_Logic_Ord_Impl0_Antisym1 as Antisym10
+  clone CreusotContracts_Logic_Ord_Impl0_Trans as Trans0
+  clone CreusotContracts_Logic_Ord_Impl0_Refl as Refl0
+  clone CreusotContracts_Logic_Ord_Impl0_CmpGtLog as CmpGtLog0
+  clone CreusotContracts_Logic_Ord_Impl0_CmpGeLog as CmpGeLog0
+  clone CreusotContracts_Logic_Ord_Impl0_CmpLtLog as CmpLtLog0
+  clone CreusotContracts_Logic_Ord_Impl0_CmpLeLog as CmpLeLog0
+  clone CreusotContracts_Logic_Int_Impl14_ModelTy as ModelTy0
+  clone CreusotContracts_Logic_Ord_Impl0_GeLog as GeLog0
+  clone CreusotContracts_Logic_Ord_Impl0_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl0_LtLog as LtLog0
+  clone CreusotContracts_Logic_Int_Impl14_Model as Model0
+  clone Core_Cmp_Ord_Max_Interface as Max0 with type self = uint64, function Model0.model = Model0.model,
+  predicate LtLog0.lt_log = LtLog0.lt_log, predicate LeLog0.le_log = LeLog0.le_log,
+  predicate GeLog0.ge_log = GeLog0.ge_log, type ModelTy0.modelTy = ModelTy0.modelTy
+  let rec cfg height [@cfg:stackify] [#"../387.rs" 29 4 31] (self : Type.c387_tree) : uint64 =
+  var _0 : uint64;
+  var self_1 : Type.c387_tree;
+  var _2 : isize;
+  var n_3 : Type.c387_node;
+  var _4 : uint64;
+  var _5 : uint64;
+  var _6 : Type.c387_tree;
+  var _7 : uint64;
+  var _8 : Type.c387_tree;
+  {
+    self_1 <- self;
+    goto BB0
+  }
+  BB0 {
+    switch (Type.c387_tree_Tree_0 self_1)
+      | Type.Core_Option_Option_None -> goto BB3
+      | Type.Core_Option_Option_Some _ -> goto BB1
+      end
+  }
+  BB1 {
+    n_3 <- Type.core_option_option_Some_0 (Type.c387_tree_Tree_0 self_1);
+    _6 <- Type.c387_node_Node_left n_3;
+    _5 <- ([#"../387.rs" 32 29 44] height _6);
+    goto BB4
+  }
+  BB2 {
+    absurd
+  }
+  BB3 {
+    _0 <- (0 : uint64);
+    goto BB7
+  }
+  BB4 {
+    _8 <- Type.c387_node_Node_right n_3;
+    _7 <- ([#"../387.rs" 32 49 65] height _8);
+    goto BB5
+  }
+  BB5 {
+    _4 <- ([#"../387.rs" 32 29 66] Max0.max _5 _7);
+    goto BB6
+  }
+  BB6 {
+    _0 <- ([#"../387.rs" 32 29 70] _4 + (1 : uint64));
+    goto BB7
+  }
+  BB7 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/bug/387.rs
+++ b/creusot/tests/should_succeed/bug/387.rs
@@ -1,0 +1,35 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+pub struct Tree(Option<Box<Node>>);
+
+#[allow(dead_code)]
+struct Node {
+    left: Tree,
+    val: u32,
+    right: Tree,
+}
+
+// To force the translation of `Tree`
+pub fn use_tree(_: &Tree) {}
+
+extern_spec! {
+    #[ensures(@result >= @self_)]
+    #[ensures(@result >= @o)]
+    #[ensures(result == self_ || result == o)]
+    #[ensures(@self_ <= @o ==> result == o)]
+    #[ensures(@o < @self_ ==> result == self_)]
+    fn std::cmp::Ord::max<Self_>(self_: Self_, o: Self_) -> Self_ where
+        Self_: Ord + Model,
+        Self_::ModelTy: OrdLogic
+}
+
+impl Tree {
+    pub fn height(&self) -> u64 {
+        match self {
+            Tree(None) => 0,
+            Tree(Some(n)) => n.left.height().max(n.right.height()) + 1,
+        }
+    }
+}

--- a/creusot/tests/should_succeed/iterators/01_range/why3session.xml
+++ b/creusot/tests/should_succeed/iterators/01_range/why3session.xml
@@ -17,7 +17,7 @@
 </theory>
 <theory name="C01Range_Impl0_Next" proved="true">
  <goal name="next&#39;vc" expl="VC for next" proved="true">
- <proof prover="2"><result status="valid" time="0.05" steps="869"/></proof>
+ <proof prover="2"><result status="valid" time="0.05" steps="867"/></proof>
  </goal>
 </theory>
 <theory name="C01Range_Impl0" proved="true">
@@ -27,7 +27,7 @@
 </theory>
 <theory name="C01Range_SumRange" proved="true">
  <goal name="sum_range&#39;vc" expl="VC for sum_range" proved="true">
- <proof prover="2"><result status="valid" time="0.26" steps="5547"/></proof>
+ <proof prover="2"><result status="valid" time="0.26" steps="5574"/></proof>
  </goal>
 </theory>
 </file>


### PR DESCRIPTION
It turns out that #387 wasn't actually caused by default implementations but by not-normalizing associated type projections. 
This caused us to fail to identify that `<u64 as Model>::ModelTy` was just `int`. 
