### PR TITLE
Specify operations on `Option` that take closures

### DIFF
--- a/creusot-contracts/src/std/option.rs
+++ b/creusot-contracts/src/std/option.rs
@@ -1,5 +1,8 @@
 use crate as creusot_contracts;
-use crate::{std::default::DefaultSpec, Resolve};
+use crate::{
+    std::{default::DefaultSpec, fun::FnOnceSpec},
+    Resolve,
+};
 use creusot_contracts_proc::*;
 
 extern_spec! {
@@ -24,6 +27,13 @@ extern_spec! {
                 #[ensures(self == None || self == Some(result))]
                 fn unwrap_or(self, default: T) -> T;
 
+                #[requires(self != None || f.precondition(()))]
+                #[ensures(self == None ==> f.postcondition_once((), result))]
+                #[ensures(self == None || self == Some(result))]
+                fn unwrap_or_else<F>(self, f: F) -> T
+                where
+                    F: FnOnce() -> T;
+
                 #[ensures(*self == None ==> result == None && ^self == None)]
                 #[ensures(
                     *self == None
@@ -37,13 +47,95 @@ extern_spec! {
                 )]
                 fn as_ref(&self) -> Option<&T>;
 
+                #[ensures(self == None ==> result == Err(err))]
+                #[ensures(self == None || exists<t: T> self == Some(t) && result == Ok(t))]
+                fn ok_or<E>(self, err: E) -> Result<T, E>;
+
+                #[requires(self != None || err.precondition(()))]
+                #[ensures(
+                    self == None ==> exists<e: E> err.postcondition_once((), e) && result == Err(e)
+                )]
+                #[ensures(self == None || exists<t: T> self == Some(t) && result == Ok(t))]
+                fn ok_or_else<E, F>(self, err: F) -> Result<T, E>
+                where
+                    F: FnOnce() -> E;
+
+                #[requires(self == None || exists<t: T> self == Some(t) && f.precondition((t,)))]
+                #[ensures(self == None ==> result == None)]
+                #[ensures(
+                    self == None
+                    || exists<t: T, u: U> self == Some(t) && result == Some(u)
+                        && f.postcondition_once((t,), u)
+                )]
+                fn map<U, F>(self, f: F) -> Option<U>
+                where
+                    F: FnOnce(T) -> U;
+
+                #[requires(self == None || exists<t: T> self == Some(t) && f.precondition((t,)))]
+                #[ensures(self == None ==> result == default)]
+                #[ensures(
+                    self == None
+                    || exists<t: T, u: U> self == Some(t) && result == u
+                        && f.postcondition_once((t,), u)
+                )]
+                fn map_or<U, F>(self, default: U, f: F) -> U
+                where
+                    F: FnOnce(T) -> U;
+
+                #[requires(
+                    (self == None && default.precondition(()))
+                    || exists<t: T> self == Some(t) && f.precondition((t,))
+                )]
+                #[ensures(self == None ==> default.postcondition_once((), result))]
+                #[ensures(
+                    self == None
+                    || exists<t: T, u: U> self == Some(t) && result == u
+                        && f.postcondition_once((t,), u)
+                )]
+                fn map_or_else<U, D, F>(self, default: D, f: F) -> U
+                where
+                    D: FnOnce() -> U,
+                    F: FnOnce(T) -> U;
+
                 #[ensures(self == None ==> result == None)]
                 #[ensures(self == None || result == optb)]
                 fn and<U>(self, optb: Option<U>) -> Option<U>;
 
+                #[requires(self == None || exists<t: T> self == Some(t) && f.precondition((t,)))]
+                #[ensures(self == None ==> result == None)]
+                #[ensures(
+                    self == None
+                    || exists<t: T> self == Some(t) && f.postcondition_once((t,), result)
+                )]
+                fn and_then<U, F>(self, f: F) -> Option<U>
+                where
+                    F: FnOnce(T) -> Option<U>;
+
                 #[ensures(self == None ==> result == optb)]
                 #[ensures(self == None || result == self)]
                 fn or(self, optb: Option<T>) -> Option<T>;
+
+                #[requires(self != None || f.precondition(()))]
+                #[ensures(self == None ==> f.postcondition_once((), result))]
+                #[ensures(self == None || result == self)]
+                fn or_else<F>(self, f: F) -> Option<T>
+                where
+                    F: FnOnce() -> Option<T>;
+
+                #[requires(
+                    self == None || exists<r: &T> self == Some(*r) && predicate.precondition((r,))
+                )]
+                #[ensures(self == None ==> result == None)]
+                #[ensures(
+                    self == None
+                    || exists<r: &T> self == Some(*r) && (
+                        (predicate.postcondition_once((r,), false) && result == None)
+                        || (predicate.postcondition_once((r,), true) && result == self)
+                    )
+                )]
+                fn filter<P>(self, predicate: P) -> Option<T>
+                where
+                    P: FnOnce(&T) -> bool;
 
                 #[ensures(result == *self && ^self == None)]
                 fn take(&mut self) -> Option<T>;

--- a/creusot/tests/should_succeed/option.rs
+++ b/creusot/tests/should_succeed/option.rs
@@ -17,6 +17,9 @@ pub fn test_option() {
     // Test `unwrap_or`
     assert!(some.unwrap_or(2) == 1);
     assert!(none.unwrap_or(2) == 2);
+    // // Test `unwrap_or_else`
+    // assert!(some.unwrap_or_else(|| 2) == 1);
+    // assert!(none.unwrap_or_else(|| 2) == 2);
 
     // Test `as_mut`
     assert!(none.as_mut().is_none());
@@ -28,16 +31,48 @@ pub fn test_option() {
     assert!(none.as_ref().is_none());
     assert!(*some.as_ref().unwrap() == 1);
 
+    // // Test `ok_or`
+    // assert!(none.ok_or(2) == Err(2));
+    // assert!(some.ok_or(2) == Ok(1));
+    // // Test `ok_or_else`
+    // assert!(none.ok_or_else(|| 2) == Err(2));
+    // assert!(some.ok_or_else(|| 2) == Ok(1));
+
+    // // Test `map`
+    // assert!(none.map(|x| x + 1).is_none());
+    // assert!(some.map(|x| x + 1).unwrap() == 2);
+    // // Test `map_or`
+    // assert!(none.map_or(5, |x| x + 1) == 5);
+    // assert!(some.map_or(5, |x| x + 1) == 2);
+    // // Test `map_or_else`
+    // assert!(none.map_or_else(|| 5, |x| x + 1) == 5);
+    // assert!(some.map_or_else(|| 5, |x| x + 1) == 2);
+
     // Test `and`
     assert!(none.and(none).is_none());
     assert!(none.and(Some(2)).is_none());
     assert!(some.and(none).is_none());
     assert!(some.and(Some(2)).unwrap() == 2);
+    // // Test `and_then`
+    // assert!(none.and_then(|_| none).is_none());
+    // assert!(none.and_then(|x| Some(x + 1)).is_none());
+    // assert!(some.and_then(|_| none).is_none());
+    // assert!(some.and_then(|x| Some(x + 1)).unwrap() == 2);
     // Test `or`
     assert!(none.or(none).is_none());
     assert!(none.or(Some(2)).unwrap() == 2);
     assert!(some.or(none).unwrap() == 1);
     assert!(some.or(Some(2)).unwrap() == 1);
+    // // Test `or_else`
+    // assert!(none.or_else(|| none).is_none());
+    // assert!(none.or_else(|| Some(2)).unwrap() == 2);
+    // assert!(some.or_else(|| none).unwrap() == 1);
+    // assert!(some.or_else(|| Some(2)).unwrap() == 1);
+
+    // // Test `filter`
+    // assert!(none.filter(|x| *x == 1).is_none());
+    // assert!(some.filter(|x| *x == 1).unwrap() == 1);
+    // assert!(some.filter(|x| *x == 2).is_none());
 
     // Test `take`
     assert!(none.take().is_none());


### PR DESCRIPTION
This is the second half of PR #504. Also adds `ok_or` and `ok_or_else`, which require some basic operations on `Result`s to be specified before the test can be verified.