### PR TITLE
RFC: Add support for functions that might panic

### DIFF
--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -22,6 +22,11 @@ pub fn invariant(_: TS1, tokens: TS1) -> TS1 {
     tokens
 }
 
+#[proc_macro_attribute]
+pub fn may_panic(_: TS1, tokens: TS1) -> TS1 {
+    tokens
+}
+
 #[proc_macro]
 pub fn proof_assert(_: TS1) -> TS1 {
     TS1::new()

--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -250,7 +250,7 @@ impl syn::visit_mut::VisitMut for SelfEscape {
 fn escape_self_in_contracts(attrs: &mut Vec<Attribute>) -> Result<()> {
     for attr in attrs {
         if let Some(id) = attr.path.get_ident() {
-            if id == "ensures" || id == "requires" {
+            if id == "ensures" || id == "requires" || id == "may_panic" {
                 let tokens = std::mem::take(&mut attr.tokens);
                 let mut term: Term = syn::parse2(tokens)?;
                 escape_self_in_term(&mut term);

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -172,6 +172,18 @@ fn sig_spec_item(tag: Ident, mut sig: Signature, p: Term) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
+    let spec_kind = parse_quote!{ creusot::spec::requires };
+    precondition(attr, tokens, spec_kind)
+}
+
+
+#[proc_macro_attribute]
+pub fn may_panic(attr: TS1, tokens: TS1) -> TS1 {
+    let spec_kind = parse_quote!{ creusot::spec::may_panic };
+    precondition(attr, tokens, spec_kind)
+}
+
+fn precondition(attr: TS1, tokens: TS1, spec_kind: Path) -> TS1 {
     let mut item = parse_macro_input!(tokens as ContractItem);
     let term = parse_macro_input!(attr as Term);
     item.mark_unused();
@@ -186,7 +198,7 @@ pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
 
             f.block.stmts.insert(0, Stmt::Item(Item::Verbatim(requires_tokens)));
             TS1::from(quote! {
-              #[creusot::spec::requires=#name_tag]
+              #[#spec_kind=#name_tag]
               #f
             })
         }
@@ -194,7 +206,7 @@ pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
             let requires_tokens = sig_spec_item(req_name, s.sig.clone(), term);
             TS1::from(quote! {
               #requires_tokens
-              #[creusot::spec::requires=#name_tag]
+              #[#spec_kind=#name_tag]
               #s
             })
         }
@@ -227,7 +239,7 @@ pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
 
             TS1::from(quote! {
                 {
-                    let #clos_name = #[creusot::spec::requires=#name_tag] #clos;
+                    let #clos_name = #[#spec_kind=#name_tag] #clos;
                     #[allow(unused_must_use)]
                     let _ =
                         #[creusot::no_translate]
@@ -243,6 +255,7 @@ pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
         }
     }
 }
+
 
 #[proc_macro_attribute]
 pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -172,14 +172,13 @@ fn sig_spec_item(tag: Ident, mut sig: Signature, p: Term) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn requires(attr: TS1, tokens: TS1) -> TS1 {
-    let spec_kind = parse_quote!{ creusot::spec::requires };
+    let spec_kind = parse_quote! { creusot::spec::requires };
     precondition(attr, tokens, spec_kind)
 }
 
-
 #[proc_macro_attribute]
 pub fn may_panic(attr: TS1, tokens: TS1) -> TS1 {
-    let spec_kind = parse_quote!{ creusot::spec::may_panic };
+    let spec_kind = parse_quote! { creusot::spec::may_panic };
     precondition(attr, tokens, spec_kind)
 }
 
@@ -255,7 +254,6 @@ fn precondition(attr: TS1, tokens: TS1, spec_kind: Path) -> TS1 {
         }
     }
 }
-
 
 #[proc_macro_attribute]
 pub fn ensures(attr: TS1, tokens: TS1) -> TS1 {

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -62,6 +62,9 @@ mod macros {
     /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
     /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
     pub use creusot_contracts_proc::maintains;
+
+    // TODO: Doc
+    pub use creusot_contracts_proc::may_panic;
 }
 
 #[cfg(not(feature = "contracts"))]
@@ -120,6 +123,9 @@ mod macros {
     /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
     /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
     pub use creusot_contracts_dummy::maintains;
+
+    // TODO: Doc
+    pub use creusot_contracts_dummy::may_panic;
 }
 
 #[cfg(feature = "contracts")]

--- a/creusot-contracts/src/std/option.rs
+++ b/creusot-contracts/src/std/option.rs
@@ -12,9 +12,13 @@ extern_spec! {
                 #[ensures(result == (*self == None))]
                 fn is_none(&self) -> bool;
 
+                #[ensures(Some(result) == self)]
+                #[may_panic(self == None)]
+                fn unwrap(self) -> T;
+
                 #[requires(self != None)]
                 #[ensures(Some(result) == self)]
-                fn unwrap(self) -> T;
+                unsafe fn unwrap_unchecked(self) -> T;
 
                 #[requires(self != None)]
                 #[ensures(Some(result) == self)]

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -675,6 +675,7 @@ impl<'tcx> CloneMap<'tcx> {
 
         // debug_assert!(topo.finished.len() >= self.names.len(), "missed a clone in {:?}", self.self_id);
 
+        decls.push(Decl::UseDecl(Use { name: "prelude.Panic".into(), as_: None }));
         self.prelude
             .iter_mut()
             .filter(|(_, v)| !(**v))

--- a/creusot/src/translated_item.rs
+++ b/creusot/src/translated_item.rs
@@ -3,7 +3,7 @@ use crate::metadata::Metadata;
 use creusot_rustc::hir::def_id::DefId;
 use indexmap::IndexMap;
 
-use why3::declaration::{Decl, Module};
+use why3::declaration::{Decl, Module, Signature};
 
 pub enum TranslatedItem {
     Logic {
@@ -98,5 +98,21 @@ impl<'a> TranslatedItem {
             TranslatedItem::Constant { modl, .. } => box std::iter::once(modl),
             TranslatedItem::Type { .. } => self.modules(),
         }
+    }
+
+    pub(crate) fn interface_signature(&self) -> Option<&Signature> {
+        let interface = match self {
+            TranslatedItem::Program { interface, .. } => interface,
+            TranslatedItem::Extern { interface, .. } => interface,
+            TranslatedItem::Logic { interface, .. } => interface,
+            _ => return None,
+        };
+
+        // TODO: This needs some filling out. Or maybe just specialize
+        // this function on only program-fns?
+        interface.decls.iter().find_map(|decl| match decl {
+            Decl::ValDecl(decl) => Some(&decl.sig),
+            _ => None,
+        })
     }
 }

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -56,6 +56,13 @@ pub(crate) fn after_analysis(mut ctx: TranslationCtx) -> Result<(), Box<dyn Erro
     }
 
     let start = Instant::now();
+
+    for impls in ctx.tcx.all_local_trait_impls(()).values() {
+        for impl_id in impls {
+            ctx.translate(impl_id.to_def_id());
+        }
+    }
+
     for def_id in ctx.tcx.hir().body_owners() {
         let def_id = def_id.to_def_id();
 
@@ -70,12 +77,6 @@ pub(crate) fn after_analysis(mut ctx: TranslationCtx) -> Result<(), Box<dyn Erro
 
         info!("Translating body {:?}", def_id);
         ctx.translate(def_id);
-    }
-
-    for impls in ctx.tcx.all_local_trait_impls(()).values() {
-        for impl_id in impls {
-            ctx.translate(impl_id.to_def_id());
-        }
     }
 
     debug!("after_analysis_translate: {:?}", start.elapsed());

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -78,16 +78,27 @@ impl<'tcx> PreContract<'tcx> {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.requires.is_empty() && self.ensures.is_empty() && self.variant.is_none() && self.may_panic.is_none()
+        self.requires.is_empty()
+            && self.ensures.is_empty()
+            && self.variant.is_none()
+            && self.may_panic.is_none()
     }
 
     #[allow(dead_code)]
     pub(crate) fn terms(&self) -> impl Iterator<Item = &Term<'tcx>> {
-        self.requires.iter().chain(self.ensures.iter()).chain(self.variant.iter()).chain(self.may_panic.iter())
+        self.requires
+            .iter()
+            .chain(self.ensures.iter())
+            .chain(self.variant.iter())
+            .chain(self.may_panic.iter())
     }
 
     fn terms_mut(&mut self) -> impl Iterator<Item = &mut Term<'tcx>> {
-        self.requires.iter_mut().chain(self.ensures.iter_mut()).chain(self.variant.iter_mut()).chain(self.may_panic.iter_mut())
+        self.requires
+            .iter_mut()
+            .chain(self.ensures.iter_mut())
+            .chain(self.variant.iter_mut())
+            .chain(self.may_panic.iter_mut())
     }
 
     pub(crate) fn ensures_conj(&self, tcx: TyCtxt<'tcx>) -> Term<'tcx> {
@@ -150,7 +161,12 @@ impl ContractClauses {
     }
 
     pub(crate) fn iter_ids(&self) -> impl Iterator<Item = DefId> + '_ {
-        self.requires.iter().chain(self.ensures.iter()).chain(self.variant.iter()).chain(self.may_panic.iter()).cloned()
+        self.requires
+            .iter()
+            .chain(self.ensures.iter())
+            .chain(self.variant.iter())
+            .chain(self.may_panic.iter())
+            .cloned()
     }
 }
 

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -71,7 +71,7 @@ impl<'tcx> PreContract<'tcx> {
         }
 
         if let Some(term) = self.may_panic {
-            out.may_panic = Some(lower_pure(ctx, names, param_env, term));
+            out.raises = Some(lower_pure(ctx, names, param_env, term));
         }
 
         out

--- a/prelude/prelude.mlw
+++ b/prelude/prelude.mlw
@@ -167,4 +167,6 @@ module Char
 
   axiom chr_code: forall c. chr (code c) = c
 end
-
+module Panic
+  exception Panic
+end

--- a/why3/src/declaration.rs
+++ b/why3/src/declaration.rs
@@ -55,7 +55,7 @@ pub struct Contract {
     pub requires: Vec<Exp>,
     pub ensures: Vec<Exp>,
     pub variant: Vec<Exp>,
-    pub may_panic: Option<Exp>,
+    pub raises: Option<Exp>,
 }
 
 impl Contract {
@@ -64,7 +64,7 @@ impl Contract {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.requires.is_empty() && self.ensures.is_empty() && self.variant.is_empty() && self.may_panic.is_none()
+        self.requires.is_empty() && self.ensures.is_empty() && self.variant.is_empty() && self.raises.is_none()
     }
 
     pub fn extend(&mut self, other: Contract) {
@@ -73,7 +73,7 @@ impl Contract {
         self.variant.extend(other.variant);
         // You can't put multiple raises expressions in whyml, but we can
         // merge this into "e1 or e2".
-        self.may_panic = match (self.may_panic.take(), other.may_panic) {
+        self.raises = match (self.raises.take(), other.raises) {
             (Some(exp), None) | (None, Some(exp)) => Some(exp),
             (None, None) => None,
             (Some(e1), Some(e2)) => Some(Exp::BinaryOp(
@@ -111,7 +111,7 @@ impl Contract {
         mut req_visitor: T,
         mut ens_visitor: T,
         mut var_visitor: T,
-        mut may_panic_visitor: T,
+        mut raises_visitor: T,
     ) {
         for req in self.requires.iter_mut() {
             req_visitor.visit_mut(req);
@@ -125,8 +125,8 @@ impl Contract {
             var_visitor.visit_mut(var);
         }
 
-        if let Some(may_panic) = &mut self.may_panic {
-            may_panic_visitor.visit_mut(may_panic);
+        if let Some(raises) = &mut self.raises {
+            raises_visitor.visit_mut(raises);
         }
     }
 
@@ -145,8 +145,8 @@ impl Contract {
             qfvs.extend(var.qfvs());
         }
 
-        if let Some(may_panic) = &self.may_panic {
-            qfvs.extend(may_panic.qfvs());
+        if let Some(raises) = &self.raises {
+            qfvs.extend(raises.qfvs());
         }
 
         qfvs

--- a/why3/src/declaration.rs
+++ b/why3/src/declaration.rs
@@ -2,7 +2,7 @@ use indexmap::IndexSet;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{
-    exp::{Binder, BinOp, Exp, ExpMutVisitor},
+    exp::{BinOp, Binder, Exp, ExpMutVisitor},
     mlcfg::{Block, BlockId},
     ty::Type,
     *,
@@ -64,7 +64,10 @@ impl Contract {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.requires.is_empty() && self.ensures.is_empty() && self.variant.is_empty() && self.raises.is_none()
+        self.requires.is_empty()
+            && self.ensures.is_empty()
+            && self.variant.is_empty()
+            && self.raises.is_none()
     }
 
     pub fn extend(&mut self, other: Contract) {
@@ -76,11 +79,7 @@ impl Contract {
         self.raises = match (self.raises.take(), other.raises) {
             (Some(exp), None) | (None, Some(exp)) => Some(exp),
             (None, None) => None,
-            (Some(e1), Some(e2)) => Some(Exp::BinaryOp(
-                BinOp::LogOr,
-                Box::new(e1),
-                Box::new(e2),
-            )),
+            (Some(e1), Some(e2)) => Some(Exp::BinaryOp(BinOp::LogOr, Box::new(e1), Box::new(e2))),
         };
     }
 

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -509,13 +509,14 @@ impl Print for Contract {
             )
         }
 
-        let raises = self.raises.as_ref().unwrap_or(&Exp::Const(Constant::Bool(false)));
-        doc = doc.append(
-            alloc
-                .text("raises ")
-                .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
-                .append(alloc.hardline()),
-        );
+        if let Some(raises) = self.raises.as_ref() {
+            doc = doc.append(
+                alloc
+                    .text("raises ")
+                    .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
+                    .append(alloc.hardline()),
+            );
+        }
 
         doc
     }

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -513,7 +513,9 @@ impl Print for Contract {
             doc = doc.append(
                 alloc
                     .text("raises ")
-                    .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
+                    .append(
+                        alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces(),
+                    )
                     .append(alloc.hardline()),
             );
         }

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -509,9 +509,9 @@ impl Print for Contract {
             )
         }
 
-        let may_panic = self.may_panic.as_ref().unwrap_or(&Exp::Const(Constant::Bool(false)));
+        let raises = self.raises.as_ref().unwrap_or(&Exp::Const(Constant::Bool(false)));
         doc = doc.append(alloc.text("raises ")
-            .append(alloc.text("Panic.Panic -> ").append(may_panic.pretty(alloc, env)).braces())
+            .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
             .append(alloc.hardline())
         );
 

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -510,9 +510,11 @@ impl Print for Contract {
         }
 
         let raises = self.raises.as_ref().unwrap_or(&Exp::Const(Constant::Bool(false)));
-        doc = doc.append(alloc.text("raises ")
-            .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
-            .append(alloc.hardline())
+        doc = doc.append(
+            alloc
+                .text("raises ")
+                .append(alloc.text("Panic.Panic -> ").append(raises.pretty(alloc, env)).braces())
+                .append(alloc.hardline()),
         );
 
         doc

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -509,6 +509,12 @@ impl Print for Contract {
             )
         }
 
+        let may_panic = self.may_panic.as_ref().unwrap_or(&Exp::Const(Constant::Bool(false)));
+        doc = doc.append(alloc.text("raises ")
+            .append(alloc.text("Panic.Panic -> ").append(may_panic.pretty(alloc, env)).braces())
+            .append(alloc.hardline())
+        );
+
         doc
     }
 }


### PR DESCRIPTION
This adds a new attribute `may_panic(condition)` in which you can specify conditions under which a function might panic. It compiles this down to a whyml exception, which works to check that that spec is actually followed. The attribute doesn't *require* that the function panics if the condition is true, it just gives it the option to.

It remains the case that by default a function may not panic - just now because it raises an exception that isn't declared, instead of hitting an `absurd`.

This probably deserves a fair bit of scrutiny, both from a "is this even a good idea" point of view, as well as from an implementation point of view. I'm not particularly familiar with either creusot or whyml, and it's definitely possible that this isn't as good an idea as it seems to me. I'm also not particularly familiar with the internals I'm modifying, and I may have missed something.

It's also 

- [ ] Missing tests (and I've barely tested it manually)
- [ ] In need of at least a few more extern_specs (e.g. for the actual panic function)
- [ ] Unclear if we should consider things like `std::process::abort` as a panic
- [ ] Adding `raises { Panic.Panic -> false }` and `use prelude.Panic` even where those could be omitted (maybe acceptable, it doesn't seem to hurt)
- [ ] Fails to prove if you add `#[may_panic(anything_other_than_false)]` to functions that don't have a panic somewhere within them (unreachable panics work though), thanks to whyml apparently checking that... I'm not sure what to do about this short of a fairly laborious approach of only emitting the `raises` attribute if we call something with a raises attribute.

I think it's in a place where it makes sense to ask for feedback on it though - is this something creusot is interested in supporting?