### PR TITLE
README: `cargo-creusot` needs to be run with a matching toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The recommended way for users to verify programs with Creusot is to use `cargo-c
 All you need to do is enter your project and run `cargo creusot`!
 This will generate MLCFG files in `target/debug/` which can then be loaded into Why3.
 
+This may only work if you're using the same rust toolchain that was used to build `creusot`:
+you can copy the [`rust-toolchain`](./rust-toolchain) file into the root of your project to
+make sure the correct toolchain is selected.
 
 To add contracts to your programs you will need to use the `creusot-contracts` crate, and enable the `contracts` feature.
 When that feature is enabled `rustc` cannot successfully compile your programs, so we recommend adding a feature to your program which conditionally enables the `contracts` feature like so:


### PR DESCRIPTION
Add a note to the README for this.