### PR TITLE
Split deps out from TranslatedItems

### DIFF
--- a/creusot/src/metadata.rs
+++ b/creusot/src/metadata.rs
@@ -180,20 +180,20 @@ pub(crate) struct BinaryMetadata<'tcx> {
 impl<'tcx> BinaryMetadata<'tcx> {
     pub(crate) fn from_parts(
         tcx: TyCtxt<'tcx>,
-        functions: &IndexMap<DefId, TranslatedItem<'tcx>>,
+        functions: &IndexMap<DefId, TranslatedItem>,
+        dependencies: &IndexMap<DefId, CloneSummary<'tcx>>,
         terms: &IndexMap<DefId, Term<'tcx>>,
         items: &CreusotItems,
         extern_specs: &HashMap<DefId, ExternSpec<'tcx>>,
     ) -> Self {
         let dependencies = functions
-            .iter()
-            .filter(|(def_id, _)| {
-                tcx.visibility(**def_id) == Visibility::Public && def_id.is_local()
-            })
-            .map(|(def_id, v)| {
+            .keys()
+            .filter(|def_id| tcx.visibility(**def_id) == Visibility::Public && def_id.is_local())
+            .map(|def_id| {
                 (
                     *def_id,
-                    v.local_dependencies()
+                    dependencies
+                        .get(def_id)
                         .map(Clone::clone)
                         .unwrap_or_default()
                         .into_iter()

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -60,14 +60,14 @@ pub fn extern_module<'tcx>(
     def_id: DefId,
 ) -> (
     Module,
-    Result<CloneSummary<'tcx>, DefId>, // Err(_) is used to refer to dependencies that should be fetched from metadata
+    Option<CloneSummary<'tcx>>, // None is used to refer to dependencies that should be fetched from metadata
 ) {
     match ctx.externs.term(def_id) {
         Some(_) => {
             match item_type(ctx.tcx, def_id) {
                 // the dependencies should be what was already stored in the metadata...
                 ItemType::Logic | ItemType::Predicate => {
-                    (translate_logic_or_predicate(ctx, def_id).0, Err(def_id))
+                    (translate_logic_or_predicate(ctx, def_id).0, None)
                 }
                 _ => unreachable!("extern_module: unexpected term for {:?}", def_id),
             }
@@ -75,8 +75,7 @@ pub fn extern_module<'tcx>(
         None => {
             let (modl, deps) = default_decl(ctx, def_id);
             // Why do we ever want to return `Err` shouldn't `deps` already be correct?
-            let deps =
-                if ctx.externs.dependencies(def_id).is_some() { Err(def_id) } else { Ok(deps) };
+            let deps = if ctx.externs.dependencies(def_id).is_some() { None } else { Some(deps) };
             (modl, deps)
         }
     }


### PR DESCRIPTION
This splits dependencies away from translated items, so we can store the dependencies for a function before recursively translating function it calls.

See discussion in #552, but while this does fix an issue where dependencies aren't properly substituted in a cloned theorem, it doesn't fix the the main ordering issue in #552.

---

Unfortunately I don't have a good test case for what this does fix, because my reproducing code still outputs the modules in the wrong order, they just have correct contents now. This is specifically the difference between the following outputs

Old:
```
module Testbin_Impl0
 [...]  
clone Testbin_Impl0_Step_Interface as Step0
  [...]
end
```

New:

```
module Testbin_Impl0
  [...]
  clone Testbin_Impl0_Step_Interface as Step0 with predicate Invariants0.invariants = Invariants0.invariants
  [...]
end
```

on this code (the second reproducer in #552)

```rust
use creusot_contracts::{predicate, maintains, requires, ensures, logic};

pub struct Transition;
pub struct Machine;

pub trait MachineTrait {
    #[predicate]
    fn invariants(self) -> bool;

    #[maintains((mut self).invariants())]
    fn step(&mut self) -> bool;
}

impl MachineTrait for Machine {
    #[predicate]
    fn invariants(self) -> bool {
        true
    }

    #[maintains((mut self).invariants())]
    fn step(&mut self) -> bool {
        self.transition();
        false
    }
}

impl Machine {
    #[requires(self.invariants())]
    pub fn transition(&self) -> Transition {
        Transition
    }
}
```