### PR TITLE
Improve error message for invalid syntax in extern_spec

### DIFF
--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -111,7 +111,10 @@ impl TraitOrImpl {
 
 impl FlatSpec {
     pub fn to_tokens(mut self) -> TokenStream {
-        escape_self_in_contracts(&mut self.attrs).unwrap();
+        let err = escape_self_in_contracts(&mut self.attrs);
+        if let Err(e) = err {
+            return e.into_compile_error();
+        }
         let args: Punctuated<Expr, Comma> = self
             .inputs
             .clone()


### PR DESCRIPTION
Changes error messages from

```
error: proc macro panicked
   --> /home/greg/p/games/bb/creusot/creusot-contracts/src/std/vec.rs:26:1
    |
26  | / extern_spec! {
27  | |     mod std {
28  | |         mod vec {
29  | |             impl<T> Vec<T> {
...   |
99  | |     }
100 | | }
    | |_^
    |
    = help: message: called `Result::unwrap()` on an `Err` value: Error("expected term")

warning: unused import: `slice::SliceIndexSpec`
 --> /home/greg/p/games/bb/creusot/creusot-contracts/src/std/vec.rs:4:31
  |
4 |     std::{iter::IteratorSpec, slice::SliceIndexSpec},
  |                               ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `DerefMut`, `Deref`, `IndexMut`, `Index`
  --> /home/greg/p/games/bb/creusot/creusot-contracts/src/std/vec.rs:11:11
   |
11 |     ops::{Deref, DerefMut, Index, IndexMut},
   |           ^^^^^  ^^^^^^^^  ^^^^^  ^^^^^^^^

warning: `creusot-contracts` (lib) generated 2 warnings
error: could not compile `creusot-contracts` due to previous error; 2 warnings emitted

```

to

```
error: expected term
  --> /home/greg/p/games/bb/creusot/creusot-contracts/src/std/vec.rs:30:29
   |
30 |                 #[ensures((@$result).len() == 0)]
   |                             ^

error: could not compile `creusot-contracts` due to previous error
```