### PR TITLE
Add basic specifications for `BigInt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "itertools",
  "log",
  "mktemp",
+ "num-bigint",
  "petgraph",
  "sequence_trie",
  "serde",
@@ -147,6 +148,7 @@ version = "0.1.0"
 dependencies = [
  "creusot-contracts-dummy",
  "creusot-contracts-proc",
+ "num-bigint",
 ]
 
 [[package]]
@@ -351,6 +353,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975de676448231fcde04b9149d2543077e166b78fc29eae5aa219e7928410da2"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/creusot-contracts/Cargo.toml
+++ b/creusot-contracts/Cargo.toml
@@ -9,8 +9,11 @@ edition = "2018"
 [dependencies]
 creusot-contracts-proc = { path = "../creusot-contracts-proc", version = "*" }
 creusot-contracts-dummy = { path = "../creusot-contracts-dummy", version = "*" }
+num-bigint = { version = "*", optional = true }
+
 
 [features]
 default = []
 typechecker = []
 contracts = []
+num_bigint = ["dep:num-bigint"]

--- a/creusot-contracts/src/bigint.rs
+++ b/creusot-contracts/src/bigint.rs
@@ -1,0 +1,55 @@
+use crate as creusot_contracts;
+use crate::*;
+use ::std::ops::*;
+use creusot_contracts_proc::*;
+use num_bigint::BigInt;
+
+impl crate::Model for num_bigint::BigInt {
+    type ModelTy = crate::Int;
+    #[logic]
+    #[trusted]
+    fn model(self) -> Self::ModelTy {
+        pearlite! { absurd }
+    }
+}
+
+extern_spec! {
+    mod num_bigint {
+        impl From<i32> for BigInt {
+            #[ensures(@result == @i)]
+            fn from(i: i32) -> BigInt;
+        }
+
+        impl PartialEq<BigInt> for BigInt {
+            #[ensures(result == (@self== @rhs))]
+            fn eq(&self, rhs: &BigInt) -> bool;
+        }
+
+        impl Add<BigInt> for BigInt {
+            #[ensures(@result == @self + @rhs)]
+            fn add(self, rhs: BigInt) -> BigInt;
+        }
+
+
+        impl Sub<BigInt> for BigInt {
+            #[ensures(@result == @self - @rhs)]
+            fn sub(self, rhs: BigInt) -> BigInt;
+        }
+
+        impl Mul<BigInt> for BigInt {
+            #[ensures(@result == @self * @rhs)]
+            fn mul(self, rhs: BigInt) -> BigInt;
+        }
+
+        impl Div<BigInt> for BigInt {
+            #[requires(@rhs != 0)]
+            #[ensures(@result == @self / @rhs)]
+            fn div(self, rhs: BigInt) -> BigInt;
+        }
+
+        impl Clone for BigInt {
+            #[ensures(result == *self)]
+            fn clone(&self) -> BigInt;
+        }
+    }
+}

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -133,6 +133,9 @@ pub mod logic;
 #[cfg(feature = "contracts")]
 pub mod std;
 
+#[cfg(all(feature = "contracts", feature = "num_bigint"))]
+pub mod bigint;
+
 #[cfg(not(feature = "contracts"))]
 pub mod std {
     pub use std::vec;

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -16,7 +16,6 @@ heck = "0.3"
 petgraph = "0.6"
 indexmap = { version = "1.7.0", features = ["serde"] }
 toml = "0.5.8"
-creusot-contracts = { path = "../creusot-contracts", features = ["typechecker"] }
 why3 = { path = "../why3", features = ["serialize"] }
 clap = "2.33"
 creusot-metadata = { path = "../creusot-metadata" }
@@ -28,6 +27,8 @@ mktemp = "0.4"
 similar = "1.3.0"
 termcolor = "1.1"
 arraydeque = "0.4"
+num-bigint = { version = "*" }
+creusot-contracts = { path = "../creusot-contracts", features = ["typechecker", "num_bigint"] }
 
 
 [[test]]

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut metadata_file = Command::cargo_bin("cargo-creusot").unwrap();
     metadata_file.current_dir(base_path);
     metadata_file
-        .args(&["creusot", "--package", "creusot-contracts", "--features=contracts"])
+        .args(&["creusot", "--package", "creusot-contracts", "--features=contracts,num_bigint"])
         .env("CREUSOT_METADATA_PATH", &temp_file)
         .env("CREUSOT_OUTPUT_FILE", "/dev/null")
         .env("RUST_BACKTRACE", "1")
@@ -62,7 +62,6 @@ fn run_creusot(file: &Path, contracts: &str) -> Option<std::process::Command> {
     cmd.env("CREUSOT_STDOUT_OUTPUT", "1");
     cmd.env("CREUSOT_SPAN", "relative");
     cmd.args(&["--extern", &format!("creusot_contracts={}", creusot_contract_path)]);
-
     let header_line = BufReader::new(File::open(&file).unwrap()).lines().nth(0).unwrap().unwrap();
 
     if header_line.contains("UNBOUNDED") {


### PR DESCRIPTION
Upon request, this module adds specifications for `BigInt` coming from the `num_bigint` crate.