### PR TITLE
Only emit implies in terms, and don't nest Pure blocks

### DIFF
--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -235,7 +235,12 @@ impl<'tcx> Lower<'_, '_, 'tcx> {
                 Exp::Final(box self.lower_term(term))
             }
             TermKind::Impl { box lhs, box rhs } => {
-                Exp::Impl(box self.lower_term(lhs), box self.lower_term(rhs))
+                let exp = Exp::Impl(box self.lower_term(lhs), box self.lower_term(rhs));
+                if Purity::Program == self.pure {
+                    Exp::Pure(box exp)
+                } else {
+                    exp
+                }
             }
             TermKind::Old { box term } => Exp::Old(box self.lower_term(term)),
             TermKind::Match { box scrutinee, mut arms } => {

--- a/creusot/src/translation/specification/lower.rs
+++ b/creusot/src/translation/specification/lower.rs
@@ -235,7 +235,9 @@ impl<'tcx> Lower<'_, '_, 'tcx> {
                 Exp::Final(box self.lower_term(term))
             }
             TermKind::Impl { box lhs, box rhs } => {
+                let pure = std::mem::replace(&mut self.pure, Purity::Logic);
                 let exp = Exp::Impl(box self.lower_term(lhs), box self.lower_term(rhs));
+                self.pure = pure;
                 if Purity::Program == self.pure {
                     Exp::Pure(box exp)
                 } else {

--- a/creusot/tests/should_succeed/bug/564.mlcfg
+++ b/creusot/tests/should_succeed/bug/564.mlcfg
@@ -1,0 +1,63 @@
+
+module C564_Invariants_Interface
+  function invariants (_ : ()) : bool
+end
+module C564_Invariants
+  function invariants [#"../564.rs" 21 0 21 23] (_ : ()) : bool =
+    [#"../564.rs" 22 4 22 8] true
+  val invariants (_wild0 : ()) : bool
+    ensures { result = invariants _wild0 }
+    
+end
+module C564_EmitsPureEq_Interface
+  clone C564_Invariants_Interface as Invariants0
+  function emits_pure_eq (_ : ()) : bool
+end
+module C564_EmitsPureEq
+  clone C564_Invariants_Interface as Invariants0
+  use mach.int.Int
+  use mach.int.Int32
+  function emits_pure_eq [#"../564.rs" 6 0 6 30] (_ : ()) : bool =
+    [#"../564.rs" 8 8 8 30] ((1 : int32) = (1 : int32)) = true
+  val emits_pure_eq (_wild0 : ()) : bool
+    requires {[#"../564.rs" 5 11 5 23] Invariants0.invariants ()}
+    ensures { result = emits_pure_eq _wild0 }
+    
+  axiom emits_pure_eq_spec : ([#"../564.rs" 5 11 5 23] Invariants0.invariants ()) -> true
+end
+module C564_EmitsPureEq_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  clone C564_Invariants as Invariants0
+  let rec ghost function emits_pure_eq (_ : ()) : bool
+    requires {[#"../564.rs" 5 11 5 23] Invariants0.invariants ()}
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    [#"../564.rs" 8 8 8 30] let a = pure {(1 : int32) = (1 : int32)} in pure {a = true}
+end
+module C564_EmitsPureImplies_Interface
+  clone C564_Invariants_Interface as Invariants0
+  function emits_pure_implies (_ : ()) : bool
+end
+module C564_EmitsPureImplies
+  clone C564_Invariants_Interface as Invariants0
+  use mach.int.Int
+  use mach.int.Int32
+  function emits_pure_implies [#"../564.rs" 14 0 14 35] (_ : ()) : bool =
+    [#"../564.rs" 15 4 17 5] (1 : int32) = (1 : int32) -> true
+  val emits_pure_implies (_wild0 : ()) : bool
+    requires {[#"../564.rs" 13 11 13 23] Invariants0.invariants ()}
+    ensures { result = emits_pure_implies _wild0 }
+    
+  axiom emits_pure_implies_spec : ([#"../564.rs" 13 11 13 23] Invariants0.invariants ()) -> true
+end
+module C564_EmitsPureImplies_Impl
+  use mach.int.Int
+  use mach.int.Int32
+  clone C564_Invariants as Invariants0
+  let rec ghost function emits_pure_implies (_ : ()) : bool
+    requires {[#"../564.rs" 13 11 13 23] Invariants0.invariants ()}
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    [#"../564.rs" 15 4 17 5] pure {(1 : int32) = (1 : int32) -> true}
+end

--- a/creusot/tests/should_succeed/bug/564.rs
+++ b/creusot/tests/should_succeed/bug/564.rs
@@ -1,0 +1,23 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[logic]
+#[requires(invariants())]
+pub fn emits_pure_eq() -> bool {
+    pearlite! {
+        (1i32 == 1i32) == true
+    }
+}
+
+#[logic]
+#[requires(invariants())]
+pub fn emits_pure_implies() -> bool {
+    pearlite! {
+        (1i32 == 1i32) ==> true
+    }
+}
+
+#[logic]
+fn invariants() -> bool {
+    true
+}

--- a/creusot/tests/should_succeed/bug/564.stderr
+++ b/creusot/tests/should_succeed/bug/564.stderr
@@ -1,0 +1,15 @@
+warning: unnecessary parentheses around function argument
+  --> 564.rs:16:9
+   |
+16 |         (1i32 == 1i32) ==> true
+   |         ^            ^
+   |
+   = note: `#[warn(unused_parens)]` on by default
+help: remove these parentheses
+   |
+16 -         (1i32 == 1i32) ==> true
+16 +         1i32 == 1i32 ==> true
+   |
+
+warning: 1 warning emitted
+

--- a/why3/src/exp.rs
+++ b/why3/src/exp.rs
@@ -345,6 +345,9 @@ impl Exp {
                     Exp::QVar(_, Purity::Program) => self.pure &= false,
                     Exp::Verbatim(_) => self.pure &= false,
                     Exp::Absurd => self.pure &= false,
+                    // This is a bit absurd, but you can't put "pure {...}"
+                    // in a term, so it's not "pure".
+                    Exp::Pure(_) => self.pure &= false,
                     _ => {
                         super_visit(self, exp);
                     }


### PR DESCRIPTION
Fixes #564

Putting these commits in one PR because my test for the first fix relies on the second fix as well (the test is only included in the second commit)... and it seems harmless enough. 

I'm not sure why BinOps handle nested exprs differently from everything else? They first lower them, and then use a variable to get around the issue that they might need to be pure while having been lowered in an impure fashion. Everything else just lowers their sub-expressions in a context with the correct version of purity. The latter method seems more elegant, but I may be missing some complexity.