### PR TITLE
Refactor why3 test arguments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
 
         ~/work/creusot/why3/bin/why3 config detect
         cat ~/.why3.conf
-    - run: cargo test --test why3 "" -- --lazy --fail-obsolete --diff-from=origin/master
+    - run: cargo test --test why3 "" -- --replay=none --diff-from=origin/master
       env:
         WHY3_CONFIG: ${{ github.workspace }}/ci/why.conf
         WHY3_PATH: ${{ github.workspace }}/../why3/bin/why3

--- a/creusot/src/options.rs
+++ b/creusot/src/options.rs
@@ -4,20 +4,32 @@ use std::{collections::HashMap, error::Error};
 
 #[derive(Parser, Serialize, Deserialize)]
 pub struct CreusotArgs {
+    /// Treat all integer values as unbounded mathematical integers
     #[clap(long)]
     unbounded: bool,
+    /// Determines how to format the spans in generated code to loading in Why3.
+    /// [Relative] is better if the generated code is meant to be checked into VCS.
+    /// [Absolute] means the files can easily be moved around your system and still work.
+    /// [None] provides the clearest diffs.
     #[clap(long, value_enum, default_value_t=SpanMode::Relative)]
     span_mode: SpanMode,
     #[clap(long)]
+    /// Only generate proofs for items matching the provided string. The string is treated
+    /// as a Rust qualified path.
     focus_on: Option<String>,
     #[clap(long)]
+    /// Location that Creusot metadata for this crate should be emitted to.
     metadata_path: Option<String>,
+    /// Tell creusot to disable metadata exports.
     #[clap(long, default_value_t = true)]
     export_metadata: bool,
+    /// Print to stdout.
     #[clap(group = "output", long)]
     stdout: bool,
+    /// Print to a file.
     #[clap(group = "output", long)]
     output_file: Option<String>,
+    /// Specify locations of metadata for external crates. The format is the same as rustc's `--extern` flag.
     #[clap(long = "creusot-extern", value_parser= parse_key_val::<String, String>, required=false)]
     extern_paths: Vec<(String, String)>,
 }

--- a/prove
+++ b/prove
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPTPATH=$(dirname "$BASH_SOURCE")
-why3 --debug=ignore_unused_vars prove -L $SCRIPTPATH/prelude $@


### PR DESCRIPTION
Cleans up the arguments to the why3 tests and opens up a new workflow by separating laziness (whether we run provers) from early termination. 

In particular, when I'm making changes to the translation I initially just want to know if any files failed to type check, I don't care about running proofs that will most likely fail. Additionally, I prefer getting a list of _every_ failed proof rather than having to run N-passes over the test suite. 