### PR TITLE
Logical Reborrow / Unnesting

### DIFF
--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -316,6 +316,12 @@ impl<'tcx> Lower<'_, 'tcx> {
                 Exp::Abs(binders, box body)
             }
             TermKind::Absurd => Exp::Absurd,
+            TermKind::Reborrow { cur, fin } => Exp::Record {
+                fields: vec![
+                    ("current".into(), self.lower_term(*cur)),
+                    ("final".into(), self.lower_term(*fin)),
+                ],
+            },
         }
     }
 

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -94,6 +94,7 @@ pub enum TermKind<'tcx> {
     Projection { lhs: Box<Term<'tcx>>, name: Field, def: DefId, substs: SubstsRef<'tcx> },
     Old { term: Box<Term<'tcx>> },
     Closure { args: Vec<Pattern<'tcx>>, body: Box<Term<'tcx>> },
+    Reborrow { cur: Box<Term<'tcx>>, fin: Box<Term<'tcx>> },
     Absurd,
 }
 impl<'tcx> TypeFoldable<'tcx> for Literal {
@@ -351,14 +352,8 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
             }
             ExprKind::Borrow { borrow_kind: BorrowKind::Shared, arg } => self.expr_term(arg),
             ExprKind::Borrow { arg, .. } => {
-                // Rust will introduce add unnecessary reborrows to code.
-                // Since we've syntactically ruled out borrowing at a higher level, we should
-                // be able erase it safely (:fingers_crossed:)
-                if let ExprKind::Deref { arg } = self.thir[arg].kind {
-                    self.expr_term(arg)
-                } else {
-                    Err(Error::new(self.thir[arg].span, "cannot perform a mutable borrow"))
-                }
+                let t = self.logical_reborrow(arg)?;
+                Ok(Term { ty, span, kind: t })
             }
             ExprKind::Adt(box AdtExpr { adt_def, variant_index, ref fields, .. }) => {
                 let mut fields: Vec<_> = fields
@@ -379,7 +374,9 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
             // Can it happen?
             ExprKind::Deref { arg } => {
                 if self.thir[arg].ty.is_box() || self.thir[arg].ty.ref_mutability() == Some(Not) {
-                    self.expr_term(arg)
+                    let mut arg = self.expr_term(arg)?;
+                    arg.ty = arg.ty.builtin_deref(false).expect("expected &T").ty;
+                    Ok(arg)
                 } else {
                     Ok(Term { ty, span, kind: TermKind::Cur { term: box self.expr_term(arg)? } })
                 }
@@ -408,42 +405,8 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
                 })
             }
             ExprKind::Field { lhs, name, .. } => {
-                let pat =
-                    field_pattern(self.thir[lhs].ty, name).expect("expr_term: no term for field");
-
-                match &self.thir[lhs].ty.kind() {
-                    TyKind::Adt(def, substs) => {
-                        let lhs = self.expr_term(lhs)?;
-                        Ok(Term {
-                            ty,
-                            span,
-                            kind: TermKind::Projection {
-                                lhs: box lhs,
-                                name,
-                                def: def.did(),
-                                substs,
-                            },
-                        })
-                    }
-                    TyKind::Tuple(_) => {
-                        let lhs = self.expr_term(lhs)?;
-                        Ok(Term {
-                            ty,
-                            span,
-                            kind: TermKind::Let {
-                                pattern: pat,
-                                // this is the wrong type
-                                body: box Term {
-                                    ty: lhs.ty,
-                                    span: creusot_rustc::span::DUMMY_SP,
-                                    kind: TermKind::Var(Symbol::intern("a")),
-                                },
-                                arg: box lhs,
-                            },
-                        })
-                    }
-                    _ => unreachable!(),
-                }
+                let lhs = self.expr_term(lhs)?;
+                Ok(Term { ty, span, kind: self.mk_projection(lhs, name)? })
             }
             ExprKind::Tuple { ref fields } => {
                 let fields: Vec<_> =
@@ -544,10 +507,13 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
                 }
             }
             PatKind::Deref { subpattern } => {
-                assert!(
-                    pat.ty.is_box() || pat.ty.ref_mutability() == Some(Not),
-                    "pattern_term: only dereference over a box or shared reference is supported"
-                );
+                if !(pat.ty.is_box() || pat.ty.ref_mutability() == Some(Not)) {
+                    return Err(Error::new(
+                        pat.span,
+                        "only deref patterns for box and & are supported",
+                    ));
+                }
+
                 self.pattern_term(subpattern)
             }
             PatKind::Constant { value } => {
@@ -621,6 +587,90 @@ impl<'a, 'tcx> ThirTerm<'a, 'tcx> {
                 Ok(((name.name, ty), pearlite(self.tcx, closure_id)?))
             }
             _ => Err(Error::new(self.thir[body].span, "unexpected error in quantifier")),
+        }
+    }
+
+    // Creates a 'logical' reborrow of a mutable borrow.
+    // The idea is that the expression `&mut ** X` for `X : &mut &mut T` should produces a pearlite value of type `&mut T`.
+    //
+    // However, this also has to deal with the idea that `* X` access the current value of a borrow in Pearlite.
+    // In actuality `&mut ** X` and `*X` are the same thing in THIR (rather the second doesn't exist).
+    // This has a **notable** consequence: an unnesting of a mutable borrow in Pearlite must be the same as its **current value**.
+    // That is: `Y = &mut ** X` means that `* Y = ** X` and `^ Y = ^* X`. This is **unlike** in programs in which the `^` and `*` are
+    // swapped. While this difference is not satisfactory, it is a natural consequence of the properties of a logic, in particular stability
+    //  under substitution. We are allowed to write the following in Pearlite:
+    //
+    // let a = * x;
+    // let b = &mut * a; // &mut cannot be writte in surface syntax.
+    //
+    // However we translate `&mut x` should be the same as if we had first substituted `a`.
+    // This is not fully satisfactory, but the other choice where we correspond to the behavior of programs is not stable under
+    // substitution.
+    fn logical_reborrow(&self, rebor_id: ExprId) -> Result<TermKind<'tcx>, Error> {
+        // Check for the simple `&mut * x` case.
+        if let ExprKind::Deref { arg } = self.thir[rebor_id].kind {
+            return Ok(self.expr_term(arg)?.kind);
+        };
+        // Handle every other case.
+        let (cur, fin) = self.logical_reborrow_inner(rebor_id)?;
+
+        Ok(TermKind::Reborrow { cur: box cur, fin: box fin })
+    }
+
+    fn logical_reborrow_inner(&self, rebor_id: ExprId) -> Result<(Term<'tcx>, Term<'tcx>), Error> {
+        let ty = self.thir[rebor_id].ty;
+        let span = self.thir[rebor_id].span;
+        match &self.thir[rebor_id].kind {
+            ExprKind::Scope { value, .. } => self.logical_reborrow_inner(*value),
+            ExprKind::Block { block } => {
+                let Block { stmts, expr, .. } = &self.thir[*block];
+                assert!(stmts.is_empty());
+                self.logical_reborrow_inner(expr.unwrap())
+            }
+            ExprKind::Field { lhs, variant_index: _, name } => {
+                let (cur, fin) = self.logical_reborrow_inner(*lhs)?;
+                Ok((
+                    Term { ty, span, kind: self.mk_projection(cur, *name)? },
+                    Term { ty, span, kind: self.mk_projection(fin, *name)? },
+                ))
+            }
+            ExprKind::Deref { arg } => {
+                let inner = self.expr_term(*arg)?;
+                if let TermKind::Var(_) = inner.kind {}
+                let ty = inner.ty.builtin_deref(false).expect("expected reference type").ty;
+
+                Ok((
+                    Term { ty, span, kind: TermKind::Cur { term: box inner.clone() } },
+                    Term { ty, span, kind: TermKind::Fin { term: box inner } },
+                ))
+            }
+            _ => Err(Error::new(
+                span,
+                "unsupported logical reborrow, only simple field projections are supproted, sorry",
+            )),
+        }
+    }
+
+    fn mk_projection(&self, lhs: Term<'tcx>, name: Field) -> Result<TermKind<'tcx>, Error> {
+        let pat = field_pattern(lhs.ty, name).expect("mk_projection: no term for field");
+
+        match &lhs.ty.kind() {
+            TyKind::Adt(def, substs) => {
+                Ok(TermKind::Projection { lhs: box lhs, name, def: def.did(), substs })
+            }
+            TyKind::Tuple(_) => {
+                Ok(TermKind::Let {
+                    pattern: pat,
+                    // this is the wrong type
+                    body: box Term {
+                        ty: lhs.ty,
+                        span: creusot_rustc::span::DUMMY_SP,
+                        kind: TermKind::Var(Symbol::intern("a")),
+                    },
+                    arg: box lhs,
+                })
+            }
+            _ => unreachable!(),
         }
     }
 }
@@ -810,6 +860,10 @@ pub fn super_visit_term<'tcx, V: TermVisitor<'tcx>>(term: &Term<'tcx>, visitor: 
         TermKind::Old { term } => visitor.visit_term(&*term),
         TermKind::Closure { args: _, body } => visitor.visit_term(&*body),
         TermKind::Absurd => {}
+        TermKind::Reborrow { cur, fin } => {
+            visitor.visit_term(&*cur);
+            visitor.visit_term(&*fin)
+        }
     }
 }
 
@@ -862,6 +916,10 @@ pub(crate) fn super_visit_mut_term<'tcx, V: TermVisitorMut<'tcx>>(
         TermKind::Old { term } => visitor.visit_mut_term(&mut *term),
         TermKind::Closure { args: _, body } => visitor.visit_mut_term(&mut *body),
         TermKind::Absurd => {}
+        TermKind::Reborrow { cur, fin } => {
+            visitor.visit_mut_term(&mut *cur);
+            visitor.visit_mut_term(&mut *fin)
+        }
     }
 }
 
@@ -962,6 +1020,10 @@ impl<'tcx> Term<'tcx> {
                 body.subst_inner(&bound, inv_subst);
             }
             TermKind::Absurd => {}
+            TermKind::Reborrow { cur, fin } => {
+                cur.subst_inner(bound, inv_subst);
+                fin.subst_inner(bound, inv_subst)
+            }
         }
     }
 }

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -197,3 +197,70 @@ module C05Pearlite_Caller
   }
   
 end
+module C05Pearlite_S_Type
+  type t_s  =
+    | C_S
+    
+end
+module C05Pearlite_Impl0_X_Stub
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function x (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+end
+module C05Pearlite_Impl0_X_Interface
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function x (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+end
+module C05Pearlite_Impl0_X
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function x [#"../05_pearlite.rs" 54 4 54 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool =
+    [#"../05_pearlite.rs" 55 8 55 12] true
+  val x (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+    ensures { result = x self }
+    
+end
+module C05Pearlite_Proj_Stub
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function proj (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+end
+module C05Pearlite_Proj_Interface
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function proj (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+end
+module C05Pearlite_Proj
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  clone C05Pearlite_Impl0_X_Stub as X0
+  function proj [#"../05_pearlite.rs" 60 0 60 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+   =
+    [#"../05_pearlite.rs" 59 0 59 8] X0.x {current = let (a, _) =  * x in a; final = let (a, _) =  ^ x in a}
+  val proj (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+    ensures { result = proj x }
+    
+end
+module C05Pearlite_Proj2_Stub
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function proj2 (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+end
+module C05Pearlite_Proj2_Interface
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  function proj2 (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+end
+module C05Pearlite_Proj2
+  use prelude.Borrow
+  use C05Pearlite_S_Type as C05Pearlite_S_Type
+  clone C05Pearlite_Impl0_X_Stub as X0
+  function proj2 [#"../05_pearlite.rs" 65 0 65 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+    
+   =
+    [#"../05_pearlite.rs" 64 0 64 8] X0.x {current = let (a, _) =  *  * x in a; final = let (a, _) =  ^  * x in a}
+  val proj2 (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+    ensures { result = proj2 x }
+    
+end

--- a/creusot/tests/should_succeed/syntax/05_pearlite.rs
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.rs
@@ -44,3 +44,33 @@ pub fn pearlite_closure(x: Ghost<Mapping<u32, bool>>) {}
 pub fn caller() {
     pearlite_closure(ghost! { pearlite! { |a| true }});
 }
+
+// Implicit logical reborrows
+
+pub struct S {}
+
+impl S {
+    #[logic]
+    pub fn x(&mut self) -> bool {
+        true
+    }
+}
+
+#[logic]
+pub fn proj(x: &mut (S, S)) -> bool {
+    x.0.x()
+}
+
+#[logic]
+pub fn proj2(x: &mut &mut (S, S)) -> bool {
+    x.0.x()
+}
+
+// Left out until I understand the semantics of `Deref` patterns.
+// #[logic]
+// pub fn proj_opt(x : &mut Option<S>)  -> bool {
+//     match x {
+//         Some(a) => a.x(),
+//         None => true,
+//     }
+// }

--- a/why3/src/exp.rs
+++ b/why3/src/exp.rs
@@ -95,6 +95,7 @@ pub enum Exp {
     Let { pattern: Pattern, arg: Box<Exp>, body: Box<Exp> },
     Var(Ident, Purity),
     QVar(QName, Purity),
+    Record { fields: Vec<(String, Exp)> },
     RecUp { record: Box<Exp>, label: String, val: Box<Exp> },
     RecField { record: Box<Exp>, label: String },
     Tuple(Vec<Exp>),
@@ -187,6 +188,7 @@ pub fn super_visit_mut<T: ExpMutVisitor>(f: &mut T, exp: &mut Exp) {
         Exp::Exists(_, e) => f.visit_mut(e),
         Exp::Attr(_, e) => f.visit_mut(e),
         Exp::Ghost(e) => f.visit_mut(e),
+        Exp::Record { fields } => fields.iter_mut().for_each(|(_, e)| f.visit_mut(e)),
     }
 }
 
@@ -248,6 +250,7 @@ pub fn super_visit<T: ExpVisitor>(f: &mut T, exp: &Exp) {
         Exp::Exists(_, e) => f.visit(e),
         Exp::Attr(_, e) => f.visit(e),
         Exp::Ghost(e) => f.visit(e),
+        Exp::Record { fields } => fields.iter().for_each(|(_, e)| f.visit(e)),
     }
 }
 
@@ -523,6 +526,7 @@ impl Exp {
             Exp::Verbatim(_) => Atom,
             Exp::Attr(_, _) => Attr,
             Exp::Ghost(_) => App,
+            Exp::Record { fields: _ } => Atom,
             // _ => unimplemented!("{:?}", self),
         }
     }

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -759,6 +759,14 @@ impl Print for Exp {
             }
             Exp::Absurd => alloc.text("absurd"),
             Exp::Old(e) => alloc.text("old").append(e.pretty(alloc, env).parens()),
+            Exp::Record { fields } => alloc
+                .intersperse(
+                    fields
+                        .iter()
+                        .map(|(nm, a)| alloc.text(nm).append(" = ").append(a.pretty(alloc, env))),
+                    "; ",
+                )
+                .braces(),
         }
     }
 }


### PR DESCRIPTION
Adds logical reborrowing / unnesting, so that we can project out mutable borrows to fields of mutable borrows in pearlite. This enables significantly more ergonomic specifications when dealing with mutable borrows.

There remains a question on which behavior to give unnesting: `&mut ** x` should it be:
- ~~`(**x, *^x)`~~
- `(**x, ^*x)`

The first is what happens in programs and is good for coherence between Pearlite and Rust, the second is perhaps more 'intuitive', you're effectively getting the borrow that's just one `*` deep. 
I'm personally leaning towards the first option, I like keeping the coherence between programs and specs.

--- 

After much agonizing I've come to accept the conclusion that the second choice is the only viable choice at least in Pearlite as it is. The short of it is that we should be stable under substitution and the second option isn't. 