### PR TITLE
Support for closures in Pearlite

### DIFF
--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -372,6 +372,7 @@ fn escape_self_in_term(t: &mut Term) {
         Term::Pearlite(TermPearlite { block, .. }) => escape_self_in_tblock(block),
         Term::Lit(TermLit { .. }) => {}
         Term::Verbatim(_) => {}
+        Term::Closure(TermClosure { body, .. }) => escape_self_in_term(body),
         Term::__Nonexhaustive => {}
     }
 }

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -230,6 +230,15 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
         }
         RT::Absurd(_) => Ok(quote_spanned! {sp=> creusot_contracts::stubs::abs() }),
         RT::Pearlite(term) => Ok(quote_spanned! {sp=> #term }),
+        RT::Closure(clos) => {
+            let inputs = &clos.inputs;
+            let retty = &clos.output;
+            let clos = encode_term(&*clos.body)?;
+
+            Ok(
+                quote_spanned! {sp=> creusot_contracts :: Mapping :: from_fn (#[creusot :: decl :: logic] #[creusot::no_translate] |#inputs| #retty #clos)},
+            )
+        }
         RT::__Nonexhaustive => todo!(),
     }
 }

--- a/creusot-contracts/src/logic/mapping.rs
+++ b/creusot-contracts/src/logic/mapping.rs
@@ -25,4 +25,11 @@ impl<A, B> Mapping<A, B> {
     pub fn cst(_: B) -> Self {
         absurd
     }
+
+    #[trusted]
+    #[logic]
+    #[creusot::builtins = "identity"]
+    pub fn from_fn<F: FnOnce(A) -> B>(_: F) -> Self {
+        absurd
+    }
 }

--- a/creusot/src/translation/function/promoted.rs
+++ b/creusot/src/translation/function/promoted.rs
@@ -13,7 +13,7 @@ use creusot_rustc::{
 };
 use why3::{
     declaration::{Contract, Decl, LetDecl, Signature},
-    exp::{Exp, Pattern},
+    exp::{Binder, Exp, Pattern},
     QName,
 };
 
@@ -31,7 +31,7 @@ pub fn promoted_signature<'tcx>(
         .map(|arg| {
             let info = &body.local_decls[arg];
             let ty = translate_ty(ctx, names, info.source_info.span, info.ty);
-            (LocalIdent::anon(arg).ident(), ty)
+            Binder::typed(LocalIdent::anon(arg).ident(), ty)
         })
         .collect();
     let retty =

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -110,6 +110,7 @@ impl ContractClauses {
     }
 }
 
+#[derive(Debug)]
 struct ScopeTree(HashMap<SourceScope, (HashSet<(Symbol, Local)>, Option<SourceScope>)>);
 
 impl ScopeTree {
@@ -158,10 +159,11 @@ impl ScopeTree {
         let mut to_visit = Some(scope);
 
         while let Some(s) = to_visit.take() {
-            self.0[&s].0.iter().for_each(|(id, loc)| {
+            let d = (HashSet::new(), None);
+            self.0.get(&s).unwrap_or_else(|| &d).0.iter().for_each(|(id, loc)| {
                 locals.entry(*id).or_insert(*loc);
             });
-            to_visit = self.0[&s].1.clone();
+            to_visit = self.0.get(&s).unwrap_or_else(|| &d).1.clone();
         }
 
         locals

--- a/creusot/src/translation/specification/builtins.rs
+++ b/creusot/src/translation/specification/builtins.rs
@@ -188,6 +188,8 @@ impl<'tcx> Lower<'_, '_, 'tcx> {
             return Some(args.remove(0));
         } else if builtin_attr == Some(Symbol::intern("ghost_deref")) {
             return Some(args.remove(0));
+        } else if builtin_attr == Some(Symbol::intern("identity")) {
+            return Some(args.remove(0));
         } else if def_id == self.ctx.tcx.get_diagnostic_item(sym::abort) {
             // Semi-questionable: we allow abort() & unreachable() in pearlite but
             // interpret them as `absurd` (aka prove false).

--- a/creusot/src/translation/ty.rs
+++ b/creusot/src/translation/ty.rs
@@ -13,7 +13,7 @@ use rustc_middle::ty::TyKind;
 use std::collections::VecDeque;
 use why3::{
     declaration::{AdtDecl, ConstructorDecl, Contract, Decl, Field, LetFun, Module, Signature},
-    exp::{Exp, Pattern},
+    exp::{Binder, Exp, Pattern},
     Ident,
 };
 
@@ -154,6 +154,10 @@ fn translate_ty_inner<'tcx>(
         }
         Closure(id, subst) => {
             ctx.translate(*id);
+
+            if util::is_logic(ctx.tcx, *id) {
+                return MlT::Tuple(Vec::new());
+            }
 
             let name = item_name(ctx.tcx, *id).to_string().to_lowercase();
             let cons = MlT::TConstructor(names.insert(*id, subst).qname_ident(name.into()));
@@ -452,7 +456,7 @@ pub fn build_accessor(
     let sig = Signature {
         name: acc_name.clone(),
         attrs: Vec::new(),
-        args: vec![("self".into(), this.clone())],
+        args: vec![Binder::typed("self".into(), this.clone())],
         retty: Some(field_ty.clone()),
         contract: Contract::new(),
     };

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -314,7 +314,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl0
   type t
@@ -397,7 +397,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
   type t

--- a/creusot/tests/should_succeed/all_zero.mlcfg
+++ b/creusot/tests/should_succeed/all_zero.mlcfg
@@ -118,7 +118,7 @@ module AllZero_AllZero_Interface
   clone AllZero_Impl0_Get_Interface as Get0
   clone AllZero_Impl0_Len_Interface as Len0
   val all_zero [@cfg:stackify] (l : borrowed (AllZero_List_Type.allzero_list_type)) : ()
-    ensures { [#"../all_zero.rs" 32 0 32 77] forall i : (int) . 0 <= i /\ i < Len0.len ( * l) -> Get0.get ( ^ l) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32) }
+    ensures { [#"../all_zero.rs" 32 0 32 77] forall i : int . 0 <= i /\ i < Len0.len ( * l) -> Get0.get ( ^ l) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32) }
     ensures { [#"../all_zero.rs" 33 10 33 34] Len0.len ( * l) = Len0.len ( ^ l) }
     
 end
@@ -138,7 +138,7 @@ module AllZero_AllZero
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve1 with type t = uint32
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = AllZero_List_Type.allzero_list_type
   let rec cfg all_zero [@cfg:stackify] [#"../all_zero.rs" 34 0 34 29] (l : borrowed (AllZero_List_Type.allzero_list_type)) : ()
-    ensures { [#"../all_zero.rs" 32 0 32 77] forall i : (int) . 0 <= i /\ i < Len0.len ( * l) -> Get0.get ( ^ l) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32) }
+    ensures { [#"../all_zero.rs" 32 0 32 77] forall i : int . 0 <= i /\ i < Len0.len ( * l) -> Get0.get ( ^ l) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32) }
     ensures { [#"../all_zero.rs" 33 10 33 34] Len0.len ( * l) = Len0.len ( ^ l) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -171,7 +171,7 @@ module AllZero_AllZero
     goto BB2
   }
   BB2 {
-    invariant zeroed { [#"../all_zero.rs" 39 4 41 88] (forall i : (int) . 0 <= i /\ i < Len0.len ( * loop_l_8) -> Get0.get ( ^ loop_l_8) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32)) -> (forall i : (int) . 0 <= i /\ i < Len0.len ( * old_l_4) -> Get0.get ( ^ old_l_4) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32)) };
+    invariant zeroed { [#"../all_zero.rs" 39 4 41 88] (forall i : int . 0 <= i /\ i < Len0.len ( * loop_l_8) -> Get0.get ( ^ loop_l_8) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32)) -> (forall i : int . 0 <= i /\ i < Len0.len ( * old_l_4) -> Get0.get ( ^ old_l_4) i = Core_Option_Option_Type.Core_Option_Option_Some_Type (0 : uint32)) };
     invariant in_len { [#"../all_zero.rs" 39 4 41 88] Len0.len ( ^ loop_l_8) = Len0.len ( * loop_l_8) -> Len0.len ( ^ old_l_4) = Len0.len ( * old_l_4) };
     switch ( * loop_l_8)
       | AllZero_List_Type.AllZero_List_Cons_Type _ _ -> goto BB3

--- a/creusot/tests/should_succeed/binary_search.mlcfg
+++ b/creusot/tests/should_succeed/binary_search.mlcfg
@@ -350,7 +350,7 @@ module BinarySearch_Impl1_IsSorted
   clone BinarySearch_Impl0_Get_Interface as Get0 with type t = uint32
   predicate is_sorted [#"../binary_search.rs" 88 4 88 30] (self : BinarySearch_List_Type.binarysearch_list_type uint32)
    =
-    [#"../binary_search.rs" 90 12 97 13] forall x2 : (int) . forall x1 : (int) . x1 <= x2 -> match ((Get0.get self x1, Get0.get self x2)) with
+    [#"../binary_search.rs" 90 12 97 13] forall x2 : int . forall x1 : int . x1 <= x2 -> match ((Get0.get self x1, Get0.get self x2)) with
       | (Core_Option_Option_Type.Core_Option_Option_Some_Type v1, Core_Option_Option_Type.Core_Option_Option_Some_Type v2) -> v1 <= v2
       | (Core_Option_Option_Type.Core_Option_Option_None_Type, Core_Option_Option_Type.Core_Option_Option_None_Type) -> true
       | _ -> false
@@ -379,9 +379,9 @@ module BinarySearch_BinarySearch_Interface
   val binary_search [@cfg:stackify] (arr : BinarySearch_List_Type.binarysearch_list_type uint32) (elem : uint32) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../binary_search.rs" 102 11 102 39] LenLogic0.len_logic arr <= 1000000}
     requires {[#"../binary_search.rs" 103 11 103 26] IsSorted0.is_sorted arr}
-    ensures { [#"../binary_search.rs" 104 0 104 73] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Get0.get arr (UInt64.to_int x) = Core_Option_Option_Type.Core_Option_Option_Some_Type elem }
-    ensures { [#"../binary_search.rs" 105 0 106 78] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . 0 <= UInt64.to_int i /\ UInt64.to_int i < UInt64.to_int x -> GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32) <= elem) }
-    ensures { [#"../binary_search.rs" 107 0 108 90] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . UInt64.to_int x < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32)) }
+    ensures { [#"../binary_search.rs" 104 0 104 73] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Get0.get arr (UInt64.to_int x) = Core_Option_Option_Type.Core_Option_Option_Some_Type elem }
+    ensures { [#"../binary_search.rs" 105 0 106 78] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . 0 <= UInt64.to_int i /\ UInt64.to_int i < UInt64.to_int x -> GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32) <= elem) }
+    ensures { [#"../binary_search.rs" 107 0 108 90] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . UInt64.to_int x < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32)) }
     
 end
 module BinarySearch_BinarySearch
@@ -405,9 +405,9 @@ module BinarySearch_BinarySearch
   let rec cfg binary_search [@cfg:stackify] [#"../binary_search.rs" 109 0 109 72] (arr : BinarySearch_List_Type.binarysearch_list_type uint32) (elem : uint32) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../binary_search.rs" 102 11 102 39] LenLogic0.len_logic arr <= 1000000}
     requires {[#"../binary_search.rs" 103 11 103 26] IsSorted0.is_sorted arr}
-    ensures { [#"../binary_search.rs" 104 0 104 73] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Get0.get arr (UInt64.to_int x) = Core_Option_Option_Type.Core_Option_Option_Some_Type elem }
-    ensures { [#"../binary_search.rs" 105 0 106 78] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . 0 <= UInt64.to_int i /\ UInt64.to_int i < UInt64.to_int x -> GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32) <= elem) }
-    ensures { [#"../binary_search.rs" 107 0 108 90] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . UInt64.to_int x < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32)) }
+    ensures { [#"../binary_search.rs" 104 0 104 73] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Get0.get arr (UInt64.to_int x) = Core_Option_Option_Type.Core_Option_Option_Some_Type elem }
+    ensures { [#"../binary_search.rs" 105 0 106 78] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . 0 <= UInt64.to_int i /\ UInt64.to_int i < UInt64.to_int x -> GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32) <= elem) }
+    ensures { [#"../binary_search.rs" 107 0 108 90] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . UInt64.to_int x < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr -> elem < GetDefault0.get_default arr (UInt64.to_int i) (0 : uint32)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Result_Result_Type.core_result_result_type usize usize;
@@ -489,8 +489,8 @@ module BinarySearch_BinarySearch
   }
   BB5 {
     invariant size_valid { [#"../binary_search.rs" 116 28 116 75] 0 < UInt64.to_int size_13 /\ UInt64.to_int size_13 + UInt64.to_int base_15 <= LenLogic0.len_logic arr_1 };
-    invariant lower_b { [#"../binary_search.rs" 116 4 116 77] forall i : (usize) . i < base_15 -> GetDefault0.get_default arr_1 (UInt64.to_int i) (0 : uint32) <= elem_2 };
-    invariant lower_b { [#"../binary_search.rs" 116 4 116 77] forall i : (usize) . UInt64.to_int base_15 + UInt64.to_int size_13 < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr_1 -> elem_2 < GetDefault0.get_default arr_1 (UInt64.to_int i) (0 : uint32) };
+    invariant lower_b { [#"../binary_search.rs" 116 4 116 77] forall i : usize . i < base_15 -> GetDefault0.get_default arr_1 (UInt64.to_int i) (0 : uint32) <= elem_2 };
+    invariant lower_b { [#"../binary_search.rs" 116 4 116 77] forall i : usize . UInt64.to_int base_15 + UInt64.to_int size_13 < UInt64.to_int i /\ UInt64.to_int i < LenLogic0.len_logic arr_1 -> elem_2 < GetDefault0.get_default arr_1 (UInt64.to_int i) (0 : uint32) };
     _22 <- size_13;
     _21 <- ([#"../binary_search.rs" 119 10 119 18] _22 > (1 : usize));
     switch (_21)

--- a/creusot/tests/should_succeed/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_succeed/bug/01_resolve_unsoundness.mlcfg
@@ -127,7 +127,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t

--- a/creusot/tests/should_succeed/bug/463.mlcfg
+++ b/creusot/tests/should_succeed/bug/463.mlcfg
@@ -89,7 +89,7 @@ module C463_Test
   var closure_3 : Closure00.c463_test_closure0;
   var y_6 : usize;
   var _7 : Closure00.c463_test_closure0;
-  var _8 : (usize);
+  var _8 : usize;
   {
     goto BB0
   }

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -279,7 +279,7 @@ module C02_FibCell
   predicate fib_cell [#"../02.rs" 80 0 80 32] (v : Alloc_Vec_Vec_Type.alloc_vec_vec_type (C02_Cell_Type.c02_cell_type (Core_Option_Option_Type.core_option_option_type usize) (C02_Fib_Type.c02_fib_type)) (Alloc_Alloc_Global_Type.alloc_alloc_global_type))
     
    =
-    [#"../02.rs" 81 4 83 5] forall i : (int) . UInt64.to_int (C02_Fib_Type.c02_fib_type_Fib_ix (C02_Cell_Type.c02_cell_type_Cell_ghost_inv (Seq.get (Model0.model v) i))) = i
+    [#"../02.rs" 81 4 83 5] forall i : int . UInt64.to_int (C02_Fib_Type.c02_fib_type_Fib_ix (C02_Cell_Type.c02_cell_type_Cell_ghost_inv (Seq.get (Model0.model v) i))) = i
 end
 module CreusotContracts_Logic_Model_Model_ModelTy_Type
   type self

--- a/creusot/tests/should_succeed/cell/03_fib_unbounded.mlcfg
+++ b/creusot/tests/should_succeed/cell/03_fib_unbounded.mlcfg
@@ -217,7 +217,7 @@ module C03FibUnbounded_FibCell
   predicate fib_cell [#"../03_fib_unbounded.rs" 62 0 62 32] (v : Alloc_Vec_Vec_Type.alloc_vec_vec_type (C03FibUnbounded_Cell_Type.c03fibunbounded_cell_type (Core_Option_Option_Type.core_option_option_type int) (C03FibUnbounded_Fib_Type.c03fibunbounded_fib_type)) (Alloc_Alloc_Global_Type.alloc_alloc_global_type))
     
    =
-    [#"../03_fib_unbounded.rs" 63 4 65 5] forall i : (int) . C03FibUnbounded_Fib_Type.c03fibunbounded_fib_type_Fib_ix (C03FibUnbounded_Cell_Type.c03fibunbounded_cell_type_Cell_ghost_inv (Seq.get (Model0.model v) i)) = i
+    [#"../03_fib_unbounded.rs" 63 4 65 5] forall i : int . C03FibUnbounded_Fib_Type.c03fibunbounded_fib_type_Fib_ix (C03FibUnbounded_Cell_Type.c03fibunbounded_cell_type_Cell_ghost_inv (Seq.get (Model0.model v) i)) = i
 end
 module CreusotContracts_Logic_Model_Model_ModelTy_Type
   type self

--- a/creusot/tests/should_succeed/checked_ops.mlcfg
+++ b/creusot/tests/should_succeed/checked_ops.mlcfg
@@ -11,7 +11,7 @@ module Core_Num_Impl7_CheckedAdd_Interface
   use Core_Option_Option_Type
   val checked_add [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
     
 end
 module Core_Num_Impl7_CheckedAdd
@@ -20,7 +20,7 @@ module Core_Num_Impl7_CheckedAdd
   use Core_Option_Option_Type
   val checked_add [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
@@ -65,8 +65,8 @@ module Core_Num_Impl7_WrappingAdd_Interface
   val wrapping_add [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_WrappingAdd
@@ -79,8 +79,8 @@ module Core_Num_Impl7_WrappingAdd
   val wrapping_add [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_SaturatingAdd_Interface
@@ -119,8 +119,8 @@ module Core_Num_Impl7_OverflowingAdd_Interface
   val overflowing_add [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -135,8 +135,8 @@ module Core_Num_Impl7_OverflowingAdd
   val overflowing_add [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -769,7 +769,7 @@ module Core_Num_Impl7_CheckedSub_Interface
   use Core_Option_Option_Type
   val checked_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
     
 end
 module Core_Num_Impl7_CheckedSub
@@ -778,7 +778,7 @@ module Core_Num_Impl7_CheckedSub
   use Core_Option_Option_Type
   val checked_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
     
 end
 module Core_Num_Impl7_WrappingSub_Interface
@@ -791,8 +791,8 @@ module Core_Num_Impl7_WrappingSub_Interface
   val wrapping_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_WrappingSub
@@ -805,8 +805,8 @@ module Core_Num_Impl7_WrappingSub
   val wrapping_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_SaturatingSub_Interface
@@ -838,8 +838,8 @@ module Core_Num_Impl7_OverflowingSub_Interface
   val overflowing_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -854,8 +854,8 @@ module Core_Num_Impl7_OverflowingSub
   val overflowing_sub [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -1452,7 +1452,7 @@ module Core_Num_Impl7_CheckedMul_Interface
   use Core_Option_Option_Type
   val checked_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
     
 end
 module Core_Num_Impl7_CheckedMul
@@ -1461,7 +1461,7 @@ module Core_Num_Impl7_CheckedMul
   use Core_Option_Option_Type
   val checked_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
     
 end
 module Core_Num_Impl7_WrappingMul_Interface
@@ -1474,8 +1474,8 @@ module Core_Num_Impl7_WrappingMul_Interface
   val wrapping_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_WrappingMul
@@ -1488,8 +1488,8 @@ module Core_Num_Impl7_WrappingMul
   val wrapping_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : uint8
     ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     
 end
 module Core_Num_Impl7_SaturatingMul_Interface
@@ -1521,8 +1521,8 @@ module Core_Num_Impl7_OverflowingMul_Interface
   val overflowing_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -1537,8 +1537,8 @@ module Core_Num_Impl7_OverflowingMul
   val overflowing_mul [@cfg:stackify] (self : uint8) (rhs : uint8) : (uint8, bool)
     ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 8) + UInt8.to_int (0 : uint8) }
     ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int (0 : uint8) /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int (255 : uint8) -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : (int) . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
+    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8) -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int (255 : uint8) - UInt8.to_int (0 : uint8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int (0 : uint8) \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int (255 : uint8)) }
     
 end
@@ -2079,7 +2079,7 @@ module Core_Num_Impl7_CheckedDiv_Interface
   use Core_Option_Option_Type
   val checked_div [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int rhs = 0 \/ UInt8.to_int self = UInt8.to_int (0 : uint8) /\ UInt8.to_int rhs = - 1) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
     
 end
 module Core_Num_Impl7_CheckedDiv
@@ -2089,7 +2089,7 @@ module Core_Num_Impl7_CheckedDiv
   use Core_Option_Option_Type
   val checked_div [@cfg:stackify] (self : uint8) (rhs : uint8) : Core_Option_Option_Type.core_option_option_type uint8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (UInt8.to_int rhs = 0 \/ UInt8.to_int self = UInt8.to_int (0 : uint8) /\ UInt8.to_int rhs = - 1) }
-    ensures { forall r : (uint8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    ensures { forall r : uint8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
     
 end
 module Core_Num_Impl7_WrappingDiv_Interface
@@ -2606,7 +2606,7 @@ module Core_Num_Impl1_CheckedAdd_Interface
   use Core_Option_Option_Type
   val checked_add [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_CheckedAdd
@@ -2615,7 +2615,7 @@ module Core_Num_Impl1_CheckedAdd
   use Core_Option_Option_Type
   val checked_add [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_WrappingAdd_Interface
@@ -2628,8 +2628,8 @@ module Core_Num_Impl1_WrappingAdd_Interface
   val wrapping_add [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_WrappingAdd
@@ -2642,8 +2642,8 @@ module Core_Num_Impl1_WrappingAdd
   val wrapping_add [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_SaturatingAdd_Interface
@@ -2675,8 +2675,8 @@ module Core_Num_Impl1_OverflowingAdd_Interface
   val overflowing_add [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -2691,8 +2691,8 @@ module Core_Num_Impl1_OverflowingAdd
   val overflowing_add [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -3576,7 +3576,7 @@ module Core_Num_Impl1_CheckedSub_Interface
   use Core_Option_Option_Type
   val checked_sub [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_CheckedSub
@@ -3585,7 +3585,7 @@ module Core_Num_Impl1_CheckedSub
   use Core_Option_Option_Type
   val checked_sub [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_WrappingSub_Interface
@@ -3598,8 +3598,8 @@ module Core_Num_Impl1_WrappingSub_Interface
   val wrapping_sub [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_WrappingSub
@@ -3612,8 +3612,8 @@ module Core_Num_Impl1_WrappingSub
   val wrapping_sub [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_SaturatingSub_Interface
@@ -3645,8 +3645,8 @@ module Core_Num_Impl1_OverflowingSub_Interface
   val overflowing_sub [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -3661,8 +3661,8 @@ module Core_Num_Impl1_OverflowingSub
   val overflowing_sub [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -4550,7 +4550,7 @@ module Core_Num_Impl1_CheckedMul_Interface
   use Core_Option_Option_Type
   val checked_mul [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_CheckedMul
@@ -4559,7 +4559,7 @@ module Core_Num_Impl1_CheckedMul
   use Core_Option_Option_Type
   val checked_mul [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8)) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
     
 end
 module Core_Num_Impl1_WrappingMul_Interface
@@ -4572,8 +4572,8 @@ module Core_Num_Impl1_WrappingMul_Interface
   val wrapping_mul [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_WrappingMul
@@ -4586,8 +4586,8 @@ module Core_Num_Impl1_WrappingMul
   val wrapping_mul [@cfg:stackify] (self : int8) (rhs : int8) : int8
     ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     
 end
 module Core_Num_Impl1_SaturatingMul_Interface
@@ -4619,8 +4619,8 @@ module Core_Num_Impl1_OverflowingMul_Interface
   val overflowing_mul [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -4635,8 +4635,8 @@ module Core_Num_Impl1_OverflowingMul
   val overflowing_mul [@cfg:stackify] (self : int8) (rhs : int8) : (int8, bool)
     ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 8) + Int8.to_int (-128 : int8) }
     ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int (-128 : int8) /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int (127 : int8) -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : (int) . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
+    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8) -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int (127 : int8) - Int8.to_int (-128 : int8) + 1)) }
     ensures { Model0.model (let (_, a) = result in a) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int (-128 : int8) \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int (127 : int8)) }
     
 end
@@ -5290,7 +5290,7 @@ module Core_Num_Impl1_CheckedDiv_Interface
   use Core_Option_Option_Type
   val checked_div [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int rhs = 0 \/ Int8.to_int self = Int8.to_int (-128 : int8) /\ Int8.to_int rhs = - 1) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
     
 end
 module Core_Num_Impl1_CheckedDiv
@@ -5300,7 +5300,7 @@ module Core_Num_Impl1_CheckedDiv
   use Core_Option_Option_Type
   val checked_div [@cfg:stackify] (self : int8) (rhs : int8) : Core_Option_Option_Type.core_option_option_type int8
     ensures { (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Int8.to_int rhs = 0 \/ Int8.to_int self = Int8.to_int (-128 : int8) /\ Int8.to_int rhs = - 1) }
-    ensures { forall r : (int8) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
+    ensures { forall r : int8 . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
     
 end
 module Core_Num_Impl1_WrappingDiv_Interface

--- a/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
@@ -121,14 +121,13 @@ module C03GenericBound_ClosureParam
   use mach.int.Int
   use mach.int.UInt32
   use prelude.Borrow
-  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = (uint32), type f = f,
+  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = uint32, type f = f, type Output0.output = ()
+  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = uint32, type f = f, type Output0.output = ()
+  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = uint32, type f = f,
   type Output0.output = ()
-  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = (uint32), type f = f, type Output0.output = ()
-  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = (uint32), type f = f,
-  type Output0.output = ()
-  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (uint32), type f = f
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = uint32, type f = f
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
-  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (uint32),
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = uint32,
   predicate Precondition0.precondition = Precondition0.precondition,
   predicate Postcondition0.postcondition = Postcondition0.postcondition, type Output0.output = ()
   let rec cfg closure_param [@cfg:stackify] [#"../03_generic_bound.rs" 3 0 3 34] (f : f) : ()
@@ -136,7 +135,7 @@ module C03GenericBound_ClosureParam
   var _0 : ();
   var f_1 : f;
   var _2 : f;
-  var _3 : (uint32);
+  var _3 : uint32;
   {
     f_1 <- f;
     goto BB0

--- a/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
@@ -123,13 +123,13 @@ module C04GenericClosure_GenericClosure
   type b
   type f
   use prelude.Borrow
-  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = (a), type f = f, type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = (a), type f = f, type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = (a), type f = f,
+  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = a, type f = f, type Output0.output = b
+  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = a, type f = f, type Output0.output = b
+  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = a, type f = f,
   type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (a), type f = f
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = a, type f = f
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = f
-  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (a),
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = a,
   predicate Precondition0.precondition = Precondition0.precondition,
   predicate Postcondition0.postcondition = Postcondition0.postcondition, type Output0.output = b
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = a
@@ -139,7 +139,7 @@ module C04GenericClosure_GenericClosure
   var f_1 : f;
   var a_2 : a;
   var _3 : f;
-  var _4 : (a);
+  var _4 : a;
   var _5 : a;
   {
     f_1 <- f;

--- a/creusot/tests/should_succeed/closures/05_map.mlcfg
+++ b/creusot/tests/should_succeed/closures/05_map.mlcfg
@@ -190,12 +190,12 @@ module C05Map_Impl0_Next
   use C05Map_Map_Type
   use mach.int.Int
   use prelude.IntSize
-  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = (a), type f = f, type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = (a), type f = f, type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = (a), type f = f,
+  clone CreusotContracts_Std1_Fun_Impl2_FnOnce as FnOnce0 with type args = a, type f = f, type Output0.output = b
+  clone CreusotContracts_Std1_Fun_Impl2_FnMut as FnMut0 with type args = a, type f = f, type Output0.output = b
+  clone CreusotContracts_Std1_Fun_Impl2_Postcondition as Postcondition0 with type args = a, type f = f,
   type Output0.output = b
-  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (a), type f = f
-  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = (a),
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = a, type f = f
+  clone Core_Ops_Function_Fn_Call_Interface as Call0 with type self = f, type args = a,
   predicate Precondition0.precondition = Precondition0.precondition,
   predicate Postcondition0.postcondition = Postcondition0.postcondition, type Output0.output = b
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve2 with type self = a
@@ -213,7 +213,7 @@ module C05Map_Impl0_Next
   var e_5 : a;
   var _6 : b;
   var _7 : f;
-  var _8 : (a);
+  var _8 : a;
   var _9 : a;
   {
     self_1 <- self;

--- a/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
@@ -147,7 +147,7 @@ module CreusotContracts_Std1_Fun_FnMutSpec_FnMutOnce
   clone CreusotContracts_Std1_Fun_FnOnceSpec_PostconditionOnce_Interface as PostconditionOnce0 with type self = self,
   type args = args, type Output0.output = Output0.output
   function fn_mut_once (self : self) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : (borrowed self) .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed self .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module Core_Ops_Function_FnOnce_CallOnce_Interface
   type self
@@ -253,7 +253,7 @@ module C06FnSpecs_Weaken2_Interface
   clone CreusotContracts_Std1_Fun_FnOnceSpec_Precondition_Interface as Precondition0 with type self = f, type args = a
   val weaken_2 [@cfg:stackify] (f : f) (a : a) : Output0.output
     requires {[#"../06_fn_specs.rs" 11 11 11 28] Precondition0.precondition f a}
-    ensures { [#"../06_fn_specs.rs" 12 0 12 93] exists f2 : (borrowed f) .  * f2 = f /\ PostconditionMut0.postcondition_mut f2 a result /\ Resolve0.resolve ( ^ f2) }
+    ensures { [#"../06_fn_specs.rs" 12 0 12 93] exists f2 : borrowed f .  * f2 = f /\ PostconditionMut0.postcondition_mut f2 a result /\ Resolve0.resolve ( ^ f2) }
     
 end
 module C06FnSpecs_Weaken2
@@ -278,7 +278,7 @@ module C06FnSpecs_Weaken2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve1 with type self = a
   let rec cfg weaken_2 [@cfg:stackify] [#"../06_fn_specs.rs" 13 0 13 66] (f : f) (a : a) : Output0.output
     requires {[#"../06_fn_specs.rs" 11 11 11 28] Precondition0.precondition f a}
-    ensures { [#"../06_fn_specs.rs" 12 0 12 93] exists f2 : (borrowed f) .  * f2 = f /\ PostconditionMut0.postcondition_mut f2 a result /\ Resolve0.resolve ( ^ f2) }
+    ensures { [#"../06_fn_specs.rs" 12 0 12 93] exists f2 : borrowed f .  * f2 = f /\ PostconditionMut0.postcondition_mut f2 a result /\ Resolve0.resolve ( ^ f2) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Output0.output;
@@ -432,7 +432,7 @@ module C06FnSpecs_FnOnceUser_Interface
   type f
   use mach.int.Int
   use prelude.UIntSize
-  clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = (usize), type f = f
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = usize, type f = f
   val fn_once_user [@cfg:stackify] (f : f) : ()
     requires {[#"../06_fn_specs.rs" 24 11 24 36] Precondition0.precondition f ((0 : usize))}
     
@@ -441,10 +441,10 @@ module C06FnSpecs_FnOnceUser
   type f
   use mach.int.Int
   use prelude.UIntSize
-  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (usize), type f = f
-  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = (usize), type f = f,
+  clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = usize, type f = f
+  clone CreusotContracts_Std1_Fun_Impl0_PostconditionOnce as PostconditionOnce0 with type args = usize, type f = f,
   type Output0.output = ()
-  clone Core_Ops_Function_FnOnce_CallOnce_Interface as CallOnce0 with type self = f, type args = (usize),
+  clone Core_Ops_Function_FnOnce_CallOnce_Interface as CallOnce0 with type self = f, type args = usize,
   predicate Precondition0.precondition = Precondition0.precondition,
   predicate PostconditionOnce0.postcondition_once = PostconditionOnce0.postcondition_once, type Output0.output = ()
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve as Resolve0 with type self = f
@@ -455,7 +455,7 @@ module C06FnSpecs_FnOnceUser
   var _0 : ();
   var f_1 : f;
   var _3 : f;
-  var _4 : (usize);
+  var _4 : usize;
   {
     f_1 <- f;
     goto BB0

--- a/creusot/tests/should_succeed/closures/08_multiple_calls.mlcfg
+++ b/creusot/tests/should_succeed/closures/08_multiple_calls.mlcfg
@@ -46,7 +46,7 @@ module C08MultipleCalls_UsesFn_Interface
   clone CreusotContracts_Std1_Fun_Impl0_Precondition_Interface as Precondition0 with type args = (), type f = f
   val uses_fn [@cfg:stackify] (f : f) : ()
     requires {[#"../08_multiple_calls.rs" 17 11 17 29] Precondition0.precondition f ()}
-    ensures { [#"../08_multiple_calls.rs" 18 0 18 70] exists r : (uint32) . exists f2 : (f) . f2 = f /\ Postcondition0.postcondition f2 () r }
+    ensures { [#"../08_multiple_calls.rs" 18 0 18 70] exists r : uint32 . exists f2 : f . f2 = f /\ Postcondition0.postcondition f2 () r }
     
 end
 module C08MultipleCalls_UsesFn
@@ -59,7 +59,7 @@ module C08MultipleCalls_UsesFn
   clone CreusotContracts_Std1_Fun_Impl0_Precondition as Precondition0 with type args = (), type f = f
   val uses_fn [@cfg:stackify] (f : f) : ()
     requires {[#"../08_multiple_calls.rs" 17 11 17 29] Precondition0.precondition f ()}
-    ensures { [#"../08_multiple_calls.rs" 18 0 18 70] exists r : (uint32) . exists f2 : (f) . f2 = f /\ Postcondition0.postcondition f2 () r }
+    ensures { [#"../08_multiple_calls.rs" 18 0 18 70] exists r : uint32 . exists f2 : f . f2 = f /\ Postcondition0.postcondition f2 () r }
     
 end
 module C08MultipleCalls_MultiUse_Closure0_Interface

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -275,7 +275,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -291,7 +291,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndexSpec_ResolveElswhere_Interface
@@ -392,7 +392,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl0
   type t
@@ -475,7 +475,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
   type t

--- a/creusot/tests/should_succeed/forall.mlcfg
+++ b/creusot/tests/should_succeed/forall.mlcfg
@@ -3,14 +3,14 @@ module Forall_F_Interface
   use mach.int.Int
   use mach.int.UInt32
   val f [@cfg:stackify] (_ : ()) : ()
-    ensures { [#"../forall.rs" 5 0 5 95] forall _x : (uint32) . true /\ true /\ true /\ true /\ true /\ true /\ true /\ true /\ true }
+    ensures { [#"../forall.rs" 5 0 5 95] forall _x : uint32 . true /\ true /\ true /\ true /\ true /\ true /\ true /\ true /\ true }
     
 end
 module Forall_F
   use mach.int.Int
   use mach.int.UInt32
   let rec cfg f [@cfg:stackify] [#"../forall.rs" 6 0 6 10] (_ : ()) : ()
-    ensures { [#"../forall.rs" 5 0 5 95] forall _x : (uint32) . true /\ true /\ true /\ true /\ true /\ true /\ true /\ true /\ true }
+    ensures { [#"../forall.rs" 5 0 5 95] forall _x : uint32 . true /\ true /\ true /\ true /\ true /\ true /\ true /\ true /\ true }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -30,7 +30,7 @@ end
 module Forall_Omg
   use mach.int.Int
   predicate omg [#"../forall.rs" 11 0 11 34] (a : int) (b : int) =
-    [#"../forall.rs" 12 4 14 7] exists c : (int) . a + c = b
+    [#"../forall.rs" 12 4 14 7] exists c : int . a + c = b
   axiom omg_spec : forall a : int, b : int . ([#"../forall.rs" 9 11 9 17] a <= b) -> ([#"../forall.rs" 10 10 10 14] true)
 end
 module Forall_Omg_Impl
@@ -40,5 +40,5 @@ module Forall_Omg_Impl
     ensures { [#"../forall.rs" 10 10 10 14] true }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"../forall.rs" 12 4 14 7] pure {exists c : (int) . a + c = b}
+    [#"../forall.rs" 12 4 14 7] pure {exists c : int . a + c = b}
 end

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -352,7 +352,7 @@ module Hashmap_Impl3_Model
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model [#"../hashmap.rs" 86 4 86 35] (self : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v) : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v)
     
-  axiom model_spec : forall self : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v . [#"../hashmap.rs" 85 4 85 70] forall k : (k) . Map.get (model self) (Model0.model k) = Get0.get (Bucket0.bucket self k) (Model0.model k)
+  axiom model_spec : forall self : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v . [#"../hashmap.rs" 85 4 85 70] forall k : k . Map.get (model self) (Model0.model k) = Get0.get (Bucket0.bucket self k) (Model0.model k)
 end
 module Hashmap_Impl5_GoodBucket_Interface
   type k
@@ -378,7 +378,7 @@ module Hashmap_Impl5_GoodBucket
   predicate good_bucket [#"../hashmap.rs" 209 4 209 57] (self : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v) (l : Hashmap_List_Type.hashmap_list_type (k, v)) (h : int)
     
    =
-    [#"../hashmap.rs" 210 8 212 9] forall v : (v) . forall k : (k) . Get0.get l (Model0.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> BucketIx0.bucket_ix self k = h
+    [#"../hashmap.rs" 210 8 212 9] forall v : v . forall k : k . Get0.get l (Model0.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> BucketIx0.bucket_ix self k = h
 end
 module Hashmap_Impl5_HashmapInv_Interface
   type k
@@ -403,7 +403,7 @@ module Hashmap_Impl5_HashmapInv
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = Hashmap_List_Type.hashmap_list_type (k, v),
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate hashmap_inv [#"../hashmap.rs" 218 4 218 33] (self : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v) =
-    [#"../hashmap.rs" 219 8 222 9] 0 < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) /\ (forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) -> GoodBucket0.good_bucket self (Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) i) i /\ NoDoubleBinding0.no_double_binding (Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) i))
+    [#"../hashmap.rs" 219 8 222 9] 0 < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) /\ (forall i : int . 0 <= i /\ i < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) -> GoodBucket0.good_bucket self (Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) i) i /\ NoDoubleBinding0.no_double_binding (Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets self)) i))
 end
 module Hashmap_Impl3_ModelTy_Type
   type k
@@ -476,7 +476,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -492,7 +492,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface
@@ -526,7 +526,7 @@ module Hashmap_Impl5_New_Interface
   val new [@cfg:stackify] (size : usize) : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v
     requires {[#"../hashmap.rs" 103 15 103 24] 0 < UInt64.to_int size}
     ensures { [#"../hashmap.rs" 104 14 104 34] HashmapInv0.hashmap_inv result }
-    ensures { [#"../hashmap.rs" 105 4 105 54] forall i : (k) . Map.get (Model0.model result) (Model1.model i) = Core_Option_Option_Type.Core_Option_Option_None_Type }
+    ensures { [#"../hashmap.rs" 105 4 105 54] forall i : k . Map.get (Model0.model result) (Model1.model i) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
 module Hashmap_Impl5_New
@@ -572,7 +572,7 @@ module Hashmap_Impl5_New
   let rec cfg new [@cfg:stackify] [#"../hashmap.rs" 106 4 106 46] (size : usize) : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v
     requires {[#"../hashmap.rs" 103 15 103 24] 0 < UInt64.to_int size}
     ensures { [#"../hashmap.rs" 104 14 104 34] HashmapInv0.hashmap_inv result }
-    ensures { [#"../hashmap.rs" 105 4 105 54] forall i : (k) . Map.get (Model0.model result) (Model1.model i) = Core_Option_Option_Type.Core_Option_Option_None_Type }
+    ensures { [#"../hashmap.rs" 105 4 105 54] forall i : k . Map.get (Model0.model result) (Model1.model i) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v;
@@ -869,7 +869,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module Core_Slice_Index_Impl2_Output_Type
   type t
@@ -911,7 +911,7 @@ module Hashmap_Impl5_Add_Interface
   val add [@cfg:stackify] (self : borrowed (Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v)) (key : k) (val' : v) : ()
     requires {[#"../hashmap.rs" 111 15 111 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 112 14 112 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 113 4 113 105] forall i : (k) . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
+    ensures { [#"../hashmap.rs" 113 4 113 105] forall i : k . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
       Core_Option_Option_Type.Core_Option_Option_Some_Type val'
     else
       Map.get (Model0.model ( * self)) (Model1.model i)
@@ -987,7 +987,7 @@ module Hashmap_Impl5_Add
   let rec cfg add [@cfg:stackify] [#"../hashmap.rs" 114 4 114 41] (self : borrowed (Hashmap_MyHashMap_Type.hashmap_myhashmap_type k v)) (key : k) (val' : v) : ()
     requires {[#"../hashmap.rs" 111 15 111 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 112 14 112 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 113 4 113 105] forall i : (k) . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
+    ensures { [#"../hashmap.rs" 113 4 113 105] forall i : k . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
       Core_Option_Option_Type.Core_Option_Option_Some_Type val'
     else
       Map.get (Model0.model ( * self)) (Model1.model i)
@@ -1099,9 +1099,9 @@ module Hashmap_Impl5_Add
     invariant xx { [#"../hashmap.rs" 123 24 123 52] GoodBucket0.good_bucket ( * self_1) ( * l_19) (UInt64.to_int index_13) };
     invariant xx { [#"../hashmap.rs" 122 8 122 51] GoodBucket0.good_bucket ( * self_1) ( ^ l_19) (UInt64.to_int index_13) -> GoodBucket0.good_bucket ( * self_1) ( ^ old_l_24) (UInt64.to_int index_13) };
     invariant get_key { [#"../hashmap.rs" 122 8 122 51] Get0.get ( ^ l_19) (Model1.model key_2) = Core_Option_Option_Type.Core_Option_Option_Some_Type val'_3 -> Get0.get ( ^ old_l_24) (Model1.model key_2) = Core_Option_Option_Type.Core_Option_Option_Some_Type val'_3 };
-    invariant get_rest { [#"../hashmap.rs" 122 8 122 51] forall i : (ModelTy0.modelTy) . Get0.get ( ^ l_19) i = Get0.get ( * l_19) i -> Get0.get ( ^ old_l_24) i = Get0.get ( * old_l_24) i };
+    invariant get_rest { [#"../hashmap.rs" 122 8 122 51] forall i : ModelTy0.modelTy . Get0.get ( ^ l_19) i = Get0.get ( * l_19) i -> Get0.get ( ^ old_l_24) i = Get0.get ( * old_l_24) i };
     invariant no_double_binding { [#"../hashmap.rs" 127 39 127 63] NoDoubleBinding0.no_double_binding ( * l_19) };
-    invariant no_double_binding_magic { [#"../hashmap.rs" 122 8 122 51] (forall i : (ModelTy0.modelTy) . Get0.get ( * l_19) i = Get0.get ( ^ l_19) i \/ i = Model1.model key_2) /\ NoDoubleBinding0.no_double_binding ( ^ l_19) -> NoDoubleBinding0.no_double_binding ( ^ old_l_24) };
+    invariant no_double_binding_magic { [#"../hashmap.rs" 122 8 122 51] (forall i : ModelTy0.modelTy . Get0.get ( * l_19) i = Get0.get ( ^ l_19) i \/ i = Model1.model key_2) /\ NoDoubleBinding0.no_double_binding ( ^ l_19) -> NoDoubleBinding0.no_double_binding ( ^ old_l_24) };
     switch ( * l_19)
       | Hashmap_List_Type.Hashmap_List_Cons_Type _ _ -> goto BB8
       | _ -> goto BB12
@@ -1520,7 +1520,7 @@ module Hashmap_Impl5_Resize_Interface
     requires {[#"../hashmap.rs" 165 15 165 43] Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * self))) < 1000}
     requires {[#"../hashmap.rs" 166 15 166 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 167 14 167 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 168 4 168 66] forall k : (k) . Map.get (Model1.model ( ^ self)) (Model2.model k) = Map.get (Model1.model ( * self)) (Model2.model k) }
+    ensures { [#"../hashmap.rs" 168 4 168 66] forall k : k . Map.get (Model1.model ( ^ self)) (Model2.model k) = Map.get (Model1.model ( * self)) (Model2.model k) }
     
 end
 module Hashmap_Impl5_Resize
@@ -1600,7 +1600,7 @@ module Hashmap_Impl5_Resize
     requires {[#"../hashmap.rs" 165 15 165 43] Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * self))) < 1000}
     requires {[#"../hashmap.rs" 166 15 166 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 167 14 167 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 168 4 168 66] forall k : (k) . Map.get (Model1.model ( ^ self)) (Model2.model k) = Map.get (Model1.model ( * self)) (Model2.model k) }
+    ensures { [#"../hashmap.rs" 168 4 168 66] forall k : k . Map.get (Model1.model ( ^ self)) (Model2.model k) = Map.get (Model1.model ( * self)) (Model2.model k) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1674,9 +1674,9 @@ module Hashmap_Impl5_Resize
     goto BB6
   }
   BB6 {
-    invariant seen { [#"../hashmap.rs" 175 8 175 111] forall k : (k) . BucketIx0.bucket_ix ( * old_self_6) k < UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
-    invariant unseen { [#"../hashmap.rs" 175 8 175 111] forall k : (k) . UInt64.to_int i_14 <= BucketIx0.bucket_ix ( * old_self_6) k /\ BucketIx0.bucket_ix ( * old_self_6) k <= Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Map.get (Model1.model new_10) (Model2.model k) = Core_Option_Option_Type.Core_Option_Option_None_Type };
-    invariant rest { [#"../hashmap.rs" 175 8 175 111] forall j : (int) . UInt64.to_int i_14 <= j /\ j < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * self_1))) j = Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) j };
+    invariant seen { [#"../hashmap.rs" 175 8 175 111] forall k : k . BucketIx0.bucket_ix ( * old_self_6) k < UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
+    invariant unseen { [#"../hashmap.rs" 175 8 175 111] forall k : k . UInt64.to_int i_14 <= BucketIx0.bucket_ix ( * old_self_6) k /\ BucketIx0.bucket_ix ( * old_self_6) k <= Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Map.get (Model1.model new_10) (Model2.model k) = Core_Option_Option_Type.Core_Option_Option_None_Type };
+    invariant rest { [#"../hashmap.rs" 175 8 175 111] forall j : int . UInt64.to_int i_14 <= j /\ j < Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * self_1))) j = Seq.get (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) j };
     invariant a { [#"../hashmap.rs" 181 23 181 40] HashmapInv0.hashmap_inv new_10 };
     invariant p { [#"../hashmap.rs" 182 23 182 49]  ^ old_self_6 =  ^ self_1 };
     invariant l { [#"../hashmap.rs" 183 23 183 73] Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) = Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * self_1))) };
@@ -1731,9 +1731,9 @@ module Hashmap_Impl5_Resize
   }
   BB16 {
     invariant a { [#"../hashmap.rs" 188 27 188 44] HashmapInv0.hashmap_inv new_10 };
-    invariant x { [#"../hashmap.rs" 188 12 188 46] forall k : (k) . BucketIx0.bucket_ix ( * old_self_6) k < UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
-    invariant x { [#"../hashmap.rs" 188 12 188 46] forall k : (k) . UInt64.to_int i_14 < BucketIx0.bucket_ix ( * old_self_6) k /\ BucketIx0.bucket_ix ( * old_self_6) k <= Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Map.get (Model1.model new_10) (Model2.model k) = Core_Option_Option_Type.Core_Option_Option_None_Type };
-    invariant zzz { [#"../hashmap.rs" 188 12 188 46] forall k : (k) . BucketIx0.bucket_ix ( * old_self_6) k = UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = match (Get0.get l_28 (Model2.model k)) with
+    invariant x { [#"../hashmap.rs" 188 12 188 46] forall k : k . BucketIx0.bucket_ix ( * old_self_6) k < UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
+    invariant x { [#"../hashmap.rs" 188 12 188 46] forall k : k . UInt64.to_int i_14 < BucketIx0.bucket_ix ( * old_self_6) k /\ BucketIx0.bucket_ix ( * old_self_6) k <= Seq.length (Model0.model (Hashmap_MyHashMap_Type.hashmap_myhashmap_type_MyHashMap_buckets ( * old_self_6))) -> Map.get (Model1.model new_10) (Model2.model k) = Core_Option_Option_Type.Core_Option_Option_None_Type };
+    invariant zzz { [#"../hashmap.rs" 188 12 188 46] forall k : k . BucketIx0.bucket_ix ( * old_self_6) k = UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = match (Get0.get l_28 (Model2.model k)) with
       | Core_Option_Option_Type.Core_Option_Option_None_Type -> Map.get (Model1.model new_10) (Model2.model k)
       | Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Core_Option_Option_Type.Core_Option_Option_Some_Type v
       end };
@@ -1780,7 +1780,7 @@ module Hashmap_Impl5_Resize
   }
   BB21 {
     _35 <- ();
-    assert { [#"../hashmap.rs" 201 12 201 115] forall k : (k) . BucketIx0.bucket_ix ( * old_self_6) k = UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
+    assert { [#"../hashmap.rs" 201 12 201 115] forall k : k . BucketIx0.bucket_ix ( * old_self_6) k = UInt64.to_int i_14 -> Map.get (Model3.model old_self_6) (Model2.model k) = Map.get (Model1.model new_10) (Model2.model k) };
     goto BB23
   }
   BB22 {

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -50,7 +50,7 @@ module HeapsortGeneric_HeapFrag
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   clone HeapsortGeneric_Parent_Interface as Parent0
   predicate heap_frag [#"../heapsort_generic.rs" 12 0 12 66] (s : Seq.seq t) (start : int) (end' : int) =
-    [#"../heapsort_generic.rs" 13 4 14 26] forall i : (int) . start <= Parent0.parent i /\ i < end' -> LeLog0.le_log (Seq.get s i) (Seq.get s (Parent0.parent i))
+    [#"../heapsort_generic.rs" 13 4 14 26] forall i : int . start <= Parent0.parent i /\ i < end' -> LeLog0.le_log (Seq.get s i) (Seq.get s (Parent0.parent i))
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self
@@ -695,8 +695,8 @@ module HeapsortGeneric_SiftDown_Interface
     requires {[#"../heapsort_generic.rs" 30 11 30 30] UInt64.to_int end' <= Seq.length (Model0.model ( * v))}
     ensures { [#"../heapsort_generic.rs" 31 10 31 38] HeapFrag0.heap_frag (Model0.model ( ^ v)) (UInt64.to_int start) (UInt64.to_int end') }
     ensures { [#"../heapsort_generic.rs" 32 10 32 34] PermutationOf0.permutation_of (Model0.model ( ^ v)) (Model1.model v) }
-    ensures { [#"../heapsort_generic.rs" 33 0 34 47] forall i : (int) . 0 <= i /\ i < UInt64.to_int start \/ UInt64.to_int end' <= i /\ i < Seq.length (Model1.model v) -> Seq.get (Model1.model v) i = Seq.get (Model0.model ( ^ v)) i }
-    ensures { [#"../heapsort_generic.rs" 35 0 37 68] forall m : (t) . (forall j : (int) . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model1.model v) j) m) -> (forall j : (int) . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model0.model ( ^ v)) j) m) }
+    ensures { [#"../heapsort_generic.rs" 33 0 34 47] forall i : int . 0 <= i /\ i < UInt64.to_int start \/ UInt64.to_int end' <= i /\ i < Seq.length (Model1.model v) -> Seq.get (Model1.model v) i = Seq.get (Model0.model ( ^ v)) i }
+    ensures { [#"../heapsort_generic.rs" 35 0 37 68] forall m : t . (forall j : int . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model1.model v) j) m) -> (forall j : int . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model0.model ( ^ v)) j) m) }
     
 end
 module HeapsortGeneric_SiftDown
@@ -777,8 +777,8 @@ module HeapsortGeneric_SiftDown
     requires {[#"../heapsort_generic.rs" 30 11 30 30] UInt64.to_int end' <= Seq.length (Model0.model ( * v))}
     ensures { [#"../heapsort_generic.rs" 31 10 31 38] HeapFrag0.heap_frag (Model0.model ( ^ v)) (UInt64.to_int start) (UInt64.to_int end') }
     ensures { [#"../heapsort_generic.rs" 32 10 32 34] PermutationOf0.permutation_of (Model0.model ( ^ v)) (Model1.model v) }
-    ensures { [#"../heapsort_generic.rs" 33 0 34 47] forall i : (int) . 0 <= i /\ i < UInt64.to_int start \/ UInt64.to_int end' <= i /\ i < Seq.length (Model1.model v) -> Seq.get (Model1.model v) i = Seq.get (Model0.model ( ^ v)) i }
-    ensures { [#"../heapsort_generic.rs" 35 0 37 68] forall m : (t) . (forall j : (int) . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model1.model v) j) m) -> (forall j : (int) . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model0.model ( ^ v)) j) m) }
+    ensures { [#"../heapsort_generic.rs" 33 0 34 47] forall i : int . 0 <= i /\ i < UInt64.to_int start \/ UInt64.to_int end' <= i /\ i < Seq.length (Model1.model v) -> Seq.get (Model1.model v) i = Seq.get (Model0.model ( ^ v)) i }
+    ensures { [#"../heapsort_generic.rs" 35 0 37 68] forall m : t . (forall j : int . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model1.model v) j) m) -> (forall j : int . UInt64.to_int start <= j /\ j < UInt64.to_int end' -> LeLog0.le_log (Seq.get (Model0.model ( ^ v)) j) m) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -856,9 +856,9 @@ module HeapsortGeneric_SiftDown
     invariant proph_const { [#"../heapsort_generic.rs" 42 29 42 49]  ^ v_1 =  ^ old_v_11 };
     invariant permutation { [#"../heapsort_generic.rs" 43 29 43 64] PermutationOf0.permutation_of (Model1.model v_1) (Model1.model old_v_11) };
     invariant i_bounds { [#"../heapsort_generic.rs" 44 26 44 51] UInt64.to_int start_2 <= UInt64.to_int i_15 /\ UInt64.to_int i_15 < UInt64.to_int end'_3 };
-    invariant unchanged { [#"../heapsort_generic.rs" 42 4 42 51] forall j : (int) . 0 <= j /\ j < UInt64.to_int start_2 \/ UInt64.to_int end'_3 <= j /\ j < Seq.length (Model1.model v_1) -> Seq.get (Model1.model old_v_11) j = Seq.get (Model1.model v_1) j };
-    invariant keep_bound { [#"../heapsort_generic.rs" 42 4 42 51] forall m : (t) . (forall j : (int) . UInt64.to_int start_2 <= j /\ j < UInt64.to_int end'_3 -> LeLog0.le_log (Seq.get (Model1.model old_v_11) j) m) -> (forall j : (int) . UInt64.to_int start_2 <= j /\ j < UInt64.to_int end'_3 -> LeLog0.le_log (Seq.get (Model1.model v_1) j) m) };
-    invariant heap { [#"../heapsort_generic.rs" 42 4 42 51] forall j : (int) . UInt64.to_int start_2 <= Parent0.parent j /\ j < UInt64.to_int end'_3 /\ UInt64.to_int i_15 <> Parent0.parent j -> LeLog0.le_log (Seq.get (Model1.model v_1) j) (Seq.get (Model1.model v_1) (Parent0.parent j)) };
+    invariant unchanged { [#"../heapsort_generic.rs" 42 4 42 51] forall j : int . 0 <= j /\ j < UInt64.to_int start_2 \/ UInt64.to_int end'_3 <= j /\ j < Seq.length (Model1.model v_1) -> Seq.get (Model1.model old_v_11) j = Seq.get (Model1.model v_1) j };
+    invariant keep_bound { [#"../heapsort_generic.rs" 42 4 42 51] forall m : t . (forall j : int . UInt64.to_int start_2 <= j /\ j < UInt64.to_int end'_3 -> LeLog0.le_log (Seq.get (Model1.model old_v_11) j) m) -> (forall j : int . UInt64.to_int start_2 <= j /\ j < UInt64.to_int end'_3 -> LeLog0.le_log (Seq.get (Model1.model v_1) j) m) };
+    invariant heap { [#"../heapsort_generic.rs" 42 4 42 51] forall j : int . UInt64.to_int start_2 <= Parent0.parent j /\ j < UInt64.to_int end'_3 /\ UInt64.to_int i_15 <> Parent0.parent j -> LeLog0.le_log (Seq.get (Model1.model v_1) j) (Seq.get (Model1.model v_1) (Parent0.parent j)) };
     invariant hole_left { [#"../heapsort_generic.rs" 42 4 42 51] let c = 2 * UInt64.to_int i_15 + 1 in c < UInt64.to_int end'_3 /\ UInt64.to_int start_2 <= Parent0.parent (UInt64.to_int i_15) -> LeLog0.le_log (Seq.get (Model1.model v_1) c) (Seq.get (Model1.model v_1) (Parent0.parent (Parent0.parent c))) };
     invariant hole_right { [#"../heapsort_generic.rs" 42 4 42 51] let c = 2 * UInt64.to_int i_15 + 2 in c < UInt64.to_int end'_3 /\ UInt64.to_int start_2 <= Parent0.parent (UInt64.to_int i_15) -> LeLog0.le_log (Seq.get (Model1.model v_1) c) (Seq.get (Model1.model v_1) (Parent0.parent (Parent0.parent c))) };
     _28 <- i_15;
@@ -1014,7 +1014,7 @@ module HeapsortGeneric_SortedRange
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   predicate sorted_range [#"../heapsort_generic.rs" 72 0 72 58] (s : Seq.seq t) (l : int) (u : int) =
-    [#"../heapsort_generic.rs" 73 4 75 5] forall j : (int) . forall i : (int) . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+    [#"../heapsort_generic.rs" 73 4 75 5] forall j : int . forall i : int . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module HeapsortGeneric_Sorted_Interface
   type t
@@ -1264,7 +1264,7 @@ module HeapsortGeneric_HeapSort
     invariant proph_const { [#"../heapsort_generic.rs" 104 29 104 49]  ^ v_1 =  ^ old_v_5 };
     invariant heap { [#"../heapsort_generic.rs" 105 22 105 44] HeapFrag0.heap_frag (Model0.model v_1) 0 (UInt64.to_int end'_29) };
     invariant sorted { [#"../heapsort_generic.rs" 106 24 106 58] SortedRange0.sorted_range (Model0.model v_1) (UInt64.to_int end'_29) (Seq.length (Model0.model v_1)) };
-    invariant heap_le { [#"../heapsort_generic.rs" 102 4 102 47] forall j : (int) . forall i : (int) . 0 <= i /\ i < UInt64.to_int end'_29 /\ UInt64.to_int end'_29 <= j /\ j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
+    invariant heap_le { [#"../heapsort_generic.rs" 102 4 102 47] forall j : int . forall i : int . 0 <= i /\ i < UInt64.to_int end'_29 /\ UInt64.to_int end'_29 <= j /\ j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
     _38 <- end'_29;
     _37 <- ([#"../heapsort_generic.rs" 109 10 109 17] _38 > (1 : usize));
     switch (_37)
@@ -1288,7 +1288,7 @@ module HeapsortGeneric_HeapSort
   }
   BB13 {
     assume { Resolve1.resolve _41 };
-    assert { [#"../heapsort_generic.rs" 113 12 113 47] let _ = HeapFragMax0.heap_frag_max (Model0.model v_1) 0 (UInt64.to_int end'_29) in forall j : (int) . forall i : (int) . 0 <= i /\ i < UInt64.to_int end'_29 /\ UInt64.to_int end'_29 <= j /\ j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
+    assert { [#"../heapsort_generic.rs" 113 12 113 47] let _ = HeapFragMax0.heap_frag_max (Model0.model v_1) 0 (UInt64.to_int end'_29) in forall j : int . forall i : int . 0 <= i /\ i < UInt64.to_int end'_29 /\ UInt64.to_int end'_29 <= j /\ j < Seq.length (Model0.model v_1) -> LeLog0.le_log (Seq.get (Model0.model v_1) i) (Seq.get (Model0.model v_1) j) };
     _44 <- ();
     _47 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _47) };

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -199,8 +199,8 @@ module Hillel_RightPad_Interface
     ensures { [#"../hillel.rs" 8 10 8 64] Seq.length (Model0.model ( ^ str)) = UInt64.to_int len \/ Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 9 0 9 66] UInt64.to_int len <= Seq.length (Model1.model str) -> Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 10 0 10 57] UInt64.to_int len > Seq.length (Model1.model str) -> Seq.length (Model0.model ( ^ str)) = UInt64.to_int len }
-    ensures { [#"../hillel.rs" 11 0 11 81] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = Seq.get (Model1.model str) i }
-    ensures { [#"../hillel.rs" 12 0 12 78] forall i : (int) . Seq.length (Model1.model str) <= i /\ i < UInt64.to_int len -> Seq.get (Model0.model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 11 0 11 81] forall i : int . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = Seq.get (Model1.model str) i }
+    ensures { [#"../hillel.rs" 12 0 12 78] forall i : int . Seq.length (Model1.model str) <= i /\ i < UInt64.to_int len -> Seq.get (Model0.model ( ^ str)) i = pad }
     
 end
 module Hillel_RightPad
@@ -232,8 +232,8 @@ module Hillel_RightPad
     ensures { [#"../hillel.rs" 8 10 8 64] Seq.length (Model0.model ( ^ str)) = UInt64.to_int len \/ Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 9 0 9 66] UInt64.to_int len <= Seq.length (Model1.model str) -> Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 10 0 10 57] UInt64.to_int len > Seq.length (Model1.model str) -> Seq.length (Model0.model ( ^ str)) = UInt64.to_int len }
-    ensures { [#"../hillel.rs" 11 0 11 81] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = Seq.get (Model1.model str) i }
-    ensures { [#"../hillel.rs" 12 0 12 78] forall i : (int) . Seq.length (Model1.model str) <= i /\ i < UInt64.to_int len -> Seq.get (Model0.model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 11 0 11 81] forall i : int . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = Seq.get (Model1.model str) i }
+    ensures { [#"../hillel.rs" 12 0 12 78] forall i : int . Seq.length (Model1.model str) <= i /\ i < UInt64.to_int len -> Seq.get (Model0.model ( ^ str)) i = pad }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -273,8 +273,8 @@ module Hillel_RightPad
     invariant old_str_bound { [#"../hillel.rs" 17 31 17 63] Seq.length (Model1.model old_str_10) <= Seq.length (Model1.model str_1) };
     invariant len_bound { [#"../hillel.rs" 16 4 16 48] Seq.length (Model1.model old_str_10) < UInt64.to_int len_2 -> Seq.length (Model1.model str_1) <= UInt64.to_int len_2 };
     invariant len_bound { [#"../hillel.rs" 16 4 16 48] Seq.length (Model1.model str_1) > UInt64.to_int len_2 -> Seq.length (Model1.model str_1) = Seq.length (Model1.model old_str_10) };
-    invariant old_elem { [#"../hillel.rs" 16 4 16 48] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model old_str_10) -> Seq.get (Model1.model str_1) i = Seq.get (Model1.model old_str_10) i };
-    invariant pad_elem { [#"../hillel.rs" 16 4 16 48] forall i : (int) . Seq.length (Model1.model old_str_10) <= i /\ i < Seq.length (Model1.model str_1) -> Seq.get (Model1.model str_1) i = pad_3 };
+    invariant old_elem { [#"../hillel.rs" 16 4 16 48] forall i : int . 0 <= i /\ i < Seq.length (Model1.model old_str_10) -> Seq.get (Model1.model str_1) i = Seq.get (Model1.model old_str_10) i };
+    invariant pad_elem { [#"../hillel.rs" 16 4 16 48] forall i : int . Seq.length (Model1.model old_str_10) <= i /\ i < Seq.length (Model1.model str_1) -> Seq.get (Model1.model str_1) i = pad_3 };
     _23 <-  * str_1;
     _22 <- ([#"../hillel.rs" 22 10 22 19] Len0.len _23);
     goto BB3
@@ -323,9 +323,9 @@ module Alloc_Vec_Impl1_Insert_Interface
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t, type a = a, axiom .
   val insert [@cfg:stackify] (self : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type t a)) (index : usize) (element : t) : ()
     ensures { Seq.length (Model0.model ( ^ self)) = Seq.length (Model1.model self) + 1 }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int index -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) i }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int index -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) i }
     ensures { Seq.get (Model0.model ( ^ self)) (UInt64.to_int index) = element }
-    ensures { forall i : (int) . UInt64.to_int index < i /\ i < Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) (i - 1) }
+    ensures { forall i : int . UInt64.to_int index < i /\ i < Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) (i - 1) }
     
 end
 module Alloc_Vec_Impl1_Insert
@@ -344,9 +344,9 @@ module Alloc_Vec_Impl1_Insert
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t, type a = a, axiom .
   val insert [@cfg:stackify] (self : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type t a)) (index : usize) (element : t) : ()
     ensures { Seq.length (Model0.model ( ^ self)) = Seq.length (Model1.model self) + 1 }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int index -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) i }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int index -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) i }
     ensures { Seq.get (Model0.model ( ^ self)) (UInt64.to_int index) = element }
-    ensures { forall i : (int) . UInt64.to_int index < i /\ i < Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) (i - 1) }
+    ensures { forall i : int . UInt64.to_int index < i /\ i < Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i = Seq.get (Model1.model self) (i - 1) }
     
 end
 module Hillel_LeftPad_Interface
@@ -368,8 +368,8 @@ module Hillel_LeftPad_Interface
   val left_pad [@cfg:stackify] (str : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) (len : usize) (pad : t) : ()
     ensures { [#"../hillel.rs" 27 10 27 64] Seq.length (Model0.model ( ^ str)) >= UInt64.to_int len /\ Seq.length (Model0.model ( ^ str)) >= Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 28 10 28 64] Seq.length (Model0.model ( ^ str)) = UInt64.to_int len \/ Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
-    ensures { [#"../hillel.rs" 29 0 29 93] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = pad }
-    ensures { [#"../hillel.rs" 30 0 30 114] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) (i + (Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str))) = Seq.get (Model1.model str) i }
+    ensures { [#"../hillel.rs" 29 0 29 93] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 30 0 30 114] forall i : int . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) (i + (Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str))) = Seq.get (Model1.model str) i }
     
 end
 module Hillel_LeftPad
@@ -400,8 +400,8 @@ module Hillel_LeftPad
   let rec cfg left_pad [@cfg:stackify] [#"../hillel.rs" 31 0 31 58] (str : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) (len : usize) (pad : t) : ()
     ensures { [#"../hillel.rs" 27 10 27 64] Seq.length (Model0.model ( ^ str)) >= UInt64.to_int len /\ Seq.length (Model0.model ( ^ str)) >= Seq.length (Model1.model str) }
     ensures { [#"../hillel.rs" 28 10 28 64] Seq.length (Model0.model ( ^ str)) = UInt64.to_int len \/ Seq.length (Model0.model ( ^ str)) = Seq.length (Model1.model str) }
-    ensures { [#"../hillel.rs" 29 0 29 93] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = pad }
-    ensures { [#"../hillel.rs" 30 0 30 114] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) (i + (Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str))) = Seq.get (Model1.model str) i }
+    ensures { [#"../hillel.rs" 29 0 29 93] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 30 0 30 114] forall i : int . 0 <= i /\ i < Seq.length (Model1.model str) -> Seq.get (Model0.model ( ^ str)) (i + (Seq.length (Model0.model ( ^ str)) - Seq.length (Model1.model str))) = Seq.get (Model1.model str) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -451,8 +451,8 @@ module Hillel_LeftPad
     invariant len_bound { [#"../hillel.rs" 35 4 35 48] Seq.length (Model1.model old_str_8) < UInt64.to_int len_2 -> Seq.length (Model1.model str_1) <= UInt64.to_int len_2 };
     invariant len_bound { [#"../hillel.rs" 35 4 35 48] Seq.length (Model1.model str_1) > UInt64.to_int len_2 -> Seq.length (Model1.model str_1) = Seq.length (Model1.model old_str_8) };
     invariant count { [#"../hillel.rs" 39 23 39 60] UInt64.to_int c_12 = Seq.length (Model1.model str_1) - Seq.length (Model1.model old_str_8) };
-    invariant old_elem { [#"../hillel.rs" 35 4 35 48] forall i : (int) . UInt64.to_int c_12 <= i /\ i < Seq.length (Model1.model str_1) -> Seq.get (Model1.model str_1) i = Seq.get (Model1.model old_str_8) (i - UInt64.to_int c_12) };
-    invariant pad_elem { [#"../hillel.rs" 35 4 35 48] forall i : (int) . 0 <= i /\ i < UInt64.to_int c_12 -> Seq.get (Model1.model str_1) i = pad_3 };
+    invariant old_elem { [#"../hillel.rs" 35 4 35 48] forall i : int . UInt64.to_int c_12 <= i /\ i < Seq.length (Model1.model str_1) -> Seq.get (Model1.model str_1) i = Seq.get (Model1.model old_str_8) (i - UInt64.to_int c_12) };
+    invariant pad_elem { [#"../hillel.rs" 35 4 35 48] forall i : int . 0 <= i /\ i < UInt64.to_int c_12 -> Seq.get (Model1.model str_1) i = pad_3 };
     _26 <-  * str_1;
     _25 <- ([#"../hillel.rs" 42 10 42 19] Len0.len _26);
     goto BB4
@@ -506,7 +506,7 @@ module Hillel_IsUnique
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
   type ModelTy0.modelTy = ModelTy0.modelTy
   predicate is_unique [#"../hillel.rs" 49 0 49 46] (s : Seq.seq t) =
-    [#"../hillel.rs" 50 4 52 5] forall j : (int) . forall i : (int) . 0 <= i /\ i < Seq.length s /\ 0 <= j /\ j < Seq.length s -> Model0.model (Seq.get s i) = Model0.model (Seq.get s j) -> i = j
+    [#"../hillel.rs" 50 4 52 5] forall j : int . forall i : int . 0 <= i /\ i < Seq.length s /\ 0 <= j /\ j < Seq.length s -> Model0.model (Seq.get s i) = Model0.model (Seq.get s j) -> i = j
 end
 module Hillel_Contains_Interface
   type t
@@ -522,7 +522,7 @@ module Hillel_Contains
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
   type ModelTy0.modelTy = ModelTy0.modelTy
   predicate contains [#"../hillel.rs" 56 0 56 51] (seq : Seq.seq t) (elem : t) =
-    [#"../hillel.rs" 57 4 59 5] exists i : (int) . 0 <= i /\ i < Seq.length seq /\ Model0.model (Seq.get seq i) = Model0.model elem
+    [#"../hillel.rs" 57 4 59 5] exists i : int . 0 <= i /\ i < Seq.length seq /\ Model0.model (Seq.get seq i) = Model0.model elem
 end
 module Hillel_IsSubset_Interface
   type t
@@ -536,7 +536,7 @@ module Hillel_IsSubset
   use mach.int.Int32
   clone Hillel_Contains_Interface as Contains0 with type t = t
   predicate is_subset [#"../hillel.rs" 63 0 63 56] (sub : Seq.seq t) (sup : Seq.seq t) =
-    [#"../hillel.rs" 64 4 66 5] forall i : (int) . 0 <= i /\ i < Seq.length sub -> Contains0.contains sup (Seq.get sub i)
+    [#"../hillel.rs" 64 4 66 5] forall i : int . 0 <= i /\ i < Seq.length sub -> Contains0.contains sup (Seq.get sub i)
 end
 module Hillel_SubsetPush_Interface
   type t
@@ -870,7 +870,7 @@ module Hillel_InsertUnique
     goto BB6
   }
   BB6 {
-    invariant not_elem { [#"../hillel.rs" 84 4 84 85] forall j : (int) . 0 <= j /\ j < UInt64.to_int i_13 -> Model2.model (Seq.get (Model0.model vec_1) j) <> Model2.model elem_2 };
+    invariant not_elem { [#"../hillel.rs" 84 4 84 85] forall j : int . 0 <= j /\ j < UInt64.to_int i_13 -> Model2.model (Seq.get (Model0.model vec_1) j) <> Model2.model elem_2 };
     _18 <- i_13;
     _20 <-  * vec_1;
     _19 <- ([#"../hillel.rs" 85 14 85 23] Len0.len _20);
@@ -1048,7 +1048,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t
@@ -1400,7 +1400,7 @@ module Hillel_Fulcrum_Interface
     requires {[#"../hillel.rs" 156 11 156 47] SumRange0.sum_range (Model0.model s) 0 (Seq.length (Model0.model s)) <= 1000}
     requires {[#"../hillel.rs" 157 11 157 25] Seq.length (Model0.model s) > 0}
     ensures { [#"../hillel.rs" 158 10 158 46] 0 <= UInt64.to_int result /\ UInt64.to_int result < Seq.length (Model0.model s) }
-    ensures { [#"../hillel.rs" 159 0 159 90] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model s) -> Score0.score (Model0.model s) (UInt64.to_int result) <= Score0.score (Model0.model s) i }
+    ensures { [#"../hillel.rs" 159 0 159 90] forall i : int . 0 <= i /\ i < Seq.length (Model0.model s) -> Score0.score (Model0.model s) (UInt64.to_int result) <= Score0.score (Model0.model s) i }
     
 end
 module Hillel_Fulcrum
@@ -1428,7 +1428,7 @@ module Hillel_Fulcrum
     requires {[#"../hillel.rs" 156 11 156 47] SumRange0.sum_range (Model0.model s) 0 (Seq.length (Model0.model s)) <= 1000}
     requires {[#"../hillel.rs" 157 11 157 25] Seq.length (Model0.model s) > 0}
     ensures { [#"../hillel.rs" 158 10 158 46] 0 <= UInt64.to_int result /\ UInt64.to_int result < Seq.length (Model0.model s) }
-    ensures { [#"../hillel.rs" 159 0 159 90] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model s) -> Score0.score (Model0.model s) (UInt64.to_int result) <= Score0.score (Model0.model s) i }
+    ensures { [#"../hillel.rs" 159 0 159 90] forall i : int . 0 <= i /\ i < Seq.length (Model0.model s) -> Score0.score (Model0.model s) (UInt64.to_int result) <= Score0.score (Model0.model s) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -1531,7 +1531,7 @@ module Hillel_Fulcrum
     invariant sum_bound { [#"../hillel.rs" 180 27 180 41] UInt32.to_int sum_28 <= UInt32.to_int total_6 };
     invariant min_i_bound { [#"../hillel.rs" 181 29 181 64] UInt64.to_int min_i_26 <= UInt64.to_int i_29 /\ UInt64.to_int min_i_26 < Seq.length (Model0.model s_1) };
     invariant min_dist { [#"../hillel.rs" 182 26 182 56] UInt32.to_int min_dist_27 = Score0.score (Model0.model s_1) (UInt64.to_int min_i_26) };
-    invariant min_i_min { [#"../hillel.rs" 178 4 178 43] forall j : (int) . 0 <= j /\ j < UInt64.to_int i_29 -> Score0.score (Model0.model s_1) (UInt64.to_int min_i_26) <= Score0.score (Model0.model s_1) j };
+    invariant min_i_min { [#"../hillel.rs" 178 4 178 43] forall j : int . 0 <= j /\ j < UInt64.to_int i_29 -> Score0.score (Model0.model s_1) (UInt64.to_int min_i_26) <= Score0.score (Model0.model s_1) j };
     _38 <- i_29;
     _40 <- s_1;
     _39 <- ([#"../hillel.rs" 184 14 184 21] Len0.len _40);

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -134,7 +134,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t
@@ -457,7 +457,7 @@ module Core_Slice_Impl0_Get_Interface
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Std1_Slice_Impl0_Model_Interface as Model0 with type t = t, axiom .
   val get [@cfg:stackify] (self : seq t) (index : i) : Core_Option_Option_Type.core_option_option_type Output0.output
-    ensures { InBounds0.in_bounds index (Model0.model self) -> (exists r : (Output0.output) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ HasValue0.has_value index (Model0.model self) r) }
+    ensures { InBounds0.in_bounds index (Model0.model self) -> (exists r : Output0.output . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ HasValue0.has_value index (Model0.model self) r) }
     ensures { InBounds0.in_bounds index (Model0.model self) \/ result = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
@@ -476,7 +476,7 @@ module Core_Slice_Impl0_Get
   type ModelTy0.modelTy = ModelTy0.modelTy
   clone CreusotContracts_Std1_Slice_Impl0_Model_Interface as Model0 with type t = t, axiom .
   val get [@cfg:stackify] (self : seq t) (index : i) : Core_Option_Option_Type.core_option_option_type Output0.output
-    ensures { InBounds0.in_bounds index (Model0.model self) -> (exists r : (Output0.output) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ HasValue0.has_value index (Model0.model self) r) }
+    ensures { InBounds0.in_bounds index (Model0.model self) -> (exists r : Output0.output . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ HasValue0.has_value index (Model0.model self) r) }
     ensures { InBounds0.in_bounds index (Model0.model self) \/ result = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
@@ -694,7 +694,7 @@ module CreusotContracts_Std1_Slice_Impl4_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_Range_Type.core_ops_range_range_type usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : (int) . 0 <= i /\ (i < UInt64.to_int (Core_Ops_Range_Range_Type.core_ops_range_range_type_Range_start self) \/ UInt64.to_int (Core_Ops_Range_Range_Type.core_ops_range_range_type_Range_end self) <= i) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ (i < UInt64.to_int (Core_Ops_Range_Range_Type.core_ops_range_range_type_Range_start self) \/ UInt64.to_int (Core_Ops_Range_Range_Type.core_ops_range_range_type_Range_end self) <= i) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module CreusotContracts_Std1_Slice_Impl3_InBounds_Interface
   type t
@@ -1541,7 +1541,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_RangeTo_Type.core_ops_range_rangeto_type usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : (int) . UInt64.to_int (Core_Ops_Range_RangeTo_Type.core_ops_range_rangeto_type_RangeTo_end self) <= i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . UInt64.to_int (Core_Ops_Range_RangeTo_Type.core_ops_range_rangeto_type_RangeTo_end self) <= i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module IndexRange_TestRangeTo_Interface
   val test_range_to [@cfg:stackify] (_ : ()) : ()
@@ -2108,7 +2108,7 @@ module CreusotContracts_Std1_Slice_Impl6_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_RangeFrom_Type.core_ops_range_rangefrom_type usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : (int) . 0 <= i /\ i < UInt64.to_int (Core_Ops_Range_RangeFrom_Type.core_ops_range_rangefrom_type_RangeFrom_start self) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i < UInt64.to_int (Core_Ops_Range_RangeFrom_Type.core_ops_range_rangefrom_type_RangeFrom_start self) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module IndexRange_TestRangeFrom_Interface
   val test_range_from [@cfg:stackify] (_ : ()) : ()
@@ -3245,7 +3245,7 @@ module CreusotContracts_Std1_Slice_Impl8_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_RangeToInclusive_Type.core_ops_range_rangetoinclusive_type usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : (int) . UInt64.to_int (Core_Ops_Range_RangeToInclusive_Type.core_ops_range_rangetoinclusive_type_RangeToInclusive_end self) < i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . UInt64.to_int (Core_Ops_Range_RangeToInclusive_Type.core_ops_range_rangetoinclusive_type_RangeToInclusive_end self) < i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module IndexRange_TestRangeToInclusive_Interface
   val test_range_to_inclusive [@cfg:stackify] (_ : ()) : ()

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -135,7 +135,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Logic_Resolve_Impl1
   type t

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -201,7 +201,7 @@ module IteNormalize_Impl0_Insert_Interface
   clone IteNormalize_Impl2_Model_Interface as Model0 with type k = k, type v = v,
   type ModelTy0.modelTy = ModelTy0.modelTy, type ModelTy1.modelTy = ModelTy1.modelTy
   val insert [@cfg:stackify] (self : borrowed (IteNormalize_BTreeMap_Type.itenormalize_btreemap_type k v)) (key : k) (value : v) : Core_Option_Option_Type.core_option_option_type v
-    ensures { [#"../ite_normalize.rs" 26 4 26 106] forall i : (k) . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
+    ensures { [#"../ite_normalize.rs" 26 4 26 106] forall i : k . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
       Core_Option_Option_Type.Core_Option_Option_Some_Type (Model2.model value)
     else
       Map.get (Model3.model self) (Model1.model i)
@@ -226,7 +226,7 @@ module IteNormalize_Impl0_Insert
   clone CreusotContracts_Logic_Model_Model_Model as Model2 with type self = v, type ModelTy0.modelTy = ModelTy1.modelTy
   clone CreusotContracts_Logic_Model_Model_Model as Model1 with type self = k, type ModelTy0.modelTy = ModelTy0.modelTy
   val insert [@cfg:stackify] (self : borrowed (IteNormalize_BTreeMap_Type.itenormalize_btreemap_type k v)) (key : k) (value : v) : Core_Option_Option_Type.core_option_option_type v
-    ensures { [#"../ite_normalize.rs" 26 4 26 106] forall i : (k) . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
+    ensures { [#"../ite_normalize.rs" 26 4 26 106] forall i : k . Map.get (Model0.model ( ^ self)) (Model1.model i) = (if Model1.model i = Model1.model key then
       Core_Option_Option_Type.Core_Option_Option_Some_Type (Model2.model value)
     else
       Map.get (Model3.model self) (Model1.model i)
@@ -1083,7 +1083,7 @@ module IteNormalize_Impl6_SimplifyHelper_Interface
   clone IteNormalize_Impl6_IsNormalized_Interface as IsNormalized0
   val simplify_helper [@cfg:stackify] (self : IteNormalize_Expr_Type.itenormalize_expr_type) (state : IteNormalize_BTreeMap_Type.itenormalize_btreemap_type usize bool) : IteNormalize_Expr_Type.itenormalize_expr_type
     requires {[#"../ite_normalize.rs" 181 15 181 35] IsNormalized0.is_normalized self}
-    ensures { [#"../ite_normalize.rs" 182 4 182 110] forall i : (usize) . (exists v : (bool) . Map.get (Model0.model state) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type (Model1.model v)) -> DoesNotContain0.does_not_contain result i }
+    ensures { [#"../ite_normalize.rs" 182 4 182 110] forall i : usize . (exists v : bool . Map.get (Model0.model state) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type (Model1.model v)) -> DoesNotContain0.does_not_contain result i }
     ensures { [#"../ite_normalize.rs" 183 14 183 36] IsSimplified0.is_simplified result }
     
 end
@@ -1130,7 +1130,7 @@ module IteNormalize_Impl6_SimplifyHelper
   type ModelTy2.modelTy = ModelTy0.modelTy, type ModelTy3.modelTy = ModelTy1.modelTy
   let rec cfg simplify_helper [@cfg:stackify] [#"../ite_normalize.rs" 185 4 185 66] (self : IteNormalize_Expr_Type.itenormalize_expr_type) (state : IteNormalize_BTreeMap_Type.itenormalize_btreemap_type usize bool) : IteNormalize_Expr_Type.itenormalize_expr_type
     requires {[#"../ite_normalize.rs" 181 15 181 35] IsNormalized0.is_normalized self}
-    ensures { [#"../ite_normalize.rs" 182 4 182 110] forall i : (usize) . (exists v : (bool) . Map.get (Model0.model state) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type (Model1.model v)) -> DoesNotContain0.does_not_contain result i }
+    ensures { [#"../ite_normalize.rs" 182 4 182 110] forall i : usize . (exists v : bool . Map.get (Model0.model state) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type (Model1.model v)) -> DoesNotContain0.does_not_contain result i }
     ensures { [#"../ite_normalize.rs" 183 14 183 36] IsSimplified0.is_simplified result }
     variant {[#"../ite_normalize.rs" 184 14 184 18] self}
     

--- a/creusot/tests/should_succeed/iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iter_mut.mlcfg
@@ -96,8 +96,8 @@ module IterMut_Impl1_IterMut_Interface
   clone IterMut_Impl0_Model_Interface as Model0 with type t = t
   val iter_mut [@cfg:stackify] (self : borrowed (IterMut_Vec_Type.itermut_vec_type t)) : IterMut_IterMut_Type.itermut_itermut_type t
     ensures { [#"../iter_mut.rs" 23 14 23 83] Seq.length (Model0.model ( * self)) = Seq.length (Model1.model result) /\ Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
-    ensures { [#"../iter_mut.rs" 24 4 24 94] forall i : (int) . 0 <= i /\ i <= Seq.length (Model0.model ( * self)) -> Seq.get (Model0.model ( * self)) i =  * Seq.get (Model1.model result) i }
-    ensures { [#"../iter_mut.rs" 25 4 25 94] forall i : (int) . 0 <= i /\ i <= Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i =  ^ Seq.get (Model1.model result) i }
+    ensures { [#"../iter_mut.rs" 24 4 24 94] forall i : int . 0 <= i /\ i <= Seq.length (Model0.model ( * self)) -> Seq.get (Model0.model ( * self)) i =  * Seq.get (Model1.model result) i }
+    ensures { [#"../iter_mut.rs" 25 4 25 94] forall i : int . 0 <= i /\ i <= Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i =  ^ Seq.get (Model1.model result) i }
     
 end
 module IterMut_Impl1_IterMut
@@ -111,8 +111,8 @@ module IterMut_Impl1_IterMut
   clone IterMut_Impl0_Model as Model0 with type t = t
   val iter_mut [@cfg:stackify] (self : borrowed (IterMut_Vec_Type.itermut_vec_type t)) : IterMut_IterMut_Type.itermut_itermut_type t
     ensures { [#"../iter_mut.rs" 23 14 23 83] Seq.length (Model0.model ( * self)) = Seq.length (Model1.model result) /\ Seq.length (Model0.model ( * self)) = Seq.length (Model0.model ( ^ self)) }
-    ensures { [#"../iter_mut.rs" 24 4 24 94] forall i : (int) . 0 <= i /\ i <= Seq.length (Model0.model ( * self)) -> Seq.get (Model0.model ( * self)) i =  * Seq.get (Model1.model result) i }
-    ensures { [#"../iter_mut.rs" 25 4 25 94] forall i : (int) . 0 <= i /\ i <= Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i =  ^ Seq.get (Model1.model result) i }
+    ensures { [#"../iter_mut.rs" 24 4 24 94] forall i : int . 0 <= i /\ i <= Seq.length (Model0.model ( * self)) -> Seq.get (Model0.model ( * self)) i =  * Seq.get (Model1.model result) i }
+    ensures { [#"../iter_mut.rs" 25 4 25 94] forall i : int . 0 <= i /\ i <= Seq.length (Model0.model ( ^ self)) -> Seq.get (Model0.model ( ^ self)) i =  ^ Seq.get (Model1.model result) i }
     
 end
 module IterMut_Impl1_Len_Interface
@@ -299,7 +299,7 @@ module IterMut_IncVec_Interface
   clone IterMut_Impl0_Model_Interface as Model0 with type t = int
   val inc_vec [@cfg:stackify] (v : borrowed (IterMut_Vec_Type.itermut_vec_type int)) : ()
     ensures { [#"../iter_mut.rs" 58 10 58 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../iter_mut.rs" 59 0 59 83] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = Seq.get (Model1.model v) i + 5 }
+    ensures { [#"../iter_mut.rs" 59 0 59 83] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = Seq.get (Model1.model v) i + 5 }
     
 end
 module IterMut_IncVec
@@ -324,7 +324,7 @@ module IterMut_IncVec
   function Model1.model = Model2.model
   let rec cfg inc_vec [@cfg:stackify] [#"../iter_mut.rs" 60 0 60 32] (v : borrowed (IterMut_Vec_Type.itermut_vec_type int)) : ()
     ensures { [#"../iter_mut.rs" 58 10 58 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../iter_mut.rs" 59 0 59 83] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = Seq.get (Model1.model v) i + 5 }
+    ensures { [#"../iter_mut.rs" 59 0 59 83] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = Seq.get (Model1.model v) i + 5 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -363,8 +363,8 @@ module IterMut_IncVec
     goto BB3
   }
   BB3 {
-    invariant incremented { [#"../iter_mut.rs" 65 4 68 6] forall i : (int) . 0 <= i /\ i < _ghost_seen_10 -> Seq.get (Model0.model ( ^ old_v_4)) i = Seq.get (Model1.model old_v_4) i + 5 };
-    invariant to_come { [#"../iter_mut.rs" 65 4 68 6] forall i : (int) . 0 <= i /\ i < Seq.length (Model2.model it_8) ->  * Seq.get (Model2.model it_8) i = Seq.get (Model1.model old_v_4) (i + _ghost_seen_10) /\  ^ Seq.get (Model2.model it_8) i = Seq.get (Model0.model ( ^ old_v_4)) (i + _ghost_seen_10) };
+    invariant incremented { [#"../iter_mut.rs" 65 4 68 6] forall i : int . 0 <= i /\ i < _ghost_seen_10 -> Seq.get (Model0.model ( ^ old_v_4)) i = Seq.get (Model1.model old_v_4) i + 5 };
+    invariant to_come { [#"../iter_mut.rs" 65 4 68 6] forall i : int . 0 <= i /\ i < Seq.length (Model2.model it_8) ->  * Seq.get (Model2.model it_8) i = Seq.get (Model1.model old_v_4) (i + _ghost_seen_10) /\  ^ Seq.get (Model2.model it_8) i = Seq.get (Model0.model ( ^ old_v_4)) (i + _ghost_seen_10) };
     invariant _ghost_seen { [#"../iter_mut.rs" 72 29 72 81] _ghost_seen_10 + Seq.length (Model2.model it_8) = Seq.length (Model1.model old_v_4) };
     _16 <- borrow_mut it_8;
     it_8 <-  ^ _16;

--- a/creusot/tests/should_succeed/iterators/01_range.mlcfg
+++ b/creusot/tests/should_succeed/iterators/01_range.mlcfg
@@ -43,7 +43,7 @@ module C01Range_Impl0_Produces
   predicate produces [#"../01_range.rs" 23 4 23 64] (self : C01Range_Range_Type.c01range_range_type) (visited : Seq.seq isize) (o : C01Range_Range_Type.c01range_range_type)
     
    =
-    [#"../01_range.rs" 24 8 29 9] C01Range_Range_Type.c01range_range_type_Range_end self = C01Range_Range_Type.c01range_range_type_Range_end o /\ C01Range_Range_Type.c01range_range_type_Range_start self <= C01Range_Range_Type.c01range_range_type_Range_start o /\ Seq.length visited = Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start o) - Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start self) /\ (forall i : (int) . 0 <= i /\ i < Seq.length visited -> Int64.to_int (Seq.get visited i) = Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start self) + i)
+    [#"../01_range.rs" 24 8 29 9] C01Range_Range_Type.c01range_range_type_Range_end self = C01Range_Range_Type.c01range_range_type_Range_end o /\ C01Range_Range_Type.c01range_range_type_Range_start self <= C01Range_Range_Type.c01range_range_type_Range_start o /\ Seq.length visited = Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start o) - Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> Int64.to_int (Seq.get visited i) = Int64.to_int (C01Range_Range_Type.c01range_range_type_Range_start self) + i)
 end
 module C01Range_Impl0_ProducesRefl_Interface
   use seq.Seq

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -100,7 +100,7 @@ module C02IterMut_Impl0_Produces
   predicate produces [#"../02_iter_mut.rs" 22 4 22 65] (self : C02IterMut_IterMut_Type.c02itermut_itermut_type t) (visited : Seq.seq (borrowed t)) (tl : C02IterMut_IterMut_Type.c02itermut_itermut_type t)
     
    =
-    [#"../02_iter_mut.rs" 24 12 29 85] Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) = Seq.length visited + Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) = Seq.length visited + Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.(==) (SeqExt.subsequence (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) (Seq.length visited) (Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)))) (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.(==) (SeqExt.subsequence (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) (Seq.length visited) (Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)))) (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ (forall i : (int) . 0 <= i /\ i < Seq.length visited -> Seq.get (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) i =  * Seq.get visited i /\ Seq.get (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) i =  ^ Seq.get visited i)
+    [#"../02_iter_mut.rs" 24 12 29 85] Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) = Seq.length visited + Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) = Seq.length visited + Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.(==) (SeqExt.subsequence (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) (Seq.length visited) (Seq.length (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)))) (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ Seq.(==) (SeqExt.subsequence (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) (Seq.length visited) (Seq.length (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)))) (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner tl)) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> Seq.get (Model0.model ( * C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) i =  * Seq.get visited i /\ Seq.get (Model0.model ( ^ C02IterMut_IterMut_Type.c02itermut_itermut_type_IterMut_inner self)) i =  ^ Seq.get visited i)
 end
 module CreusotContracts_Std1_Slice_Impl0
   type t
@@ -599,7 +599,7 @@ module C02IterMut_AllZero_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val all_zero [@cfg:stackify] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
     ensures { [#"../02_iter_mut.rs" 68 10 68 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../02_iter_mut.rs" 69 0 69 69] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
+    ensures { [#"../02_iter_mut.rs" 69 0 69 69] forall i : int . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
     
 end
 module C02IterMut_AllZero
@@ -642,7 +642,7 @@ module C02IterMut_AllZero
   function Model1.model = Model0.model, function Model2.model = Model1.model
   let rec cfg all_zero [@cfg:stackify] [#"../02_iter_mut.rs" 70 0 70 35] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
     ensures { [#"../02_iter_mut.rs" 68 10 68 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../02_iter_mut.rs" 69 0 69 69] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
+    ensures { [#"../02_iter_mut.rs" 69 0 69 69] forall i : int . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -693,7 +693,7 @@ module C02IterMut_AllZero
   }
   BB5 {
     invariant structural { [#"../02_iter_mut.rs" 71 4 71 91] Produces0.produces iter_old_7 produced_11 iter_4 };
-    invariant user { [#"../02_iter_mut.rs" 71 4 71 91] forall i : (int) . 0 <= i /\ i < Seq.length produced_11 -> UInt64.to_int ( ^ Seq.get produced_11 i) = 0 };
+    invariant user { [#"../02_iter_mut.rs" 71 4 71 91] forall i : int . 0 <= i /\ i < Seq.length produced_11 -> UInt64.to_int ( ^ Seq.get produced_11 i) = 0 };
     _19 <- borrow_mut iter_4;
     iter_4 <-  ^ _19;
     _18 <- ([#"../02_iter_mut.rs" 71 4 71 91] Next0.next _19);

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -157,7 +157,7 @@ module CreusotContracts_Std1_Slice_Impl11_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.core_slice_iter_iter_type t) (visited : Seq.seq t) (rhs : Core_Slice_Iter_Iter_Type.core_slice_iter_iter_type t)
     
    =
-    Seq.length (Model0.model self) = Seq.length visited + Seq.length (Model0.model rhs) /\ Seq.(==) (SeqExt.subsequence (Model0.model self) (Seq.length visited) (Seq.length (Model0.model self))) (Model0.model rhs) /\ (forall i : (int) . 0 <= i /\ i < Seq.length visited -> Seq.get (Model0.model self) i = Seq.get visited i)
+    Seq.length (Model0.model self) = Seq.length visited + Seq.length (Model0.model rhs) /\ Seq.(==) (SeqExt.subsequence (Model0.model self) (Seq.length visited) (Seq.length (Model0.model self))) (Model0.model rhs) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> Seq.get (Model0.model self) i = Seq.get visited i)
 end
 module Core_Option_Option_Type
   type core_option_option_type 't =
@@ -859,7 +859,7 @@ module CreusotContracts_Std1_Slice_Impl12_Produces
   predicate produces (self : Core_Slice_Iter_IterMut_Type.core_slice_iter_itermut_type t) (visited : Seq.seq (borrowed t)) (tl : Core_Slice_Iter_IterMut_Type.core_slice_iter_itermut_type t)
     
    =
-    Seq.length ( * Model0.model self) = Seq.length visited + Seq.length ( * Model0.model tl) /\ Seq.length ( ^ Model0.model self) = Seq.length visited + Seq.length ( ^ Model0.model tl) /\ Seq.(==) (SeqExt.subsequence ( * Model0.model self) (Seq.length visited) (Seq.length ( * Model0.model self))) ( * Model0.model tl) /\ Seq.(==) (SeqExt.subsequence ( ^ Model0.model self) (Seq.length visited) (Seq.length ( ^ Model0.model self))) ( ^ Model0.model tl) /\ (forall i : (int) . 0 <= i /\ i < Seq.length visited -> Seq.get ( * Model0.model self) i =  * Seq.get visited i /\ Seq.get ( ^ Model0.model self) i =  ^ Seq.get visited i)
+    Seq.length ( * Model0.model self) = Seq.length visited + Seq.length ( * Model0.model tl) /\ Seq.length ( ^ Model0.model self) = Seq.length visited + Seq.length ( ^ Model0.model tl) /\ Seq.(==) (SeqExt.subsequence ( * Model0.model self) (Seq.length visited) (Seq.length ( * Model0.model self))) ( * Model0.model tl) /\ Seq.(==) (SeqExt.subsequence ( ^ Model0.model self) (Seq.length visited) (Seq.length ( ^ Model0.model self))) ( ^ Model0.model tl) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> Seq.get ( * Model0.model self) i =  * Seq.get visited i /\ Seq.get ( ^ Model0.model self) i =  ^ Seq.get visited i)
 end
 module Core_Slice_Iter_Impl187_Item_Type
   type t
@@ -1012,7 +1012,7 @@ module C03StdIterators_AllZero_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val all_zero [@cfg:stackify] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
     ensures { [#"../03_std_iterators.rs" 26 10 26 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
+    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : int . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
     
 end
 module C03StdIterators_AllZero
@@ -1061,7 +1061,7 @@ module C03StdIterators_AllZero
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve as Resolve0 with type t = Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
   let rec cfg all_zero [@cfg:stackify] [#"../03_std_iterators.rs" 28 0 28 35] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
     ensures { [#"../03_std_iterators.rs" 26 10 26 35] Seq.length (Model0.model ( ^ v)) = Seq.length (Model1.model v) }
-    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
+    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : int . 0 <= i /\ i < Seq.length (Model1.model v) -> UInt64.to_int (Seq.get (Model0.model ( ^ v)) i) = 0 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1121,7 +1121,7 @@ module C03StdIterators_AllZero
   }
   BB6 {
     invariant structural { [#"../03_std_iterators.rs" 29 4 29 91] Produces0.produces iter_old_9 produced_13 iter_4 };
-    invariant user { [#"../03_std_iterators.rs" 29 4 29 91] forall i : (int) . 0 <= i /\ i < Seq.length produced_13 -> UInt64.to_int ( ^ Seq.get produced_13 i) = 0 };
+    invariant user { [#"../03_std_iterators.rs" 29 4 29 91] forall i : int . 0 <= i /\ i < Seq.length produced_13 -> UInt64.to_int ( ^ Seq.get produced_13 i) = 0 };
     _21 <- borrow_mut iter_4;
     iter_4 <-  ^ _21;
     _20 <- ([#"../03_std_iterators.rs" 29 4 29 91] Next0.next _21);

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -237,7 +237,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -253,7 +253,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -509,7 +509,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module Alloc_Vec_Impl16
   type t
@@ -588,7 +588,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
   type t
@@ -620,7 +620,7 @@ module Knapsack_Knapsack01Dyn_Interface
   val knapsack01_dyn [@cfg:stackify] (items : Alloc_Vec_Vec_Type.alloc_vec_vec_type (Knapsack_Item_Type.knapsack_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (max_weight : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (Knapsack_Item_Type.knapsack_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     requires {[#"../knapsack.rs" 42 11 42 36] Seq.length (Model0.model items) < 10000000}
     requires {[#"../knapsack.rs" 43 11 43 33] UInt64.to_int max_weight < 10000000}
-    requires {[#"../knapsack.rs" 44 0 44 91] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (Knapsack_Item_Type.knapsack_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
+    requires {[#"../knapsack.rs" 44 0 44 91] forall i : int . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (Knapsack_Item_Type.knapsack_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
     
 end
 module Knapsack_Knapsack01Dyn
@@ -705,7 +705,7 @@ module Knapsack_Knapsack01Dyn
   let rec cfg knapsack01_dyn [@cfg:stackify] [#"../knapsack.rs" 45 0 45 91] (items : Alloc_Vec_Vec_Type.alloc_vec_vec_type (Knapsack_Item_Type.knapsack_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (max_weight : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (Knapsack_Item_Type.knapsack_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     requires {[#"../knapsack.rs" 42 11 42 36] Seq.length (Model0.model items) < 10000000}
     requires {[#"../knapsack.rs" 43 11 43 33] UInt64.to_int max_weight < 10000000}
-    requires {[#"../knapsack.rs" 44 0 44 91] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (Knapsack_Item_Type.knapsack_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
+    requires {[#"../knapsack.rs" 44 0 44 91] forall i : int . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (Knapsack_Item_Type.knapsack_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.alloc_vec_vec_type (Knapsack_Item_Type.knapsack_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type);
@@ -850,9 +850,9 @@ module Knapsack_Knapsack01Dyn
   }
   BB8 {
     invariant items_len { [#"../knapsack.rs" 50 27 50 68] Seq.length (Model0.model items_1) + 1 = Seq.length (Model2.model best_value_6) };
-    invariant weight_len { [#"../knapsack.rs" 50 4 50 70] forall i : (int) . 0 <= i /\ i < Seq.length (Model2.model best_value_6) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model3.model (Seq.get (Model2.model best_value_6) i)) };
-    invariant best_value { [#"../knapsack.rs" 50 4 50 70] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= UInt64.to_int i_13 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) = M0.m (Model0.model items_1) ii ww };
-    invariant best_value_bounds { [#"../knapsack.rs" 50 4 50 70] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) <= 10000000 * ii };
+    invariant weight_len { [#"../knapsack.rs" 50 4 50 70] forall i : int . 0 <= i /\ i < Seq.length (Model2.model best_value_6) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model3.model (Seq.get (Model2.model best_value_6) i)) };
+    invariant best_value { [#"../knapsack.rs" 50 4 50 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UInt64.to_int i_13 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) = M0.m (Model0.model items_1) ii ww };
+    invariant best_value_bounds { [#"../knapsack.rs" 50 4 50 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) <= 10000000 * ii };
     _21 <- i_13;
     _23 <- items_1;
     _22 <- ([#"../knapsack.rs" 57 14 57 25] Len0.len _23);
@@ -894,10 +894,10 @@ module Knapsack_Knapsack01Dyn
   }
   BB17 {
     invariant items_len2 { [#"../knapsack.rs" 64 32 64 73] Seq.length (Model0.model items_1) + 1 = Seq.length (Model2.model best_value_6) };
-    invariant weight_len2 { [#"../knapsack.rs" 64 8 64 75] forall i : (int) . 0 <= i /\ i < Seq.length (Model2.model best_value_6) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model3.model (Seq.get (Model2.model best_value_6) i)) };
-    invariant best_value2 { [#"../knapsack.rs" 64 8 64 75] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= UInt64.to_int i_13 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) = M0.m (Model0.model items_1) ii ww };
-    invariant best_value2 { [#"../knapsack.rs" 64 8 64 75] forall ww : (int) . 0 <= ww /\ ww <= UInt64.to_int w_28 - 1 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) (UInt64.to_int i_13 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_13 + 1) ww };
-    invariant best_value_bounds { [#"../knapsack.rs" 64 8 64 75] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) <= 10000000 * ii };
+    invariant weight_len2 { [#"../knapsack.rs" 64 8 64 75] forall i : int . 0 <= i /\ i < Seq.length (Model2.model best_value_6) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model3.model (Seq.get (Model2.model best_value_6) i)) };
+    invariant best_value2 { [#"../knapsack.rs" 64 8 64 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UInt64.to_int i_13 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) = M0.m (Model0.model items_1) ii ww };
+    invariant best_value2 { [#"../knapsack.rs" 64 8 64 75] forall ww : int . 0 <= ww /\ ww <= UInt64.to_int w_28 - 1 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) (UInt64.to_int i_13 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_13 + 1) ww };
+    invariant best_value_bounds { [#"../knapsack.rs" 64 8 64 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model3.model (Seq.get (Model2.model best_value_6) ii)) ww) <= 10000000 * ii };
     _36 <- w_28;
     _37 <- max_weight_2;
     _35 <- ([#"../knapsack.rs" 74 14 74 29] _36 <= _37);

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -235,7 +235,7 @@ module KnapsackFull_M
       MinMax.max (m items (i - 1) w) (m items (i - 1) (w - UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_weight (Seq.get items (i - 1)))) + UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_value (Seq.get items (i - 1))))
     
   )
-  axiom m_spec : forall items : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name), i : int, w : int . ([#"../knapsack_full.rs" 56 11 56 37] 0 <= i /\ i <= Seq.length items) -> ([#"../knapsack_full.rs" 57 11 57 17] 0 <= w) -> ([#"../knapsack_full.rs" 59 0 61 2] forall j : (int) . forall s : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . 0 <= j /\ j <= Seq.length s /\ SubseqRev0.subseq_rev s j items i /\ SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= m items i w) && ([#"../knapsack_full.rs" 58 10 58 21] m items i w >= 0)
+  axiom m_spec : forall items : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name), i : int, w : int . ([#"../knapsack_full.rs" 56 11 56 37] 0 <= i /\ i <= Seq.length items) -> ([#"../knapsack_full.rs" 57 11 57 17] 0 <= w) -> ([#"../knapsack_full.rs" 59 0 61 2] forall j : int . forall s : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . 0 <= j /\ j <= Seq.length s /\ SubseqRev0.subseq_rev s j items i /\ SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= m items i w) && ([#"../knapsack_full.rs" 58 10 58 21] m items i w >= 0)
 end
 module KnapsackFull_M_Impl
   type name
@@ -253,7 +253,7 @@ module KnapsackFull_M_Impl
     requires {[#"../knapsack_full.rs" 56 11 56 37] 0 <= i /\ i <= Seq.length items}
     requires {[#"../knapsack_full.rs" 57 11 57 17] 0 <= w}
     ensures { [#"../knapsack_full.rs" 58 10 58 21] result >= 0 }
-    ensures { [#"../knapsack_full.rs" 59 0 61 2] forall j : (int) . forall s : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . 0 <= j /\ j <= Seq.length s /\ SubseqRev0.subseq_rev s j items i /\ SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= result }
+    ensures { [#"../knapsack_full.rs" 59 0 61 2] forall j : int . forall s : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . 0 <= j /\ j <= Seq.length s /\ SubseqRev0.subseq_rev s j items i /\ SumWeights0.sum_weights s j <= w -> SumValues0.sum_values s j <= result }
     variant {[#"../knapsack_full.rs" 55 10 55 11] i}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -381,7 +381,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -397,7 +397,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -653,7 +653,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module Alloc_Vec_Impl16
   type t
@@ -732,7 +732,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module CreusotContracts_Logic_Resolve_Impl2_Resolve_Interface
   type t
@@ -770,10 +770,10 @@ module KnapsackFull_Knapsack01Dyn_Interface
   val knapsack01_dyn [@cfg:stackify] (items : Alloc_Vec_Vec_Type.alloc_vec_vec_type (KnapsackFull_Item_Type.knapsackfull_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (max_weight : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (KnapsackFull_Item_Type.knapsackfull_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     requires {[#"../knapsack_full.rs" 73 11 73 36] Seq.length (Model0.model items) < 10000000}
     requires {[#"../knapsack_full.rs" 74 11 74 33] UInt64.to_int max_weight < 10000000}
-    requires {[#"../knapsack_full.rs" 75 0 75 91] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
+    requires {[#"../knapsack_full.rs" 75 0 75 91] forall i : int . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
     ensures { [#"../knapsack_full.rs" 76 10 76 62] SumWeights0.sum_weights (Model1.model result) (Seq.length (Model1.model result)) <= UInt64.to_int max_weight }
     ensures { [#"../knapsack_full.rs" 77 10 77 56] SubseqRev0.subseq_rev (Model1.model result) 0 (Model0.model items) (Seq.length (Model0.model items)) }
-    ensures { [#"../knapsack_full.rs" 78 0 80 2] forall s : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . SubseqRev0.subseq_rev s 0 (Model0.model items) (Seq.length (Model0.model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UInt64.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (Model1.model result) (Seq.length (Model1.model result)) }
+    ensures { [#"../knapsack_full.rs" 78 0 80 2] forall s : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . SubseqRev0.subseq_rev s 0 (Model0.model items) (Seq.length (Model0.model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UInt64.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (Model1.model result) (Seq.length (Model1.model result)) }
     
 end
 module KnapsackFull_Knapsack01Dyn
@@ -863,10 +863,10 @@ module KnapsackFull_Knapsack01Dyn
   let rec cfg knapsack01_dyn [@cfg:stackify] [#"../knapsack_full.rs" 81 0 81 91] (items : Alloc_Vec_Vec_Type.alloc_vec_vec_type (KnapsackFull_Item_Type.knapsackfull_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (max_weight : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (KnapsackFull_Item_Type.knapsackfull_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     requires {[#"../knapsack_full.rs" 73 11 73 36] Seq.length (Model0.model items) < 10000000}
     requires {[#"../knapsack_full.rs" 74 11 74 33] UInt64.to_int max_weight < 10000000}
-    requires {[#"../knapsack_full.rs" 75 0 75 91] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
+    requires {[#"../knapsack_full.rs" 75 0 75 91] forall i : int . 0 <= i /\ i < Seq.length (Model0.model items) -> UInt64.to_int (KnapsackFull_Item_Type.knapsackfull_item_type_Item_value (Seq.get (Model0.model items) i)) <= 10000000}
     ensures { [#"../knapsack_full.rs" 76 10 76 62] SumWeights0.sum_weights (Model1.model result) (Seq.length (Model1.model result)) <= UInt64.to_int max_weight }
     ensures { [#"../knapsack_full.rs" 77 10 77 56] SubseqRev0.subseq_rev (Model1.model result) 0 (Model0.model items) (Seq.length (Model0.model items)) }
-    ensures { [#"../knapsack_full.rs" 78 0 80 2] forall s : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . SubseqRev0.subseq_rev s 0 (Model0.model items) (Seq.length (Model0.model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UInt64.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (Model1.model result) (Seq.length (Model1.model result)) }
+    ensures { [#"../knapsack_full.rs" 78 0 80 2] forall s : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . SubseqRev0.subseq_rev s 0 (Model0.model items) (Seq.length (Model0.model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UInt64.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (Model1.model result) (Seq.length (Model1.model result)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.alloc_vec_vec_type (KnapsackFull_Item_Type.knapsackfull_item_type name) (Alloc_Alloc_Global_Type.alloc_alloc_global_type);
@@ -1011,9 +1011,9 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB8 {
     invariant items_len { [#"../knapsack_full.rs" 86 27 86 68] Seq.length (Model0.model items_1) + 1 = Seq.length (Model3.model best_value_9) };
-    invariant weight_len { [#"../knapsack_full.rs" 86 4 86 70] forall i : (int) . 0 <= i /\ i < Seq.length (Model3.model best_value_9) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model4.model (Seq.get (Model3.model best_value_9) i)) };
-    invariant best_value { [#"../knapsack_full.rs" 86 4 86 70] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= UInt64.to_int i_16 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) = M0.m (Model0.model items_1) ii ww };
-    invariant best_value_bounds { [#"../knapsack_full.rs" 86 4 86 70] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) <= 10000000 * ii };
+    invariant weight_len { [#"../knapsack_full.rs" 86 4 86 70] forall i : int . 0 <= i /\ i < Seq.length (Model3.model best_value_9) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model4.model (Seq.get (Model3.model best_value_9) i)) };
+    invariant best_value { [#"../knapsack_full.rs" 86 4 86 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UInt64.to_int i_16 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) = M0.m (Model0.model items_1) ii ww };
+    invariant best_value_bounds { [#"../knapsack_full.rs" 86 4 86 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) <= 10000000 * ii };
     _24 <- i_16;
     _26 <- items_1;
     _25 <- ([#"../knapsack_full.rs" 93 14 93 25] Len0.len _26);
@@ -1055,10 +1055,10 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB17 {
     invariant items_len2 { [#"../knapsack_full.rs" 100 32 100 73] Seq.length (Model0.model items_1) + 1 = Seq.length (Model3.model best_value_9) };
-    invariant weight_len2 { [#"../knapsack_full.rs" 100 8 100 75] forall i : (int) . 0 <= i /\ i < Seq.length (Model3.model best_value_9) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model4.model (Seq.get (Model3.model best_value_9) i)) };
-    invariant best_value2 { [#"../knapsack_full.rs" 100 8 100 75] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= UInt64.to_int i_16 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) = M0.m (Model0.model items_1) ii ww };
-    invariant best_value2 { [#"../knapsack_full.rs" 100 8 100 75] forall ww : (int) . 0 <= ww /\ ww <= UInt64.to_int w_31 - 1 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) (UInt64.to_int i_16 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_16 + 1) ww };
-    invariant best_value_bounds { [#"../knapsack_full.rs" 100 8 100 75] forall ww : (int) . forall ii : (int) . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) <= 10000000 * ii };
+    invariant weight_len2 { [#"../knapsack_full.rs" 100 8 100 75] forall i : int . 0 <= i /\ i < Seq.length (Model3.model best_value_9) -> UInt64.to_int max_weight_2 + 1 = Seq.length (Model4.model (Seq.get (Model3.model best_value_9) i)) };
+    invariant best_value2 { [#"../knapsack_full.rs" 100 8 100 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UInt64.to_int i_16 /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) = M0.m (Model0.model items_1) ii ww };
+    invariant best_value2 { [#"../knapsack_full.rs" 100 8 100 75] forall ww : int . 0 <= ww /\ ww <= UInt64.to_int w_31 - 1 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) (UInt64.to_int i_16 + 1))) ww) = M0.m (Model0.model items_1) (UInt64.to_int i_16 + 1) ww };
+    invariant best_value_bounds { [#"../knapsack_full.rs" 100 8 100 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Model0.model items_1) /\ 0 <= ww /\ ww <= UInt64.to_int max_weight_2 -> UInt64.to_int (Seq.get (Model4.model (Seq.get (Model3.model best_value_9) ii)) ww) <= 10000000 * ii };
     _39 <- w_31;
     _40 <- max_weight_2;
     _38 <- ([#"../knapsack_full.rs" 110 14 110 29] _39 <= _40);
@@ -1191,9 +1191,9 @@ module KnapsackFull_Knapsack01Dyn
   BB39 {
     invariant j_items_len { [#"../knapsack_full.rs" 125 29 125 49] UInt64.to_int j_86 <= Seq.length (Model0.model items_1) };
     invariant left_weight_le_max { [#"../knapsack_full.rs" 126 36 126 63] UInt64.to_int left_weight_85 <= UInt64.to_int max_weight_2 };
-    invariant result_weight { [#"../knapsack_full.rs" 125 4 125 51] forall r : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SumWeights0.sum_weights r (Seq.length (Model1.model result_82)) <= UInt64.to_int left_weight_85 -> SumWeights0.sum_weights r 0 <= UInt64.to_int max_weight_2 };
-    invariant result_value { [#"../knapsack_full.rs" 125 4 125 51] forall r : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SumValues0.sum_values r (Seq.length (Model1.model result_82)) = M0.m (Model0.model items_1) (UInt64.to_int j_86) (UInt64.to_int left_weight_85) -> SumValues0.sum_values r 0 = M0.m (Model0.model items_1) (Seq.length (Model0.model items_1)) (UInt64.to_int max_weight_2) };
-    invariant result_subseq { [#"../knapsack_full.rs" 125 4 125 51] forall r : (Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name)) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : (int) . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SubseqRev0.subseq_rev r (Seq.length (Model1.model result_82)) (Model0.model items_1) (UInt64.to_int j_86) -> SubseqRev0.subseq_rev r 0 (Model0.model items_1) (Seq.length (Model0.model items_1)) };
+    invariant result_weight { [#"../knapsack_full.rs" 125 4 125 51] forall r : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SumWeights0.sum_weights r (Seq.length (Model1.model result_82)) <= UInt64.to_int left_weight_85 -> SumWeights0.sum_weights r 0 <= UInt64.to_int max_weight_2 };
+    invariant result_value { [#"../knapsack_full.rs" 125 4 125 51] forall r : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SumValues0.sum_values r (Seq.length (Model1.model result_82)) = M0.m (Model0.model items_1) (UInt64.to_int j_86) (UInt64.to_int left_weight_85) -> SumValues0.sum_values r 0 = M0.m (Model0.model items_1) (Seq.length (Model0.model items_1)) (UInt64.to_int max_weight_2) };
+    invariant result_subseq { [#"../knapsack_full.rs" 125 4 125 51] forall r : Seq.seq (KnapsackFull_Item_Type.knapsackfull_item_type name) . Seq.length (Model1.model result_82) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (Model1.model result_82) -> Seq.get (Model1.model result_82) i = Seq.get r i) /\ SubseqRev0.subseq_rev r (Seq.length (Model1.model result_82)) (Model0.model items_1) (UInt64.to_int j_86) -> SubseqRev0.subseq_rev r 0 (Model0.model items_1) (Seq.length (Model0.model items_1)) };
     _95 <- j_86;
     _94 <- ([#"../knapsack_full.rs" 142 10 142 15] (0 : usize) < _95);
     switch (_94)

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -136,7 +136,7 @@ module ListIndexMut_IndexMut_Interface
     ensures { [#"../list_index_mut.rs" 40 10 40 51] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type ( * result) = Get0.get ( * param_l) (UInt64.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 41 10 41 51] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type ( ^ result) = Get0.get ( ^ param_l) (UInt64.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 42 10 42 40] Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { [#"../list_index_mut.rs" 43 0 43 114] forall i : (int) . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    ensures { [#"../list_index_mut.rs" 43 0 43 114] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     
 end
 module ListIndexMut_IndexMut
@@ -161,7 +161,7 @@ module ListIndexMut_IndexMut
     ensures { [#"../list_index_mut.rs" 40 10 40 51] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type ( * result) = Get0.get ( * param_l) (UInt64.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 41 10 41 51] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type ( ^ result) = Get0.get ( ^ param_l) (UInt64.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 42 10 42 40] Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { [#"../list_index_mut.rs" 43 0 43 114] forall i : (int) . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    ensures { [#"../list_index_mut.rs" 43 0 43 114] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UInt64.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : borrowed uint32;
@@ -207,7 +207,7 @@ module ListIndexMut_IndexMut
     invariant get_target_now { [#"../list_index_mut.rs" 49 32 49 71] Get0.get ( * l_13) (UInt64.to_int ix_14) = Get0.get ( * old_l_9) (UInt64.to_int param_ix_2) };
     invariant get_target_fin { [#"../list_index_mut.rs" 50 32 50 71] Get0.get ( ^ l_13) (UInt64.to_int ix_14) = Get0.get ( ^ old_l_9) (UInt64.to_int param_ix_2) };
     invariant len { [#"../list_index_mut.rs" 48 4 48 58] Len0.len ( ^ l_13) = Len0.len ( * l_13) -> Len0.len ( ^ old_l_9) = Len0.len ( * old_l_9) };
-    invariant untouched { [#"../list_index_mut.rs" 48 4 48 58] (forall i : (int) . 0 <= i /\ i < Len0.len ( * l_13) /\ i <> UInt64.to_int ix_14 -> Get0.get ( ^ l_13) i = Get0.get ( * l_13) i) -> (forall i : (int) . 0 <= i /\ i < Len0.len ( * old_l_9) /\ i <> UInt64.to_int param_ix_2 -> Get0.get ( ^ old_l_9) i = Get0.get ( * old_l_9) i) };
+    invariant untouched { [#"../list_index_mut.rs" 48 4 48 58] (forall i : int . 0 <= i /\ i < Len0.len ( * l_13) /\ i <> UInt64.to_int ix_14 -> Get0.get ( ^ l_13) i = Get0.get ( * l_13) i) -> (forall i : int . 0 <= i /\ i < Len0.len ( * old_l_9) /\ i <> UInt64.to_int param_ix_2 -> Get0.get ( ^ old_l_9) i = Get0.get ( * old_l_9) i) };
     _23 <- ix_14;
     _22 <- ([#"../list_index_mut.rs" 57 10 57 16] _23 > (0 : usize));
     switch (_22)
@@ -274,7 +274,7 @@ module ListIndexMut_Write_Interface
     requires {[#"../list_index_mut.rs" 71 11 71 24] UInt64.to_int ix < Len0.len ( * l)}
     ensures { [#"../list_index_mut.rs" 72 10 72 33] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type v = Get0.get ( ^ l) (UInt64.to_int ix) }
     ensures { [#"../list_index_mut.rs" 73 10 73 28] Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { [#"../list_index_mut.rs" 74 0 74 88] forall i : (int) . 0 <= i /\ i < Len0.len ( * l) /\ i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
+    ensures { [#"../list_index_mut.rs" 74 0 74 88] forall i : int . 0 <= i /\ i < Len0.len ( * l) /\ i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     
 end
 module ListIndexMut_Write
@@ -297,7 +297,7 @@ module ListIndexMut_Write
     requires {[#"../list_index_mut.rs" 71 11 71 24] UInt64.to_int ix < Len0.len ( * l)}
     ensures { [#"../list_index_mut.rs" 72 10 72 33] ListIndexMut_Option_Type.ListIndexMut_Option_Some_Type v = Get0.get ( ^ l) (UInt64.to_int ix) }
     ensures { [#"../list_index_mut.rs" 73 10 73 28] Len0.len ( ^ l) = Len0.len ( * l) }
-    ensures { [#"../list_index_mut.rs" 74 0 74 88] forall i : (int) . 0 <= i /\ i < Len0.len ( * l) /\ i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
+    ensures { [#"../list_index_mut.rs" 74 0 74 88] forall i : int . 0 <= i /\ i < Len0.len ( * l) /\ i <> UInt64.to_int ix -> Get0.get ( * l) i = Get0.get ( ^ l) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -23,7 +23,7 @@ module MappingTest_Impl0_Model
   use mach.int.Int32
   use MappingTest_T_Type
   function model [#"../mapping_test.rs" 18 4 18 35] (self : MappingTest_T_Type.mappingtest_t_type) : Map.map int int
-  axiom model_spec : forall self : MappingTest_T_Type.mappingtest_t_type . [#"../mapping_test.rs" 15 4 17 76] forall i : (int) . Map.get (model self) i = (if 0 <= i /\ i < Int32.to_int (MappingTest_T_Type.mappingtest_t_type_T_a self) then
+  axiom model_spec : forall self : MappingTest_T_Type.mappingtest_t_type . [#"../mapping_test.rs" 15 4 17 76] forall i : int . Map.get (model self) i = (if 0 <= i /\ i < Int32.to_int (MappingTest_T_Type.mappingtest_t_type_T_a self) then
     1
   else
     0

--- a/creusot/tests/should_succeed/mutex.mlcfg
+++ b/creusot/tests/should_succeed/mutex.mlcfg
@@ -68,7 +68,7 @@ module Mutex_Impl0_GetMut_Interface
   clone Mutex_Inv_Inv_Interface as Inv0 with type self = i, type t = t
   val get_mut [@cfg:stackify] (self : borrowed (Mutex_Mutex_Type.mutex_mutex_type t i)) : borrowed t
     ensures { [#"../mutex.rs" 29 4 29 38] Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( * self)) ( * result) }
-    ensures { [#"../mutex.rs" 30 4 30 53] forall v : (t) . Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( ^ self)) v = true }
+    ensures { [#"../mutex.rs" 30 4 30 53] forall v : t . Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( ^ self)) v = true }
     
 end
 module Mutex_Impl0_GetMut
@@ -79,7 +79,7 @@ module Mutex_Impl0_GetMut
   clone Mutex_Inv_Inv as Inv0 with type self = i, type t = t
   val get_mut [@cfg:stackify] (self : borrowed (Mutex_Mutex_Type.mutex_mutex_type t i)) : borrowed t
     ensures { [#"../mutex.rs" 29 4 29 38] Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( * self)) ( * result) }
-    ensures { [#"../mutex.rs" 30 4 30 53] forall v : (t) . Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( ^ self)) v = true }
+    ensures { [#"../mutex.rs" 30 4 30 53] forall v : t . Inv0.inv (Mutex_Mutex_Type.mutex_mutex_type_Mutex_1 ( ^ self)) v = true }
     
 end
 module Mutex_GuardInner_Type

--- a/creusot/tests/should_succeed/option.mlcfg
+++ b/creusot/tests/should_succeed/option.mlcfg
@@ -93,7 +93,7 @@ module Core_Option_Impl0_AsMut_Interface
   use Core_Option_Option_Type
   val as_mut [@cfg:stackify] (self : borrowed (Core_Option_Option_Type.core_option_option_type t)) : Core_Option_Option_Type.core_option_option_type (borrowed t)
     ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type /\  ^ self = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
+    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
     
 end
 module Core_Option_Impl0_AsMut
@@ -102,7 +102,7 @@ module Core_Option_Impl0_AsMut
   use Core_Option_Option_Type
   val as_mut [@cfg:stackify] (self : borrowed (Core_Option_Option_Type.core_option_option_type t)) : Core_Option_Option_Type.core_option_option_type (borrowed t)
     ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type /\  ^ self = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
+    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface
@@ -122,7 +122,7 @@ module Core_Option_Impl0_AsRef_Interface
   use Core_Option_Option_Type
   val as_ref [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
     
 end
 module Core_Option_Impl0_AsRef
@@ -131,7 +131,7 @@ module Core_Option_Impl0_AsRef
   use Core_Option_Option_Type
   val as_ref [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
     
 end
 module Core_Option_Impl0_And_Interface
@@ -232,7 +232,7 @@ module Core_Option_Impl2_Copied_Interface
   use Core_Option_Option_Type
   val copied [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
     
 end
 module Core_Option_Impl2_Copied
@@ -241,7 +241,7 @@ module Core_Option_Impl2_Copied
   use Core_Option_Option_Type
   val copied [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
     
 end
 module Core_Option_Impl3_Copied_Interface
@@ -251,7 +251,7 @@ module Core_Option_Impl3_Copied_Interface
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = t
   val copied [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type (borrowed t)) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (borrowed t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : borrowed t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl3_Copied
@@ -261,7 +261,7 @@ module Core_Option_Impl3_Copied
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = t
   val copied [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type (borrowed t)) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (borrowed t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : borrowed t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl2_Cloned_Interface
@@ -270,7 +270,7 @@ module Core_Option_Impl2_Cloned_Interface
   use Core_Option_Option_Type
   val cloned [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
     
 end
 module Core_Option_Impl2_Cloned
@@ -279,7 +279,7 @@ module Core_Option_Impl2_Cloned
   use Core_Option_Option_Type
   val cloned [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type t) }
     
 end
 module Core_Option_Impl3_Cloned_Interface
@@ -289,7 +289,7 @@ module Core_Option_Impl3_Cloned_Interface
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = t
   val cloned [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type (borrowed t)) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (borrowed t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : borrowed t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl3_Cloned
@@ -299,7 +299,7 @@ module Core_Option_Impl3_Cloned
   clone CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface as Resolve0 with type t = t
   val cloned [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type (borrowed t)) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : (borrowed t) . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists t : borrowed t . self = Core_Option_Option_Type.Core_Option_Option_Some_Type t /\ result = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl39_Flatten_Interface

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -187,7 +187,7 @@ module RedBlackTree_Impl0_SameMappings
   predicate same_mappings [#"../red_black_tree.rs" 42 4 42 43] (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (o : RedBlackTree_Node_Type.redblacktree_tree_type k v)
     
    =
-    [#"../red_black_tree.rs" 43 8 45 9] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping self k v = HasMapping0.has_mapping o k v
+    [#"../red_black_tree.rs" 43 8 45 9] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping self k v = HasMapping0.has_mapping o k v
 end
 module RedBlackTree_Impl0_ModelAcc_Interface
   type k
@@ -250,7 +250,7 @@ module RedBlackTree_Impl0_ModelAccHasMapping
       | RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_None_Type) -> ()
       | RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type (RedBlackTree_Node_Type.RedBlackTree_Node_Type left _ key val' right)) -> let _ = model_acc_has_mapping left accu k in let accu1 = ModelAcc0.model_acc left accu in let accu2 = Map.set accu1 (Model0.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type val') in model_acc_has_mapping right accu2 k
       end
-  axiom model_acc_has_mapping_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v), k : ModelTy0.modelTy . [#"../red_black_tree.rs" 63 4 64 93] Map.get (ModelAcc0.model_acc self accu) k = Map.get accu k \/ (exists v : (v) . Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ HasMapping0.has_mapping self k v)
+  axiom model_acc_has_mapping_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v), k : ModelTy0.modelTy . [#"../red_black_tree.rs" 63 4 64 93] Map.get (ModelAcc0.model_acc self accu) k = Map.get accu k \/ (exists v : v . Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ HasMapping0.has_mapping self k v)
 end
 module RedBlackTree_Impl0_ModelAccHasMapping_Impl
   type k
@@ -265,7 +265,7 @@ module RedBlackTree_Impl0_ModelAccHasMapping_Impl
   clone RedBlackTree_Impl0_ModelAcc as ModelAcc0 with type k = k, type v = v, type ModelTy0.modelTy = ModelTy0.modelTy,
   function Model0.model = Model0.model
   let rec ghost function model_acc_has_mapping (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v)) (k : ModelTy0.modelTy) : ()
-    ensures { [#"../red_black_tree.rs" 63 4 64 93] Map.get (ModelAcc0.model_acc self accu) k = Map.get accu k \/ (exists v : (v) . Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ HasMapping0.has_mapping self k v) }
+    ensures { [#"../red_black_tree.rs" 63 4 64 93] Map.get (ModelAcc0.model_acc self accu) k = Map.get accu k \/ (exists v : v . Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ HasMapping0.has_mapping self k v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 67 12 75 13] match (self) with
@@ -299,7 +299,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate lt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 546 2 546 35] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type
+    [#"../red_black_tree.rs" 547 95 548 30] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type
 end
 module RedBlackTree_Impl4_BstInvariantHere_Interface
   type k
@@ -320,7 +320,7 @@ module RedBlackTree_Impl4_BstInvariantHere
   predicate bst_invariant_here [#"../red_black_tree.rs" 175 4 175 39] (self : RedBlackTree_Node_Type.redblacktree_node_type k v)
     
    =
-    [#"../red_black_tree.rs" 177 12 178 88] (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self) k v -> LtLog0.lt_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self))) /\ (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right self) k v -> LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self)) k)
+    [#"../red_black_tree.rs" 177 12 178 88] (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self) k v -> LtLog0.lt_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self))) /\ (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right self) k v -> LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self)) k)
 end
 module RedBlackTree_Impl5_BstInvariant_Interface
   type k
@@ -350,7 +350,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate le_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 543 7 543 43] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type
+    [#"../red_black_tree.rs" 545 13 545 49] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   type self
@@ -365,7 +365,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 544 31 544 81] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 545 84 546 27] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   type self
@@ -380,7 +380,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 547 21 547 68] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 549 20 549 67] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
   type self
@@ -391,7 +391,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate ge_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 549 42 549 75] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type
+    [#"../red_black_tree.rs" 550 82 551 26] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   type self
@@ -406,7 +406,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 550 8 550 55] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 552 13 552 60] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
   type self
@@ -417,7 +417,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   predicate gt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 552 35 553 0] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type
+    [#"../red_black_tree.rs" 553 106 554 33] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   type self
@@ -432,7 +432,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 553 35 553 85] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 555 1 555 51] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   type self
@@ -445,7 +445,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 554 42 555 6] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Equal_Type
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 556 53 556 84] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Equal_Type
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   type self
@@ -458,7 +458,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.core_cmp_ordering_type) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.core_cmp_ordering_type . ([#"../red_black_tree.rs" 555 58 556 11] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 556 29 556 46] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 556 63 556 80] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.core_cmp_ordering_type . ([#"../red_black_tree.rs" 557 27 557 44] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 558 16 558 33] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 559 3 559 20] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   type self
@@ -471,7 +471,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 558 9 558 39] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type) -> ([#"../red_black_tree.rs" 559 9 560 14] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 561 15 561 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type) -> ([#"../red_black_tree.rs" 562 0 563 1] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   type self
@@ -484,7 +484,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 561 18 561 51] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type) -> ([#"../red_black_tree.rs" 562 6 563 4] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 564 34 566 4] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Greater_Type) -> ([#"../red_black_tree.rs" 567 0 569 23] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Less_Type)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   type self
@@ -497,7 +497,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   use Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 564 36 566 18] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Equal_Type)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 570 44 571 43] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.Core_Cmp_Ordering_Equal_Type)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Interface
   type k
@@ -538,7 +538,7 @@ module RedBlackTree_Impl0_HasMappingModelAcc
       | RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_None_Type) -> ()
       | RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type (RedBlackTree_Node_Type.RedBlackTree_Node_Type left _ key val' right)) -> let _ = has_mapping_model_acc left accu k in let accu1 = ModelAcc0.model_acc left accu in let accu2 = Map.set accu1 (Model0.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type val') in let _ = has_mapping_model_acc right accu2 k in ModelAccHasMapping0.model_acc_has_mapping right accu2 k
       end
-  axiom has_mapping_model_acc_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v), k : ModelTy0.modelTy . ([#"../red_black_tree.rs" 80 15 80 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 81 4 81 94] forall v : (v) . HasMapping0.has_mapping self k v -> Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v)
+  axiom has_mapping_model_acc_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v), k : ModelTy0.modelTy . ([#"../red_black_tree.rs" 80 15 80 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 81 4 81 94] forall v : v . HasMapping0.has_mapping self k v -> Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Impl
   type k
@@ -590,7 +590,7 @@ module RedBlackTree_Impl0_HasMappingModelAcc_Impl
   predicate BstInvariantHere0.bst_invariant_here = BstInvariantHere0.bst_invariant_here
   let rec ghost function has_mapping_model_acc (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (accu : Map.map ModelTy0.modelTy (Core_Option_Option_Type.core_option_option_type v)) (k : ModelTy0.modelTy) : ()
     requires {[#"../red_black_tree.rs" 80 15 80 35] BstInvariant0.bst_invariant self}
-    ensures { [#"../red_black_tree.rs" 81 4 81 94] forall v : (v) . HasMapping0.has_mapping self k v -> Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
+    ensures { [#"../red_black_tree.rs" 81 4 81 94] forall v : v . HasMapping0.has_mapping self k v -> Map.get (ModelAcc0.model_acc self accu) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 87 12 96 13] match (self) with
@@ -690,7 +690,7 @@ module RedBlackTree_Impl0_HasMappingModel
     
    =
     [#"../red_black_tree.rs" 108 12 108 61] let _ = ModelAccHasMapping0.model_acc_has_mapping self (Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type)) k in HasMappingModelAcc0.has_mapping_model_acc self (Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type)) k
-  axiom has_mapping_model_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, k : ModelTy0.modelTy . ([#"../red_black_tree.rs" 101 15 101 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 102 4 102 82] forall v : (v) . HasMapping0.has_mapping self k v = (Map.get (Model0.model self) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v))
+  axiom has_mapping_model_spec : forall self : RedBlackTree_Node_Type.redblacktree_tree_type k v, k : ModelTy0.modelTy . ([#"../red_black_tree.rs" 101 15 101 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 102 4 102 82] forall v : v . HasMapping0.has_mapping self k v = (Map.get (Model0.model self) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v))
 end
 module RedBlackTree_Impl0_HasMappingModel_Impl
   type k
@@ -750,7 +750,7 @@ module RedBlackTree_Impl0_HasMappingModel_Impl
   function ModelAcc0.model_acc = ModelAcc0.model_acc
   let rec ghost function has_mapping_model (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (k : ModelTy0.modelTy) : ()
     requires {[#"../red_black_tree.rs" 101 15 101 35] BstInvariant0.bst_invariant self}
-    ensures { [#"../red_black_tree.rs" 102 4 102 82] forall v : (v) . HasMapping0.has_mapping self k v = (Map.get (Model0.model self) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v) }
+    ensures { [#"../red_black_tree.rs" 102 4 102 82] forall v : v . HasMapping0.has_mapping self k v = (Map.get (Model0.model self) k = Core_Option_Option_Type.Core_Option_Option_Some_Type v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 108 12 108 61] let _ = ModelAccHasMapping0.model_acc_has_mapping self (Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type)) k in HasMappingModelAcc0.has_mapping_model_acc self (Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type)) k
@@ -893,7 +893,7 @@ module RedBlackTree_Impl1_HasMapping
     
    =
     [#"../red_black_tree.rs" 134 8 137 9] HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self) k v \/ HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right self) k v \/ k = Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self) /\ v = RedBlackTree_Node_Type.redblacktree_node_type_Node_val self
-  axiom has_mapping_spec : forall self : RedBlackTree_Node_Type.redblacktree_node_type k v, k : ModelTy0.modelTy, v : v . [#"../red_black_tree.rs" 131 4 132 86] forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . self = node -> has_mapping self k v = HasMapping0.has_mapping (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) k v
+  axiom has_mapping_spec : forall self : RedBlackTree_Node_Type.redblacktree_node_type k v, k : ModelTy0.modelTy, v : v . [#"../red_black_tree.rs" 131 4 132 86] forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . self = node -> has_mapping self k v = HasMapping0.has_mapping (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) k v
 end
 module RedBlackTree_Impl1_HasMapping_Impl
   type k
@@ -907,7 +907,7 @@ module RedBlackTree_Impl1_HasMapping_Impl
   clone RedBlackTree_Impl0_HasMapping as HasMapping0 with type k = k, type v = v,
   type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model0.model
   let rec ghost function has_mapping (self : RedBlackTree_Node_Type.redblacktree_node_type k v) (k : ModelTy0.modelTy) (v : v) : bool
-    ensures { [#"../red_black_tree.rs" 131 4 132 86] forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . self = node -> result = HasMapping0.has_mapping (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) k v }
+    ensures { [#"../red_black_tree.rs" 131 4 132 86] forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . self = node -> result = HasMapping0.has_mapping (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) k v }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 134 8 137 9] HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self) k v || HasMapping0.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right self) k v || (let b = Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key self) in pure {k = b}) && pure {v = RedBlackTree_Node_Type.redblacktree_node_type_Node_val self}
@@ -934,7 +934,7 @@ module RedBlackTree_Impl1_SameMappings
   predicate same_mappings [#"../red_black_tree.rs" 141 4 141 43] (self : RedBlackTree_Node_Type.redblacktree_node_type k v) (o : RedBlackTree_Node_Type.redblacktree_node_type k v)
     
    =
-    [#"../red_black_tree.rs" 142 8 144 9] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping self k v = HasMapping0.has_mapping o k v
+    [#"../red_black_tree.rs" 142 8 144 9] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping self k v = HasMapping0.has_mapping o k v
 end
 module RedBlackTree_Impl2_Model_Interface
   type k
@@ -1118,7 +1118,7 @@ module RedBlackTree_Impl6_MatchT
     
    =
     [#"../red_black_tree.rs" 241 12 241 60] Color1.color tree = RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self /\ ColorInvariant0.color_invariant tree
-  axiom match_t_spec : forall self : RedBlackTree_Cpl_Type.redblacktree_cpl_type, tree : RedBlackTree_Node_Type.redblacktree_tree_type k v . ([#"../red_black_tree.rs" 235 4 238 43] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> match_t self tree = (forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node)) && ([#"../red_black_tree.rs" 230 4 234 44] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> match_t self tree = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node))) && ([#"../red_black_tree.rs" 225 4 229 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> match_t self tree = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree <> Core_Option_Option_Type.Core_Option_Option_None_Type /\ (forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node))) && ([#"../red_black_tree.rs" 221 4 224 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> match_t self tree = (exists node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node))
+  axiom match_t_spec : forall self : RedBlackTree_Cpl_Type.redblacktree_cpl_type, tree : RedBlackTree_Node_Type.redblacktree_tree_type k v . ([#"../red_black_tree.rs" 235 4 238 43] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> match_t self tree = (forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node)) && ([#"../red_black_tree.rs" 230 4 234 44] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> match_t self tree = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node))) && ([#"../red_black_tree.rs" 225 4 229 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> match_t self tree = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree <> Core_Option_Option_Type.Core_Option_Option_None_Type /\ (forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node))) && ([#"../red_black_tree.rs" 221 4 224 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> match_t self tree = (exists node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node))
 end
 module RedBlackTree_Impl6_MatchT_Impl
   type k
@@ -1140,10 +1140,10 @@ module RedBlackTree_Impl6_MatchT_Impl
   clone RedBlackTree_Impl6_MatchN as MatchN0 with type k = k, type v = v,
   predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant
   let rec ghost function match_t (self : RedBlackTree_Cpl_Type.redblacktree_cpl_type) (tree : RedBlackTree_Node_Type.redblacktree_tree_type k v) : bool
-    ensures { [#"../red_black_tree.rs" 221 4 224 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> result = (exists node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node) }
-    ensures { [#"../red_black_tree.rs" 225 4 229 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> result = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree <> Core_Option_Option_Type.Core_Option_Option_None_Type /\ (forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node)) }
-    ensures { [#"../red_black_tree.rs" 230 4 234 44] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> result = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node)) }
-    ensures { [#"../red_black_tree.rs" 235 4 238 43] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> result = (forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node) }
+    ensures { [#"../red_black_tree.rs" 221 4 224 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> result = (exists node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node) }
+    ensures { [#"../red_black_tree.rs" 225 4 229 41] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> result = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree <> Core_Option_Option_Type.Core_Option_Option_None_Type /\ (forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) node)) }
+    ensures { [#"../red_black_tree.rs" 230 4 234 44] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> result = (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node)) }
+    ensures { [#"../red_black_tree.rs" 235 4 238 43] RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> result = (forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node -> MatchN0.match_n (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) node) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 241 12 241 60] (let a = Color1.color tree in pure {a = RedBlackTree_Cpl_Type.redblacktree_cpl_type_CPL_0 self}) && ColorInvariant0.color_invariant tree
@@ -1231,7 +1231,7 @@ module RedBlackTree_Impl7_MatchT
   predicate match_t [#"../red_black_tree.rs" 256 4 256 46] (self : RedBlackTree_Cpn_Type.redblacktree_cpn_type l r) (tree : RedBlackTree_Node_Type.redblacktree_tree_type k v)
     
    =
-    [#"../red_black_tree.rs" 257 8 260 9] exists node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n self node
+    [#"../red_black_tree.rs" 257 8 260 9] exists node : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree = Core_Option_Option_Type.Core_Option_Option_Some_Type node /\ MatchN0.match_n self node
 end
 module RedBlackTree_Impl10_Height_Interface
   type k
@@ -1343,7 +1343,7 @@ module RedBlackTree_Impl11_Height
       | RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type -> Height0.height (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self)
       | RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Height0.height (RedBlackTree_Node_Type.redblacktree_node_type_Node_left self) + 1
       end
-  axiom height_spec : forall self : RedBlackTree_Node_Type.redblacktree_node_type k v . [#"../red_black_tree.rs" 343 4 344 77] forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . self = node -> height self = Height0.height (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node))
+  axiom height_spec : forall self : RedBlackTree_Node_Type.redblacktree_node_type k v . [#"../red_black_tree.rs" 343 4 344 77] forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . self = node -> height self = Height0.height (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node))
 end
 module RedBlackTree_Impl11_Height_Impl
   type k
@@ -1357,7 +1357,7 @@ module RedBlackTree_Impl11_Height_Impl
   use Core_Option_Option_Type
   clone RedBlackTree_Impl10_Height as Height0 with type k = k, type v = v, axiom .
   let rec ghost function height (self : RedBlackTree_Node_Type.redblacktree_node_type k v) : int
-    ensures { [#"../red_black_tree.rs" 343 4 344 77] forall node : (RedBlackTree_Node_Type.redblacktree_node_type k v) . self = node -> result = Height0.height (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) }
+    ensures { [#"../red_black_tree.rs" 343 4 344 77] forall node : RedBlackTree_Node_Type.redblacktree_node_type k v . self = node -> result = Height0.height (RedBlackTree_Node_Type.RedBlackTree_Tree_Type (Core_Option_Option_Type.Core_Option_Option_Some_Type node)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 347 12 350 13] match (RedBlackTree_Node_Type.redblacktree_node_type_Node_color self) with
@@ -1543,7 +1543,7 @@ module CreusotContracts_Logic_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-    [#"../red_black_tree.rs" 660 8 660 22]  ^ self =  * self
+    [#"../red_black_tree.rs" 664 15 664 29]  ^ self =  * self
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
@@ -1628,7 +1628,7 @@ module RedBlackTree_Impl15_RotateRight_Interface
     ensures { [#"../red_black_tree.rs" 419 14 419 41] LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self))) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) }
     ensures { [#"../red_black_tree.rs" 420 14 420 42] Color0.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type }
     ensures { [#"../red_black_tree.rs" 421 14 421 44] RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 422 4 425 36] exists r : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 422 4 425 36] exists r : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
     
 end
 module RedBlackTree_Impl15_RotateRight
@@ -1725,7 +1725,7 @@ module RedBlackTree_Impl15_RotateRight
     ensures { [#"../red_black_tree.rs" 419 14 419 41] LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self))) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) }
     ensures { [#"../red_black_tree.rs" 420 14 420 42] Color0.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type }
     ensures { [#"../red_black_tree.rs" 421 14 421 44] RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 422 4 425 36] exists r : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 422 4 425 36] exists r : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1820,7 +1820,7 @@ module RedBlackTree_Impl15_RotateRight
     assume { Resolve4.resolve _32 };
     assert { [#"../red_black_tree.rs" 455 8 455 78] HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * old_self_11)) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self_1))) (RedBlackTree_Node_Type.redblacktree_node_type_Node_val ( * self_1)) };
     _33 <- ();
-    assert { [#"../red_black_tree.rs" 456 8 456 114] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left x_15) k v -> HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * old_self_11)) k v };
+    assert { [#"../red_black_tree.rs" 456 8 456 114] forall v : v . forall k : ModelTy0.modelTy . HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left x_15) k v -> HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * old_self_11)) k v };
     goto BB7
   }
   BB7 {
@@ -1881,7 +1881,7 @@ module RedBlackTree_Impl15_RotateLeft_Interface
     ensures { [#"../red_black_tree.rs" 470 14 470 41] LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self))) }
     ensures { [#"../red_black_tree.rs" 471 14 471 41] Color0.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type }
     ensures { [#"../red_black_tree.rs" 472 14 472 44] RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 473 4 476 36] exists r : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 473 4 476 36] exists r : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
     
 end
 module RedBlackTree_Impl15_RotateLeft
@@ -1978,7 +1978,7 @@ module RedBlackTree_Impl15_RotateLeft
     ensures { [#"../red_black_tree.rs" 470 14 470 41] LtLog0.lt_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self))) }
     ensures { [#"../red_black_tree.rs" 471 14 471 41] Color0.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type }
     ensures { [#"../red_black_tree.rs" 472 14 472 44] RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 473 4 476 36] exists r : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 473 4 476 36] exists r : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l /\ (RedBlackTree_Node_Type.redblacktree_node_type_Node_left l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right l, RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self), RedBlackTree_Node_Type.redblacktree_node_type_Node_left r, RedBlackTree_Node_Type.redblacktree_node_type_Node_right r) /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -2073,7 +2073,7 @@ module RedBlackTree_Impl15_RotateLeft
     assume { Resolve4.resolve _32 };
     assert { [#"../red_black_tree.rs" 483 8 483 79] HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * old_self_11)) (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self_1))) (RedBlackTree_Node_Type.redblacktree_node_type_Node_val ( * self_1)) };
     _33 <- ();
-    assert { [#"../red_black_tree.rs" 484 8 484 116] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right x_15) k v -> HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * old_self_11)) k v };
+    assert { [#"../red_black_tree.rs" 484 8 484 116] forall v : v . forall k : ModelTy0.modelTy . HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right x_15) k v -> HasMapping1.has_mapping (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * old_self_11)) k v };
     goto BB7
   }
   BB7 {
@@ -2112,7 +2112,7 @@ module Core_Option_Impl0_AsMut_Interface
   use Core_Option_Option_Type
   val as_mut [@cfg:stackify] (self : borrowed (Core_Option_Option_Type.core_option_option_type t)) : Core_Option_Option_Type.core_option_option_type (borrowed t)
     ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type /\  ^ self = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
+    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
     
 end
 module Core_Option_Impl0_AsMut
@@ -2121,7 +2121,7 @@ module Core_Option_Impl0_AsMut
   use Core_Option_Option_Type
   val as_mut [@cfg:stackify] (self : borrowed (Core_Option_Option_Type.core_option_option_type t)) : Core_Option_Option_Type.core_option_option_type (borrowed t)
     ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type /\  ^ self = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
+    ensures {  * self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\  * self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * r) /\  ^ self = Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ r)) }
     
 end
 module RedBlackTree_Impl15_FlipColors_Interface
@@ -2148,8 +2148,8 @@ module RedBlackTree_Impl15_FlipColors_Interface
     ensures { [#"../red_black_tree.rs" 493 14 493 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 494 14 494 42] SameMappings0.same_mappings ( * self) ( ^ self) }
     ensures { [#"../red_black_tree.rs" 495 14 495 40] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 496 4 498 70] exists l2 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l1 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l1 }
-    ensures { [#"../red_black_tree.rs" 499 4 501 90] exists r2 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists r1 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r1 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 }
+    ensures { [#"../red_black_tree.rs" 496 4 498 70] exists l2 : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l1 : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l1 }
+    ensures { [#"../red_black_tree.rs" 499 4 501 90] exists r2 : RedBlackTree_Node_Type.redblacktree_node_type k v . exists r1 : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r1 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 }
     
 end
 module RedBlackTree_Impl15_FlipColors
@@ -2236,8 +2236,8 @@ module RedBlackTree_Impl15_FlipColors
     ensures { [#"../red_black_tree.rs" 493 14 493 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 494 14 494 42] SameMappings0.same_mappings ( * self) ( ^ self) }
     ensures { [#"../red_black_tree.rs" 495 14 495 40] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 496 4 498 70] exists l2 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists l1 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l1 }
-    ensures { [#"../red_black_tree.rs" 499 4 501 90] exists r2 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . exists r1 : (RedBlackTree_Node_Type.redblacktree_node_type k v) . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r1 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 }
+    ensures { [#"../red_black_tree.rs" 496 4 498 70] exists l2 : RedBlackTree_Node_Type.redblacktree_node_type k v . exists l1 : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key l1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color l1 }
+    ensures { [#"../red_black_tree.rs" 499 4 501 90] exists r2 : RedBlackTree_Node_Type.redblacktree_node_type k v . exists r1 : RedBlackTree_Node_Type.redblacktree_node_type k v . RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r1 /\ RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( ^ self)) = Core_Option_Option_Type.Core_Option_Option_Some_Type r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_left r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_left r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_right r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_right r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r2 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_color r1 /\ RedBlackTree_Node_Type.redblacktree_node_type_Node_key r1 = RedBlackTree_Node_Type.redblacktree_node_type_Node_key r2 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -2373,7 +2373,7 @@ module Core_Option_Impl0_AsRef_Interface
   use Core_Option_Option_Type
   val as_ref [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
     
 end
 module Core_Option_Impl0_AsRef
@@ -2382,7 +2382,7 @@ module Core_Option_Impl0_AsRef
   use Core_Option_Option_Type
   val as_ref [@cfg:stackify] (self : Core_Option_Option_Type.core_option_option_type t) : Core_Option_Option_Type.core_option_option_type t
     ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type -> result = Core_Option_Option_Type.Core_Option_Option_None_Type }
-    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : (t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
+    ensures { self = Core_Option_Option_Type.Core_Option_Option_None_Type \/ (exists r : t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r /\ self = Core_Option_Option_Type.Core_Option_Option_Some_Type r) }
     
 end
 module RedBlackTree_Impl15_Balance_Interface
@@ -2774,12 +2774,12 @@ module RedBlackTree_Impl15_MoveRedLeft_Interface
     requires {[#"../red_black_tree.rs" 541 15 541 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 542 15 542 86] MatchN0.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * self)}
     ensures { [#"../red_black_tree.rs" 543 14 543 44] InternalInvariant0.internal_invariant ( * result) }
-    ensures { [#"../red_black_tree.rs" 544 4 546 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
+    ensures { [#"../red_black_tree.rs" 544 4 546 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 547 4 547 97] Height0.height ( * result) = Height0.height ( ^ result) -> Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 548 14 548 42] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * result) }
-    ensures { [#"../red_black_tree.rs" 549 4 549 101] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
-    ensures { [#"../red_black_tree.rs" 550 4 551 47] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) -> HasMapping0.has_mapping ( * result) k v }
-    ensures { [#"../red_black_tree.rs" 552 4 553 108] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
+    ensures { [#"../red_black_tree.rs" 549 4 549 101] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
+    ensures { [#"../red_black_tree.rs" 550 4 551 47] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) -> HasMapping0.has_mapping ( * result) k v }
+    ensures { [#"../red_black_tree.rs" 552 4 553 108] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
     ensures { [#"../red_black_tree.rs" 554 14 555 61] MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * result) \/ MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) }
     ensures { [#"../red_black_tree.rs" 556 4 557 45] ColorInvariant0.color_invariant ( ^ result) /\ (Color1.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * result)) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ result) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) -> ColorInvariant0.color_invariant ( ^ self) }
     
@@ -2903,12 +2903,12 @@ module RedBlackTree_Impl15_MoveRedLeft
     requires {[#"../red_black_tree.rs" 541 15 541 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 542 15 542 86] MatchN0.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * self)}
     ensures { [#"../red_black_tree.rs" 543 14 543 44] InternalInvariant0.internal_invariant ( * result) }
-    ensures { [#"../red_black_tree.rs" 544 4 546 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
+    ensures { [#"../red_black_tree.rs" 544 4 546 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 547 4 547 97] Height0.height ( * result) = Height0.height ( ^ result) -> Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 548 14 548 42] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * result) }
-    ensures { [#"../red_black_tree.rs" 549 4 549 101] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
-    ensures { [#"../red_black_tree.rs" 550 4 551 47] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) -> HasMapping0.has_mapping ( * result) k v }
-    ensures { [#"../red_black_tree.rs" 552 4 553 108] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
+    ensures { [#"../red_black_tree.rs" 549 4 549 101] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
+    ensures { [#"../red_black_tree.rs" 550 4 551 47] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log k (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) -> HasMapping0.has_mapping ( * result) k v }
+    ensures { [#"../red_black_tree.rs" 552 4 553 108] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
     ensures { [#"../red_black_tree.rs" 554 14 555 61] MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * result) \/ MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) }
     ensures { [#"../red_black_tree.rs" 556 4 557 45] ColorInvariant0.color_invariant ( ^ result) /\ (Color1.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_right ( * result)) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ result) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) -> ColorInvariant0.color_invariant ( ^ self) }
     
@@ -3062,12 +3062,12 @@ module RedBlackTree_Impl15_MoveRedRight_Interface
     requires {[#"../red_black_tree.rs" 570 15 570 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 571 15 571 86] MatchN0.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)))) ( * self)}
     ensures { [#"../red_black_tree.rs" 572 14 572 44] InternalInvariant0.internal_invariant ( * result) }
-    ensures { [#"../red_black_tree.rs" 573 4 575 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
+    ensures { [#"../red_black_tree.rs" 573 4 575 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 576 4 576 97] Height0.height ( * result) = Height0.height ( ^ result) -> Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 577 14 577 42] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * result) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
-    ensures { [#"../red_black_tree.rs" 578 4 578 101] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
-    ensures { [#"../red_black_tree.rs" 579 4 580 47] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) k -> HasMapping0.has_mapping ( * result) k v }
-    ensures { [#"../red_black_tree.rs" 581 4 582 108] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
+    ensures { [#"../red_black_tree.rs" 578 4 578 101] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
+    ensures { [#"../red_black_tree.rs" 579 4 580 47] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) k -> HasMapping0.has_mapping ( * result) k v }
+    ensures { [#"../red_black_tree.rs" 581 4 582 108] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
     ensures { [#"../red_black_tree.rs" 583 14 584 61] MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) \/ MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) }
     ensures { [#"../red_black_tree.rs" 585 4 586 45] ColorInvariant0.color_invariant ( ^ result) /\ (Color1.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * result)) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ result) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) -> ColorInvariant0.color_invariant ( ^ self) }
     
@@ -3185,12 +3185,12 @@ module RedBlackTree_Impl15_MoveRedRight
     requires {[#"../red_black_tree.rs" 570 15 570 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 571 15 571 86] MatchN0.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)))) ( * self)}
     ensures { [#"../red_black_tree.rs" 572 14 572 44] InternalInvariant0.internal_invariant ( * result) }
-    ensures { [#"../red_black_tree.rs" 573 4 575 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
+    ensures { [#"../red_black_tree.rs" 573 4 575 48] InternalInvariant0.internal_invariant ( ^ result) /\ Height0.height ( * result) = Height0.height ( ^ result) /\ (forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ result) k v -> HasMapping0.has_mapping ( * result) k v) -> InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 576 4 576 97] Height0.height ( * result) = Height0.height ( ^ result) -> Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 577 14 577 42] RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * result) = RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self) }
-    ensures { [#"../red_black_tree.rs" 578 4 578 101] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
-    ensures { [#"../red_black_tree.rs" 579 4 580 47] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) k -> HasMapping0.has_mapping ( * result) k v }
-    ensures { [#"../red_black_tree.rs" 581 4 582 108] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
+    ensures { [#"../red_black_tree.rs" 578 4 578 101] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * result) k v -> HasMapping0.has_mapping ( * self) k v }
+    ensures { [#"../red_black_tree.rs" 579 4 580 47] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v /\ LeLog0.le_log (Model0.model (RedBlackTree_Node_Type.redblacktree_node_type_Node_key ( * self))) k -> HasMapping0.has_mapping ( * result) k v }
+    ensures { [#"../red_black_tree.rs" 581 4 582 108] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (HasMapping0.has_mapping ( ^ result) k v \/ HasMapping0.has_mapping ( * self) k v /\ not HasMapping0.has_mapping ( * result) k v) }
     ensures { [#"../red_black_tree.rs" 583 14 584 61] MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) \/ MatchN1.match_n (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type))) ( * result) }
     ensures { [#"../red_black_tree.rs" 585 4 586 45] ColorInvariant0.color_invariant ( ^ result) /\ (Color1.color (RedBlackTree_Node_Type.redblacktree_node_type_Node_left ( * result)) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> RedBlackTree_Node_Type.redblacktree_node_type_Node_color ( ^ result) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) -> ColorInvariant0.color_invariant ( ^ self) }
     
@@ -3401,7 +3401,7 @@ module CreusotContracts_Logic_Model_Impl0_Model
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : t) : ModelTy0.modelTy =
-    [#"../red_black_tree.rs" 511 7 511 22] Model0.model self
+    [#"../red_black_tree.rs" 512 100 513 4] Model0.model self
 end
 module Core_Cmp_Ord_Cmp_Interface
   type self
@@ -3414,7 +3414,7 @@ module Core_Cmp_Ord_Cmp_Interface
   clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = self,
   type ModelTy0.modelTy = ModelTy0.modelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.core_cmp_ordering_type
-    ensures { [#"../red_black_tree.rs" 840 48 840 80] result = CmpLog0.cmp_log (Model0.model self) (Model1.model other) }
+    ensures { [#"../red_black_tree.rs" 842 35 843 28] result = CmpLog0.cmp_log (Model0.model self) (Model1.model other) }
     
 end
 module Core_Cmp_Ord_Cmp
@@ -3428,7 +3428,7 @@ module Core_Cmp_Ord_Cmp
   clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = self,
   type ModelTy0.modelTy = ModelTy0.modelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.core_cmp_ordering_type
-    ensures { [#"../red_black_tree.rs" 840 48 840 80] result = CmpLog0.cmp_log (Model0.model self) (Model1.model other) }
+    ensures { [#"../red_black_tree.rs" 842 35 843 28] result = CmpLog0.cmp_log (Model0.model self) (Model1.model other) }
     
 end
 module CreusotContracts_Logic_Model_Impl0
@@ -3460,7 +3460,7 @@ module RedBlackTree_Impl16_InsertRec_Interface
     ensures { [#"../red_black_tree.rs" 611 14 611 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 612 14 613 39] MatchT0.match_t (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( ^ self) /\ Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type \/ ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 614 14 614 44] HasMapping0.has_mapping ( ^ self) (Model0.model key) val' }
-    ensures { [#"../red_black_tree.rs" 615 4 615 111] forall v : (v) . forall k : (ModelTy0.modelTy) . k = Model0.model key \/ HasMapping0.has_mapping ( * self) k v = HasMapping0.has_mapping ( ^ self) k v }
+    ensures { [#"../red_black_tree.rs" 615 4 615 111] forall v : v . forall k : ModelTy0.modelTy . k = Model0.model key \/ HasMapping0.has_mapping ( * self) k v = HasMapping0.has_mapping ( ^ self) k v }
     
 end
 module RedBlackTree_Impl16_InsertRec
@@ -3587,7 +3587,7 @@ module RedBlackTree_Impl16_InsertRec
     ensures { [#"../red_black_tree.rs" 611 14 611 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 612 14 613 39] MatchT0.match_t (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( ^ self) /\ Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type \/ ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 614 14 614 44] HasMapping0.has_mapping ( ^ self) (Model0.model key) val' }
-    ensures { [#"../red_black_tree.rs" 615 4 615 111] forall v : (v) . forall k : (ModelTy0.modelTy) . k = Model0.model key \/ HasMapping0.has_mapping ( * self) k v = HasMapping0.has_mapping ( ^ self) k v }
+    ensures { [#"../red_black_tree.rs" 615 4 615 111] forall v : v . forall k : ModelTy0.modelTy . k = Model0.model key \/ HasMapping0.has_mapping ( * self) k v = HasMapping0.has_mapping ( ^ self) k v }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -3999,8 +3999,8 @@ module Alloc_Boxed_Impl54_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 788 27 788 44]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 789 19 790 14]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 791 52 792 3]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 792 32 792 49]  ^ self =  ^ result }
     
 end
 module Alloc_Boxed_Impl54_AsMut
@@ -4008,8 +4008,8 @@ module Alloc_Boxed_Impl54_AsMut
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 788 27 788 44]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 789 19 790 14]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 791 52 792 3]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 792 32 792 49]  ^ self =  ^ result }
     
 end
 module CreusotContracts_Logic_Resolve_Impl0_Resolve_Interface
@@ -4023,7 +4023,7 @@ module CreusotContracts_Logic_Resolve_Impl0_Resolve
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve1 with type self = t2
   clone CreusotContracts_Logic_Resolve_Resolve_Resolve_Interface as Resolve0 with type self = t1
   predicate resolve (self : (t1, t2)) =
-    [#"../red_black_tree.rs" 656 49 657 39] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../red_black_tree.rs" 659 17 660 24] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
 end
 module Alloc_Boxed_Impl54
   type t
@@ -4065,8 +4065,8 @@ module RedBlackTree_Impl16_DeleteMaxRec_Interface
     ensures { [#"../red_black_tree.rs" 651 14 651 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 652 14 652 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 653 14 653 54] HasMapping0.has_mapping ( * self) (Model0.model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 654 4 654 88] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (Model0.model (let (a, _) = result in a)) }
-    ensures { [#"../red_black_tree.rs" 655 4 656 61] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 654 4 654 88] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (Model0.model (let (a, _) = result in a)) }
+    ensures { [#"../red_black_tree.rs" 655 4 656 61] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 657 14 657 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 658 4 658 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -4220,8 +4220,8 @@ module RedBlackTree_Impl16_DeleteMaxRec
     ensures { [#"../red_black_tree.rs" 651 14 651 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 652 14 652 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 653 14 653 54] HasMapping0.has_mapping ( * self) (Model0.model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 654 4 654 88] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (Model0.model (let (a, _) = result in a)) }
-    ensures { [#"../red_black_tree.rs" 655 4 656 61] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 654 4 654 88] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (Model0.model (let (a, _) = result in a)) }
+    ensures { [#"../red_black_tree.rs" 655 4 656 61] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 657 14 657 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 658 4 658 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -4462,7 +4462,7 @@ module RedBlackTree_Impl16_DeleteMax_Interface
     requires {[#"../red_black_tree.rs" 676 15 676 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 677 14 677 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 678 4 678 83] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Model0.model ( ^ self) = Model0.model ( * self) /\ Model0.model ( * self) = Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 679 4 682 48] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : (ModelTy0.modelTy) . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log k2 (Model1.model k)) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
+    ensures { [#"../red_black_tree.rs" 679 4 682 48] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : ModelTy0.modelTy . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log k2 (Model1.model k)) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
 end
 module RedBlackTree_Impl16_DeleteMax
@@ -4591,7 +4591,7 @@ module RedBlackTree_Impl16_DeleteMax
     requires {[#"../red_black_tree.rs" 676 15 676 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 677 14 677 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 678 4 678 83] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Model0.model ( ^ self) = Model0.model ( * self) /\ Model0.model ( * self) = Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 679 4 682 48] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : (ModelTy0.modelTy) . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log k2 (Model1.model k)) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
+    ensures { [#"../red_black_tree.rs" 679 4 682 48] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : ModelTy0.modelTy . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log k2 (Model1.model k)) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.core_option_option_type (k, v);
@@ -4770,8 +4770,8 @@ module RedBlackTree_Impl16_DeleteMinRec_Interface
     ensures { [#"../red_black_tree.rs" 704 14 704 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 705 14 705 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 706 14 706 54] HasMapping0.has_mapping ( * self) (Model0.model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 707 4 707 88] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (Model0.model (let (a, _) = result in a)) k }
-    ensures { [#"../red_black_tree.rs" 708 4 709 61] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 707 4 707 88] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (Model0.model (let (a, _) = result in a)) k }
+    ensures { [#"../red_black_tree.rs" 708 4 709 61] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 710 14 710 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 711 4 711 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -4915,8 +4915,8 @@ module RedBlackTree_Impl16_DeleteMinRec
     ensures { [#"../red_black_tree.rs" 704 14 704 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 705 14 705 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 706 14 706 54] HasMapping0.has_mapping ( * self) (Model0.model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 707 4 707 88] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (Model0.model (let (a, _) = result in a)) k }
-    ensures { [#"../red_black_tree.rs" 708 4 709 61] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 707 4 707 88] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (Model0.model (let (a, _) = result in a)) k }
+    ensures { [#"../red_black_tree.rs" 708 4 709 61] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 710 14 710 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 711 4 711 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -5129,7 +5129,7 @@ module RedBlackTree_Impl16_DeleteMin_Interface
     requires {[#"../red_black_tree.rs" 726 15 726 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 727 14 727 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 728 4 728 83] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Model0.model ( ^ self) = Model0.model ( * self) /\ Model0.model ( * self) = Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 729 4 732 48] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : (ModelTy0.modelTy) . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log (Model1.model k) k2) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
+    ensures { [#"../red_black_tree.rs" 729 4 732 48] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : ModelTy0.modelTy . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log (Model1.model k) k2) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
 end
 module RedBlackTree_Impl16_DeleteMin
@@ -5258,7 +5258,7 @@ module RedBlackTree_Impl16_DeleteMin
     requires {[#"../red_black_tree.rs" 726 15 726 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 727 14 727 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 728 4 728 83] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Model0.model ( ^ self) = Model0.model ( * self) /\ Model0.model ( * self) = Const.const (Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 729 4 732 48] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : (ModelTy0.modelTy) . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log (Model1.model k) k2) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
+    ensures { [#"../red_black_tree.rs" 729 4 732 48] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Map.get (Model0.model ( * self)) (Model1.model k) = Core_Option_Option_Type.Core_Option_Option_Some_Type v /\ (forall k2 : ModelTy0.modelTy . Map.get (Model0.model ( * self)) k2 = Core_Option_Option_Type.Core_Option_Option_None_Type \/ LeLog0.le_log (Model1.model k) k2) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model k) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.core_option_option_type (k, v);
@@ -5451,9 +5451,9 @@ module RedBlackTree_Impl16_DeleteRec_Interface
     requires {[#"../red_black_tree.rs" 752 15 753 62] MatchT0.match_t (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) ( * self) \/ MatchT1.match_t (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * self)}
     ensures { [#"../red_black_tree.rs" 754 14 754 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 755 14 755 50] Height0.height ( * self) = Height0.height ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 756 4 756 78] forall v : (v) . result = Core_Option_Option_Type.Core_Option_Option_None_Type -> not HasMapping0.has_mapping ( * self) (Model0.model key) v }
-    ensures { [#"../red_black_tree.rs" 757 4 758 57] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Model0.model key = Model0.model k /\ HasMapping0.has_mapping ( * self) (Model0.model k) v }
-    ensures { [#"../red_black_tree.rs" 759 4 759 114] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 756 4 756 78] forall v : v . result = Core_Option_Option_Type.Core_Option_Option_None_Type -> not HasMapping0.has_mapping ( * self) (Model0.model key) v }
+    ensures { [#"../red_black_tree.rs" 757 4 758 57] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Model0.model key = Model0.model k /\ HasMapping0.has_mapping ( * self) (Model0.model k) v }
+    ensures { [#"../red_black_tree.rs" 759 4 759 114] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 760 14 760 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 761 4 761 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -5657,9 +5657,9 @@ module RedBlackTree_Impl16_DeleteRec
     requires {[#"../red_black_tree.rs" 752 15 753 62] MatchT0.match_t (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) ( * self) \/ MatchT1.match_t (RedBlackTree_Cpn_Type.RedBlackTree_Cpn_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Red_Type)) (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type))) ( * self)}
     ensures { [#"../red_black_tree.rs" 754 14 754 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 755 14 755 50] Height0.height ( * self) = Height0.height ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 756 4 756 78] forall v : (v) . result = Core_Option_Option_Type.Core_Option_Option_None_Type -> not HasMapping0.has_mapping ( * self) (Model0.model key) v }
-    ensures { [#"../red_black_tree.rs" 757 4 758 57] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Model0.model key = Model0.model k /\ HasMapping0.has_mapping ( * self) (Model0.model k) v }
-    ensures { [#"../red_black_tree.rs" 759 4 759 114] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( ^ self) k v = (Model0.model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 756 4 756 78] forall v : v . result = Core_Option_Option_Type.Core_Option_Option_None_Type -> not HasMapping0.has_mapping ( * self) (Model0.model key) v }
+    ensures { [#"../red_black_tree.rs" 757 4 758 57] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) -> Model0.model key = Model0.model k /\ HasMapping0.has_mapping ( * self) (Model0.model k) v }
+    ensures { [#"../red_black_tree.rs" 759 4 759 114] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( ^ self) k v = (Model0.model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 760 14 760 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 761 4 761 69] Color1.color ( * self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type -> Color1.color ( ^ self) = RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type }
     
@@ -6174,7 +6174,7 @@ module CreusotContracts_Logic_Model_Impl1_Model
   clone CreusotContracts_Logic_Model_Model_Model_Interface as Model0 with type self = t,
   type ModelTy0.modelTy = ModelTy0.modelTy
   function model (self : borrowed t) : ModelTy0.modelTy =
-    [#"../red_black_tree.rs" 513 5 513 20] Model0.model ( * self)
+    [#"../red_black_tree.rs" 516 4 516 19] Model0.model ( * self)
 end
 module CreusotContracts_Logic_Model_Impl1
   type t
@@ -6196,7 +6196,7 @@ module RedBlackTree_Impl16_Delete_Interface
     requires {[#"../red_black_tree.rs" 806 15 806 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 807 14 807 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 808 14 808 63] (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 809 4 810 46] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) /\ Model1.model k = Model1.model key -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
+    ensures { [#"../red_black_tree.rs" 809 4 810 46] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) /\ Model1.model k = Model1.model key -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     ensures { [#"../red_black_tree.rs" 811 14 811 49] Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model key) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
 end
@@ -6325,7 +6325,7 @@ module RedBlackTree_Impl16_Delete
     requires {[#"../red_black_tree.rs" 806 15 806 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 807 14 807 33] Invariant0.invariant' ( ^ self) }
     ensures { [#"../red_black_tree.rs" 808 14 808 63] (result = Core_Option_Option_Type.Core_Option_Option_None_Type) = (Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type) }
-    ensures { [#"../red_black_tree.rs" 809 4 810 46] forall v : (v) . forall k : (k) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) /\ Model1.model k = Model1.model key -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
+    ensures { [#"../red_black_tree.rs" 809 4 810 46] forall v : v . forall k : k . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (k, v) /\ Model1.model k = Model1.model key -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     ensures { [#"../red_black_tree.rs" 811 14 811 49] Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model1.model key) (Core_Option_Option_Type.Core_Option_Option_None_Type) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -6499,7 +6499,7 @@ module RedBlackTree_Impl16_Get_Interface
   clone RedBlackTree_Impl12_Invariant_Interface as Invariant0 with type k = k, type v = v
   val get [@cfg:stackify] (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (key : k) : Core_Option_Option_Type.core_option_option_type v
     requires {[#"../red_black_tree.rs" 832 15 832 34] Invariant0.invariant' self}
-    ensures { [#"../red_black_tree.rs" 833 4 833 83] forall v : (v) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
+    ensures { [#"../red_black_tree.rs" 833 4 833 83] forall v : v . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     ensures { [#"../red_black_tree.rs" 834 4 834 62] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
@@ -6600,7 +6600,7 @@ module RedBlackTree_Impl16_Get
   function ModelAcc0.model_acc = ModelAcc0.model_acc, axiom .
   let rec cfg get [@cfg:stackify] [#"../red_black_tree.rs" 835 4 835 44] (self : RedBlackTree_Node_Type.redblacktree_tree_type k v) (key : k) : Core_Option_Option_Type.core_option_option_type v
     requires {[#"../red_black_tree.rs" 832 15 832 34] Invariant0.invariant' self}
-    ensures { [#"../red_black_tree.rs" 833 4 833 83] forall v : (v) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
+    ensures { [#"../red_black_tree.rs" 833 4 833 83] forall v : v . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     ensures { [#"../red_black_tree.rs" 834 4 834 62] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Map.get (Model0.model self) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -6649,7 +6649,7 @@ module RedBlackTree_Impl16_Get
   }
   BB2 {
     invariant bst_inv { [#"../red_black_tree.rs" 839 29 839 52] BstInvariant0.bst_invariant tree_11 };
-    invariant has_mapping { [#"../red_black_tree.rs" 839 8 839 54] forall v : (v) . HasMapping0.has_mapping self_1 (Model1.model key_2) v = HasMapping0.has_mapping tree_11 (Model1.model key_2) v };
+    invariant has_mapping { [#"../red_black_tree.rs" 839 8 839 54] forall v : v . HasMapping0.has_mapping self_1 (Model1.model key_2) v = HasMapping0.has_mapping tree_11 (Model1.model key_2) v };
     _16 <- RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node tree_11;
     assume { Resolve0.resolve tree_11 };
     switch (_16)
@@ -6743,7 +6743,7 @@ module RedBlackTree_Impl16_GetMut_Interface
   val get_mut [@cfg:stackify] (self : borrowed (RedBlackTree_Node_Type.redblacktree_tree_type k v)) (key : k) : Core_Option_Option_Type.core_option_option_type (borrowed v)
     requires {[#"../red_black_tree.rs" 851 15 851 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 852 14 852 33] Invariant0.invariant' ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 853 4 854 89] forall v : (borrowed v) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * v) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model2.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ v)) }
+    ensures { [#"../red_black_tree.rs" 853 4 854 89] forall v : borrowed v . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * v) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model2.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ v)) }
     ensures { [#"../red_black_tree.rs" 855 4 855 93] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type /\ Map.get (Model0.model ( ^ self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
@@ -6856,7 +6856,7 @@ module RedBlackTree_Impl16_GetMut
   let rec cfg get_mut [@cfg:stackify] [#"../red_black_tree.rs" 856 4 856 56] (self : borrowed (RedBlackTree_Node_Type.redblacktree_tree_type k v)) (key : k) : Core_Option_Option_Type.core_option_option_type (borrowed v)
     requires {[#"../red_black_tree.rs" 851 15 851 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 852 14 852 33] Invariant0.invariant' ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 853 4 854 89] forall v : (borrowed v) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * v) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model2.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ v)) }
+    ensures { [#"../red_black_tree.rs" 853 4 854 89] forall v : borrowed v . result = Core_Option_Option_Type.Core_Option_Option_Some_Type v -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_Some_Type ( * v) /\ Model0.model ( ^ self) = Map.set (Model0.model ( * self)) (Model2.model key) (Core_Option_Option_Type.Core_Option_Option_Some_Type ( ^ v)) }
     ensures { [#"../red_black_tree.rs" 855 4 855 93] result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Map.get (Model0.model ( * self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type /\ Map.get (Model0.model ( ^ self)) (Model1.model key) = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -6915,12 +6915,12 @@ module RedBlackTree_Impl16_GetMut
     invariant bst_inv { [#"../red_black_tree.rs" 862 29 862 52] BstInvariant0.bst_invariant ( * tree_16) };
     invariant height_inv { [#"../red_black_tree.rs" 863 32 863 58] HeightInvariant0.height_invariant ( * tree_16) };
     invariant color_inv { [#"../red_black_tree.rs" 864 31 864 56] ColorInvariant0.color_invariant ( * tree_16) };
-    invariant mapping_prof_key { [#"../red_black_tree.rs" 862 8 862 54] forall v : (v) . HasMapping0.has_mapping ( ^ tree_16) (Model2.model key_2) v = HasMapping0.has_mapping ( ^ old_self_12) (Model2.model key_2) v };
-    invariant mapping_cur_key { [#"../red_black_tree.rs" 862 8 862 54] forall v : (v) . HasMapping0.has_mapping ( * tree_16) (Model2.model key_2) v = HasMapping0.has_mapping ( * old_self_12) (Model2.model key_2) v };
-    invariant bst_inv_proph { [#"../red_black_tree.rs" 862 8 862 54] (forall v : (v) . forall k : (ModelTy0.modelTy) . k = Model2.model key_2 \/ HasMapping0.has_mapping ( * tree_16) k v = HasMapping0.has_mapping ( ^ tree_16) k v) -> BstInvariant0.bst_invariant ( ^ tree_16) -> BstInvariant0.bst_invariant ( ^ old_self_12) };
+    invariant mapping_prof_key { [#"../red_black_tree.rs" 862 8 862 54] forall v : v . HasMapping0.has_mapping ( ^ tree_16) (Model2.model key_2) v = HasMapping0.has_mapping ( ^ old_self_12) (Model2.model key_2) v };
+    invariant mapping_cur_key { [#"../red_black_tree.rs" 862 8 862 54] forall v : v . HasMapping0.has_mapping ( * tree_16) (Model2.model key_2) v = HasMapping0.has_mapping ( * old_self_12) (Model2.model key_2) v };
+    invariant bst_inv_proph { [#"../red_black_tree.rs" 862 8 862 54] (forall v : v . forall k : ModelTy0.modelTy . k = Model2.model key_2 \/ HasMapping0.has_mapping ( * tree_16) k v = HasMapping0.has_mapping ( ^ tree_16) k v) -> BstInvariant0.bst_invariant ( ^ tree_16) -> BstInvariant0.bst_invariant ( ^ old_self_12) };
     invariant height_inv_proph { [#"../red_black_tree.rs" 862 8 862 54] Height0.height ( * tree_16) = Height0.height ( ^ tree_16) /\ HeightInvariant0.height_invariant ( ^ tree_16) -> HeightInvariant0.height_invariant ( ^ old_self_12) };
     invariant color_inv_proph { [#"../red_black_tree.rs" 862 8 862 54] MatchT0.match_t (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (Color0.color ( * tree_16))) ( ^ tree_16) -> MatchT0.match_t (RedBlackTree_Cpl_Type.RedBlackTree_Cpl_Type (RedBlackTree_Color_Type.RedBlackTree_Color_Black_Type)) ( ^ old_self_12) };
-    invariant mapping_proph { [#"../red_black_tree.rs" 862 8 862 54] forall v : (v) . forall k : (ModelTy0.modelTy) . HasMapping0.has_mapping ( * tree_16) k v = HasMapping0.has_mapping ( ^ tree_16) k v -> HasMapping0.has_mapping ( * old_self_12) k v = HasMapping0.has_mapping ( ^ old_self_12) k v };
+    invariant mapping_proph { [#"../red_black_tree.rs" 862 8 862 54] forall v : v . forall k : ModelTy0.modelTy . HasMapping0.has_mapping ( * tree_16) k v = HasMapping0.has_mapping ( ^ tree_16) k v -> HasMapping0.has_mapping ( * old_self_12) k v = HasMapping0.has_mapping ( ^ old_self_12) k v };
     _28 <- borrow_mut (RedBlackTree_Node_Type.redblacktree_tree_type_Tree_node ( * tree_16));
     tree_16 <- { tree_16 with current = (let RedBlackTree_Node_Type.RedBlackTree_Tree_Type a =  * tree_16 in RedBlackTree_Node_Type.RedBlackTree_Tree_Type ( ^ _28)) };
     assume { Resolve1.resolve tree_16 };
@@ -7022,14 +7022,14 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 794 18 799 0] result = self }
+    ensures { [#"../red_black_tree.rs" 797 28 807 22] result = self }
     
 end
 module Core_Clone_Clone_Clone
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 794 18 799 0] result = self }
+    ensures { [#"../red_black_tree.rs" 797 28 807 22] result = self }
     
 end
 module RedBlackTree_Impl17

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -39,7 +39,7 @@ module SelectionSortGeneric_SortedRange
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   predicate sorted_range [#"../selection_sort_generic.rs" 7 0 7 58] (s : Seq.seq t) (l : int) (u : int) =
-    [#"../selection_sort_generic.rs" 8 4 10 5] forall j : (int) . forall i : (int) . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+    [#"../selection_sort_generic.rs" 8 4 10 5] forall j : int . forall i : int . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module SelectionSortGeneric_Sorted_Interface
   type t
@@ -68,7 +68,7 @@ module SelectionSortGeneric_Partition
   use mach.int.Int32
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   predicate partition [#"../selection_sort_generic.rs" 21 0 21 47] (v : Seq.seq t) (i : int) =
-    [#"../selection_sort_generic.rs" 22 4 22 106] forall k2 : (int) . forall k1 : (int) . 0 <= k1 /\ k1 < i /\ i <= k2 /\ k2 < Seq.length v -> LeLog0.le_log (Seq.get v k1) (Seq.get v k2)
+    [#"../selection_sort_generic.rs" 22 4 22 106] forall k2 : int . forall k1 : int . 0 <= k1 /\ k1 < i /\ i <= k2 /\ k2 < Seq.length v -> LeLog0.le_log (Seq.get v k1) (Seq.get v k2)
 end
 module Core_Ptr_NonNull_NonNull_Type
   use prelude.Opaque
@@ -808,7 +808,7 @@ module SelectionSortGeneric_SelectionSort
     goto BB5
   }
   BB5 {
-    invariant min_is_min { [#"../selection_sort_generic.rs" 38 8 38 92] forall k : (int) . UInt64.to_int i_4 <= k /\ k < UInt64.to_int j_20 -> LeLog0.le_log (Seq.get (Model1.model v_1) (UInt64.to_int min_19)) (Seq.get (Model1.model v_1) k) };
+    invariant min_is_min { [#"../selection_sort_generic.rs" 38 8 38 92] forall k : int . UInt64.to_int i_4 <= k /\ k < UInt64.to_int j_20 -> LeLog0.le_log (Seq.get (Model1.model v_1) (UInt64.to_int min_19)) (Seq.get (Model1.model v_1) k) };
     invariant j_bound { [#"../selection_sort_generic.rs" 39 29 39 57] UInt64.to_int i_4 <= UInt64.to_int j_20 /\ UInt64.to_int j_20 <= Seq.length (Model1.model v_1) };
     invariant min_bound { [#"../selection_sort_generic.rs" 40 31 40 54] UInt64.to_int i_4 <= UInt64.to_int min_19 /\ UInt64.to_int min_19 < UInt64.to_int j_20 };
     _27 <- j_20;

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -154,7 +154,7 @@ module SparseArray_Impl0_Model
   clone SparseArray_Impl1_IsElt_Interface as IsElt0 with type t = t
   function model [#"../sparse_array.rs" 38 4 38 35] (self : SparseArray_Sparse_Type.sparsearray_sparse_type t) : Seq.seq (Core_Option_Option_Type.core_option_option_type t)
     
-  axiom model_spec : forall self : SparseArray_Sparse_Type.sparsearray_sparse_type t . ([#"../sparse_array.rs" 35 4 37 6] forall i : (int) . Seq.get (model self) i = (if IsElt0.is_elt self i then
+  axiom model_spec : forall self : SparseArray_Sparse_Type.sparsearray_sparse_type t . ([#"../sparse_array.rs" 35 4 37 6] forall i : int . Seq.get (model self) i = (if IsElt0.is_elt self i then
     Core_Option_Option_Type.Core_Option_Option_Some_Type (Seq.get (Model0.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_values self)) i)
   else
     Core_Option_Option_Type.Core_Option_Option_None_Type
@@ -222,7 +222,7 @@ module SparseArray_Impl1_SparseInv
   clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = SparseArray_Sparse_Type.sparsearray_sparse_type t,
   type ModelTy0.modelTy = ModelTy0.modelTy
   predicate sparse_inv [#"../sparse_array.rs" 62 4 62 32] (self : SparseArray_Sparse_Type.sparsearray_sparse_type t) =
-    [#"../sparse_array.rs" 63 8 74 9] UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_n self) <= UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model0.model self) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model1.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_values self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_idx self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_back self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ (forall i : (int) . 0 <= i /\ i < UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_n self) -> match (Seq.get (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_back self)) i) with
+    [#"../sparse_array.rs" 63 8 74 9] UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_n self) <= UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model0.model self) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model1.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_values self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_idx self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ Seq.length (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_back self)) = UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ (forall i : int . 0 <= i /\ i < UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_n self) -> match (Seq.get (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_back self)) i) with
       | j -> 0 <= UInt64.to_int j /\ UInt64.to_int j < UInt64.to_int (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size self) /\ UInt64.to_int (Seq.get (Model2.model (SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_idx self)) (UInt64.to_int j)) = i
       end)
 end
@@ -713,7 +713,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module SparseArray_Impl1_Set_Interface
   type t
@@ -737,7 +737,7 @@ module SparseArray_Impl1_Set_Interface
     requires {[#"../sparse_array.rs" 110 15 110 34] UInt64.to_int i < Seq.length (Model0.model ( * self))}
     ensures { [#"../sparse_array.rs" 111 14 111 34] SparseInv0.sparse_inv ( ^ self) }
     ensures { [#"../sparse_array.rs" 112 14 112 46] Seq.length (Model0.model ( ^ self)) = Seq.length (Model0.model ( * self)) }
-    ensures { [#"../sparse_array.rs" 113 4 113 69] forall j : (int) . j <> UInt64.to_int i -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures { [#"../sparse_array.rs" 113 4 113 69] forall j : int . j <> UInt64.to_int i -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
     ensures { [#"../sparse_array.rs" 114 14 114 37] Seq.get (Model0.model ( ^ self)) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     
 end
@@ -797,7 +797,7 @@ module SparseArray_Impl1_Set
     requires {[#"../sparse_array.rs" 110 15 110 34] UInt64.to_int i < Seq.length (Model0.model ( * self))}
     ensures { [#"../sparse_array.rs" 111 14 111 34] SparseInv0.sparse_inv ( ^ self) }
     ensures { [#"../sparse_array.rs" 112 14 112 46] Seq.length (Model0.model ( ^ self)) = Seq.length (Model0.model ( * self)) }
-    ensures { [#"../sparse_array.rs" 113 4 113 69] forall j : (int) . j <> UInt64.to_int i -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
+    ensures { [#"../sparse_array.rs" 113 4 113 69] forall j : int . j <> UInt64.to_int i -> Seq.get (Model0.model ( ^ self)) j = Seq.get (Model0.model ( * self)) j }
     ensures { [#"../sparse_array.rs" 114 14 114 37] Seq.get (Model0.model ( ^ self)) (UInt64.to_int i) = Core_Option_Option_Type.Core_Option_Option_Some_Type v }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -965,7 +965,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -981,7 +981,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module SparseArray_Create_Interface
@@ -1002,7 +1002,7 @@ module SparseArray_Create_Interface
   val create [@cfg:stackify] (sz : usize) (dummy : t) : SparseArray_Sparse_Type.sparsearray_sparse_type t
     ensures { [#"../sparse_array.rs" 135 10 135 29] SparseInv0.sparse_inv result }
     ensures { [#"../sparse_array.rs" 136 10 136 27] SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size result = sz }
-    ensures { [#"../sparse_array.rs" 137 0 137 47] forall i : (int) . Seq.get (Model0.model result) i = Core_Option_Option_Type.Core_Option_Option_None_Type }
+    ensures { [#"../sparse_array.rs" 137 0 137 47] forall i : int . Seq.get (Model0.model result) i = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
 end
 module SparseArray_Create
@@ -1032,7 +1032,7 @@ module SparseArray_Create
   let rec cfg create [@cfg:stackify] [#"../sparse_array.rs" 138 0 138 64] (sz : usize) (dummy : t) : SparseArray_Sparse_Type.sparsearray_sparse_type t
     ensures { [#"../sparse_array.rs" 135 10 135 29] SparseInv0.sparse_inv result }
     ensures { [#"../sparse_array.rs" 136 10 136 27] SparseArray_Sparse_Type.sparsearray_sparse_type_Sparse_size result = sz }
-    ensures { [#"../sparse_array.rs" 137 0 137 47] forall i : (int) . Seq.get (Model0.model result) i = Core_Option_Option_Type.Core_Option_Option_None_Type }
+    ensures { [#"../sparse_array.rs" 137 0 137 47] forall i : int . Seq.get (Model0.model result) i = Core_Option_Option_Type.Core_Option_Option_None_Type }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : SparseArray_Sparse_Type.sparsearray_sparse_type t;

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -16,7 +16,7 @@ module SumOfOdds_IsSquare
   use mach.int.Int
   clone SumOfOdds_Sqr_Interface as Sqr0
   predicate is_square [#"../sum_of_odds.rs" 12 0 12 28] (y : int) =
-    [#"../sum_of_odds.rs" 13 4 13 44] exists z : (int) . y = Sqr0.sqr z
+    [#"../sum_of_odds.rs" 13 4 13 44] exists z : int . y = Sqr0.sqr z
 end
 module SumOfOdds_SumOfOdd_Interface
   use mach.int.Int

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -95,3 +95,84 @@ module C05Pearlite_Field1IsTrue
       | _ -> false
       end
 end
+module C05Pearlite_GhostClosure_Interface
+  val ghost_closure [@cfg:stackify] (_ : ()) : ()
+end
+module C05Pearlite_GhostClosure
+  use mach.int.Int
+  use mach.int.UInt32
+  use map.Map
+  let rec cfg ghost_closure [@cfg:stackify] [#"../05_pearlite.rs" 38 0 38 22] (_ : ()) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  ghost var x_1 : Map.map uint32 uint32;
+  var _4 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _4 <- ();
+    x_1 <- ghost ([#"../05_pearlite.rs" 39 12 39 49] fun (a : uint32) -> a);
+    goto BB1
+  }
+  BB1 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C05Pearlite_PearliteClosure_Interface
+  use map.Map
+  use mach.int.Int
+  use mach.int.UInt32
+  val pearlite_closure [@cfg:stackify] (ghost x : Map.map uint32 bool) : ()
+end
+module C05Pearlite_PearliteClosure
+  use map.Map
+  use mach.int.Int
+  use mach.int.UInt32
+  let rec cfg pearlite_closure [@cfg:stackify] [#"../05_pearlite.rs" 42 0 42 53] (ghost x : Map.map uint32 bool) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  ghost var x_1 : Map.map uint32 bool;
+  {
+    x_1 <- x;
+    goto BB0
+  }
+  BB0 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C05Pearlite_Caller_Interface
+  val caller [@cfg:stackify] (_ : ()) : ()
+end
+module C05Pearlite_Caller
+  use mach.int.Int
+  use mach.int.UInt32
+  use map.Map
+  clone C05Pearlite_PearliteClosure_Interface as PearliteClosure0
+  let rec cfg caller [@cfg:stackify] [#"../05_pearlite.rs" 44 0 44 15] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var _1 : ();
+  ghost var _2 : Map.map uint32 bool;
+  var _5 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _5 <- ();
+    _2 <- ghost ([#"../05_pearlite.rs" 45 21 45 53] fun (a : uint32) -> true);
+    goto BB1
+  }
+  BB1 {
+    _1 <- ([#"../05_pearlite.rs" 45 4 45 54] PearliteClosure0.pearlite_closure _2);
+    goto BB2
+  }
+  BB2 {
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/syntax/05_pearlite.rs
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.rs
@@ -34,3 +34,13 @@ pub fn field1_is_true(x: B) -> bool {
         }
     }
 }
+
+pub fn ghost_closure() {
+    let x = ghost! { pearlite! { |a : u32| a  } };
+}
+
+pub fn pearlite_closure(x: Ghost<Mapping<u32, bool>>) {}
+
+pub fn caller() {
+    pearlite_closure(ghost! { pearlite! { |a| true }});
+}

--- a/creusot/tests/should_succeed/syntax/05_pearlite.stderr
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.stderr
@@ -1,0 +1,22 @@
+warning: unused variable: `x`
+  --> 05_pearlite.rs:39:9
+   |
+39 |     let x = ghost! { pearlite! { |a : u32| a  } };
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `x`
+  --> 05_pearlite.rs:42:25
+   |
+42 | pub fn pearlite_closure(x: Ghost<Mapping<u32, bool>>) {}
+   |                         ^ help: if this is intentional, prefix it with an underscore: `_x`
+
+warning: unused variable: `a`
+  --> 05_pearlite.rs:45:44
+   |
+45 |     pearlite_closure(ghost! { pearlite! { |a| true }});
+   |                                            ^ help: if this is intentional, prefix it with an underscore: `_a`
+
+warning: 3 warnings emitted
+

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -2,12 +2,12 @@
 module C12GhostCode_GhostArg_Interface
   use mach.int.Int
   use mach.int.UInt32
-  val ghost_arg [@cfg:stackify] (g : uint32) : ()
+  val ghost_arg [@cfg:stackify] (ghost g : uint32) : ()
 end
 module C12GhostCode_GhostArg
   use mach.int.Int
   use mach.int.UInt32
-  let rec cfg ghost_arg [@cfg:stackify] [#"../12_ghost_code.rs" 4 0 4 31] (g : uint32) : ()
+  let rec cfg ghost_arg [@cfg:stackify] [#"../12_ghost_code.rs" 4 0 4 31] (ghost g : uint32) : ()
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   ghost var g_1 : uint32;
@@ -137,7 +137,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -121,7 +121,7 @@ module Core_Slice_Impl0_SplitFirstMut_Interface
   type ModelTy0.modelTy = ModelTy0.modelTy
   val split_first_mut [@cfg:stackify] (self : borrowed (seq t)) : Core_Option_Option_Type.core_option_option_type (borrowed t, borrowed (seq t))
     ensures { result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Seq.length (Model0.model self) = 0 /\  ^ self =  * self /\ Model1.model ( * self) = Seq.empty  }
-    ensures { forall tail : (borrowed (seq t)) . forall first : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (first, tail) /\  * first = Seq.get (Model1.model ( * self)) 0 /\  ^ first = Seq.get (Model1.model ( ^ self)) 0 /\ Seq.length (Model1.model ( * self)) > 0 /\ Seq.length (Model1.model ( ^ self)) > 0 /\ Model1.model ( * tail) = Tail0.tail (Model1.model ( * self)) /\ Model1.model ( ^ tail) = Tail0.tail (Model1.model ( ^ self)) }
+    ensures { forall tail : borrowed (seq t) . forall first : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (first, tail) /\  * first = Seq.get (Model1.model ( * self)) 0 /\  ^ first = Seq.get (Model1.model ( ^ self)) 0 /\ Seq.length (Model1.model ( * self)) > 0 /\ Seq.length (Model1.model ( ^ self)) > 0 /\ Model1.model ( * tail) = Tail0.tail (Model1.model ( * self)) /\ Model1.model ( ^ tail) = Tail0.tail (Model1.model ( ^ self)) }
     
 end
 module Core_Slice_Impl0_SplitFirstMut
@@ -139,7 +139,7 @@ module Core_Slice_Impl0_SplitFirstMut
   type ModelTy0.modelTy = ModelTy0.modelTy
   val split_first_mut [@cfg:stackify] (self : borrowed (seq t)) : Core_Option_Option_Type.core_option_option_type (borrowed t, borrowed (seq t))
     ensures { result = Core_Option_Option_Type.Core_Option_Option_None_Type -> Seq.length (Model0.model self) = 0 /\  ^ self =  * self /\ Model1.model ( * self) = Seq.empty  }
-    ensures { forall tail : (borrowed (seq t)) . forall first : (borrowed t) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (first, tail) /\  * first = Seq.get (Model1.model ( * self)) 0 /\  ^ first = Seq.get (Model1.model ( ^ self)) 0 /\ Seq.length (Model1.model ( * self)) > 0 /\ Seq.length (Model1.model ( ^ self)) > 0 /\ Model1.model ( * tail) = Tail0.tail (Model1.model ( * self)) /\ Model1.model ( ^ tail) = Tail0.tail (Model1.model ( ^ self)) }
+    ensures { forall tail : borrowed (seq t) . forall first : borrowed t . result = Core_Option_Option_Type.Core_Option_Option_Some_Type (first, tail) /\  * first = Seq.get (Model1.model ( * self)) 0 /\  ^ first = Seq.get (Model1.model ( ^ self)) 0 /\ Seq.length (Model1.model ( * self)) > 0 /\ Seq.length (Model1.model ( ^ self)) > 0 /\ Model1.model ( * tail) = Tail0.tail (Model1.model ( * self)) /\ Model1.model ( ^ tail) = Tail0.tail (Model1.model ( ^ self)) }
     
 end
 module CreusotContracts_Logic_Resolve_Impl1_Resolve_Interface

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -261,7 +261,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module Core_Slice_Index_Impl2_Output_Type
   type t
@@ -285,7 +285,7 @@ module C01_AllZero_Interface
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = uint32,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val all_zero [@cfg:stackify] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type uint32 (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
-    ensures { [#"../01.rs" 5 0 5 74] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
+    ensures { [#"../01.rs" 5 0 5 74] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
     ensures { [#"../01.rs" 6 10 6 36] Seq.length (Model0.model ( * v)) = Seq.length (Model0.model ( ^ v)) }
     
 end
@@ -315,7 +315,7 @@ module C01_AllZero
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with type t = uint32,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, function Model0.model = Model0.model
   let rec cfg all_zero [@cfg:stackify] [#"../01.rs" 7 0 7 33] (v : borrowed (Alloc_Vec_Vec_Type.alloc_vec_vec_type uint32 (Alloc_Alloc_Global_Type.alloc_alloc_global_type))) : ()
-    ensures { [#"../01.rs" 5 0 5 74] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
+    ensures { [#"../01.rs" 5 0 5 74] forall i : int . 0 <= i /\ i < Seq.length (Model0.model ( ^ v)) -> Seq.get (Model0.model ( ^ v)) i = (0 : uint32) }
     ensures { [#"../01.rs" 6 10 6 36] Seq.length (Model0.model ( * v)) = Seq.length (Model0.model ( ^ v)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -351,7 +351,7 @@ module C01_AllZero
   BB2 {
     invariant proph_const { [#"../01.rs" 12 29 12 49]  ^ v_1 =  ^ old_v_5 };
     invariant in_bounds { [#"../01.rs" 13 27 13 65] Seq.length (Model0.model ( * v_1)) = Seq.length (Model0.model ( * old_v_5)) };
-    invariant all_zero { [#"../01.rs" 12 4 12 51] forall j : (int) . 0 <= j /\ j < UInt64.to_int i_4 -> Seq.get (Model0.model ( * v_1)) j = (0 : uint32) };
+    invariant all_zero { [#"../01.rs" 12 4 12 51] forall j : int . 0 <= j /\ j < UInt64.to_int i_4 -> Seq.get (Model0.model ( * v_1)) j = (0 : uint32) };
     _14 <- i_4;
     _16 <-  * v_1;
     _15 <- ([#"../01.rs" 15 14 15 21] Len0.len _16);

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -39,7 +39,7 @@ module C02Gnome_SortedRange
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   predicate sorted_range [#"../02_gnome.rs" 6 0 6 58] (s : Seq.seq t) (l : int) (u : int) =
-    [#"../02_gnome.rs" 7 4 9 5] forall j : (int) . forall i : (int) . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+    [#"../02_gnome.rs" 7 4 9 5] forall j : int . forall i : int . l <= i /\ i < j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module C02Gnome_Sorted_Interface
   type t

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -10,7 +10,7 @@ module C04BinarySearch_SortedRange
   use mach.int.Int
   use mach.int.UInt32
   predicate sorted_range [#"../04_binary_search.rs" 5 0 5 52] (s : Seq.seq uint32) (l : int) (u : int) =
-    [#"../04_binary_search.rs" 6 4 8 5] forall j : (int) . forall i : (int) . l <= i /\ i < j /\ j < u -> Seq.get s i <= Seq.get s j
+    [#"../04_binary_search.rs" 6 4 8 5] forall j : int . forall i : int . l <= i /\ i < j /\ j < u -> Seq.get s i <= Seq.get s j
 end
 module C04BinarySearch_Sorted_Interface
   use seq.Seq
@@ -308,9 +308,9 @@ module C04BinarySearch_BinarySearch_Interface
   val binary_search [@cfg:stackify] (arr : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint32 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (elem : uint32) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../04_binary_search.rs" 16 11 16 38] Seq.length (Model0.model arr) <= 18446744073709551615}
     requires {[#"../04_binary_search.rs" 17 11 17 23] Sorted0.sorted (Model0.model arr)}
-    ensures { [#"../04_binary_search.rs" 18 0 18 66] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
-    ensures { [#"../04_binary_search.rs" 19 0 20 51] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . i < x -> Seq.get (Model0.model arr) (UInt64.to_int i) <= elem) }
-    ensures { [#"../04_binary_search.rs" 21 0 22 70] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . x < i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> elem < Seq.get (Model0.model arr) (UInt64.to_int i)) }
+    ensures { [#"../04_binary_search.rs" 18 0 18 66] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
+    ensures { [#"../04_binary_search.rs" 19 0 20 51] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . i < x -> Seq.get (Model0.model arr) (UInt64.to_int i) <= elem) }
+    ensures { [#"../04_binary_search.rs" 21 0 22 70] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . x < i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> elem < Seq.get (Model0.model arr) (UInt64.to_int i)) }
     
 end
 module C04BinarySearch_BinarySearch
@@ -345,9 +345,9 @@ module C04BinarySearch_BinarySearch
   let rec cfg binary_search [@cfg:stackify] [#"../04_binary_search.rs" 23 0 23 71] (arr : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint32 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (elem : uint32) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../04_binary_search.rs" 16 11 16 38] Seq.length (Model0.model arr) <= 18446744073709551615}
     requires {[#"../04_binary_search.rs" 17 11 17 23] Sorted0.sorted (Model0.model arr)}
-    ensures { [#"../04_binary_search.rs" 18 0 18 66] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
-    ensures { [#"../04_binary_search.rs" 19 0 20 51] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . i < x -> Seq.get (Model0.model arr) (UInt64.to_int i) <= elem) }
-    ensures { [#"../04_binary_search.rs" 21 0 22 70] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . x < i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> elem < Seq.get (Model0.model arr) (UInt64.to_int i)) }
+    ensures { [#"../04_binary_search.rs" 18 0 18 66] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
+    ensures { [#"../04_binary_search.rs" 19 0 20 51] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . i < x -> Seq.get (Model0.model arr) (UInt64.to_int i) <= elem) }
+    ensures { [#"../04_binary_search.rs" 21 0 22 70] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . x < i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> elem < Seq.get (Model0.model arr) (UInt64.to_int i)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Result_Result_Type.core_result_result_type usize usize;
@@ -429,8 +429,8 @@ module C04BinarySearch_BinarySearch
   }
   BB5 {
     invariant size_valid { [#"../04_binary_search.rs" 30 28 30 70] 0 < UInt64.to_int size_13 /\ UInt64.to_int size_13 + UInt64.to_int base_15 <= Seq.length (Model0.model arr_1) };
-    invariant lower_b { [#"../04_binary_search.rs" 30 4 30 72] forall i : (usize) . i < base_15 -> Seq.get (Model0.model arr_1) (UInt64.to_int i) <= elem_2 };
-    invariant lower_b { [#"../04_binary_search.rs" 30 4 30 72] forall i : (usize) . UInt64.to_int base_15 + UInt64.to_int size_13 < UInt64.to_int i /\ UInt64.to_int i < Seq.length (Model0.model arr_1) -> elem_2 < Seq.get (Model0.model arr_1) (UInt64.to_int i) };
+    invariant lower_b { [#"../04_binary_search.rs" 30 4 30 72] forall i : usize . i < base_15 -> Seq.get (Model0.model arr_1) (UInt64.to_int i) <= elem_2 };
+    invariant lower_b { [#"../04_binary_search.rs" 30 4 30 72] forall i : usize . UInt64.to_int base_15 + UInt64.to_int size_13 < UInt64.to_int i /\ UInt64.to_int i < Seq.length (Model0.model arr_1) -> elem_2 < Seq.get (Model0.model arr_1) (UInt64.to_int i) };
     _22 <- size_13;
     _21 <- ([#"../04_binary_search.rs" 33 10 33 18] _22 > (1 : usize));
     switch (_21)

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -39,7 +39,7 @@ module C05BinarySearchGeneric_SortedRange
   use mach.int.Int
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface as LeLog0 with type self = t
   predicate sorted_range [#"../05_binary_search_generic.rs" 6 0 6 63] (s : Seq.seq t) (l : int) (u : int) =
-    [#"../05_binary_search_generic.rs" 7 4 9 5] forall j : (int) . forall i : (int) . l <= i /\ i <= j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
+    [#"../05_binary_search_generic.rs" 7 4 9 5] forall j : int . forall i : int . l <= i /\ i <= j /\ j < u -> LeLog0.le_log (Seq.get s i) (Seq.get s j)
 end
 module C05BinarySearchGeneric_Sorted_Interface
   type t
@@ -538,9 +538,9 @@ module C05BinarySearchGeneric_BinarySearch_Interface
   val binary_search [@cfg:stackify] (arr : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (elem : t) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../05_binary_search_generic.rs" 17 11 17 38] Seq.length (Model0.model arr) <= 18446744073709551615}
     requires {[#"../05_binary_search_generic.rs" 18 11 18 23] Sorted0.sorted (Model0.model arr)}
-    ensures { [#"../05_binary_search_generic.rs" 19 0 19 66] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
-    ensures { [#"../05_binary_search_generic.rs" 20 0 21 51] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . i < x -> LeLog0.le_log (Seq.get (Model0.model arr) (UInt64.to_int i)) elem) }
-    ensures { [#"../05_binary_search_generic.rs" 22 0 23 71] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . x <= i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> LtLog0.lt_log elem (Seq.get (Model0.model arr) (UInt64.to_int i))) }
+    ensures { [#"../05_binary_search_generic.rs" 19 0 19 66] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
+    ensures { [#"../05_binary_search_generic.rs" 20 0 21 51] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . i < x -> LeLog0.le_log (Seq.get (Model0.model arr) (UInt64.to_int i)) elem) }
+    ensures { [#"../05_binary_search_generic.rs" 22 0 23 71] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . x <= i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> LtLog0.lt_log elem (Seq.get (Model0.model arr) (UInt64.to_int i))) }
     
 end
 module C05BinarySearchGeneric_BinarySearch
@@ -611,9 +611,9 @@ module C05BinarySearchGeneric_BinarySearch
   let rec cfg binary_search [@cfg:stackify] [#"../05_binary_search_generic.rs" 24 0 24 86] (arr : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (elem : t) : Core_Result_Result_Type.core_result_result_type usize usize
     requires {[#"../05_binary_search_generic.rs" 17 11 17 38] Seq.length (Model0.model arr) <= 18446744073709551615}
     requires {[#"../05_binary_search_generic.rs" 18 11 18 23] Sorted0.sorted (Model0.model arr)}
-    ensures { [#"../05_binary_search_generic.rs" 19 0 19 66] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
-    ensures { [#"../05_binary_search_generic.rs" 20 0 21 51] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . i < x -> LeLog0.le_log (Seq.get (Model0.model arr) (UInt64.to_int i)) elem) }
-    ensures { [#"../05_binary_search_generic.rs" 22 0 23 71] forall x : (usize) . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : (usize) . x <= i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> LtLog0.lt_log elem (Seq.get (Model0.model arr) (UInt64.to_int i))) }
+    ensures { [#"../05_binary_search_generic.rs" 19 0 19 66] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Ok_Type x -> Seq.get (Model0.model arr) (UInt64.to_int x) = elem }
+    ensures { [#"../05_binary_search_generic.rs" 20 0 21 51] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . i < x -> LeLog0.le_log (Seq.get (Model0.model arr) (UInt64.to_int i)) elem) }
+    ensures { [#"../05_binary_search_generic.rs" 22 0 23 71] forall x : usize . result = Core_Result_Result_Type.Core_Result_Result_Err_Type x -> (forall i : usize . x <= i /\ UInt64.to_int i < Seq.length (Model0.model arr) -> LtLog0.lt_log elem (Seq.get (Model0.model arr) (UInt64.to_int i))) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Result_Result_Type.core_result_result_type usize usize;
@@ -712,8 +712,8 @@ module C05BinarySearchGeneric_BinarySearch
   }
   BB10 {
     invariant size_valid { [#"../05_binary_search_generic.rs" 31 28 31 70] 0 < UInt64.to_int size_13 /\ UInt64.to_int size_13 + UInt64.to_int base_15 <= Seq.length (Model0.model arr_1) };
-    invariant lower_b { [#"../05_binary_search_generic.rs" 31 4 31 72] forall i : (usize) . i < base_15 -> LeLog0.le_log (Seq.get (Model0.model arr_1) (UInt64.to_int i)) elem_2 };
-    invariant lower_b { [#"../05_binary_search_generic.rs" 31 4 31 72] forall i : (usize) . UInt64.to_int base_15 + UInt64.to_int size_13 <= UInt64.to_int i /\ UInt64.to_int i < Seq.length (Model0.model arr_1) -> LtLog0.lt_log elem_2 (Seq.get (Model0.model arr_1) (UInt64.to_int i)) };
+    invariant lower_b { [#"../05_binary_search_generic.rs" 31 4 31 72] forall i : usize . i < base_15 -> LeLog0.le_log (Seq.get (Model0.model arr_1) (UInt64.to_int i)) elem_2 };
+    invariant lower_b { [#"../05_binary_search_generic.rs" 31 4 31 72] forall i : usize . UInt64.to_int base_15 + UInt64.to_int size_13 <= UInt64.to_int i /\ UInt64.to_int i < Seq.length (Model0.model arr_1) -> LtLog0.lt_log elem_2 (Seq.get (Model0.model arr_1) (UInt64.to_int i)) };
     _22 <- size_13;
     _21 <- ([#"../05_binary_search_generic.rs" 34 10 34 18] _22 > (1 : usize));
     switch (_21)

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -232,7 +232,7 @@ module C06KnightsTour_Impl1_Wf
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = Alloc_Vec_Vec_Type.alloc_vec_vec_type usize (Alloc_Alloc_Global_Type.alloc_alloc_global_type),
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate wf [#"../06_knights_tour.rs" 30 4 30 23] (self : C06KnightsTour_Board_Type.c06knightstour_board_type) =
-    [#"../06_knights_tour.rs" 31 8 35 9] UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) <= 1000 /\ Seq.length (Model0.model (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_field self)) = UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) /\ (forall i : (int) . 0 <= i /\ i < UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) -> Seq.length (Model1.model (Seq.get (Model0.model (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_field self)) i)) = UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self))
+    [#"../06_knights_tour.rs" 31 8 35 9] UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) <= 1000 /\ Seq.length (Model0.model (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_field self)) = UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) /\ (forall i : int . 0 <= i /\ i < UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self) -> Seq.length (Model1.model (Seq.get (Model0.model (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_field self)) i)) = UInt64.to_int (C06KnightsTour_Board_Type.c06knightstour_board_type_Board_size self))
 end
 module CreusotContracts_Std1_Vec_Impl0
   type t
@@ -279,7 +279,7 @@ module Alloc_Vec_FromElem_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_FromElem
@@ -295,7 +295,7 @@ module Alloc_Vec_FromElem
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val from_elem [@cfg:stackify] (elem : t) (n : usize) : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { Seq.length (Model0.model result) = UInt64.to_int n }
-    ensures { forall i : (int) . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
+    ensures { forall i : int . 0 <= i /\ i < UInt64.to_int n -> Seq.get (Model0.model result) i = elem }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -345,7 +345,7 @@ module CreusotContracts_Std1_Vec_Impl3_Resolve
   clone CreusotContracts_Std1_Vec_Impl0_Model_Interface as Model0 with type t = t,
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.alloc_vec_vec_type t (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) =
-    forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
+    forall i : int . 0 <= i /\ i < Seq.length (Model0.model self) -> Resolve0.resolve (Seq.get (Model0.model self) i)
 end
 module CreusotContracts_Std1_Vec_Impl3
   type t
@@ -446,7 +446,7 @@ module C06KnightsTour_Impl1_New
   }
   BB4 {
     invariant i_size { [#"../06_knights_tour.rs" 44 28 44 37] i_7 <= size_1 };
-    invariant rows { [#"../06_knights_tour.rs" 44 8 44 39] forall j : (int) . 0 <= j /\ j < UInt64.to_int i_7 -> Seq.length (Model1.model (Seq.get (Model0.model rows_5) j)) = UInt64.to_int size_1 };
+    invariant rows { [#"../06_knights_tour.rs" 44 8 44 39] forall j : int . 0 <= j /\ j < UInt64.to_int i_7 -> Seq.length (Model1.model (Seq.get (Model0.model rows_5) j)) = UInt64.to_int size_1 };
     invariant row_len { [#"../06_knights_tour.rs" 47 29 47 48] Seq.length (Model0.model rows_5) = UInt64.to_int i_7 };
     _14 <- i_7;
     _15 <- size_1;
@@ -824,7 +824,7 @@ module C06KnightsTour_Moves_Interface
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val moves [@cfg:stackify] (_ : ()) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (isize, isize) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { [#"../06_knights_tour.rs" 101 10 101 30] Seq.length (Model0.model result) = 8 }
-    ensures { [#"../06_knights_tour.rs" 102 0 102 149] forall i : (int) . 0 <= i /\ i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 /\ - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
+    ensures { [#"../06_knights_tour.rs" 102 0 102 149] forall i : int . 0 <= i /\ i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 /\ - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
     
 end
 module C06KnightsTour_Moves
@@ -839,7 +839,7 @@ module C06KnightsTour_Moves
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, axiom .
   val moves [@cfg:stackify] (_ : ()) : Alloc_Vec_Vec_Type.alloc_vec_vec_type (isize, isize) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)
     ensures { [#"../06_knights_tour.rs" 101 10 101 30] Seq.length (Model0.model result) = 8 }
-    ensures { [#"../06_knights_tour.rs" 102 0 102 149] forall i : (int) . 0 <= i /\ i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 /\ - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
+    ensures { [#"../06_knights_tour.rs" 102 0 102 149] forall i : int . 0 <= i /\ i < 8 -> - 2 <= Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (a, _) = Seq.get (Model0.model result) i in a) <= 2 /\ - 2 <= Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) /\ Int64.to_int (let (_, a) = Seq.get (Model0.model result) i in a) <= 2 }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -1150,7 +1150,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module C06KnightsTour_Impl1_Set_Interface
   use prelude.Borrow
@@ -1319,7 +1319,7 @@ module C06KnightsTour_Min_Interface
   clone CreusotContracts_Logic_Model_Impl0_Model_Interface as Model0 with type t = Alloc_Vec_Vec_Type.alloc_vec_vec_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) (Alloc_Alloc_Global_Type.alloc_alloc_global_type),
   type ModelTy0.modelTy = ModelTy0.modelTy
   val min [@cfg:stackify] (v : Alloc_Vec_Vec_Type.alloc_vec_vec_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) : Core_Option_Option_Type.core_option_option_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type)
-    ensures { [#"../06_knights_tour.rs" 117 0 118 67] forall r : ((usize, C06KnightsTour_Point_Type.c06knightstour_point_type)) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : (int) . 0 <= i /\ i < Seq.length (Model0.model v) /\ Seq.get (Model0.model v) i = r) }
+    ensures { [#"../06_knights_tour.rs" 117 0 118 67] forall r : (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : int . 0 <= i /\ i < Seq.length (Model0.model v) /\ Seq.get (Model0.model v) i = r) }
     
 end
 module C06KnightsTour_Min
@@ -1350,7 +1350,7 @@ module C06KnightsTour_Min
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with type t = (usize, C06KnightsTour_Point_Type.c06knightstour_point_type),
   type a = Alloc_Alloc_Global_Type.alloc_alloc_global_type, function Model0.model = Model1.model
   let rec cfg min [@cfg:stackify] [#"../06_knights_tour.rs" 119 0 119 58] (v : Alloc_Vec_Vec_Type.alloc_vec_vec_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) : Core_Option_Option_Type.core_option_option_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type)
-    ensures { [#"../06_knights_tour.rs" 117 0 118 67] forall r : ((usize, C06KnightsTour_Point_Type.c06knightstour_point_type)) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : (int) . 0 <= i /\ i < Seq.length (Model0.model v) /\ Seq.get (Model0.model v) i = r) }
+    ensures { [#"../06_knights_tour.rs" 117 0 118 67] forall r : (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) . result = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : int . 0 <= i /\ i < Seq.length (Model0.model v) /\ Seq.get (Model0.model v) i = r) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.core_option_option_type (usize, C06KnightsTour_Point_Type.c06knightstour_point_type);
@@ -1397,7 +1397,7 @@ module C06KnightsTour_Min
     goto BB1
   }
   BB1 {
-    invariant post { [#"../06_knights_tour.rs" 122 4 123 79] forall r : ((usize, C06KnightsTour_Point_Type.c06knightstour_point_type)) . min_4 = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : (int) . 0 <= i /\ i < Seq.length (Model0.model v_1) /\ Seq.get (Model0.model v_1) i = r) };
+    invariant post { [#"../06_knights_tour.rs" 122 4 123 79] forall r : (usize, C06KnightsTour_Point_Type.c06knightstour_point_type) . min_4 = Core_Option_Option_Type.Core_Option_Option_Some_Type r -> (exists i : int . 0 <= i /\ i < Seq.length (Model0.model v_1) /\ Seq.get (Model0.model v_1) i = r) };
     _9 <- i_3;
     _11 <- v_1;
     _10 <- ([#"../06_knights_tour.rs" 124 14 124 21] Len0.len _11);
@@ -1759,7 +1759,7 @@ module C06KnightsTour_KnightsTour
     goto BB10
   }
   BB10 {
-    invariant c { [#"../06_knights_tour.rs" 164 8 165 57] forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model candidates_33) -> InBounds0.in_bounds board_7 (let (_, a) = Seq.get (Model0.model candidates_33) i in a) };
+    invariant c { [#"../06_knights_tour.rs" 164 8 165 57] forall i : int . 0 <= i /\ i < Seq.length (Model0.model candidates_33) -> InBounds0.in_bounds board_7 (let (_, a) = Seq.get (Model0.model candidates_33) i in a) };
     _38 <- i_34;
     _41 <- ([#"../06_knights_tour.rs" 166 18 166 25] Moves0.moves ());
     goto BB11

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -362,7 +362,7 @@ module CreusotContracts_Std1_Slice_Impl3_ResolveElswhere
   use mach.int.Int32
   use mach.int.UInt64
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : (int) . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    forall i : int . 0 <= i /\ i <> UInt64.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
 end
 module Core_Slice_Index_Impl2_Output_Type
   type t

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -98,7 +98,7 @@ module C08Haystack_MatchAt
   predicate match_at [#"../08_haystack.rs" 7 0 7 77] (needle : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (haystack : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (pos : int) (len : int)
     
    =
-    [#"../08_haystack.rs" 8 4 12 5] len <= Seq.length (Model0.model needle) /\ pos <= Seq.length (Model0.model haystack) - len /\ (forall i : (int) . 0 <= i /\ i < len -> Seq.get (Model0.model needle) i = Seq.get (Model0.model haystack) (pos + i))
+    [#"../08_haystack.rs" 8 4 12 5] len <= Seq.length (Model0.model needle) /\ pos <= Seq.length (Model0.model haystack) - len /\ (forall i : int . 0 <= i /\ i < len -> Seq.get (Model0.model needle) i = Seq.get (Model0.model haystack) (pos + i))
 end
 module CreusotContracts_Logic_Model_Impl0
   type t
@@ -300,8 +300,8 @@ module C08Haystack_Search_Interface
   val search [@cfg:stackify] (needle : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (haystack : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) : usize
     requires {[#"../08_haystack.rs" 15 11 15 71] Seq.length (Model0.model needle) >= 1 /\ Seq.length (Model0.model needle) <= Seq.length (Model0.model haystack)}
     ensures { [#"../08_haystack.rs" 16 10 16 91] UInt64.to_int result = Seq.length (Model0.model haystack) \/ UInt64.to_int result < Seq.length (Model0.model haystack) - Seq.length (Model0.model needle) + 1 }
-    ensures { [#"../08_haystack.rs" 17 0 19 110] UInt64.to_int result < Seq.length (Model0.model haystack) -> MatchAt0.match_at needle haystack (UInt64.to_int result) (Seq.length (Model0.model needle)) /\ (forall i : (int) . 0 <= i /\ i < UInt64.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
-    ensures { [#"../08_haystack.rs" 20 0 20 145] UInt64.to_int result = Seq.length (Model0.model haystack) -> (forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
+    ensures { [#"../08_haystack.rs" 17 0 19 110] UInt64.to_int result < Seq.length (Model0.model haystack) -> MatchAt0.match_at needle haystack (UInt64.to_int result) (Seq.length (Model0.model needle)) /\ (forall i : int . 0 <= i /\ i < UInt64.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
+    ensures { [#"../08_haystack.rs" 20 0 20 145] UInt64.to_int result = Seq.length (Model0.model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (Model0.model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
     
 end
 module C08Haystack_Search
@@ -334,8 +334,8 @@ module C08Haystack_Search
   let rec cfg search [@cfg:stackify] [#"../08_haystack.rs" 21 0 21 60] (needle : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) (haystack : Alloc_Vec_Vec_Type.alloc_vec_vec_type uint8 (Alloc_Alloc_Global_Type.alloc_alloc_global_type)) : usize
     requires {[#"../08_haystack.rs" 15 11 15 71] Seq.length (Model0.model needle) >= 1 /\ Seq.length (Model0.model needle) <= Seq.length (Model0.model haystack)}
     ensures { [#"../08_haystack.rs" 16 10 16 91] UInt64.to_int result = Seq.length (Model0.model haystack) \/ UInt64.to_int result < Seq.length (Model0.model haystack) - Seq.length (Model0.model needle) + 1 }
-    ensures { [#"../08_haystack.rs" 17 0 19 110] UInt64.to_int result < Seq.length (Model0.model haystack) -> MatchAt0.match_at needle haystack (UInt64.to_int result) (Seq.length (Model0.model needle)) /\ (forall i : (int) . 0 <= i /\ i < UInt64.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
-    ensures { [#"../08_haystack.rs" 20 0 20 145] UInt64.to_int result = Seq.length (Model0.model haystack) -> (forall i : (int) . 0 <= i /\ i < Seq.length (Model0.model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
+    ensures { [#"../08_haystack.rs" 17 0 19 110] UInt64.to_int result < Seq.length (Model0.model haystack) -> MatchAt0.match_at needle haystack (UInt64.to_int result) (Seq.length (Model0.model needle)) /\ (forall i : int . 0 <= i /\ i < UInt64.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
+    ensures { [#"../08_haystack.rs" 20 0 20 145] UInt64.to_int result = Seq.length (Model0.model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (Model0.model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (Model0.model needle))) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -396,7 +396,7 @@ module C08Haystack_Search
     goto BB1
   }
   BB1 {
-    invariant no_match { [#"../08_haystack.rs" 23 4 23 111] forall k : (int) . 0 <= k /\ k < UInt64.to_int i_8 -> not MatchAt0.match_at needle_1 haystack_2 k (Seq.length (Model0.model needle_1)) };
+    invariant no_match { [#"../08_haystack.rs" 23 4 23 111] forall k : int . 0 <= k /\ k < UInt64.to_int i_8 -> not MatchAt0.match_at needle_1 haystack_2 k (Seq.length (Model0.model needle_1)) };
     _13 <- i_8;
     _17 <- haystack_2;
     _16 <- ([#"../08_haystack.rs" 24 14 24 28] Len0.len _17);

--- a/why3/src/declaration.rs
+++ b/why3/src/declaration.rs
@@ -2,7 +2,7 @@ use indexmap::IndexSet;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{
-    exp::{Exp, ExpMutVisitor},
+    exp::{Binder, Exp, ExpMutVisitor},
     mlcfg::{Block, BlockId},
     ty::Type,
     *,
@@ -146,7 +146,7 @@ pub struct Signature {
     pub name: Ident,
     pub attrs: Vec<Attribute>,
     pub retty: Option<Type>,
-    pub args: Vec<(Ident, Type)>,
+    pub args: Vec<Binder>,
     pub contract: Contract,
 }
 

--- a/why3/src/ty.rs
+++ b/why3/src/ty.rs
@@ -4,7 +4,7 @@ use indexmap::IndexSet;
 #[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Type {
     Bool,


### PR DESCRIPTION
This adds support for closures in Pearlite. A closure written within `pearlite! { .. }` will be compiled to a `Mapping` (aka a Why3 function). This should allow us to clean up some proofs (`sparse_array` @claudemarche?) and generally make certain specs simpler. 

I also added support for `ghost` arguments in program functions. 

TODO:

- [ ] Tests