### PR TITLE
Add spec for Instant and refine spec for Duration

### DIFF
--- a/creusot-contracts/src/logic/ord.rs
+++ b/creusot-contracts/src/logic/ord.rs
@@ -232,3 +232,42 @@ impl<A: OrdLogic, B: OrdLogic> OrdLogic for (A, B) {
     #[logic]
     fn eq_cmp(_: Self, _: Self) {}
 }
+
+impl<T: OrdLogic> OrdLogic for Option<T> {
+    #[logic]
+    fn cmp_log(self, o: Self) -> Ordering {
+        match (self, o) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(x), Some(y)) => x.cmp_log(y),
+        }
+    }
+
+    #[logic]
+    fn cmp_le_log(_: Self, _: Self) {}
+
+    #[logic]
+    fn cmp_lt_log(_: Self, _: Self) {}
+
+    #[logic]
+    fn cmp_ge_log(_: Self, _: Self) {}
+
+    #[logic]
+    fn cmp_gt_log(_: Self, _: Self) {}
+
+    #[logic]
+    fn refl(_: Self) {}
+
+    #[logic]
+    fn trans(_: Self, _: Self, _: Self, _: Ordering) {}
+
+    #[logic]
+    fn antisym1(_: Self, _: Self) {}
+
+    #[logic]
+    fn antisym2(_: Self, _: Self) {}
+
+    #[logic]
+    fn eq_cmp(_: Self, _: Self) {}
+}

--- a/creusot-contracts/src/logic/ord.rs
+++ b/creusot-contracts/src/logic/ord.rs
@@ -244,30 +244,43 @@ impl<T: OrdLogic> OrdLogic for Option<T> {
         }
     }
 
-    #[logic]
-    fn cmp_le_log(_: Self, _: Self) {}
+    #[law]
+    #[ensures(x.le_log(y) == (x.cmp_log(y) != Ordering::Greater))]
+    fn cmp_le_log(x: Self, y: Self) {}
 
-    #[logic]
-    fn cmp_lt_log(_: Self, _: Self) {}
+    #[law]
+    #[ensures(x.lt_log(y) == (x.cmp_log(y) == Ordering::Less))]
+    fn cmp_lt_log(x: Self, y: Self) {}
 
-    #[logic]
-    fn cmp_ge_log(_: Self, _: Self) {}
+    #[law]
+    #[ensures(x.ge_log(y) == (x.cmp_log(y) != Ordering::Less))]
+    fn cmp_ge_log(x: Self, y: Self) {}
 
-    #[logic]
-    fn cmp_gt_log(_: Self, _: Self) {}
+    #[law]
+    #[ensures(x.gt_log(y) == (x.cmp_log(y) == Ordering::Greater))]
+    fn cmp_gt_log(x: Self, y: Self) {}
 
-    #[logic]
-    fn refl(_: Self) {}
+    #[law]
+    #[ensures(x.cmp_log(x) == Ordering::Equal)]
+    fn refl(x: Self) {}
 
-    #[logic]
-    fn trans(_: Self, _: Self, _: Self, _: Ordering) {}
+    #[law]
+    #[requires(x.cmp_log(y) == o)]
+    #[requires(y.cmp_log(z) == o)]
+    #[ensures(x.cmp_log(z) == o)]
+    fn trans(x: Self, y: Self, z: Self, o: Ordering) {}
 
-    #[logic]
-    fn antisym1(_: Self, _: Self) {}
+    #[law]
+    #[requires(x.cmp_log(y) == Ordering::Less)]
+    #[ensures(y.cmp_log(x) == Ordering::Greater)]
+    fn antisym1(x: Self, y: Self) {}
 
-    #[logic]
-    fn antisym2(_: Self, _: Self) {}
+    #[law]
+    #[requires(x.cmp_log(y) == Ordering::Greater)]
+    #[ensures(y.cmp_log(x) == Ordering::Less)]
+    fn antisym2(x: Self, y: Self) {}
 
-    #[logic]
-    fn eq_cmp(_: Self, _: Self) {}
+    #[law]
+    #[ensures((x == y) == (x.cmp_log(y) == Ordering::Equal))]
+    fn eq_cmp(x: Self, y: Self) {}
 }

--- a/creusot/tests/should_succeed/bug/387.mlcfg
+++ b/creusot/tests/should_succeed/bug/387.mlcfg
@@ -253,15 +253,15 @@ module CreusotContracts_Logic_Int_Impl14_DeepModel
     ensures { result = deep_model self }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Stub
   use mach.int.Int
   predicate ge_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Interface
   use mach.int.Int
   predicate ge_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog
+module CreusotContracts_Logic_Ord_Impl2_GeLog
   use mach.int.Int
   use int.Int
   predicate ge_log (self : int) (_2' : int) =
@@ -270,15 +270,15 @@ module CreusotContracts_Logic_Ord_Impl1_GeLog
     ensures { result = ge_log self _2' }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Interface
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog
+module CreusotContracts_Logic_Ord_Impl2_LeLog
   use mach.int.Int
   use int.Int
   predicate le_log (self : int) (_2' : int) =
@@ -287,15 +287,15 @@ module CreusotContracts_Logic_Ord_Impl1_LeLog
     ensures { result = le_log self _2' }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Stub
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Interface
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog
+module CreusotContracts_Logic_Ord_Impl2_LtLog
   use mach.int.Int
   use int.Int
   predicate lt_log (self : int) (_2' : int) =
@@ -322,9 +322,9 @@ module C387_Impl0_Height
   use prelude.Borrow
   use prelude.IntSize
   clone CreusotContracts_Logic_Int_Impl14_DeepModelTy_Type as DeepModelTy0
-  clone CreusotContracts_Logic_Ord_Impl1_LtLog as LtLog0
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog as LeLog0
-  clone CreusotContracts_Logic_Ord_Impl1_GeLog as GeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LtLog as LtLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_GeLog as GeLog0
   clone CreusotContracts_Logic_Int_Impl14_DeepModel as DeepModel0
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use C387_Node_Type as C387_Node_Type

--- a/creusot/tests/should_succeed/constrained_types.mlcfg
+++ b/creusot/tests/should_succeed/constrained_types.mlcfg
@@ -271,15 +271,15 @@ module CreusotContracts_Model_Impl8_DeepModel
     ensures { result = deep_model self }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Stub
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Interface
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog
+module CreusotContracts_Logic_Ord_Impl2_LtLog
   use mach.int.Int
   use int.Int
   predicate lt_log (self : int) (_2' : int) =
@@ -318,7 +318,7 @@ module ConstrainedTypes_UsesConcreteInstance
   use mach.int.UInt32
   use prelude.Borrow
   clone CreusotContracts_Logic_Int_Impl12_DeepModel as DeepModel2
-  clone CreusotContracts_Logic_Ord_Impl1_LtLog as LtLog1
+  clone CreusotContracts_Logic_Ord_Impl2_LtLog as LtLog1
   use mach.int.Int
   clone CreusotContracts_Logic_Int_Impl12_DeepModelTy_Type as DeepModelTy1
   clone CreusotContracts_Model_Impl8_DeepModel as DeepModel1 with

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -15,58 +15,6 @@ module CreusotContracts_Std1_Time_NanosToSecs
     ensures { result = nanos_to_secs nanos }
     
 end
-module Core_Time_Nanoseconds_Type
-  use mach.int.Int
-  use mach.int.UInt32
-  type t_nanoseconds  =
-    | C_Nanoseconds uint32
-    
-end
-module Core_Time_Duration_Type
-  use mach.int.Int
-  use mach.int.UInt64
-  use Core_Time_Nanoseconds_Type as Core_Time_Nanoseconds_Type
-  type t_duration  =
-    | C_Duration uint64 (Core_Time_Nanoseconds_Type.t_nanoseconds)
-    
-end
-module Core_Num_Impl11_Max_Stub
-  use mach.int.Int
-  use prelude.UInt128
-  val constant mAX'  : uint128
-end
-module Core_Num_Impl11_Max
-  use mach.int.Int
-  use prelude.UInt128
-  let constant mAX'  : uint128 = [@vc:do_not_keep_trace] [@vc:sp]
-    (340282366920938463463374607431768211455 : uint128)
-end
-module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
-  use mach.int.Int
-  use prelude.UInt128
-  use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
-  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-end
-module CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface
-  use mach.int.Int
-  use prelude.UInt128
-  use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
-  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= UInt128.to_int Max0.mAX'
-end
-module CreusotContracts_Std1_Time_Impl0_ShallowModel
-  use mach.int.Int
-  use prelude.UInt128
-  use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
-  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-  val shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-    ensures { result = shallow_model self }
-    
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= UInt128.to_int Max0.mAX'
-end
 module CreusotContracts_Std1_Time_SecsToNanos_Stub
   use mach.int.Int
   function secs_to_nanos (secs : int) : int
@@ -83,6 +31,21 @@ module CreusotContracts_Std1_Time_SecsToNanos
     ensures { result = secs_to_nanos secs }
     
 end
+module Core_Time_Nanoseconds_Type
+  use mach.int.Int
+  use mach.int.UInt32
+  type t_nanoseconds  =
+    | C_Nanoseconds uint32
+    
+end
+module Core_Time_Duration_Type
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Nanoseconds_Type as Core_Time_Nanoseconds_Type
+  type t_duration  =
+    | C_Duration uint64 (Core_Time_Nanoseconds_Type.t_nanoseconds)
+    
+end
 module Core_Num_Impl10_Max_Stub
   use mach.int.Int
   use mach.int.UInt64
@@ -94,17 +57,46 @@ module Core_Num_Impl10_Max
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
     (18446744073709551615 : uint64)
 end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+  val shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+    ensures { result = shallow_model self }
+    
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
 module Core_Time_Impl1_New_Interface
   use mach.int.UInt64
   use mach.int.UInt32
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max1
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
-  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
-    axiom .
   clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
   clone CreusotContracts_Std1_Time_NanosToSecs_Stub as NanosToSecs0
   val new [@cfg:stackify] (secs : uint64) (nanos : uint32) : Core_Time_Duration_Type.t_duration
     requires {UInt64.to_int secs + NanosToSecs0.nanos_to_secs (UInt32.to_int nanos) <= UInt64.to_int Max0.mAX'}
@@ -115,13 +107,13 @@ module Core_Time_Impl1_New
   use mach.int.UInt64
   use mach.int.UInt32
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max1
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
-  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
-    axiom .
   clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
   clone CreusotContracts_Std1_Time_NanosToSecs_Interface as NanosToSecs0
   val new [@cfg:stackify] (secs : uint64) (nanos : uint32) : Core_Time_Duration_Type.t_duration
     requires {UInt64.to_int secs + NanosToSecs0.nanos_to_secs (UInt32.to_int nanos) <= UInt64.to_int Max0.mAX'}
@@ -188,38 +180,47 @@ module CreusotContracts_Std1_Time_Impl0_ShallowModelTy_Type
 end
 module Core_Time_Impl1_AsNanos_Interface
   use prelude.UInt128
-  use prelude.Borrow
+  use mach.int.UInt64
   use mach.int.Int
+  use prelude.Borrow
   clone CreusotContracts_Std1_Time_Impl0_ShallowModelTy_Type as ShallowModelTy0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   val as_nanos [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) : uint128
     ensures { UInt128.to_int result = ShallowModel0.shallow_model self }
+    ensures { UInt128.to_int result <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999 }
     
 end
 module Core_Time_Impl1_AsNanos
   use prelude.UInt128
-  use prelude.Borrow
+  use mach.int.UInt64
   use mach.int.Int
+  use prelude.Borrow
   clone CreusotContracts_Std1_Time_Impl0_ShallowModelTy_Type as ShallowModelTy0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   val as_nanos [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) : uint128
     ensures { UInt128.to_int result = ShallowModel0.shallow_model self }
+    ensures { UInt128.to_int result <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999 }
     
 end
 module Core_Time_Impl1_FromSecs_Interface
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_secs [@cfg:stackify] (secs : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
@@ -228,11 +229,12 @@ end
 module Core_Time_Impl1_FromSecs
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_secs [@cfg:stackify] (secs : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
@@ -241,10 +243,12 @@ end
 module Core_Time_Impl1_FromMillis_Interface
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_millis [@cfg:stackify] (millis : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int millis * 1000000 }
@@ -253,10 +257,12 @@ end
 module Core_Time_Impl1_FromMillis
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_millis [@cfg:stackify] (millis : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int millis * 1000000 }
@@ -265,10 +271,12 @@ end
 module Core_Time_Impl1_FromMicros_Interface
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_micros [@cfg:stackify] (micros : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int micros * 1000 }
@@ -277,10 +285,12 @@ end
 module Core_Time_Impl1_FromMicros
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_micros [@cfg:stackify] (micros : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int micros * 1000 }
@@ -289,10 +299,12 @@ end
 module Core_Time_Impl1_FromNanos_Interface
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_nanos [@cfg:stackify] (nanos : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int nanos }
@@ -301,10 +313,12 @@ end
 module Core_Time_Impl1_FromNanos
   use mach.int.UInt64
   use mach.int.Int
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_nanos [@cfg:stackify] (nanos : uint64) : Core_Time_Duration_Type.t_duration
     ensures { ShallowModel0.shallow_model result = UInt64.to_int nanos }
@@ -614,7 +628,7 @@ module Core_Time_Impl1_CheckedAdd_Interface
   use mach.int.UInt64
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max1
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
@@ -623,7 +637,8 @@ module Core_Time_Impl1_CheckedAdd_Interface
   clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_NanosToSecs_Stub as NanosToSecs0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_add [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
@@ -635,7 +650,7 @@ module Core_Time_Impl1_CheckedAdd
   use mach.int.UInt64
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max1
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
@@ -644,7 +659,8 @@ module Core_Time_Impl1_CheckedAdd
   clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_NanosToSecs_Interface as NanosToSecs0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_add [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
@@ -687,7 +703,8 @@ module Core_Time_Impl1_CheckedSub_Interface
   use mach.int.Int
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
@@ -695,6 +712,7 @@ module Core_Time_Impl1_CheckedSub_Interface
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_sub [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs < 0 -> result = Core_Option_Option_Type.C_None }
@@ -705,7 +723,8 @@ module Core_Time_Impl1_CheckedSub
   use mach.int.Int
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
@@ -713,6 +732,7 @@ module Core_Time_Impl1_CheckedSub
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_sub [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs < 0 -> result = Core_Option_Option_Type.C_None }
@@ -725,7 +745,7 @@ module Core_Time_Impl1_CheckedMul_Interface
   use mach.int.UInt64
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max1
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
@@ -734,7 +754,8 @@ module Core_Time_Impl1_CheckedMul_Interface
   clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_NanosToSecs_Stub as NanosToSecs0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_mul [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : uint32) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
@@ -747,7 +768,7 @@ module Core_Time_Impl1_CheckedMul
   use mach.int.UInt64
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
-  clone Core_Num_Impl11_Max_Stub as Max1
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
@@ -756,7 +777,8 @@ module Core_Time_Impl1_CheckedMul
   clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_NanosToSecs_Interface as NanosToSecs0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_mul [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : uint32) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
     ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
@@ -766,12 +788,14 @@ end
 module Core_Time_Impl1_CheckedDiv_Interface
   use mach.int.Int
   use mach.int.UInt32
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
@@ -785,12 +809,14 @@ end
 module Core_Time_Impl1_CheckedDiv
   use mach.int.Int
   use mach.int.UInt32
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   use mach.int.Int
   clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
   use Core_Time_Duration_Type as Core_Time_Duration_Type
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
@@ -801,40 +827,104 @@ module Core_Time_Impl1_CheckedDiv
     ensures { rhs <> (0 : uint32) -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (div (ShallowModel0.shallow_model self) (UInt32.to_int rhs)) }
     
 end
-module CreusotContracts_Std1_Time_Impl1_DeepModel_Stub
+module Core_Time_Impl2_Add_Interface
   use mach.int.Int
-  use prelude.UInt128
+  use mach.int.UInt64
   use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val add [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
+    requires {ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999}
+    ensures { ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    
+end
+module Core_Time_Impl2_Add
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val add [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
+    requires {ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999}
+    ensures { ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    
+end
+module Core_Time_Impl4_Sub_Interface
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val sub [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
+    requires {ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0}
+    ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    
+end
+module Core_Time_Impl4_Sub
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val sub [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
+    requires {ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0}
+    ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    
+end
+module CreusotContracts_Std1_Time_Impl1_DeepModel_Stub
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   function deep_model (self : Core_Time_Duration_Type.t_duration) : int
 end
 module CreusotContracts_Std1_Time_Impl1_DeepModel_Interface
   use mach.int.Int
-  use prelude.UInt128
+  use mach.int.UInt64
   use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   function deep_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= UInt128.to_int Max0.mAX'
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module CreusotContracts_Std1_Time_Impl1_DeepModel
   use mach.int.Int
-  use prelude.UInt128
+  use mach.int.UInt64
   use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
     val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   function deep_model (self : Core_Time_Duration_Type.t_duration) : int
   val deep_model (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= UInt128.to_int Max0.mAX'
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module Duration_TestDuration_Interface
   val test_duration [@cfg:stackify] [#"../duration.rs" 7 0 7 22] (_1' : ()) : ()
@@ -846,12 +936,15 @@ module Duration_TestDuration
   use mach.int.UInt64
   use mach.int.UInt32
   use Core_Time_Duration_Type as Core_Time_Duration_Type
-  clone Core_Num_Impl11_Max as Max1
+  clone CreusotContracts_Std1_Time_SecsToNanos as SecsToNanos0
+  clone Core_Num_Impl10_Max as Max0
   clone CreusotContracts_Std1_Time_Impl0_ShallowModel as ShallowModel0 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   clone CreusotContracts_Std1_Time_Impl1_DeepModel as DeepModel1 with
-    val Max0.mAX' = Max1.mAX',
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     axiom .
   use mach.int.Int
@@ -868,23 +961,31 @@ module Duration_TestDuration
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Std1_Time_SecsToNanos as SecsToNanos0
-  clone Core_Num_Impl10_Max as Max0
   clone CreusotContracts_Std1_Time_NanosToSecs as NanosToSecs0
+  clone Core_Time_Impl4_Sub_Interface as Sub0 with
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Core_Time_Impl2_Add_Interface as Add0 with
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_CheckedDiv_Interface as CheckedDiv0 with
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_CheckedMul_Interface as CheckedMul0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function NanosToSecs0.nanos_to_secs = NanosToSecs0.nanos_to_secs,
     val Max0.mAX' = Max0.mAX',
     function DeepModel0.deep_model = DeepModel0.deep_model,
-    val Max1.mAX' = Max1.mAX'
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_CheckedSub_Interface as CheckedSub0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function DeepModel0.deep_model = DeepModel0.deep_model,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Option_Impl0_IsSome_Interface as IsSome0 with
     type t = Core_Time_Duration_Type.t_duration
   clone Core_Option_Impl0_IsNone_Interface as IsNone0 with
@@ -894,7 +995,7 @@ module Duration_TestDuration
     function NanosToSecs0.nanos_to_secs = NanosToSecs0.nanos_to_secs,
     val Max0.mAX' = Max0.mAX',
     function DeepModel0.deep_model = DeepModel0.deep_model,
-    val Max1.mAX' = Max1.mAX'
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_AsMicros_Interface as AsMicros0 with
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function NanosToMicros0.nanos_to_micros = NanosToMicros0.nanos_to_micros
@@ -916,25 +1017,29 @@ module Duration_TestDuration
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone Core_Time_Impl1_FromNanos_Interface as FromNanos0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_FromMicros_Interface as FromMicros0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_FromMillis_Interface as FromMillis0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_FromSecs_Interface as FromSecs0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
-    val Max0.mAX' = Max1.mAX'
+    val Max0.mAX' = Max0.mAX'
   clone Core_Time_Impl1_AsNanos_Interface as AsNanos0 with
-    function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   clone Core_Time_Impl1_New_Interface as New0 with
     function NanosToSecs0.nanos_to_secs = NanosToSecs0.nanos_to_secs,
     val Max0.mAX' = Max0.mAX',
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
-    val Max1.mAX' = Max1.mAX'
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
   let rec cfg test_duration [@cfg:stackify] [#"../duration.rs" 7 0 7 22] (_1' : ()) : ()
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1077,6 +1182,14 @@ module Duration_TestDuration
   var _142 : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration);
   var _143 : Core_Time_Duration_Type.t_duration;
   var _144 : ();
+  var sum_145 : Core_Time_Duration_Type.t_duration;
+  var _146 : Core_Time_Duration_Type.t_duration;
+  var _147 : Core_Time_Duration_Type.t_duration;
+  var difference_148 : Core_Time_Duration_Type.t_duration;
+  var _149 : Core_Time_Duration_Type.t_duration;
+  var _150 : Core_Time_Duration_Type.t_duration;
+  var _151 : ();
+  var _153 : ();
   {
     goto BB0
   }
@@ -1474,6 +1587,22 @@ module Duration_TestDuration
   }
   BB71 {
     _138 <- ();
+    _146 <- d_millis_14;
+    _147 <- d_micros_17;
+    sum_145 <- ([#"../duration.rs" 50 14 50 33] Add0.add _146 _147);
+    goto BB72
+  }
+  BB72 {
+    _149 <- d_millis_14;
+    _150 <- d_micros_17;
+    difference_148 <- ([#"../duration.rs" 51 21 51 40] Sub0.sub _149 _150);
+    goto BB73
+  }
+  BB73 {
+    assert { [#"../duration.rs" 52 18 52 35] ShallowModel0.shallow_model sum_145 = 1001000 };
+    _151 <- ();
+    assert { [#"../duration.rs" 53 18 53 39] ShallowModel0.shallow_model difference_148 = 999000 };
+    _153 <- ();
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/duration.rs
+++ b/creusot/tests/should_succeed/duration.rs
@@ -46,4 +46,9 @@ pub fn test_duration() {
 
     assert!(d_secs.checked_div(0).is_none());
     assert!(d_secs.checked_div(10).is_some());
+
+    let sum = d_millis + d_micros;
+    let difference = d_millis - d_micros;
+    proof_assert!(@sum == 1_001_000);
+    proof_assert!(@difference == 999000);
 }

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -1,0 +1,2075 @@
+
+module Std_Sys_Unix_Time_Nanoseconds_Type
+  use mach.int.Int
+  use mach.int.UInt32
+  type t_nanoseconds  =
+    | C_Nanoseconds uint32
+    
+end
+module Std_Sys_Unix_Time_Timespec_Type
+  use mach.int.Int
+  use mach.int.Int64
+  use Std_Sys_Unix_Time_Nanoseconds_Type as Std_Sys_Unix_Time_Nanoseconds_Type
+  type t_timespec  =
+    | C_Timespec int64 (Std_Sys_Unix_Time_Nanoseconds_Type.t_nanoseconds)
+    
+end
+module Std_Sys_Unix_Time_Inner_Instant_Type
+  use Std_Sys_Unix_Time_Timespec_Type as Std_Sys_Unix_Time_Timespec_Type
+  type t_instant  =
+    | C_Instant (Std_Sys_Unix_Time_Timespec_Type.t_timespec)
+    
+end
+module Std_Time_Instant_Type
+  use Std_Sys_Unix_Time_Inner_Instant_Type as Std_Sys_Unix_Time_Inner_Instant_Type
+  type t_instant  =
+    | C_Instant (Std_Sys_Unix_Time_Inner_Instant_Type.t_instant)
+    
+end
+module CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  function shallow_model (self : Std_Time_Instant_Type.t_instant) : int
+end
+module CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  function shallow_model (self : Std_Time_Instant_Type.t_instant) : int
+  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . shallow_model self >= 0
+end
+module CreusotContracts_Std1_Time_Impl2_ShallowModel
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  function shallow_model (self : Std_Time_Instant_Type.t_instant) : int
+  val shallow_model (self : Std_Time_Instant_Type.t_instant) : int
+    ensures { result = shallow_model self }
+    
+  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . shallow_model self >= 0
+end
+module Std_Time_Impl0_Now_Interface
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
+    axiom .
+  val now [@cfg:stackify] (_1' : ()) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model result >= 0 }
+    
+end
+module Std_Time_Impl0_Now
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel0 with
+    axiom .
+  val now [@cfg:stackify] (_1' : ()) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model result >= 0 }
+    
+end
+module CreusotContracts_Std1_Time_SecsToNanos_Stub
+  use mach.int.Int
+  function secs_to_nanos (secs : int) : int
+end
+module CreusotContracts_Std1_Time_SecsToNanos_Interface
+  use mach.int.Int
+  function secs_to_nanos (secs : int) : int
+end
+module CreusotContracts_Std1_Time_SecsToNanos
+  use mach.int.Int
+  function secs_to_nanos (secs : int) : int =
+    secs * 1000000000
+  val secs_to_nanos (secs : int) : int
+    ensures { result = secs_to_nanos secs }
+    
+end
+module Core_Time_Nanoseconds_Type
+  use mach.int.Int
+  use mach.int.UInt32
+  type t_nanoseconds  =
+    | C_Nanoseconds uint32
+    
+end
+module Core_Time_Duration_Type
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Nanoseconds_Type as Core_Time_Nanoseconds_Type
+  type t_duration  =
+    | C_Duration uint64 (Core_Time_Nanoseconds_Type.t_nanoseconds)
+    
+end
+module Core_Num_Impl10_Max_Stub
+  use mach.int.Int
+  use mach.int.UInt64
+  val constant mAX'  : uint64
+end
+module Core_Num_Impl10_Max
+  use mach.int.Int
+  use mach.int.UInt64
+  let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
+    (18446744073709551615 : uint64)
+end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
+module CreusotContracts_Std1_Time_Impl0_ShallowModel
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+  val shallow_model (self : Core_Time_Duration_Type.t_duration) : int
+    ensures { result = shallow_model self }
+    
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
+module Core_Time_Impl1_FromSecs_Interface
+  use mach.int.UInt64
+  use mach.int.Int
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val from_secs [@cfg:stackify] (secs : uint64) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
+    
+end
+module Core_Time_Impl1_FromSecs
+  use mach.int.UInt64
+  use mach.int.Int
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val from_secs [@cfg:stackify] (secs : uint64) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
+    
+end
+module Std_Time_Impl0_Elapsed_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val elapsed [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model result >= 0 }
+    
+end
+module Std_Time_Impl0_Elapsed
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val elapsed [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model result >= 0 }
+    
+end
+module CreusotContracts_Model_DeepModel_DeepModelTy_Type
+  type self
+  type deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel_Stub
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel_Interface
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+  val deep_model (self : self) : DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module CreusotContracts_Model_Impl0_DeepModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  function deep_model (self : t) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_Impl0_DeepModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  function deep_model (self : t) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_Impl0_DeepModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
+    type self = t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  function deep_model (self : t) : DeepModelTy0.deepModelTy =
+    DeepModel0.deep_model self
+  val deep_model (self : t) : DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module Core_Cmp_Ordering_Type
+  type t_ordering  =
+    | C_Less
+    | C_Equal
+    | C_Greater
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : self) (_2' : self) : Core_Cmp_Ordering_Type.t_ordering
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : self) (_2' : self) : Core_Cmp_Ordering_Type.t_ordering
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : self) (_2' : self) : Core_Cmp_Ordering_Type.t_ordering
+  val cmp_log (self : self) (_2' : self) : Core_Cmp_Ordering_Type.t_ordering
+    ensures { result = cmp_log self _2' }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
+  type self
+  predicate ge_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface
+  type self
+  predicate ge_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GeLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  predicate ge_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+  val ge_log (self : self) (o : self) : bool
+    ensures { result = ge_log self o }
+    
+end
+module Core_Cmp_PartialOrd_Ge_Interface
+  type self
+  type rhs
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel1 with
+    type t = rhs,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel0 with
+    type t = self,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val ge [@cfg:stackify] (self : self) (other : rhs) : bool
+    ensures { result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    
+end
+module Core_Cmp_PartialOrd_Ge
+  type self
+  type rhs
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with
+    type self = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel1 with
+    type t = rhs,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel0 with
+    type t = self,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val ge [@cfg:stackify] (self : self) (other : rhs) : bool
+    ensures { result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    
+end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+end
+module CreusotContracts_Model_Impl10_DeepModel_Stub
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+end
+module CreusotContracts_Model_Impl10_DeepModel_Interface
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+end
+module CreusotContracts_Model_Impl10_DeepModel
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
+    type self = t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+   =
+    match (self) with
+      | Core_Option_Option_Type.C_Some t -> Core_Option_Option_Type.C_Some (DeepModel0.deep_model t)
+      | Core_Option_Option_Type.C_None -> Core_Option_Option_Type.C_None
+      end
+  val deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
+  type self
+  type shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Stub
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Interface
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+  val shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_ShallowModel_ShallowModel_Stub as ShallowModel0 with
+    type self = t,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
+    ShallowModel0.shallow_model self
+  val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub
+  type self
+  predicate lt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface
+  type self
+  predicate lt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LtLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  predicate lt_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+  val lt_log (self : self) (o : self) : bool
+    ensures { result = lt_log self o }
+    
+end
+module CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type
+  use mach.int.Int
+  type deepModelTy  =
+    int
+end
+module CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type
+  use mach.int.Int
+  type shallowModelTy  =
+    int
+end
+module Std_Time_Impl0_CheckedAdd_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = Core_Option_Option_Type.t_option int
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel1 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val checked_add [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
+    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> LtLog0.lt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    
+end
+module Std_Time_Impl0_CheckedAdd
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with
+    type self = Core_Option_Option_Type.t_option int
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel1 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val checked_add [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
+    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> LtLog0.lt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    
+end
+module Core_Option_Impl0_Unwrap_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val unwrap [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : t
+    requires {self <> Core_Option_Option_Type.C_None}
+    ensures { Core_Option_Option_Type.C_Some result = self }
+    
+end
+module Core_Option_Impl0_Unwrap
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val unwrap [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : t
+    requires {self <> Core_Option_Option_Type.C_None}
+    ensures { Core_Option_Option_Type.C_Some result = self }
+    
+end
+module Std_Time_Impl21_Eq_Interface
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Std_Time_Impl21_Eq
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Std_Time_Impl1_Add_Interface
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val add [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self < ShallowModel1.shallow_model result }
+    
+end
+module Std_Time_Impl1_Add
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val add [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self < ShallowModel1.shallow_model result }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
+  type self
+  predicate gt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface
+  type self
+  predicate gt_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_GtLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  predicate gt_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+  val gt_log (self : self) (o : self) : bool
+    ensures { result = gt_log self o }
+    
+end
+module Std_Time_Impl0_CheckedSub_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = Core_Option_Option_Type.t_option int
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel1 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Model_Impl10_DeepModel_Stub as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val checked_sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
+    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> GtLog0.gt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    
+end
+module Std_Time_Impl0_CheckedSub
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy0
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with
+    type self = Core_Option_Option_Type.t_option int
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel1 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Model_Impl10_DeepModel_Interface as DeepModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val checked_sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
+    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> GtLog0.gt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    
+end
+module Std_Time_Impl3_Sub_Interface
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self > ShallowModel1.shallow_model result }
+    
+end
+module Std_Time_Impl3_Sub
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  val sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
+    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self > ShallowModel1.shallow_model result }
+    
+end
+module Std_Time_Impl5_Sub_Interface
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel1 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
+    axiom .
+  val sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result = 0 }
+    
+end
+module Std_Time_Impl5_Sub
+  use mach.int.Int
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel1 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel0 with
+    axiom .
+  val sub [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result = 0 }
+    
+end
+module CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type
+  use mach.int.Int
+  type deepModelTy  =
+    int
+end
+module Core_Time_Impl29_Eq_Interface
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel0 with
+    type t = Core_Time_Duration_Type.t_duration,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (other : Core_Time_Duration_Type.t_duration) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Core_Time_Impl29_Eq
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel0 with
+    type t = Core_Time_Duration_Type.t_duration,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Core_Time_Duration_Type.t_duration) (other : Core_Time_Duration_Type.t_duration) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Core_Cmp_PartialOrd_Gt_Interface
+  type self
+  type rhs
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel1 with
+    type t = rhs,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel0 with
+    type t = self,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val gt [@cfg:stackify] (self : self) (other : rhs) : bool
+    ensures { result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    
+end
+module Core_Cmp_PartialOrd_Gt
+  type self
+  type rhs
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with
+    type self = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel1 with
+    type t = rhs,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel0 with
+    type t = self,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val gt [@cfg:stackify] (self : self) (other : rhs) : bool
+    ensures { result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    
+end
+module Std_Time_Impl0_DurationSince_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel2 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    
+end
+module Std_Time_Impl0_DurationSince
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel2 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    
+end
+module Std_Time_Impl0_CheckedDurationSince_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val checked_duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
+    ensures { ShallowModel0.shallow_model self >= ShallowModel1.shallow_model earlier -> result <> Core_Option_Option_Type.C_None }
+    ensures { ShallowModel0.shallow_model self < ShallowModel1.shallow_model earlier -> result = Core_Option_Option_Type.C_None }
+    
+end
+module Std_Time_Impl0_CheckedDurationSince
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val checked_duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
+    ensures { ShallowModel0.shallow_model self >= ShallowModel1.shallow_model earlier -> result <> Core_Option_Option_Type.C_None }
+    ensures { ShallowModel0.shallow_model self < ShallowModel1.shallow_model earlier -> result = Core_Option_Option_Type.C_None }
+    
+end
+module Core_Option_Impl0_IsSome_Interface
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val is_some [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (self <> Core_Option_Option_Type.C_None) }
+    
+end
+module Core_Option_Impl0_IsSome
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val is_some [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (self <> Core_Option_Option_Type.C_None) }
+    
+end
+module Core_Option_Impl0_IsNone_Interface
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val is_none [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    
+end
+module Core_Option_Impl0_IsNone
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val is_none [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    
+end
+module Std_Time_Impl0_SaturatingDurationSince_Interface
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel2 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val saturating_duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    
+end
+module Std_Time_Impl0_SaturatingDurationSince
+  use mach.int.Int
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Time_SecsToNanos_Interface as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface as ShallowModel2 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface as ShallowModel1 with
+    axiom .
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val saturating_duration_since [@cfg:stackify] (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
+    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    
+end
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Stub
+  use mach.int.Int
+  predicate ge_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Interface
+  use mach.int.Int
+  predicate ge_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl2_GeLog
+  use mach.int.Int
+  use int.Int
+  predicate ge_log (self : int) (_2' : int) =
+    Int.(>=) self _2'
+  val ge_log (self : int) (_2' : int) : bool
+    ensures { result = ge_log self _2' }
+    
+end
+module CreusotContracts_Logic_Ord_Impl2_GtLog_Stub
+  use mach.int.Int
+  predicate gt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl2_GtLog_Interface
+  use mach.int.Int
+  predicate gt_log (self : int) (_2' : int)
+end
+module CreusotContracts_Logic_Ord_Impl2_GtLog
+  use mach.int.Int
+  use int.Int
+  predicate gt_log (self : int) (_2' : int) =
+    Int.(>) self _2'
+  val gt_log (self : int) (_2' : int) : bool
+    ensures { result = gt_log self _2' }
+    
+end
+module CreusotContracts_Std1_Time_Impl1_DeepModel_Stub
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  function deep_model (self : Core_Time_Duration_Type.t_duration) : int
+end
+module CreusotContracts_Std1_Time_Impl1_DeepModel_Interface
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  function deep_model (self : Core_Time_Duration_Type.t_duration) : int
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
+module CreusotContracts_Std1_Time_Impl1_DeepModel
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
+  clone Core_Num_Impl10_Max_Stub as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub as ShallowModel0 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  function deep_model (self : Core_Time_Duration_Type.t_duration) : int
+  val deep_model (self : Core_Time_Duration_Type.t_duration) : int
+    ensures { result = deep_model self }
+    
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+end
+module CreusotContracts_Std1_Time_Impl3_DeepModel_Stub
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
+    axiom .
+  function deep_model (self : Std_Time_Instant_Type.t_instant) : int
+end
+module CreusotContracts_Std1_Time_Impl3_DeepModel_Interface
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
+    axiom .
+  function deep_model (self : Std_Time_Instant_Type.t_instant) : int
+  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0
+end
+module CreusotContracts_Std1_Time_Impl3_DeepModel
+  use mach.int.Int
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
+    axiom .
+  function deep_model (self : Std_Time_Instant_Type.t_instant) : int
+  val deep_model (self : Std_Time_Instant_Type.t_instant) : int
+    ensures { result = deep_model self }
+    
+  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub
+  type self
+  predicate le_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Interface
+  type self
+  predicate le_log (self : self) (o : self)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_LeLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  predicate le_log (self : self) (o : self) =
+    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+  val le_log (self : self) (o : self) : bool
+    ensures { result = le_log self o }
+    
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = self
+  function cmp_le_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = self
+  function cmp_le_log (x : self) (y : self) : ()
+  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = self
+  function cmp_le_log (x : self) (y : self) : ()
+  val cmp_le_log (x : self) (y : self) : ()
+    ensures { result = cmp_le_log x y }
+    
+  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = self
+  function cmp_lt_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = self
+  function cmp_lt_log (x : self) (y : self) : ()
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = self
+  function cmp_lt_log (x : self) (y : self) : ()
+  val cmp_lt_log (x : self) (y : self) : ()
+    ensures { result = cmp_lt_log x y }
+    
+  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = self
+  function cmp_ge_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = self
+  function cmp_ge_log (x : self) (y : self) : ()
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = self
+  function cmp_ge_log (x : self) (y : self) : ()
+  val cmp_ge_log (x : self) (y : self) : ()
+    ensures { result = cmp_ge_log x y }
+    
+  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = self
+  function cmp_gt_log (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = self
+  function cmp_gt_log (x : self) (y : self) : ()
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = self
+  function cmp_gt_log (x : self) (y : self) : ()
+  val cmp_gt_log (x : self) (y : self) : ()
+    ensures { result = cmp_gt_log x y }
+    
+  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function refl (x : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function refl (x : self) : ()
+  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Refl
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function refl (x : self) : ()
+  val refl (x : self) : ()
+    ensures { result = refl x }
+    
+  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Trans
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+  val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+    requires {CmpLog0.cmp_log x y = o}
+    requires {CmpLog0.cmp_log y z = o}
+    ensures { result = trans x y z o }
+    
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym1 (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym1 (x : self) (y : self) : ()
+  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym1 (x : self) (y : self) : ()
+  val antisym1 (x : self) (y : self) : ()
+    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    ensures { result = antisym1 x y }
+    
+  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym2 (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym2 (x : self) (y : self) : ()
+  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+end
+module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function antisym2 (x : self) (y : self) : ()
+  val antisym2 (x : self) (y : self) : ()
+    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    ensures { result = antisym2 x y }
+    
+  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function eq_cmp (x : self) (y : self) : ()
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+end
+module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
+  type self
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = self
+  function eq_cmp (x : self) (y : self) : ()
+  val eq_cmp (x : self) (y : self) : ()
+    ensures { result = eq_cmp x y }
+    
+  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function cmp_log (self : Core_Option_Option_Type.t_option t) (o : Core_Option_Option_Type.t_option t) : Core_Cmp_Ordering_Type.t_ordering
+    
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLog_Interface
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function cmp_log (self : Core_Option_Option_Type.t_option t) (o : Core_Option_Option_Type.t_option t) : Core_Cmp_Ordering_Type.t_ordering
+    
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLog
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
+    type self = t
+  function cmp_log (self : Core_Option_Option_Type.t_option t) (o : Core_Option_Option_Type.t_option t) : Core_Cmp_Ordering_Type.t_ordering
+    
+   =
+    match ((self, o)) with
+      | (Core_Option_Option_Type.C_None, Core_Option_Option_Type.C_None) -> Core_Cmp_Ordering_Type.C_Equal
+      | (Core_Option_Option_Type.C_None, Core_Option_Option_Type.C_Some _) -> Core_Cmp_Ordering_Type.C_Less
+      | (Core_Option_Option_Type.C_Some _, Core_Option_Option_Type.C_None) -> Core_Cmp_Ordering_Type.C_Greater
+      | (Core_Option_Option_Type.C_Some x, Core_Option_Option_Type.C_Some y) -> CmpLog0.cmp_log x y
+      end
+  val cmp_log (self : Core_Option_Option_Type.t_option t) (o : Core_Option_Option_Type.t_option t) : Core_Cmp_Ordering_Type.t_ordering
+    ensures { result = cmp_log self o }
+    
+end
+module CreusotContracts_Logic_Ord_Impl2_CmpLog_Stub
+  use mach.int.Int
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering
+end
+module CreusotContracts_Logic_Ord_Impl2_CmpLog_Interface
+  use mach.int.Int
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering
+end
+module CreusotContracts_Logic_Ord_Impl2_CmpLog
+  use mach.int.Int
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  function cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering =
+    if self < o then
+      Core_Cmp_Ordering_Type.C_Less
+    else
+      if self = o then Core_Cmp_Ordering_Type.C_Equal else Core_Cmp_Ordering_Type.C_Greater
+    
+  val cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering
+    ensures { result = cmp_log self o }
+    
+end
+module Instant_TestInstant_Interface
+  val test_instant [@cfg:stackify] [#"../instant.rs" 7 0 7 21] (_1' : ()) : ()
+end
+module Instant_TestInstant
+  use prelude.Borrow
+  use mach.int.Int
+  use mach.int.UInt64
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl2_CmpLog as CmpLog1
+  use mach.int.Int
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog as CmpLog0 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog1.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog1 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2 as Antisym20 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1 as Antisym10 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Trans as Trans0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_Refl as Refl0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    predicate GtLog0.gt_log = GtLog0.gt_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog as CmpGeLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    predicate GeLog0.ge_log = GeLog1.ge_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    predicate LtLog0.lt_log = LtLog0.lt_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog as CmpLeLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    predicate LeLog0.le_log = LeLog0.le_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  use Std_Time_Instant_Type as Std_Time_Instant_Type
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModel as ShallowModel0 with
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl3_DeepModel as DeepModel4 with
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    axiom .
+  use Core_Time_Duration_Type as Core_Time_Duration_Type
+  clone CreusotContracts_Std1_Time_SecsToNanos as SecsToNanos0
+  clone Core_Num_Impl10_Max as Max0
+  clone CreusotContracts_Std1_Time_Impl0_ShallowModel as ShallowModel1 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    axiom .
+  clone CreusotContracts_Std1_Time_Impl1_DeepModel as DeepModel3 with
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    axiom .
+  clone CreusotContracts_Logic_Ord_Impl2_GtLog as GtLog1
+  clone CreusotContracts_Std1_Time_Impl3_DeepModelTy_Type as DeepModelTy1
+  clone CreusotContracts_Model_Impl0_DeepModel as DeepModel2 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy1.deepModelTy,
+    function DeepModel0.deep_model = DeepModel4.deep_model
+  clone CreusotContracts_Std1_Time_Impl2_ShallowModelTy_Type as ShallowModelTy0
+  clone CreusotContracts_Model_Impl1_ShallowModel as ShallowModel2 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model
+  clone CreusotContracts_Model_Impl10_DeepModel as DeepModel1 with
+    type t = Std_Time_Instant_Type.t_instant,
+    type DeepModelTy0.deepModelTy = DeepModelTy1.deepModelTy,
+    function DeepModel0.deep_model = DeepModel4.deep_model
+  clone CreusotContracts_Std1_Time_Impl1_DeepModelTy_Type as DeepModelTy0
+  clone CreusotContracts_Logic_Ord_Impl2_GeLog as GeLog0
+  clone CreusotContracts_Model_Impl0_DeepModel as DeepModel0 with
+    type t = Core_Time_Duration_Type.t_duration,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
+    function DeepModel0.deep_model = DeepModel3.deep_model
+  clone Std_Time_Impl0_SaturatingDurationSince_Interface as SaturatingDurationSince0 with
+    function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel2.shallow_model = ShallowModel1.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Core_Option_Impl0_IsNone_Interface as IsNone0 with
+    type t = Core_Time_Duration_Type.t_duration
+  clone Core_Option_Impl0_IsSome_Interface as IsSome0 with
+    type t = Core_Time_Duration_Type.t_duration
+  clone Std_Time_Impl0_CheckedDurationSince_Interface as CheckedDurationSince0 with
+    function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel0.shallow_model
+  clone Std_Time_Impl0_DurationSince_Interface as DurationSince0 with
+    function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel2.shallow_model = ShallowModel1.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Core_Cmp_PartialOrd_Gt_Interface as Gt0 with
+    type self = Core_Time_Duration_Type.t_duration,
+    type rhs = Core_Time_Duration_Type.t_duration,
+    function DeepModel0.deep_model = DeepModel0.deep_model,
+    function DeepModel1.deep_model = DeepModel0.deep_model,
+    predicate GtLog0.gt_log = GtLog1.gt_log,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone Core_Time_Impl29_Eq_Interface as Eq1 with
+    function DeepModel0.deep_model = DeepModel0.deep_model
+  clone Std_Time_Impl5_Sub_Interface as Sub1 with
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel1.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Std_Time_Impl3_Sub_Interface as Sub0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Std_Time_Impl0_CheckedSub_Interface as CheckedSub0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    function DeepModel0.deep_model = DeepModel1.deep_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    predicate GtLog0.gt_log = GtLog0.gt_log,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Std_Time_Impl1_Add_Interface as Add0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Std_Time_Impl21_Eq_Interface as Eq0 with
+    function DeepModel0.deep_model = DeepModel2.deep_model
+  clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
+    type t = Std_Time_Instant_Type.t_instant
+  clone Std_Time_Impl0_CheckedAdd_Interface as CheckedAdd0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    function DeepModel0.deep_model = DeepModel1.deep_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    predicate LtLog0.lt_log = LtLog0.lt_log,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Core_Cmp_PartialOrd_Ge_Interface as Ge0 with
+    type self = Core_Time_Duration_Type.t_duration,
+    type rhs = Core_Time_Duration_Type.t_duration,
+    function DeepModel0.deep_model = DeepModel0.deep_model,
+    function DeepModel1.deep_model = DeepModel0.deep_model,
+    predicate GeLog0.ge_log = GeLog0.ge_log,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone Std_Time_Impl0_Elapsed_Interface as Elapsed0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    val Max0.mAX' = Max0.mAX',
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos
+  clone Core_Time_Impl1_FromSecs_Interface as FromSecs0 with
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
+    function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
+    val Max0.mAX' = Max0.mAX'
+  clone Std_Time_Impl0_Now_Interface as Now0 with
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model
+  let rec cfg test_instant [@cfg:stackify] [#"../instant.rs" 7 0 7 21] (_1' : ()) : ()
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var instant_1 : Std_Time_Instant_Type.t_instant;
+  var zero_dur_2 : Core_Time_Duration_Type.t_duration;
+  var _3 : ();
+  var _4 : bool;
+  var _5 : bool;
+  var _6 : Core_Time_Duration_Type.t_duration;
+  var _7 : Core_Time_Duration_Type.t_duration;
+  var _8 : Std_Time_Instant_Type.t_instant;
+  var _9 : Core_Time_Duration_Type.t_duration;
+  var _10 : ();
+  var _11 : ();
+  var _12 : bool;
+  var _13 : bool;
+  var _14 : Std_Time_Instant_Type.t_instant;
+  var _15 : Std_Time_Instant_Type.t_instant;
+  var _16 : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant);
+  var _17 : Std_Time_Instant_Type.t_instant;
+  var _18 : Core_Time_Duration_Type.t_duration;
+  var _19 : Std_Time_Instant_Type.t_instant;
+  var _20 : ();
+  var _21 : ();
+  var _22 : bool;
+  var _23 : bool;
+  var _24 : Std_Time_Instant_Type.t_instant;
+  var _25 : Std_Time_Instant_Type.t_instant;
+  var _26 : Std_Time_Instant_Type.t_instant;
+  var _27 : Core_Time_Duration_Type.t_duration;
+  var _28 : Std_Time_Instant_Type.t_instant;
+  var _29 : ();
+  var three_seconds_30 : Core_Time_Duration_Type.t_duration;
+  var greater_instant_31 : Std_Time_Instant_Type.t_instant;
+  var _32 : Std_Time_Instant_Type.t_instant;
+  var _33 : Core_Time_Duration_Type.t_duration;
+  var _34 : ();
+  var even_greater_instant_36 : Std_Time_Instant_Type.t_instant;
+  var _37 : Std_Time_Instant_Type.t_instant;
+  var _38 : Core_Time_Duration_Type.t_duration;
+  var _39 : ();
+  var _41 : ();
+  var _42 : bool;
+  var _43 : bool;
+  var _44 : Std_Time_Instant_Type.t_instant;
+  var _45 : Std_Time_Instant_Type.t_instant;
+  var _46 : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant);
+  var _47 : Std_Time_Instant_Type.t_instant;
+  var _48 : Core_Time_Duration_Type.t_duration;
+  var _49 : Std_Time_Instant_Type.t_instant;
+  var _50 : ();
+  var _51 : ();
+  var _52 : bool;
+  var _53 : bool;
+  var _54 : Std_Time_Instant_Type.t_instant;
+  var _55 : Std_Time_Instant_Type.t_instant;
+  var _56 : Std_Time_Instant_Type.t_instant;
+  var _57 : Core_Time_Duration_Type.t_duration;
+  var _58 : Std_Time_Instant_Type.t_instant;
+  var _59 : ();
+  var lesser_instant_60 : Std_Time_Instant_Type.t_instant;
+  var _61 : Std_Time_Instant_Type.t_instant;
+  var _62 : Core_Time_Duration_Type.t_duration;
+  var _63 : ();
+  var _65 : ();
+  var _66 : bool;
+  var _67 : bool;
+  var _68 : Core_Time_Duration_Type.t_duration;
+  var _69 : Core_Time_Duration_Type.t_duration;
+  var _70 : Std_Time_Instant_Type.t_instant;
+  var _71 : Std_Time_Instant_Type.t_instant;
+  var _72 : Core_Time_Duration_Type.t_duration;
+  var _73 : ();
+  var _74 : ();
+  var _75 : bool;
+  var _76 : bool;
+  var _77 : Core_Time_Duration_Type.t_duration;
+  var _78 : Core_Time_Duration_Type.t_duration;
+  var _79 : Std_Time_Instant_Type.t_instant;
+  var _80 : Std_Time_Instant_Type.t_instant;
+  var _81 : Core_Time_Duration_Type.t_duration;
+  var _82 : ();
+  var _83 : ();
+  var _84 : bool;
+  var _85 : bool;
+  var _86 : Core_Time_Duration_Type.t_duration;
+  var _87 : Core_Time_Duration_Type.t_duration;
+  var _88 : Std_Time_Instant_Type.t_instant;
+  var _89 : Std_Time_Instant_Type.t_instant;
+  var _90 : Core_Time_Duration_Type.t_duration;
+  var _91 : ();
+  var _92 : ();
+  var _93 : bool;
+  var _94 : bool;
+  var _95 : Core_Time_Duration_Type.t_duration;
+  var _96 : Core_Time_Duration_Type.t_duration;
+  var _97 : Std_Time_Instant_Type.t_instant;
+  var _98 : Std_Time_Instant_Type.t_instant;
+  var _99 : Core_Time_Duration_Type.t_duration;
+  var _100 : ();
+  var _101 : ();
+  var _102 : bool;
+  var _103 : bool;
+  var _104 : Core_Time_Duration_Type.t_duration;
+  var _105 : Core_Time_Duration_Type.t_duration;
+  var _106 : Std_Time_Instant_Type.t_instant;
+  var _107 : Std_Time_Instant_Type.t_instant;
+  var _108 : Core_Time_Duration_Type.t_duration;
+  var _109 : ();
+  var _110 : ();
+  var _111 : bool;
+  var _112 : bool;
+  var _113 : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration);
+  var _114 : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration);
+  var _115 : Std_Time_Instant_Type.t_instant;
+  var _116 : Std_Time_Instant_Type.t_instant;
+  var _117 : ();
+  var _118 : ();
+  var _119 : bool;
+  var _120 : bool;
+  var _121 : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration);
+  var _122 : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration);
+  var _123 : Std_Time_Instant_Type.t_instant;
+  var _124 : Std_Time_Instant_Type.t_instant;
+  var _125 : ();
+  var _126 : ();
+  var _127 : bool;
+  var _128 : bool;
+  var _129 : Core_Time_Duration_Type.t_duration;
+  var _130 : Core_Time_Duration_Type.t_duration;
+  var _131 : Std_Time_Instant_Type.t_instant;
+  var _132 : Std_Time_Instant_Type.t_instant;
+  var _133 : Core_Time_Duration_Type.t_duration;
+  var _134 : ();
+  var _135 : ();
+  var _136 : bool;
+  var _137 : bool;
+  var _138 : Core_Time_Duration_Type.t_duration;
+  var _139 : Core_Time_Duration_Type.t_duration;
+  var _140 : Std_Time_Instant_Type.t_instant;
+  var _141 : Std_Time_Instant_Type.t_instant;
+  var _142 : Core_Time_Duration_Type.t_duration;
+  var _143 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    instant_1 <- ([#"../instant.rs" 8 18 8 32] Now0.now ());
+    goto BB1
+  }
+  BB1 {
+    zero_dur_2 <- ([#"../instant.rs" 9 19 9 41] FromSecs0.from_secs ([#"../instant.rs" 9 39 9 40] (0 : uint64)));
+    goto BB2
+  }
+  BB2 {
+    _8 <- instant_1;
+    _7 <- ([#"../instant.rs" 10 12 10 29] Elapsed0.elapsed _8);
+    goto BB3
+  }
+  BB3 {
+    _6 <- _7;
+    _9 <- zero_dur_2;
+    _5 <- ([#"../instant.rs" 10 12 10 41] Ge0.ge _6 _9);
+    goto BB4
+  }
+  BB4 {
+    _4 <- not _5;
+    switch (_4)
+      | False -> goto BB6
+      | True -> goto BB5
+      end
+  }
+  BB5 {
+    absurd
+  }
+  BB6 {
+    _3 <- ();
+    _17 <- instant_1;
+    _18 <- zero_dur_2;
+    _16 <- ([#"../instant.rs" 12 12 12 41] CheckedAdd0.checked_add _17 _18);
+    goto BB7
+  }
+  BB7 {
+    _15 <- ([#"../instant.rs" 12 12 12 50] Unwrap0.unwrap _16);
+    goto BB8
+  }
+  BB8 {
+    _14 <- _15;
+    _19 <- instant_1;
+    _13 <- ([#"../instant.rs" 12 12 12 61] Eq0.eq _14 _19);
+    goto BB9
+  }
+  BB9 {
+    _12 <- not _13;
+    switch (_12)
+      | False -> goto BB11
+      | True -> goto BB10
+      end
+  }
+  BB10 {
+    absurd
+  }
+  BB11 {
+    _11 <- ();
+    _26 <- instant_1;
+    _27 <- zero_dur_2;
+    _25 <- ([#"../instant.rs" 13 12 13 30] Add0.add _26 _27);
+    goto BB12
+  }
+  BB12 {
+    _24 <- _25;
+    _28 <- instant_1;
+    _23 <- ([#"../instant.rs" 13 12 13 41] Eq0.eq _24 _28);
+    goto BB13
+  }
+  BB13 {
+    _22 <- not _23;
+    switch (_22)
+      | False -> goto BB15
+      | True -> goto BB14
+      end
+  }
+  BB14 {
+    absurd
+  }
+  BB15 {
+    _21 <- ();
+    three_seconds_30 <- ([#"../instant.rs" 14 24 14 46] FromSecs0.from_secs ([#"../instant.rs" 14 44 14 45] (3 : uint64)));
+    goto BB16
+  }
+  BB16 {
+    _32 <- instant_1;
+    _33 <- three_seconds_30;
+    greater_instant_31 <- ([#"../instant.rs" 15 26 15 49] Add0.add _32 _33);
+    goto BB17
+  }
+  BB17 {
+    assert { [#"../instant.rs" 16 18 16 45] ShallowModel0.shallow_model instant_1 < ShallowModel0.shallow_model greater_instant_31 };
+    _34 <- ();
+    _37 <- greater_instant_31;
+    _38 <- three_seconds_30;
+    even_greater_instant_36 <- ([#"../instant.rs" 17 31 17 62] Add0.add _37 _38);
+    goto BB18
+  }
+  BB18 {
+    assert { [#"../instant.rs" 18 18 18 50] ShallowModel0.shallow_model instant_1 < ShallowModel0.shallow_model even_greater_instant_36 };
+    _39 <- ();
+    _47 <- instant_1;
+    _48 <- zero_dur_2;
+    _46 <- ([#"../instant.rs" 20 12 20 41] CheckedSub0.checked_sub _47 _48);
+    goto BB19
+  }
+  BB19 {
+    _45 <- ([#"../instant.rs" 20 12 20 50] Unwrap0.unwrap _46);
+    goto BB20
+  }
+  BB20 {
+    _44 <- _45;
+    _49 <- instant_1;
+    _43 <- ([#"../instant.rs" 20 12 20 61] Eq0.eq _44 _49);
+    goto BB21
+  }
+  BB21 {
+    _42 <- not _43;
+    switch (_42)
+      | False -> goto BB23
+      | True -> goto BB22
+      end
+  }
+  BB22 {
+    absurd
+  }
+  BB23 {
+    _41 <- ();
+    _56 <- instant_1;
+    _57 <- zero_dur_2;
+    _55 <- ([#"../instant.rs" 21 12 21 30] Sub0.sub _56 _57);
+    goto BB24
+  }
+  BB24 {
+    _54 <- _55;
+    _58 <- instant_1;
+    _53 <- ([#"../instant.rs" 21 12 21 41] Eq0.eq _54 _58);
+    goto BB25
+  }
+  BB25 {
+    _52 <- not _53;
+    switch (_52)
+      | False -> goto BB27
+      | True -> goto BB26
+      end
+  }
+  BB26 {
+    absurd
+  }
+  BB27 {
+    _51 <- ();
+    _61 <- instant_1;
+    _62 <- three_seconds_30;
+    lesser_instant_60 <- ([#"../instant.rs" 22 25 22 48] Sub0.sub _61 _62);
+    goto BB28
+  }
+  BB28 {
+    assert { [#"../instant.rs" 23 18 23 44] ShallowModel0.shallow_model instant_1 > ShallowModel0.shallow_model lesser_instant_60 };
+    _63 <- ();
+    _70 <- instant_1;
+    _71 <- instant_1;
+    _69 <- ([#"../instant.rs" 24 12 24 29] Sub1.sub _70 _71);
+    goto BB29
+  }
+  BB29 {
+    _68 <- _69;
+    _72 <- zero_dur_2;
+    _67 <- ([#"../instant.rs" 24 12 24 41] Eq1.eq _68 _72);
+    goto BB30
+  }
+  BB30 {
+    _66 <- not _67;
+    switch (_66)
+      | False -> goto BB32
+      | True -> goto BB31
+      end
+  }
+  BB31 {
+    absurd
+  }
+  BB32 {
+    _65 <- ();
+    _79 <- instant_1;
+    _80 <- greater_instant_31;
+    _78 <- ([#"../instant.rs" 25 12 25 37] Sub1.sub _79 _80);
+    goto BB33
+  }
+  BB33 {
+    _77 <- _78;
+    _81 <- zero_dur_2;
+    _76 <- ([#"../instant.rs" 25 12 25 49] Eq1.eq _77 _81);
+    goto BB34
+  }
+  BB34 {
+    _75 <- not _76;
+    switch (_75)
+      | False -> goto BB36
+      | True -> goto BB35
+      end
+  }
+  BB35 {
+    absurd
+  }
+  BB36 {
+    _74 <- ();
+    _88 <- greater_instant_31;
+    _89 <- instant_1;
+    _87 <- ([#"../instant.rs" 26 12 26 37] Sub1.sub _88 _89);
+    goto BB37
+  }
+  BB37 {
+    _86 <- _87;
+    _90 <- zero_dur_2;
+    _85 <- ([#"../instant.rs" 26 12 26 48] Gt0.gt _86 _90);
+    goto BB38
+  }
+  BB38 {
+    _84 <- not _85;
+    switch (_84)
+      | False -> goto BB40
+      | True -> goto BB39
+      end
+  }
+  BB39 {
+    absurd
+  }
+  BB40 {
+    _83 <- ();
+    _97 <- greater_instant_31;
+    _98 <- instant_1;
+    _96 <- ([#"../instant.rs" 28 12 28 51] DurationSince0.duration_since _97 _98);
+    goto BB41
+  }
+  BB41 {
+    _95 <- _96;
+    _99 <- zero_dur_2;
+    _94 <- ([#"../instant.rs" 28 12 28 62] Gt0.gt _95 _99);
+    goto BB42
+  }
+  BB42 {
+    _93 <- not _94;
+    switch (_93)
+      | False -> goto BB44
+      | True -> goto BB43
+      end
+  }
+  BB43 {
+    absurd
+  }
+  BB44 {
+    _92 <- ();
+    _106 <- instant_1;
+    _107 <- greater_instant_31;
+    _105 <- ([#"../instant.rs" 29 12 29 51] DurationSince0.duration_since _106 _107);
+    goto BB45
+  }
+  BB45 {
+    _104 <- _105;
+    _108 <- zero_dur_2;
+    _103 <- ([#"../instant.rs" 29 12 29 63] Eq1.eq _104 _108);
+    goto BB46
+  }
+  BB46 {
+    _102 <- not _103;
+    switch (_102)
+      | False -> goto BB48
+      | True -> goto BB47
+      end
+  }
+  BB47 {
+    absurd
+  }
+  BB48 {
+    _101 <- ();
+    _115 <- greater_instant_31;
+    _116 <- instant_1;
+    _114 <- ([#"../instant.rs" 30 12 30 59] CheckedDurationSince0.checked_duration_since _115 _116);
+    goto BB49
+  }
+  BB49 {
+    _113 <- _114;
+    _112 <- ([#"../instant.rs" 30 12 30 69] IsSome0.is_some _113);
+    goto BB50
+  }
+  BB50 {
+    _111 <- not _112;
+    switch (_111)
+      | False -> goto BB52
+      | True -> goto BB51
+      end
+  }
+  BB51 {
+    absurd
+  }
+  BB52 {
+    _110 <- ();
+    _123 <- instant_1;
+    _124 <- greater_instant_31;
+    _122 <- ([#"../instant.rs" 31 12 31 59] CheckedDurationSince0.checked_duration_since _123 _124);
+    goto BB53
+  }
+  BB53 {
+    _121 <- _122;
+    _120 <- ([#"../instant.rs" 31 12 31 69] IsNone0.is_none _121);
+    goto BB54
+  }
+  BB54 {
+    _119 <- not _120;
+    switch (_119)
+      | False -> goto BB56
+      | True -> goto BB55
+      end
+  }
+  BB55 {
+    absurd
+  }
+  BB56 {
+    _118 <- ();
+    _131 <- greater_instant_31;
+    _132 <- instant_1;
+    _130 <- ([#"../instant.rs" 32 12 32 62] SaturatingDurationSince0.saturating_duration_since _131 _132);
+    goto BB57
+  }
+  BB57 {
+    _129 <- _130;
+    _133 <- zero_dur_2;
+    _128 <- ([#"../instant.rs" 32 12 32 73] Gt0.gt _129 _133);
+    goto BB58
+  }
+  BB58 {
+    _127 <- not _128;
+    switch (_127)
+      | False -> goto BB60
+      | True -> goto BB59
+      end
+  }
+  BB59 {
+    absurd
+  }
+  BB60 {
+    _126 <- ();
+    _140 <- instant_1;
+    _141 <- greater_instant_31;
+    _139 <- ([#"../instant.rs" 33 12 33 62] SaturatingDurationSince0.saturating_duration_since _140 _141);
+    goto BB61
+  }
+  BB61 {
+    _138 <- _139;
+    _142 <- zero_dur_2;
+    _137 <- ([#"../instant.rs" 33 12 33 74] Eq1.eq _138 _142);
+    goto BB62
+  }
+  BB62 {
+    _136 <- not _137;
+    switch (_136)
+      | False -> goto BB64
+      | True -> goto BB63
+      end
+  }
+  BB63 {
+    absurd
+  }
+  BB64 {
+    _135 <- ();
+    _0 <- ();
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -1352,6 +1352,308 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLog
     ensures { result = cmp_log self o }
     
 end
+module CreusotContracts_Logic_Ord_Impl1_CmpLeLog_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLeLog_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLeLog
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = cmp_le_log x y }
+    
+  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLtLog_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLtLog_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpLtLog
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = cmp_lt_log x y }
+    
+  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGeLog_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGeLog_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGeLog
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = cmp_ge_log x y }
+    
+  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGtLog_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGtLog_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_Impl1_CmpGtLog
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
+    type self = Core_Option_Option_Type.t_option t
+  function cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = cmp_gt_log x y }
+    
+  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+end
+module CreusotContracts_Logic_Ord_Impl1_Refl_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function refl (x : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_Refl_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function refl (x : Core_Option_Option_Type.t_option t) : ()
+  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+end
+module CreusotContracts_Logic_Ord_Impl1_Refl
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function refl (x : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val refl (x : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = refl x }
+    
+  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+end
+module CreusotContracts_Logic_Ord_Impl1_Trans_Stub
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+    
+end
+module CreusotContracts_Logic_Ord_Impl1_Trans_Interface
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+    
+  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+end
+module CreusotContracts_Logic_Ord_Impl1_Trans
+  type t
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+    
+   =
+    ()
+  val trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
+    requires {CmpLog0.cmp_log x y = o}
+    requires {CmpLog0.cmp_log y z = o}
+    ensures { result = trans x y z o }
+    
+  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym1_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym1_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym1
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    ensures { result = antisym1 x y }
+    
+  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym2_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym2_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+end
+module CreusotContracts_Logic_Ord_Impl1_Antisym2
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    ensures { result = antisym2 x y }
+    
+  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+end
+module CreusotContracts_Logic_Ord_Impl1_EqCmp_Stub
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+end
+module CreusotContracts_Logic_Ord_Impl1_EqCmp_Interface
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+end
+module CreusotContracts_Logic_Ord_Impl1_EqCmp
+  type t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
+    type t = t
+  function eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
+    ()
+  val eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
+    ensures { result = eq_cmp x y }
+    
+  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+end
 module CreusotContracts_Logic_Ord_Impl2_CmpLog_Stub
   use mach.int.Int
   use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
@@ -1389,12 +1691,58 @@ module Instant_TestInstant
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog as CmpLog0 with
     type t = int,
     function CmpLog0.cmp_log = CmpLog1.cmp_log
+  clone CreusotContracts_Logic_Ord_Impl1_EqCmp as EqCmp1 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_Impl1_Antisym2 as Antisym21 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_Impl1_Antisym1 as Antisym11 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_Impl1_Trans as Trans1 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_Impl1_Refl as Refl1 with
+    type t = int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_Impl1_CmpGtLog as CmpGtLog1 with
+    type t = int,
+    predicate GtLog0.gt_log = GtLog0.gt_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog as GeLog1 with
     type self = Core_Option_Option_Type.t_option int,
     function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_Impl1_CmpGeLog as CmpGeLog1 with
+    type t = int,
+    predicate GeLog0.ge_log = GeLog1.ge_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
+  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with
+    type self = Core_Option_Option_Type.t_option int,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLtLog as CmpLtLog1 with
+    type t = int,
+    predicate LtLog0.lt_log = LtLog0.lt_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog as LeLog0 with
     type self = Core_Option_Option_Type.t_option int,
     function CmpLog0.cmp_log = CmpLog0.cmp_log
+  clone CreusotContracts_Logic_Ord_Impl1_CmpLeLog as CmpLeLog1 with
+    type t = int,
+    predicate LeLog0.le_log = LeLog0.le_log,
+    function CmpLog0.cmp_log = CmpLog0.cmp_log,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp as EqCmp0 with
     type self = Core_Option_Option_Type.t_option int,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
@@ -1415,9 +1763,6 @@ module Instant_TestInstant
     type self = Core_Option_Option_Type.t_option int,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone CreusotContracts_Logic_Ord_OrdLogic_GtLog as GtLog0 with
-    type self = Core_Option_Option_Type.t_option int,
-    function CmpLog0.cmp_log = CmpLog0.cmp_log
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog as CmpGtLog0 with
     type self = Core_Option_Option_Type.t_option int,
     predicate GtLog0.gt_log = GtLog0.gt_log,
@@ -1428,9 +1773,6 @@ module Instant_TestInstant
     predicate GeLog0.ge_log = GeLog1.ge_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone CreusotContracts_Logic_Ord_OrdLogic_LtLog as LtLog0 with
-    type self = Core_Option_Option_Type.t_option int,
-    function CmpLog0.cmp_log = CmpLog0.cmp_log
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog as CmpLtLog0 with
     type self = Core_Option_Option_Type.t_option int,
     predicate LtLog0.lt_log = LtLog0.lt_log,

--- a/creusot/tests/should_succeed/instant.rs
+++ b/creusot/tests/should_succeed/instant.rs
@@ -1,0 +1,34 @@
+extern crate creusot_contracts;
+
+use creusot_contracts::*;
+
+use std::time::{Duration, Instant};
+
+pub fn test_instant() {
+    let instant = Instant::now();
+    let zero_dur = Duration::from_secs(0);
+    assert!(instant.elapsed() >= zero_dur);
+
+    assert!(instant.checked_add(zero_dur).unwrap() == instant);
+    assert!(instant + zero_dur == instant);
+    let three_seconds = Duration::from_secs(3);
+    let greater_instant = instant + three_seconds;
+    proof_assert!(@instant < @greater_instant);
+    let even_greater_instant = greater_instant + three_seconds;
+    proof_assert!(@instant < @even_greater_instant);
+
+    assert!(instant.checked_sub(zero_dur).unwrap() == instant);
+    assert!(instant - zero_dur == instant);
+    let lesser_instant = instant - three_seconds;
+    proof_assert!(@instant > @lesser_instant);
+    assert!(instant - instant == zero_dur);
+    assert!(instant - greater_instant == zero_dur);
+    assert!(greater_instant - instant > zero_dur);
+
+    assert!(greater_instant.duration_since(instant) > zero_dur);
+    assert!(instant.duration_since(greater_instant) == zero_dur);
+    assert!(greater_instant.checked_duration_since(instant).is_some());
+    assert!(instant.checked_duration_since(greater_instant).is_none());
+    assert!(greater_instant.saturating_duration_since(instant) > zero_dur);
+    assert!(instant.saturating_duration_since(greater_instant) == zero_dur);
+}

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -1549,15 +1549,15 @@ module CreusotContracts_Std1_Vec_Impl9_Resolve
     ensures { result = resolve self }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Interface
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog
+module CreusotContracts_Logic_Ord_Impl2_LeLog
   use mach.int.Int
   use int.Int
   predicate le_log (self : int) (_2' : int) =
@@ -1569,7 +1569,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Stub
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -1591,7 +1591,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -1614,7 +1614,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -1661,7 +1661,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   use seq.Seq
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -2018,7 +2018,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
   use prelude.Borrow
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -2201,7 +2201,7 @@ module KnapsackFull_Knapsack01Dyn
     type t = Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = ShallowModelTy2.shallowModelTy,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog as EndLog0 with
     type idx = usize

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -4969,7 +4969,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 766 5 766 64] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 784 1 785 19] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module Core_Cmp_Ord_Cmp
@@ -4984,7 +4984,7 @@ module Core_Cmp_Ord_Cmp
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 766 5 766 64] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 784 1 785 19] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl16_InsertRec_Interface
@@ -5849,8 +5849,8 @@ module Alloc_Boxed_Impl54_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 713 4 713 21]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 713 50 713 67]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 726 31 727 7]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 728 26 728 43]  ^ self =  ^ result }
     
 end
 module Alloc_Boxed_Impl54_AsMut
@@ -5858,8 +5858,8 @@ module Alloc_Boxed_Impl54_AsMut
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 713 4 713 21]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 713 50 713 67]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 726 31 727 7]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 728 26 728 43]  ^ self =  ^ result }
     
 end
 module CreusotContracts_Resolve_Impl0_Resolve_Stub
@@ -10047,14 +10047,14 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 717 25 725 66] result = self }
+    ensures { [#"../red_black_tree.rs" 737 24 746 4] result = self }
     
 end
 module Core_Clone_Clone_Clone
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 717 25 725 66] result = self }
+    ensures { [#"../red_black_tree.rs" 737 24 746 4] result = self }
     
 end
 module RedBlackTree_Impl17

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -4969,7 +4969,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 784 1 785 19] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 798 25 799 18] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module Core_Cmp_Ord_Cmp
@@ -4984,7 +4984,7 @@ module Core_Cmp_Ord_Cmp
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 784 1 785 19] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 798 25 799 18] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl16_InsertRec_Interface
@@ -5849,8 +5849,8 @@ module Alloc_Boxed_Impl54_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 726 31 727 7]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 728 26 728 43]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 742 31 743 3]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 743 32 744 12]  ^ self =  ^ result }
     
 end
 module Alloc_Boxed_Impl54_AsMut
@@ -5858,8 +5858,8 @@ module Alloc_Boxed_Impl54_AsMut
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 726 31 727 7]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 728 26 728 43]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 742 31 743 3]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 743 32 744 12]  ^ self =  ^ result }
     
 end
 module CreusotContracts_Resolve_Impl0_Resolve_Stub
@@ -10047,14 +10047,14 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 737 24 746 4] result = self }
+    ensures { [#"../red_black_tree.rs" 754 6 764 11] result = self }
     
 end
 module Core_Clone_Clone_Clone
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 737 24 746 4] result = self }
+    ensures { [#"../red_black_tree.rs" 754 6 764 11] result = self }
     
 end
 module RedBlackTree_Impl17

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -446,15 +446,15 @@ module Core_Iter_Range_Impl12_Next
       end }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Interface
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog
+module CreusotContracts_Logic_Ord_Impl2_LeLog
   use mach.int.Int
   use int.Int
   predicate le_log (self : int) (_2' : int) =
@@ -466,7 +466,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Stub
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -488,7 +488,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -511,7 +511,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -558,7 +558,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   use seq.Seq
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -766,7 +766,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
   use prelude.Borrow
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -803,7 +803,7 @@ module Sum_SumFirstN
   use seq.Seq
   use prelude.Borrow
   use prelude.IntSize
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog as EndLog0 with
     type idx = uint32

--- a/creusot/tests/should_succeed/syntax/10_mutual_rec_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/10_mutual_rec_types.mlcfg
@@ -254,15 +254,15 @@ module CreusotContracts_Logic_Int_Impl14_DeepModel
     ensures { result = deep_model self }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Stub
   use mach.int.Int
   predicate ge_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_GeLog_Interface
   use mach.int.Int
   predicate ge_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_GeLog
+module CreusotContracts_Logic_Ord_Impl2_GeLog
   use mach.int.Int
   use int.Int
   predicate ge_log (self : int) (_2' : int) =
@@ -271,15 +271,15 @@ module CreusotContracts_Logic_Ord_Impl1_GeLog
     ensures { result = ge_log self _2' }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Interface
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog
+module CreusotContracts_Logic_Ord_Impl2_LeLog
   use mach.int.Int
   use int.Int
   predicate le_log (self : int) (_2' : int) =
@@ -288,15 +288,15 @@ module CreusotContracts_Logic_Ord_Impl1_LeLog
     ensures { result = le_log self _2' }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Stub
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LtLog_Interface
   use mach.int.Int
   predicate lt_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LtLog
+module CreusotContracts_Logic_Ord_Impl2_LtLog
   use mach.int.Int
   use int.Int
   predicate lt_log (self : int) (_2' : int) =
@@ -324,9 +324,9 @@ module C10MutualRecTypes_Impl0_Height
   use prelude.Borrow
   use prelude.IntSize
   clone CreusotContracts_Logic_Int_Impl14_DeepModelTy_Type as DeepModelTy0
-  clone CreusotContracts_Logic_Ord_Impl1_LtLog as LtLog0
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog as LeLog0
-  clone CreusotContracts_Logic_Ord_Impl1_GeLog as GeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LtLog as LtLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_GeLog as GeLog0
   clone CreusotContracts_Logic_Int_Impl14_DeepModel as DeepModel0
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use C10MutualRecTypes_Node_Type as C10MutualRecTypes_Node_Type

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -845,15 +845,15 @@ module Alloc_Vec_Impl16_Index
     ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Stub
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog_Interface
+module CreusotContracts_Logic_Ord_Impl2_LeLog_Interface
   use mach.int.Int
   predicate le_log (self : int) (_2' : int)
 end
-module CreusotContracts_Logic_Ord_Impl1_LeLog
+module CreusotContracts_Logic_Ord_Impl2_LeLog
   use mach.int.Int
   use int.Int
   predicate le_log (self : int) (_2' : int) =
@@ -865,7 +865,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Stub
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -887,7 +887,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -910,7 +910,7 @@ end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
@@ -957,7 +957,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   use seq.Seq
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -1242,7 +1242,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
   use prelude.Borrow
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   use mach.int.Int
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog_Stub as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog_Stub as LeLog0
   clone CreusotContracts_Std1_Ops_Impl5_EndLog_Stub as EndLog0 with
     type idx = idx
   clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
@@ -1504,7 +1504,7 @@ module C08Haystack_Search
   clone CreusotContracts_Std1_Iter_Impl0_IntoIterPre as IntoIterPre1 with
     type i = Core_Ops_Range_Range_Type.t_range usize,
     predicate Invariant0.invariant' = Invariant1.invariant'
-  clone CreusotContracts_Logic_Ord_Impl1_LeLog as LeLog0
+  clone CreusotContracts_Logic_Ord_Impl2_LeLog as LeLog0
   use Core_Ops_Range_RangeInclusive_Type as Core_Ops_Range_RangeInclusive_Type
   clone CreusotContracts_Std1_Ops_Impl5_EndLog as EndLog0 with
     type idx = usize


### PR DESCRIPTION
This PR does:
* implement `OrdLogic` for `Option<T>`
* tighten the upper bounds for `Duration` for accuracy
* define spec for simple addition and subtraction for `Duration`
  * updates the test accordingly
* add spec and test for `Instant`

While `Instant` is an opaque type, I've chosen the model type to be `Int` because it allows for easy relative reasoning between `Instant`s after doing arithmetic.