### PR TITLE
Proper unnest for move closures

### DIFF
--- a/creusot/tests/should_succeed/closures/01_basic.mlcfg
+++ b/creusot/tests/should_succeed/closures/01_basic.mlcfg
@@ -45,7 +45,7 @@ module C01Basic_UsesClosure_Closure0
     [#"../01_basic.rs" 1 0 1 0] true
   predicate resolve (_1' : c01basic_usesclosure_closure0) =
     true
-  let rec cfg c01Basic_UsesClosure_Closure0 [@cfg:stackify] [#"../01_basic.rs" 5 14 5 16] (_1' : c01basic_usesclosure_closure0) : bool
+  let rec cfg c01Basic_UsesClosure_Closure0 [@cfg:stackify] [#"../01_basic.rs" 6 14 6 16] (_1' : c01basic_usesclosure_closure0) : bool
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : bool;
@@ -83,7 +83,7 @@ module C01Basic_UsesClosure
   use prelude.Borrow
   clone C01Basic_UsesClosure_Closure0_Interface as Closure00 with
     axiom .
-  let rec cfg uses_closure [@cfg:stackify] [#"../01_basic.rs" 3 0 3 21] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
+  let rec cfg uses_closure [@cfg:stackify] [#"../01_basic.rs" 4 0 4 21] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var y_1 : bool;
   var _x_2 : bool;
@@ -101,7 +101,7 @@ module C01Basic_UsesClosure
     _3 <- _4;
     assume { Closure00.resolve _4 };
     _6 <- ();
-    _x_2 <- ([#"../01_basic.rs" 5 13 5 21] let () = _6 in Closure00.c01Basic_UsesClosure_Closure0 _3);
+    _x_2 <- ([#"../01_basic.rs" 6 13 6 21] let () = _6 in Closure00.c01Basic_UsesClosure_Closure0 _3);
     goto BB1
   }
   BB1 {
@@ -158,7 +158,7 @@ module C01Basic_MultiArg_Closure0
     [#"../01_basic.rs" 1 0 1 0] let (a, b) = args in true
   predicate resolve (_1' : c01basic_multiarg_closure0) =
     true
-  let rec cfg c01Basic_MultiArg_Closure0 [@cfg:stackify] [#"../01_basic.rs" 9 12 9 18] (_1' : c01basic_multiarg_closure0) (a : int32) (b : int32) : int32
+  let rec cfg c01Basic_MultiArg_Closure0 [@cfg:stackify] [#"../01_basic.rs" 10 12 10 18] (_1' : c01basic_multiarg_closure0) (a : int32) (b : int32) : int32
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : int32;
@@ -176,7 +176,7 @@ module C01Basic_MultiArg_Closure0
   BB0 {
     _4 <- a_2;
     _5 <- b_3;
-    _0 <- ([#"../01_basic.rs" 9 19 9 24] _4 + _5);
+    _0 <- ([#"../01_basic.rs" 10 19 10 24] _4 + _5);
     return _0
   }
   
@@ -190,7 +190,7 @@ module C01Basic_MultiArg
   use prelude.Borrow
   clone C01Basic_MultiArg_Closure0_Interface as Closure00 with
     axiom .
-  let rec cfg multi_arg [@cfg:stackify] [#"../01_basic.rs" 8 0 8 18] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
+  let rec cfg multi_arg [@cfg:stackify] [#"../01_basic.rs" 9 0 9 18] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var x_1 : Closure00.c01basic_multiarg_closure0;
   var _a_2 : int32;
@@ -204,10 +204,297 @@ module C01Basic_MultiArg
     _3 <- x_1;
     assume { Closure00.resolve x_1 };
     _4 <- ((0 : int32), (3 : int32));
-    _a_2 <- ([#"../01_basic.rs" 10 13 10 22] let (a, b) = _4 in Closure00.c01Basic_MultiArg_Closure0 _3 a b);
+    _a_2 <- ([#"../01_basic.rs" 11 13 11 22] let (a, b) = _4 in Closure00.c01Basic_MultiArg_Closure0 _3 a b);
     goto BB1
   }
   BB1 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+     ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module C01Basic_MoveClosure_Closure0_Interface
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.Int32
+  type c01basic_moveclosure_closure0  =
+    | C01Basic_MoveClosure_Closure0 (borrowed int32)
+    
+  let function c01basic_moveclosure_closure0_0 (self : c01basic_moveclosure_closure0) : borrowed int32
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C01Basic_MoveClosure_Closure0 a -> a
+      end
+  clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
+    type t = int32
+  predicate precondition [@cfg:stackify] (self : c01basic_moveclosure_closure0) (_ : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate unnest (self : c01basic_moveclosure_closure0) (_2' : c01basic_moveclosure_closure0) =
+    true
+  predicate postcondition_mut [@cfg:stackify] (self : borrowed c01basic_moveclosure_closure0) (_ : ()) (result : ()) =
+    ([#"../01_basic.rs" 1 0 1 0] true) && unnest ( * self) ( ^ self)
+  predicate postcondition_once [@cfg:stackify] (self : c01basic_moveclosure_closure0) (_ : ()) (result : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate resolve (_1' : c01basic_moveclosure_closure0) =
+    Resolve0.resolve (c01basic_moveclosure_closure0_0 _1')
+  val c01Basic_MoveClosure_Closure0 [@cfg:stackify] (_1' : borrowed c01basic_moveclosure_closure0) : ()
+    ensures { unnest ( * _1') ( ^ _1') }
+    
+end
+module C01Basic_MoveClosure_Closure0
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.Int32
+  type c01basic_moveclosure_closure0  =
+    | C01Basic_MoveClosure_Closure0 (borrowed int32)
+    
+  let function c01basic_moveclosure_closure0_0 (self : c01basic_moveclosure_closure0) : borrowed int32
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C01Basic_MoveClosure_Closure0 a -> a
+      end
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = int32
+  predicate precondition [@cfg:stackify] (self : c01basic_moveclosure_closure0) (_ : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate unnest (self : c01basic_moveclosure_closure0) (_2' : c01basic_moveclosure_closure0) =
+    true
+  predicate postcondition_mut [@cfg:stackify] (self : borrowed c01basic_moveclosure_closure0) (_ : ()) (result : ()) =
+    ([#"../01_basic.rs" 1 0 1 0] true) && unnest ( * self) ( ^ self)
+  predicate postcondition_once [@cfg:stackify] (self : c01basic_moveclosure_closure0) (_ : ()) (result : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate resolve (_1' : c01basic_moveclosure_closure0) =
+    Resolve0.resolve (c01basic_moveclosure_closure0_0 _1')
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+    type t = c01basic_moveclosure_closure0
+  let rec cfg c01Basic_MoveClosure_Closure0 [@cfg:stackify] [#"../01_basic.rs" 19 16 19 23] (_1' : borrowed c01basic_moveclosure_closure0) : ()
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var _1 : borrowed c01basic_moveclosure_closure0;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    _1 <- { _1 with current = (let C01Basic_MoveClosure_Closure0 a =  * _1 in C01Basic_MoveClosure_Closure0 ({ (c01basic_moveclosure_closure0_0 ( * _1)) with current = ([#"../01_basic.rs" 20 8 20 15]  * c01basic_moveclosure_closure0_0 ( * _1) + (1 : int32)) })) };
+    assume { Resolve1.resolve _1 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C01Basic_MoveClosure_Interface
+  val move_closure [@cfg:stackify] (_ : ()) : ()
+end
+module C01Basic_MoveClosure
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.Int32
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = int32
+  clone C01Basic_MoveClosure_Closure0_Interface as Closure00 with
+    predicate Resolve0.resolve = Resolve0.resolve,
+    axiom .
+  let rec cfg move_closure [@cfg:stackify] [#"../01_basic.rs" 16 0 16 21] (_ : ()) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var a_1 : borrowed int32;
+  var _2 : int32;
+  var x_3 : Closure00.c01basic_moveclosure_closure0;
+  var _4 : ();
+  var _5 : borrowed Closure00.c01basic_moveclosure_closure0;
+  var _6 : ();
+  var _7 : ();
+  var _8 : borrowed Closure00.c01basic_moveclosure_closure0;
+  var _9 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _2 <- (0 : int32);
+    a_1 <- borrow_mut _2;
+    _2 <-  ^ a_1;
+    x_3 <- Closure00.C01Basic_MoveClosure_Closure0 a_1;
+    _5 <- borrow_mut x_3;
+    x_3 <-  ^ _5;
+    _6 <- ();
+    _4 <- ([#"../01_basic.rs" 23 4 23 9] let () = _6 in Closure00.c01Basic_MoveClosure_Closure0 _5);
+    goto BB1
+  }
+  BB1 {
+    _8 <- borrow_mut x_3;
+    x_3 <-  ^ _8;
+    assume { Closure00.resolve x_3 };
+    _9 <- ();
+    _7 <- ([#"../01_basic.rs" 24 4 24 9] let () = _9 in Closure00.c01Basic_MoveClosure_Closure0 _8);
+    goto BB2
+  }
+  BB2 {
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C01Basic_NewRef_Interface
+  type t
+  use prelude.Borrow
+  val new_ref [@cfg:stackify] (_ : ()) : borrowed t
+end
+module C01Basic_NewRef
+  type t
+  use prelude.Borrow
+  val new_ref [@cfg:stackify] (_ : ()) : borrowed t
+end
+module C01Basic_MoveMut_Closure0_Interface
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.UInt32
+  type c01basic_movemut_closure0  =
+    | C01Basic_MoveMut_Closure0 (borrowed uint32)
+    
+  let function c01basic_movemut_closure0_0 (self : c01basic_movemut_closure0) : borrowed uint32
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C01Basic_MoveMut_Closure0 a -> a
+      end
+  clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
+    type t = uint32
+  predicate precondition [@cfg:stackify] (self : c01basic_movemut_closure0) (_ : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate unnest (self : c01basic_movemut_closure0) (_2' : c01basic_movemut_closure0) =
+    true
+  predicate postcondition_mut [@cfg:stackify] (self : borrowed c01basic_movemut_closure0) (_ : ()) (result : ()) =
+    ([#"../01_basic.rs" 1 0 1 0] true) && unnest ( * self) ( ^ self)
+  predicate postcondition_once [@cfg:stackify] (self : c01basic_movemut_closure0) (_ : ()) (result : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate resolve (_1' : c01basic_movemut_closure0) =
+    Resolve0.resolve (c01basic_movemut_closure0_0 _1')
+  val c01Basic_MoveMut_Closure0 [@cfg:stackify] (_1' : borrowed c01basic_movemut_closure0) : ()
+    ensures { unnest ( * _1') ( ^ _1') }
+    
+end
+module C01Basic_MoveMut_Closure0
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.UInt32
+  type c01basic_movemut_closure0  =
+    | C01Basic_MoveMut_Closure0 (borrowed uint32)
+    
+  let function c01basic_movemut_closure0_0 (self : c01basic_movemut_closure0) : borrowed uint32
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C01Basic_MoveMut_Closure0 a -> a
+      end
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = uint32
+  predicate precondition [@cfg:stackify] (self : c01basic_movemut_closure0) (_ : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate unnest (self : c01basic_movemut_closure0) (_2' : c01basic_movemut_closure0) =
+    true
+  predicate postcondition_mut [@cfg:stackify] (self : borrowed c01basic_movemut_closure0) (_ : ()) (result : ()) =
+    ([#"../01_basic.rs" 1 0 1 0] true) && unnest ( * self) ( ^ self)
+  predicate postcondition_once [@cfg:stackify] (self : c01basic_movemut_closure0) (_ : ()) (result : ()) =
+    [#"../01_basic.rs" 1 0 1 0] true
+  predicate resolve (_1' : c01basic_movemut_closure0) =
+    Resolve0.resolve (c01basic_movemut_closure0_0 _1')
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+    type t = c01basic_movemut_closure0
+  clone C01Basic_NewRef_Interface as NewRef0 with
+    type t = uint32
+  let rec cfg c01Basic_MoveMut_Closure0 [@cfg:stackify] [#"../01_basic.rs" 35 16 35 23] (_1' : borrowed c01basic_movemut_closure0) : ()
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var _1 : borrowed c01basic_movemut_closure0;
+  var _2 : borrowed uint32;
+  var _3 : borrowed uint32;
+  {
+    _1 <- _1';
+    goto BB0
+  }
+  BB0 {
+    _3 <- ([#"../01_basic.rs" 36 12 36 21] NewRef0.new_ref ());
+    goto BB1
+  }
+  BB1 {
+    _2 <- borrow_mut ( * _3);
+    _3 <- { _3 with current = ( ^ _2) };
+    assume { Resolve0.resolve _3 };
+    assume { Resolve0.resolve (c01basic_movemut_closure0_0 ( * _1)) };
+    _1 <- { _1 with current = (let C01Basic_MoveMut_Closure0 a =  * _1 in C01Basic_MoveMut_Closure0 _2) };
+    _2 <- any borrowed uint32;
+    assume { Resolve1.resolve _1 };
+    _0 <- ();
+    return _0
+  }
+  
+end
+module C01Basic_MoveMut_Interface
+  val move_mut [@cfg:stackify] (_ : ()) : ()
+end
+module C01Basic_MoveMut
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.UInt32
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = uint32
+  clone C01Basic_MoveMut_Closure0_Interface as Closure00 with
+    predicate Resolve0.resolve = Resolve0.resolve,
+    axiom .
+  let rec cfg move_mut [@cfg:stackify] [#"../01_basic.rs" 32 0 32 17] (_ : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var x_1 : borrowed uint32;
+  var _2 : uint32;
+  var a_3 : Closure00.c01basic_movemut_closure0;
+  var _4 : ();
+  var _5 : borrowed Closure00.c01basic_movemut_closure0;
+  var _6 : ();
+  var _7 : ();
+  var _8 : borrowed Closure00.c01basic_movemut_closure0;
+  var _9 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    _2 <- (0 : uint32);
+    x_1 <- borrow_mut _2;
+    _2 <-  ^ x_1;
+    a_3 <- Closure00.C01Basic_MoveMut_Closure0 x_1;
+    _5 <- borrow_mut a_3;
+    a_3 <-  ^ _5;
+    _6 <- ();
+    _4 <- ([#"../01_basic.rs" 38 4 38 9] let () = _6 in Closure00.c01Basic_MoveMut_Closure0 _5);
+    goto BB1
+  }
+  BB1 {
+    _8 <- borrow_mut a_3;
+    a_3 <-  ^ _8;
+    assume { Closure00.resolve a_3 };
+    _9 <- ();
+    _7 <- ([#"../01_basic.rs" 39 4 39 9] let () = _9 in Closure00.c01Basic_MoveMut_Closure0 _8);
+    goto BB2
+  }
+  BB2 {
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/closures/01_basic.rs
+++ b/creusot/tests/should_succeed/closures/01_basic.rs
@@ -1,4 +1,5 @@
 extern crate creusot_contracts;
+use creusot_contracts::*;
 
 pub fn uses_closure() {
     let y = true;
@@ -10,10 +11,30 @@ pub fn multi_arg() {
     let _a = (x)(0, 3);
 }
 
-// fn generic_closure<T>(x: T) -> T{
-//   (|| { x })()
-// }
+// Sadly, the unnesting predicate is weakened when we capture things by *value*
+// even if we treat it like a reference capture.
+pub fn move_closure() {
+    let a = &mut 0i32;
 
-// fn call_closure() {
-//   closure_param(|x : u32| { () })
-// }
+    let mut x = move || {
+        *a += 1;
+    };
+
+    (x)();
+    (x)();
+}
+
+#[trusted]
+pub fn new_ref<'a, T>() -> &'a mut T {
+    panic!()
+}
+
+pub fn move_mut() {
+    let mut x = &mut 0u32;
+
+    let mut a = move || {
+        x = new_ref();
+    };
+    (a)();
+    (a)();
+}

--- a/creusot/tests/should_succeed/closures/01_basic.stderr
+++ b/creusot/tests/should_succeed/closures/01_basic.stderr
@@ -1,0 +1,20 @@
+warning: value assigned to `x` is never read
+  --> 01_basic.rs:36:9
+   |
+36 |         x = new_ref();
+   |         ^
+   |
+   = help: maybe it is overwritten before being read?
+   = note: `#[warn(unused_assignments)]` on by default
+
+warning: unused variable: `x`
+  --> 01_basic.rs:36:9
+   |
+36 |         x = new_ref();
+   |         ^
+   |
+   = help: did you mean to capture by reference instead?
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Use better information to calculate the unnesting predicate. We can distinguish between the differetn kinds of captures this way.
