### PR TITLE
Add support for non-associated constants

### DIFF
--- a/creusot/src/util.rs
+++ b/creusot/src/util.rs
@@ -287,7 +287,7 @@ pub(crate) fn item_type(tcx: TyCtxt<'_>, def_id: DefId) -> ItemType {
                 ItemType::Program
             }
         }
-        DefKind::AssocConst => ItemType::Constant,
+        DefKind::AssocConst | DefKind::Const => ItemType::Constant,
         DefKind::Closure => ItemType::Closure,
         DefKind::Struct | DefKind::Enum | DefKind::Union => ItemType::Type,
         DefKind::AssocTy => ItemType::AssocTy,

--- a/creusot/tests/should_succeed/lang/const.mlcfg
+++ b/creusot/tests/should_succeed/lang/const.mlcfg
@@ -1,0 +1,28 @@
+
+module Const_Foo
+  
+end
+module Const_Foo_Interface
+  use mach.int.Int
+  use prelude.UIntSize
+  val foo [@cfg:stackify] (_ : ()) : usize
+    ensures { [#"../const.rs" 7 10 7 27] result = (42 : usize) }
+    
+end
+module Const_Foo
+  use mach.int.Int
+  use prelude.UIntSize
+  let rec cfg foo [@cfg:stackify] [#"../const.rs" 8 0 8 21] (_ : ()) : usize
+    ensures { [#"../const.rs" 7 10 7 27] result = (42 : usize) }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : usize;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- (42 : usize);
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/lang/const.rs
+++ b/creusot/tests/should_succeed/lang/const.rs
@@ -1,0 +1,10 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::ensures;
+
+const FOO: usize = 42;
+
+#[ensures(result == 42usize)]
+pub fn foo() -> usize {
+    FOO
+}


### PR DESCRIPTION
This feels a bit too easy, but it seems like it just works? I've had this change locally for awhile now, and haven't run into any issues.

I wasn't sure if the test should go under `lang` or `syntax`?