### PR TITLE
Cleanup constant code a bit

### DIFF
--- a/creusot/src/translation/fmir.rs
+++ b/creusot/src/translation/fmir.rs
@@ -48,7 +48,8 @@ pub enum Expr<'tcx> {
     UnaryOp(UnOp, Box<Expr<'tcx>>),
     Constructor(DefId, SubstsRef<'tcx>, Vec<Expr<'tcx>>),
     Call(DefId, SubstsRef<'tcx>, Vec<Expr<'tcx>>),
-    Constant(Literal),
+    // Get rid and replace with a Term<'tcx>?
+    Constant(Literal<'tcx>),
     Cast(Box<Expr<'tcx>>, Ty<'tcx>, Ty<'tcx>),
     Tuple(Vec<Expr<'tcx>>),
     Span(Span, Box<Expr<'tcx>>),

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -413,7 +413,7 @@ impl<'body, 'tcx> BodyTranslator<'body, 'tcx> {
         match operand {
             Operand::Copy(pl) | Operand::Move(pl) => Expr::Place(*pl),
             Operand::Constant(c) => {
-                crate::constant::from_mir_constant(self.param_env(), self.ctx, self.names, c)
+                crate::constant::from_mir_constant(self.param_env(), self.ctx, c)
             }
         }
     }

--- a/creusot/src/translation/function/promoted.rs
+++ b/creusot/src/translation/function/promoted.rs
@@ -193,6 +193,6 @@ fn translate_operand<'tcx>(
 
     match operand {
         Move(pl) | Copy(pl) => translate_rplace_inner(ctx, names, body, pl.local, pl.projection),
-        Constant(c) => from_mir_constant(param_env, ctx, names, c).to_why(ctx, names, Some(body)),
+        Constant(c) => from_mir_constant(param_env, ctx, c).to_why(ctx, names, Some(body)),
     }
 }

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -61,7 +61,7 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                     if is_ghost_closure(self.tcx, c.literal.ty()).is_some() {
                         return;
                     };
-                    crate::constant::from_mir_constant(self.param_env(), self.ctx, self.names, c)
+                    crate::constant::from_mir_constant(self.param_env(), self.ctx, c)
                 }
             },
             Rvalue::Ref(_, ss, pl) => match ss {

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -18,7 +18,7 @@ use creusot_rustc::{
         def_id::{DefId, LocalDefId},
         HirId, OwnerId,
     },
-    macros::{Decodable, Encodable, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable},
+    macros::{TyDecodable, TyEncodable, TypeFoldable, TypeVisitable},
     middle::{
         mir::Mutability::*,
         thir::{
@@ -76,7 +76,7 @@ pub struct Term<'tcx> {
 #[derive(Clone, Debug, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable)]
 pub enum TermKind<'tcx> {
     Var(Symbol),
-    Lit(Literal),
+    Lit(Literal<'tcx>),
     Item(DefId, SubstsRef<'tcx>),
     Binary { op: BinOp, lhs: Box<Term<'tcx>>, rhs: Box<Term<'tcx>> },
     Unary { op: UnOp, arg: Box<Term<'tcx>> },
@@ -97,7 +97,7 @@ pub enum TermKind<'tcx> {
     Reborrow { cur: Box<Term<'tcx>>, fin: Box<Term<'tcx>> },
     Absurd,
 }
-impl<'tcx> TypeFoldable<'tcx> for Literal {
+impl<'tcx> TypeFoldable<'tcx> for Literal<'tcx> {
     fn try_fold_with<F: creusot_rustc::middle::ty::FallibleTypeFolder<'tcx>>(
         self,
         _: &mut F,
@@ -106,7 +106,7 @@ impl<'tcx> TypeFoldable<'tcx> for Literal {
     }
 }
 
-impl<'tcx> TypeVisitable<'tcx> for Literal {
+impl<'tcx> TypeVisitable<'tcx> for Literal<'tcx> {
     fn visit_with<V: creusot_rustc::middle::ty::TypeVisitor<'tcx>>(
         &self,
         _: &mut V,
@@ -115,8 +115,9 @@ impl<'tcx> TypeVisitable<'tcx> for Literal {
     }
 }
 
-#[derive(Clone, Debug, Decodable, Encodable)]
-pub enum Literal {
+// FIXME: Clean up this type: clarify use of ZST, Function, Integer types
+#[derive(Clone, Debug, TyDecodable, TyEncodable)]
+pub enum Literal<'tcx> {
     Bool(bool),
     // TODO: Find a way to make this a BigInt type
     Integer(i128),
@@ -125,7 +126,7 @@ pub enum Literal {
     Float(f64),
     String(String),
     ZST,
-    Function,
+    Function(DefId, SubstsRef<'tcx>),
 }
 
 #[derive(Clone, Debug, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable)]


### PR DESCRIPTION
Removes the `CloneMap` from `constant.rs` :) 

I also think that the handling of promoteds is probably wrong. From my understanding, a MIR body can refer to promoteds of *other* MIR bodies. This means that we can't just translate promoteds to local constants in a body, but instead they need to be treated as standalone items (with no `DefId`). 

Additionally, the `Literal` type in `pearlite.rs` is a little sketchy, it's become a grab bag of random stuff, and its unclear how different it is from `TermKind::Item` in certain cases. It needs cleanup.
