### PR TITLE
Add dependency on parent type when indexing fields

### DIFF
--- a/creusot/src/translation/function/place.rs
+++ b/creusot/src/translation/function/place.rs
@@ -70,7 +70,7 @@ pub(crate) fn create_assign_inner<'tcx>(
                 }
             }
             Field(ix, _) => match place_ty.ty.kind() {
-                TyKind::Adt(def, _) => {
+                TyKind::Adt(def, subst) => {
                     let variant_id = place_ty.variant_index.unwrap_or_else(|| 0u32.into());
                     let variant = &def.variants()[variant_id];
                     let var_size = variant.fields.len();
@@ -86,6 +86,7 @@ pub(crate) fn create_assign_inner<'tcx>(
 
                     let tyname = constructor_qname(ctx, variant);
 
+                    names.insert(def.did(), subst);
                     inner = Let {
                         pattern: ConsP(tyname.clone(), field_pats),
                         arg: box translate_rplace_inner(ctx, names, body, lhs.local, stump),
@@ -180,10 +181,11 @@ pub(crate) fn translate_rplace_inner<'tcx>(
                 }
             }
             Field(ix, _) => match place_ty.ty.kind() {
-                TyKind::Adt(def, _) => {
+                TyKind::Adt(def, subst) => {
                     let variant_id = place_ty.variant_index.unwrap_or_else(|| 0u32.into());
                     let variant = &def.variants()[variant_id];
 
+                    names.insert(def.did(), subst);
                     ctx.translate_accessor(def.variants()[variant_id].fields[ix.as_usize()].did);
                     let accessor_name =
                         variant_accessor_name(ctx, def.did(), variant, ix.as_usize());

--- a/creusot/tests/should_succeed/bug/570.mlcfg
+++ b/creusot/tests/should_succeed/bug/570.mlcfg
@@ -1,0 +1,88 @@
+
+module C570_S1_Type
+  use mach.int.Int
+  use mach.int.Int32
+  type t_s1  =
+    | C_S1 int32
+    
+  let function s1_f (self : t_s1) : int32 = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_S1 a -> a
+      end
+end
+module C570_S2_Type
+  use C570_S1_Type as C570_S1_Type
+  type t_s2  =
+    | C_S2 (C570_S1_Type.t_s1)
+    
+  let function s2_s1 (self : t_s2) : C570_S1_Type.t_s1 = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_S2 a -> a
+      end
+end
+module C570_TestProgram_Interface
+  use C570_S2_Type as C570_S2_Type
+  val test_program [@cfg:stackify] (s : C570_S2_Type.t_s2) : ()
+end
+module C570_TestProgram
+  use C570_S2_Type as C570_S2_Type
+  use mach.int.Int
+  use mach.int.Int32
+  use C570_S1_Type as C570_S1_Type
+  let rec cfg test_program [@cfg:stackify] [#"../570.rs" 12 0 12 26] (s : C570_S2_Type.t_s2) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var s_1 : C570_S2_Type.t_s2;
+  var _2 : int32;
+  {
+    s_1 <- s;
+    goto BB0
+  }
+  BB0 {
+    _2 <- C570_S1_Type.s1_f (C570_S2_Type.s2_s1 s_1);
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C570_TestAssign_Interface
+  use C570_S2_Type as C570_S2_Type
+  val test_assign [@cfg:stackify] (s : C570_S2_Type.t_s2) : ()
+end
+module C570_TestAssign
+  use C570_S2_Type as C570_S2_Type
+  use mach.int.Int
+  use mach.int.Int32
+  use C570_S1_Type as C570_S1_Type
+  let rec cfg test_assign [@cfg:stackify] [#"../570.rs" 16 0 16 29] (s : C570_S2_Type.t_s2) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var s_1 : C570_S2_Type.t_s2;
+  {
+    s_1 <- s;
+    goto BB0
+  }
+  BB0 {
+    s_1 <- (let C570_S2_Type.C_S2 a = s_1 in C570_S2_Type.C_S2 (let C570_S1_Type.C_S1 a = C570_S2_Type.s2_s1 s_1 in C570_S1_Type.C_S1 (2 : int32)));
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C570_TestLogic_Stub
+  use C570_S2_Type as C570_S2_Type
+  function test_logic (s : C570_S2_Type.t_s2) : ()
+end
+module C570_TestLogic_Interface
+  use C570_S2_Type as C570_S2_Type
+  function test_logic (s : C570_S2_Type.t_s2) : ()
+end
+module C570_TestLogic
+  use C570_S2_Type as C570_S2_Type
+  use C570_S1_Type as C570_S1_Type
+  function test_logic [#"../570.rs" 21 0 21 24] (s : C570_S2_Type.t_s2) : () =
+    [#"../570.rs" 20 0 20 8] let _ = C570_S1_Type.s1_f (C570_S2_Type.s2_s1 s) in ()
+  val test_logic (s : C570_S2_Type.t_s2) : ()
+    ensures { result = test_logic s }
+    
+end

--- a/creusot/tests/should_succeed/bug/570.rs
+++ b/creusot/tests/should_succeed/bug/570.rs
@@ -1,0 +1,23 @@
+extern crate creusot_contracts;
+use creusot_contracts::logic;
+
+pub struct S1 {
+    pub f: i32,
+}
+
+pub struct S2 {
+    pub s1: S1,
+}
+
+pub fn test_program(s: S2) {
+    s.s1.f;
+}
+
+pub fn test_assign(mut s: S2) {
+    s.s1.f = 2;
+}
+
+#[logic]
+pub fn test_logic(s: S2) {
+    s.s1.f;
+}


### PR DESCRIPTION
Fixes #570.

This takes the approach of just importing the modules that we use explicitly, which of the 3 approaches mentioned in #570 feels like the cleanest to me... but since I just posted a question there about whether I even understand how `use` is supposed to work in why3 correctly, you should probably check that you agree with me before merging this.

 I'm suspicious that I might be missing similar issues by doing

```rust
// Filter out enum variants, and maybe other things...
if !matches!(util::item_type(ctx.tcx, variant.def_id), ItemType::Unsupported(_))
```

 I haven't yet gone out of my way to try to find (or convince myself of the lack of) those similar issues. If you remove the check, a bunch of tests break with "unsupported definition kind" - but there might be a more principled version of the check available too.
 
 This PR is arguably a bit premature given the above, but I'm not going to have time to work on it for the next few days, so I thought I'd push it anyways.
