### PR TITLE
Specify `split_at_mut`

### DIFF
--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -104,12 +104,10 @@ extern_spec! {
         #[ensures({
             let (l,r) = result;  let sl = (@self).len();
             ((@^self).len() == sl) &&
-            ((@l).len() == @mid && (@r).len() == sl - @mid) &&
-            ((@^l).len() == @mid && (@^r).len() == sl - @mid) &&
-            (forall<i:usize> @i < @mid
-                ==> (@l)[@i] == (@self)[@i] && (@^l)[@i] == (@^self)[@i]) &&
-            (forall<i:usize> @i >= @mid && @i < sl
-                ==> (@r)[@i] == (@self)[@mid-@i] && (@^r)[@i] == (@^self)[@mid-@i])
+            (@self).subsequence(0, @mid).ext_eq(@l) &&
+            (@self).subsequence(@mid, sl).ext_eq(@r) &&
+            (@^self).subsequence(0, @mid).ext_eq(@^l) &&
+            (@^self).subsequence(@mid, sl).ext_eq(@^r)
         })]
         fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
 

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -100,6 +100,19 @@ extern_spec! {
         })]
         fn get<I : SliceIndexSpec<[T]>>(&self, ix: I) -> Option<&<I as SliceIndex<[T]>>::Output>;
 
+        #[requires(@mid <= (@self).len())]
+        #[ensures({
+            let (l,r) = result;  let sl = (@self).len();
+            ((@^self).len() == sl) &&
+            ((@l).len() == @mid && (@r).len() == sl - @mid) &&
+            ((@^l).len() == @mid && (@^r).len() == sl - @mid) &&
+            (forall<i:usize> @i < @mid
+                ==> (@l)[@i] == (@self)[@i] && (@^l)[@i] == (@^self)[@i]) &&
+            (forall<i:usize> @i >= @mid && @i < sl
+                ==> (@r)[@i] == (@self)[@mid-@i] && (@^r)[@i] == (@^self)[@mid-@i])
+        })]
+        fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
+
         #[ensures(result == None ==> (@self).len() == 0 && ^self == *self && @*self == Seq::EMPTY)]
         #[ensures(forall<first: &mut T, tail: &mut [T]>
                   result == Some((first, tail))


### PR DESCRIPTION
For some reason, equality in this module is on the values rather than on models of values.
Mistakes are likely, I don't have much Creusot experience.

Closes #499.