### PR TITLE
Updated toolchain to nightly-2022-10-04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -88,9 +88,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -161,7 +161,7 @@ dependencies = [
  "sequence_trie",
  "serde",
  "serde_json",
- "similar",
+ "similar 1.3.0",
  "termcolor",
  "toml",
  "unescape",
@@ -192,7 +192,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -219,16 +219,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -238,9 +232,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -251,25 +245,24 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -299,9 +292,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -335,20 +328,19 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -357,39 +349,37 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.8.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15226a375927344c78d39dc6b49e2d5562a5b0705e26a589093c6792e52eed8e"
+checksum = "581d4e3314cae4536e5d22ffd23189d4a374696c5ef733eadafae0ed273fd303"
 dependencies = [
  "console",
  "lazy_static",
- "serde",
- "serde_json",
- "serde_yaml",
- "similar",
- "uuid",
+ "linked-hash-map",
+ "similar 2.2.0",
+ "yaml-rust",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jobserver"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
@@ -402,9 +392,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libgit2-sys"
@@ -448,30 +438,24 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mktemp"
@@ -479,7 +463,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975de676448231fcde04b9149d2543077e166b78fc29eae5aa219e7928410da2"
 dependencies = [
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -514,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl-probe"
@@ -526,9 +510,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
  "autocfg",
  "cc",
@@ -539,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "pearlite-syn"
@@ -556,15 +540,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -578,9 +562,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "predicates"
-version = "2.0.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "itertools",
@@ -589,25 +573,25 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
- "treeline",
+ "termtree",
 ]
 
 [[package]]
 name = "pretty"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29afd15870fab34b2a8884481a68f052b3d720cfb29666d7ae0ac2a42ea10289"
+checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
 dependencies = [
  "arrayvec",
  "log",
@@ -641,36 +625,36 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300f2a835d808734ee295d45007adacb9ebb29dd3ae2424acfa17930cae541da"
+checksum = "ed13bcd201494ab44900a96490291651d200730904221832b9547d24a87d332b"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
+checksum = "5234cd6063258a5e32903b53b1b6ac043a0541c8adc1f610f67b0326c7a578fa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -679,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -696,15 +680,15 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "sequence_trie"
@@ -714,18 +698,18 @@ checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -734,25 +718,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
-dependencies = [
- "dtoa",
- "indexmap",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -762,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,9 +747,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -780,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -798,10 +776,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
+name = "termtree"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "tinyvec"
@@ -820,18 +804,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "typed-arena"
@@ -853,34 +831,33 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -889,6 +866,15 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
 ]
@@ -916,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "why3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ members = [
 ]
 
 [profile.dev]
-split-debuginfo = "unpacked"
+#split-debuginfo = "unpacked"

--- a/ci/rust-toolchain
+++ b/ci/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-25"
+channel = "nightly-2022-10-04"
 components = [ "rustfmt", "rustc-dev", "llvm-tools-preview" ]

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -4,10 +4,11 @@ use extern_spec::ExternSpecs;
 use pearlite_syn::*;
 use proc_macro::TokenStream as TS1;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use std::iter;
 use syn::{
     parse::{Parse, Result},
+    spanned::Spanned,
     token::{Brace, Comma},
     *,
 };
@@ -465,22 +466,24 @@ pub fn logic(_: TS1, tokens: TS1) -> TS1 {
 }
 
 fn logic_sig(sig: TraitItemSignature) -> TS1 {
-    TS1::from(quote! {
+    let span = sig.span();
+    TS1::from(quote_spanned! {span=>
         #[creusot::decl::logic]
         #sig
     })
 }
 
 fn logic_item(log: LogicItem) -> TS1 {
+    let span = log.sig.span();
+
     let term = log.body;
     let vis = log.vis;
     let def = log.defaultness;
     let sig = log.sig;
     let attrs = log.attrs;
-
     let req_body = pretyping::encode_block(&term).unwrap();
 
-    TS1::from(quote! {
+    TS1::from(quote_spanned! {span=>
         #[creusot::decl::logic]
         #(#attrs)*
         #vis #def #sig {
@@ -510,13 +513,15 @@ pub fn predicate(_: TS1, tokens: TS1) -> TS1 {
 }
 
 fn predicate_sig(sig: TraitItemSignature) -> TS1 {
-    TS1::from(quote! {
+    let span = sig.span();
+    TS1::from(quote_spanned! {span=>
         #[creusot::decl::predicate]
         #sig
     })
 }
 
 fn predicate_item(log: LogicItem) -> TS1 {
+    let span = log.sig.span();
     let term = log.body;
     let vis = log.vis;
     let def = log.defaultness;
@@ -525,7 +530,7 @@ fn predicate_item(log: LogicItem) -> TS1 {
 
     let req_body = pretyping::encode_block(&term).unwrap();
 
-    TS1::from(quote! {
+    TS1::from(quote_spanned! {span=>
         #[creusot::decl::predicate]
         #(#attrs)*
         #vis #def #sig {

--- a/creusot-rustc/src/lib.rs
+++ b/creusot-rustc/src/lib.rs
@@ -24,4 +24,3 @@ pub extern crate rustc_span as span;
 pub extern crate rustc_target as target;
 pub extern crate rustc_trait_selection as trait_selection;
 pub extern crate rustc_type_ir as type_ir;
-pub extern crate rustc_typeck as typeck;

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -11,7 +11,7 @@ use creusot_rustc::{
     hir::Unsafety,
     middle::{
         ty,
-        ty::{EarlyBinder, ParamEnv, Subst},
+        ty::{EarlyBinder, ParamEnv},
     },
 };
 use rustc_middle::ty::{Ty, TyKind};
@@ -73,7 +73,8 @@ impl<'tcx> Lower<'_, 'tcx> {
                 let method = (id, subst);
                 debug!("resolved_method={:?}", method);
                 self.lookup_builtin(method, &mut Vec::new()).unwrap_or_else(|| {
-                    let uneval = ty::Unevaluated::new(ty::WithOptConstParam::unknown(id), subst);
+                    let uneval =
+                        ty::UnevaluatedConst::new(ty::WithOptConstParam::unknown(id), subst);
 
                     let constant = self.ctx.tcx.mk_const(ty::ConstS {
                         kind: ty::ConstKind::Unevaluated(uneval),

--- a/creusot/src/clone_map.rs
+++ b/creusot/src/clone_map.rs
@@ -3,7 +3,7 @@ use creusot_rustc::{
     infer::traits::ImplSource,
     middle::ty::{
         self,
-        subst::{InternalSubsts, Subst, SubstsRef},
+        subst::{InternalSubsts, SubstsRef},
         DefIdTree, EarlyBinder, ProjectionTy, Ty, TyCtxt, TyKind, TypeFoldable, TypeSuperVisitable,
         TypeVisitor,
     },

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -13,7 +13,7 @@ use creusot_rustc::{
         mir::visit::Visitor,
         ty::{TyCtxt, TyKind},
     },
-    smir::mir::{AggregateKind, BasicBlock, Body, ConstantKind, Location, Operand, Rvalue},
+    smir::mir::{AggregateKind, BasicBlock, Body, Location, Operand, Rvalue},
     span::Symbol,
 };
 
@@ -104,10 +104,8 @@ impl<'tcx> Visitor<'tcx> for InvariantClosures<'tcx> {
                 self.closures.insert(id.to_def_id());
             }
             Rvalue::Use(Operand::Constant(box ck)) => {
-                if let ConstantKind::Ty(c) = ck.literal {
-                    if let Some(def_id) = is_ghost_closure(self.tcx, c.ty()) {
-                        self.closures.insert(def_id);
-                    }
+                if let Some(def_id) = is_ghost_closure(self.tcx, ck.literal.ty()) {
+                    self.closures.insert(def_id);
                 }
             }
             _ => {}
@@ -127,10 +125,8 @@ impl<'tcx> Visitor<'tcx> for ClosureLocations {
                 self.locations.insert(id.to_def_id(), loc);
             }
             Rvalue::Use(Operand::Constant(box ck)) => {
-                if let ConstantKind::Ty(c) = ck.literal {
-                    if let TyKind::Closure(def_id, _) = c.ty().peel_refs().kind() {
-                        self.locations.insert(*def_id, loc);
-                    }
+                if let TyKind::Closure(def_id, _) = ck.literal.ty().peel_refs().kind() {
+                    self.locations.insert(*def_id, loc);
                 }
             }
             _ => {}

--- a/creusot/src/gather_spec_closures.rs
+++ b/creusot/src/gather_spec_closures.rs
@@ -13,7 +13,7 @@ use creusot_rustc::{
         mir::visit::Visitor,
         ty::{TyCtxt, TyKind},
     },
-    smir::mir::{AggregateKind, BasicBlock, Body, Location, Operand, Rvalue},
+    smir::mir::{AggregateKind, BasicBlock, Body, ConstantKind, Location, Operand, Rvalue},
     span::Symbol,
 };
 
@@ -104,7 +104,7 @@ impl<'tcx> Visitor<'tcx> for InvariantClosures<'tcx> {
                 self.closures.insert(id.to_def_id());
             }
             Rvalue::Use(Operand::Constant(box ck)) => {
-                if let Some(c) = ck.literal.const_for_ty() {
+                if let ConstantKind::Ty(c) = ck.literal {
                     if let Some(def_id) = is_ghost_closure(self.tcx, c.ty()) {
                         self.closures.insert(def_id);
                     }
@@ -127,7 +127,7 @@ impl<'tcx> Visitor<'tcx> for ClosureLocations {
                 self.locations.insert(id.to_def_id(), loc);
             }
             Rvalue::Use(Operand::Constant(box ck)) => {
-                if let Some(c) = ck.literal.const_for_ty() {
+                if let ConstantKind::Ty(c) = ck.literal {
                     if let TyKind::Closure(def_id, _) = c.ty().peel_refs().kind() {
                         self.locations.insert(*def_id, loc);
                     }

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_private, register_tool)]
 #![feature(box_syntax, box_patterns, control_flow_enum, drain_filter)]
-#![feature(let_else, never_type, try_blocks)]
+#![feature(let_chains, never_type, try_blocks)]
 
 #[macro_use]
 extern crate log;

--- a/creusot/src/rustc_extensions/renumber.rs
+++ b/creusot/src/rustc_extensions/renumber.rs
@@ -66,8 +66,4 @@ impl<'a, 'tcx> MutVisitor<'tcx> for NllVisitor<'a, 'tcx> {
         let old_region = *region;
         *region = self.renumber_regions(old_region);
     }
-
-    fn visit_const(&mut self, constant: &mut ty::Const<'tcx>, _location: Location) {
-        *constant = self.renumber_regions(*constant);
-    }
 }

--- a/creusot/src/translation/constant.rs
+++ b/creusot/src/translation/constant.rs
@@ -8,7 +8,10 @@ use crate::{
 use creusot_rustc::{
     hir::def_id::DefId,
     middle::{
-        mir::interpret::{AllocRange, ConstValue},
+        mir::{
+            interpret::{AllocRange, ConstValue},
+            UnevaluatedConst,
+        },
         ty::{Const, ConstKind, ParamEnv, Ty, TyCtxt},
     },
     smir::mir::ConstantKind,
@@ -68,6 +71,10 @@ pub(crate) fn from_mir_constant_kind<'tcx>(
         }
     }
 
+    if let ConstantKind::Unevaluated(UnevaluatedConst { promoted: Some(p), .. }, _) = ck {
+        return Expr::Exp(Exp::impure_var(format!("promoted{:?}", p.as_usize()).into()));
+    }
+
     return Expr::Constant(try_to_bits(ctx, names, env, ck.ty(), span, ck));
 }
 
@@ -86,10 +93,6 @@ pub(crate) fn from_ty_const<'tcx>(
             names.import_builtin_module(nm.clone().module_qname());
             return Expr::Exp(Exp::pure_qvar(nm.without_search_path()));
     };
-
-    // if let ConstKind::Unevaluated(UnevaluatedConst{ promoted: Some(p), .. }) = c.kind() {
-    //     return Expr::Exp(Exp::impure_var(format!("promoted{:?}", p.as_usize()).into()));
-    // }
 
     if let ConstKind::Param(_) = c.kind() {
         ctx.crash_and_error(span, "const generic parameters are not yet supported");

--- a/creusot/src/translation/external.rs
+++ b/creusot/src/translation/external.rs
@@ -16,7 +16,7 @@ use creusot_rustc::{
     middle::{
         thir::{self, visit::Visitor, Expr, ExprKind, Thir},
         ty::{
-            subst::{GenericArgKind, InternalSubsts, Subst, SubstsRef},
+            subst::{GenericArgKind, InternalSubsts, SubstsRef},
             EarlyBinder, Predicate, TyCtxt, TyKind, WithOptConstParam,
         },
     },

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -207,7 +207,7 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
             current_block: (Vec::new(), None),
             past_blocks: BTreeMap::new(),
             ctx,
-            fresh_id: body.basic_blocks().len(),
+            fresh_id: body.basic_blocks.len(),
             names,
             invariants,
             assertions,

--- a/creusot/src/translation/function/place.rs
+++ b/creusot/src/translation/function/place.rs
@@ -150,6 +150,7 @@ pub(crate) fn create_assign_inner<'tcx>(
             }
             ConstantIndex { .. } => unimplemented!("ConstantIndex"),
             Subslice { .. } => unimplemented!("Subslice"),
+            OpaqueCast(_) => unimplemented!("OpaqueCast"),
         }
     }
 
@@ -222,6 +223,7 @@ pub(crate) fn translate_rplace_inner<'tcx>(
             }
             ConstantIndex { .. } => unimplemented!("constant index projection"),
             Subslice { .. } => unimplemented!("subslice projection"),
+            OpaqueCast(_) => unimplemented!("opaque cast projection"),
         }
         place_ty = place_ty.projection_ty(ctx.tcx, *elem);
     }

--- a/creusot/src/translation/function/promoted.rs
+++ b/creusot/src/translation/function/promoted.rs
@@ -60,7 +60,7 @@ pub(crate) fn translate_promoted<'tcx>(
 ) -> CreusotResult<Decl> {
     let mut previous_block = None;
     let mut exp = Exp::impure_var("_0".into());
-    for (id, bbd) in body.basic_blocks().iter_enumerated().rev() {
+    for (id, bbd) in body.basic_blocks.iter_enumerated().rev() {
         // Safety check
         match bbd.terminator().kind {
             TerminatorKind::Return => {

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -1,8 +1,8 @@
 use creusot_rustc::{
     borrowck::borrow_set::TwoPhaseActivation,
     smir::mir::{
-        BinOp, BorrowKind::*, CastKind, ConstantKind, Location, Operand::*, Place, Rvalue,
-        SourceInfo, Statement, StatementKind,
+        BinOp, BorrowKind::*, CastKind, Location, Operand::*, Place, Rvalue, SourceInfo, Statement,
+        StatementKind,
     },
 };
 
@@ -58,10 +58,8 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                     Expr::Copy(*pl)
                 }
                 Constant(box c) => {
-                    if let ConstantKind::Ty(c) = c.literal {
-                        if is_ghost_closure(self.tcx, c.ty()).is_some() {
-                            return;
-                        }
+                    if is_ghost_closure(self.tcx, c.literal.ty()).is_some() {
+                        return;
                     };
                     crate::constant::from_mir_constant(self.param_env(), self.ctx, self.names, c)
                 }

--- a/creusot/src/translation/function/terminator.rs
+++ b/creusot/src/translation/function/terminator.rs
@@ -47,10 +47,9 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
         match &terminator.kind {
             Goto { target } => self.emit_terminator(mk_goto(*target)),
             SwitchInt { discr, targets, .. } => {
-                let real_discr =
-                    discriminator_for_switch(&self.body.basic_blocks()[location.block])
-                        .map(Operand::Move)
-                        .unwrap_or_else(|| discr.clone());
+                let real_discr = discriminator_for_switch(&self.body.basic_blocks[location.block])
+                    .map(Operand::Move)
+                    .unwrap_or_else(|| discr.clone());
 
                 let discriminant = self.translate_operand(&real_discr);
                 let switch = make_switch(

--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -12,7 +12,7 @@ use creusot_rustc::{
         ty::{
             self,
             subst::{InternalSubsts, SubstsRef},
-            EarlyBinder, Subst, TyCtxt,
+            EarlyBinder, TyCtxt,
         },
     },
     smir::mir::{Body, Local, Location, SourceScope},

--- a/creusot/src/translation/traits.rs
+++ b/creusot/src/translation/traits.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use creusot_rustc::{
     hir::def_id::DefId,
     middle::ty::{
-        subst::SubstsRef, AssocItemContainer::*, EarlyBinder, ParamEnv, Subst, TraitRef, TyCtxt,
+        subst::SubstsRef, AssocItemContainer::*, EarlyBinder, ParamEnv, TraitRef, TyCtxt,
     },
     resolve::Namespace,
     trait_selection::traits::ImplSource,

--- a/creusot/tests/should_fail/bug/211.stderr
+++ b/creusot/tests/should_fail/bug/211.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `B` and `C` not covered
+error[E0004]: non-exhaustive patterns: `E::B` and `E::C` not covered
   --> 211.rs:10:11
    |
 10 |     match s.0 {
-   |           ^^^ patterns `B` and `C` not covered
+   |           ^^^ patterns `E::B` and `E::C` not covered
    |
 note: `E` defined here
   --> 211.rs:3:5
@@ -18,7 +18,7 @@ note: `E` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 11 ~         E::A => {}
-12 +         B | C => todo!()
+12 +         E::B | E::C => todo!()
    |
 
 warning: load the `creusot_contract` crate to enable resolution of mutable borrows.

--- a/creusot/tests/should_fail/cycle.stderr
+++ b/creusot/tests/should_fail/cycle.stderr
@@ -6,7 +6,7 @@ warning: unused import: `creusot_contracts::*`
   |
   = note: `#[warn(unused_imports)]` on by default
 
-error[creusot]: encountered a cycle during translation: [{DefId(0:5 ~ cycle[930b]::f)}, {DefId(0:6 ~ cycle[930b]::g)}, {DefId(0:5 ~ cycle[930b]::f)}]
+error[creusot]: encountered a cycle during translation: [{DefId(0:5 ~ cycle[63e8]::f)}, {DefId(0:6 ~ cycle[63e8]::g)}, {DefId(0:5 ~ cycle[63e8]::f)}]
  --> cycle.rs:4:1
   |
 4 | pub fn f() {

--- a/creusot/tests/should_fail/inexhaustive_match.stderr
+++ b/creusot/tests/should_fail/inexhaustive_match.stderr
@@ -1,8 +1,8 @@
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Option::Some(_)` not covered
  --> inexhaustive_match.rs:8:11
   |
 8 |     match x {
-  |           ^ pattern `Some(_)` not covered
+  |           ^ pattern `Option::Some(_)` not covered
   |
 note: `Option<()>` defined here
  --> inexhaustive_match.rs:2:5
@@ -15,7 +15,7 @@ note: `Option<()>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
   |
 9 ~         None => (),
-10~         Some(_) => todo!(),
+10~         Option::Some(_) => todo!(),
   |
 
 warning: load the `creusot_contract` crate to enable resolution of mutable borrows.

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -750,7 +750,7 @@ module CreusotContracts_Std1_Slice_Impl4_HasValue
     ensures { result = has_value self seq out }
     
 end
-module Core_Slice_Index_Impl3_Output_Type
+module Core_Slice_Index_Impl4_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -866,7 +866,7 @@ module IndexRange_TestRange
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy0 with type t = int32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model1 with type t = seq int32,
     type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone Core_Slice_Index_Impl3_Output_Type as Output0 with type t = int32
+  clone Core_Slice_Index_Impl4_Output_Type as Output0 with type t = int32
   clone CreusotContracts_Std1_Slice_Impl4_HasValue as HasValue0 with type t = int32,
     function Model0.model = Model2.model
   clone CreusotContracts_Std1_Slice_Impl4_InBounds as InBounds0 with type t = int32
@@ -1629,7 +1629,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
     ensures { result = has_value self seq out }
     
 end
-module Core_Slice_Index_Impl4_Output_Type
+module Core_Slice_Index_Impl5_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -1688,7 +1688,7 @@ module IndexRange_TestRangeTo
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy0 with type t = int32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model1 with type t = seq int32,
     type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone Core_Slice_Index_Impl4_Output_Type as Output0 with type t = int32
+  clone Core_Slice_Index_Impl5_Output_Type as Output0 with type t = int32
   clone CreusotContracts_Std1_Slice_Impl5_HasValue as HasValue0 with type t = int32,
     function Model0.model = Model2.model
   clone CreusotContracts_Std1_Slice_Impl5_InBounds as InBounds0 with type t = int32
@@ -2215,7 +2215,7 @@ module CreusotContracts_Std1_Slice_Impl6_HasValue
     ensures { result = has_value self seq out }
     
 end
-module Core_Slice_Index_Impl5_Output_Type
+module Core_Slice_Index_Impl6_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -2278,7 +2278,7 @@ module IndexRange_TestRangeFrom
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy0 with type t = int32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model1 with type t = seq int32,
     type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone Core_Slice_Index_Impl5_Output_Type as Output0 with type t = int32
+  clone Core_Slice_Index_Impl6_Output_Type as Output0 with type t = int32
   clone CreusotContracts_Std1_Slice_Impl6_HasValue as HasValue0 with type t = int32,
     function Model0.model = Model2.model
   clone CreusotContracts_Std1_Slice_Impl6_InBounds as InBounds0 with type t = int32
@@ -2823,7 +2823,7 @@ module CreusotContracts_Std1_Slice_Impl7_HasValue
     ensures { result = has_value self seq out }
     
 end
-module Core_Slice_Index_Impl6_Output_Type
+module Core_Slice_Index_Impl7_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -2874,7 +2874,7 @@ module IndexRange_TestRangeFull
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy0 with type t = int32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model1 with type t = seq int32,
     type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone Core_Slice_Index_Impl6_Output_Type as Output0 with type t = int32
+  clone Core_Slice_Index_Impl7_Output_Type as Output0 with type t = int32
   clone CreusotContracts_Std1_Slice_Impl7_HasValue as HasValue0 with type t = int32,
     function Model0.model = Model2.model
   clone CreusotContracts_Std1_Slice_Impl7_InBounds as InBounds0 with type t = int32
@@ -3391,7 +3391,7 @@ module CreusotContracts_Std1_Slice_Impl8_HasValue
     ensures { result = has_value self seq out }
     
 end
-module Core_Slice_Index_Impl8_Output_Type
+module Core_Slice_Index_Impl9_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -3454,7 +3454,7 @@ module IndexRange_TestRangeToInclusive
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy0 with type t = int32
   clone CreusotContracts_Logic_Model_Impl0_Model as Model1 with type t = seq int32,
     type ModelTy0.modelTy = ModelTy0.modelTy, function Model0.model = Model2.model
-  clone Core_Slice_Index_Impl8_Output_Type as Output0 with type t = int32
+  clone Core_Slice_Index_Impl9_Output_Type as Output0 with type t = int32
   clone CreusotContracts_Std1_Slice_Impl8_HasValue as HasValue0 with type t = int32,
     function Model0.model = Model2.model
   clone CreusotContracts_Std1_Slice_Impl8_InBounds as InBounds0 with type t = int32

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -723,7 +723,7 @@ module CreusotContracts_Std1_Slice_Impl7_ResolveElswhere
     ensures { result = resolve_elswhere self _old _fin }
     
 end
-module Core_Slice_Index_Impl6_Output_Type
+module Core_Slice_Index_Impl7_Output_Type
   type t
   use prelude.Slice
   use seq.Seq
@@ -767,7 +767,7 @@ module C02IterMut_IterMut
   use prelude.Slice
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   clone CreusotContracts_Std1_Slice_Impl0_ModelTy_Type as ModelTy1 with type t = t
-  clone Core_Slice_Index_Impl6_Output_Type as Output0 with type t = t
+  clone Core_Slice_Index_Impl7_Output_Type as Output0 with type t = t
   clone CreusotContracts_Std1_Slice_Impl7_ResolveElswhere as ResolveElswhere0 with type t = t
   clone CreusotContracts_Std1_Slice_Impl7_HasValue as HasValue0 with type t = t, function Model0.model = Model0.model
   clone CreusotContracts_Std1_Slice_Impl7_InBounds as InBounds0 with type t = t


### PR DESCRIPTION
Updates the toolchain to help with #594.  This seems to have modified the behaviour of `def_span`.
In the following test:
```rust
extern crate creusot_contracts;
use creusot_contracts::*;

#[logic]
#[ensures(true && false)]
#[creusot::builtins = "dummy_function"]
fn builtin_with_contract() {}
```
it now gives a span from line for leading to the error:
```
error[creusot]: cannot specify both `creusot::builtins` and a contract on the same definition
 --> builtin_with_contract.rs:4:1
  |
4 | #[logic]
  | ^^^^^^^^
  |
  = note: this error originates in the attribute macro `logic` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error
```
instead of a span from line 7 leading to the error:
```
warning: function `builtin_with_contract` is never used
 --> builtin_with_contract.rs:7:4
  |
7 | fn builtin_with_contract() {}
  |    ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default

error[creusot]: cannot specify both `creusot::builtins` and a contract on the same definition
 --> builtin_with_contract.rs:7:1
  |
7 | fn builtin_with_contract() {}
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error; 1 warning emitted
```