### PR TITLE
Improve pearlite macros

### DIFF
--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -268,6 +268,7 @@ fn escape_self_in_contracts(attrs: &mut Vec<Attribute>) -> Result<()> {
 
 fn escape_self_in_term(t: &mut Term) {
     match t {
+        Term::Macro(_) => {}
         Term::Array(TermArray { elems, .. }) => {
             for elem in elems {
                 escape_self_in_term(elem)
@@ -368,7 +369,7 @@ fn escape_self_in_term(t: &mut Term) {
         Term::Forall(TermForall { term, .. }) => escape_self_in_term(term),
         Term::Exists(TermExists { term, .. }) => escape_self_in_term(term),
         Term::Absurd(TermAbsurd { .. }) => {}
-        Term::Pearlite(TermPearlite { term, .. }) => escape_self_in_term(term),
+        Term::Pearlite(TermPearlite { block, .. }) => escape_self_in_tblock(block),
         Term::Lit(TermLit { .. }) => {}
         Term::Verbatim(_) => {}
         Term::__Nonexhaustive => {}

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -528,8 +528,14 @@ pub fn trusted(_: TS1, tokens: TS1) -> TS1 {
 
 #[proc_macro]
 pub fn pearlite(tokens: TS1) -> TS1 {
-    let term: Term = parse_macro_input!(tokens);
-    TS1::from(pretyping::encode_term(&term).unwrap())
+    let block = parse_macro_input!(tokens with TBlock::parse_within);
+    TS1::from(
+        block
+            .iter()
+            .map(pretyping::encode_stmt)
+            .collect::<std::result::Result<TokenStream, _>>()
+            .unwrap(),
+    )
 }
 
 #[proc_macro]

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -30,6 +30,8 @@ impl EncodeError {
 pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
     let sp = term.span();
     match term {
+        // Macros could contain further pearlite expressions..
+        RT::Macro(m) => Ok(quote_spanned! {sp=> #m}),
         RT::Array(_) => Err(EncodeError::Unsupported(term.span(), "Array".into())),
         RT::Binary(TermBinary { left, op, right }) => {
             let mut left = left;
@@ -237,7 +239,7 @@ pub fn encode_block(block: &TBlock) -> Result<TokenStream, EncodeError> {
     Ok(quote! { { #(#stmts)* } })
 }
 
-fn encode_stmt(stmt: &TermStmt) -> Result<TokenStream, EncodeError> {
+pub fn encode_stmt(stmt: &TermStmt) -> Result<TokenStream, EncodeError> {
     match stmt {
         TermStmt::Local(TLocal { pat, init, .. }) => {
             if let Some((_, init)) = init {
@@ -253,6 +255,7 @@ fn encode_stmt(stmt: &TermStmt) -> Result<TokenStream, EncodeError> {
             let term = encode_term(t)?;
             Ok(quote! { #term #s })
         }
+        TermStmt::Item(i) => Ok(quote! { #i }),
     }
 }
 

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -89,7 +89,7 @@ module C05Pearlite_Field1IsTrue
   use mach.int.Int
   use mach.int.Int32
   predicate field1_is_true [#"../05_pearlite.rs" 27 0 27 31] (x : C05Pearlite_B_Type.c05pearlite_b_type) =
-    [#"../05_pearlite.rs" 29 8 33 9] match (x) with
+    [#"../05_pearlite.rs" 30 8 34 9] match (x) with
       | C05Pearlite_B_Type.C05Pearlite_B_Type (True) _ -> true
       | C05Pearlite_B_Type.C05Pearlite_B_Type _f field2 -> UInt32.to_int field2 = 0
       | _ -> false

--- a/creusot/tests/should_succeed/syntax/05_pearlite.rs
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.rs
@@ -26,6 +26,7 @@ pub fn struct_order(x: B) {}
 #[allow(unreachable_patterns)]
 fn field1_is_true(x: B) -> bool {
     pearlite! {
+        use crate::B; // verify that imports work properly
         match x {
             B { field1: true, .. } => true,
             B { field2, field1: _f } => @field2 == 0,

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -178,23 +178,29 @@ fn test_pearlite() {
     TermPearlite {
         pearlite_token: Keyword [pearlite],
         bang_token: Bang,
-        brace_token: Brace,
-        term: TermPath {
-            inner: ExprPath {
-                attrs: [],
-                qself: None,
-                path: Path {
-                    leading_colon: None,
-                    segments: [
-                        PathSegment {
-                            ident: Ident(
-                                x,
-                            ),
-                            arguments: None,
+        block: TBlock {
+            brace_token: Brace,
+            stmts: [
+                Expr(
+                    TermPath {
+                        inner: ExprPath {
+                            attrs: [],
+                            qself: None,
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident(
+                                            x,
+                                        ),
+                                        arguments: None,
+                                    },
+                                ],
+                            },
                         },
-                    ],
-                },
-            },
+                    },
+                ),
+            ],
         },
     }
     "###);


### PR DESCRIPTION
Slight improvements to the pearlite macros:

- Can now call other macros, though they cannot contain nested pearlite expressions (annoying syn apis :()
- Can now `use` inside of pearlite expressions. 