### PR TITLE
Add spec for VecDeque

### DIFF
--- a/creusot-contracts/src/std.rs
+++ b/creusot-contracts/src/std.rs
@@ -4,6 +4,7 @@ pub mod boxed;
 pub mod clone;
 pub mod cmp;
 pub mod default;
+pub mod deque;
 pub mod iter;
 pub mod mem;
 pub mod num;

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -1,0 +1,74 @@
+use crate::{std::alloc::Allocator, *};
+pub use ::std::collections::VecDeque;
+
+impl<T, A: Allocator> ShallowModel for VecDeque<T, A> {
+    type ShallowModelTy = Seq<T>;
+
+    #[logic]
+    #[trusted]
+    #[ensures(result.len() <= @usize::MAX)]
+    fn shallow_model(self) -> Seq<T> {
+        pearlite! { absurd }
+    }
+}
+
+impl<T: DeepModel, A: Allocator> DeepModel for VecDeque<T, A> {
+    type DeepModelTy = Seq<T::DeepModelTy>;
+
+    #[logic]
+    #[trusted]
+    #[ensures(self.shallow_model().len() == result.len())]
+    #[ensures(forall<i: Int> 0 <= i && i < self.shallow_model().len()
+              ==> result[i] == (@self)[i].deep_model())]
+    fn deep_model(self) -> Self::DeepModelTy {
+        pearlite! { absurd }
+    }
+}
+
+extern_spec! {
+    mod std {
+        mod collections {
+            impl<T> VecDeque<T> {
+                #[ensures((@result).len() == 0)]
+                fn new() -> Self;
+
+                #[ensures((@result).len() == 0)]
+                fn with_capacity(capacity: usize) -> Self;
+            }
+
+            impl<T, A: Allocator> VecDeque<T, A> {
+                #[ensures(@result == (@self).len())]
+                fn len(&self) -> usize;
+
+                #[ensures(result == ((@self).len() == 0))]
+                fn is_empty(&self) -> bool;
+
+                #[ensures((@^self).len() == 0)]
+                fn clear(&mut self);
+
+                #[ensures(match result {
+                    Some(t) =>
+                        @^self == (@self).subsequence(1, (@self).len()) &&
+                        @self == Seq::singleton(t).concat(@^self),
+                    None => *self == ^self && (@self).len() == 0
+                })]
+                fn pop_front(&mut self) -> Option<T>;
+
+                #[ensures(match result {
+                    Some(t) =>
+                        @^self == (@self).subsequence(0, (@self).len() - 1) &&
+                        @self == (@^self).push(t),
+                    None => *self == ^self && (@self).len() == 0
+                })]
+                fn pop_back(&mut self) -> Option<T>;
+
+                #[ensures((@^self).len() == (@self).len() + 1)]
+                #[ensures((@^self) == Seq::singleton(value).concat(@self))]
+                fn push_front(&mut self, value: T);
+
+                #[ensures(@^self == (@self).push(value))]
+                fn push_back(&mut self, value: T);
+            }
+        }
+    }
+}

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -4969,7 +4969,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 798 25 799 18] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 798 40 799 33] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module Core_Cmp_Ord_Cmp
@@ -4984,7 +4984,7 @@ module Core_Cmp_Ord_Cmp
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp [@cfg:stackify] (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 798 25 799 18] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 798 40 799 33] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl16_InsertRec_Interface
@@ -5849,8 +5849,8 @@ module Alloc_Boxed_Impl54_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 742 31 743 3]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 743 32 744 12]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 743 1 743 18]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 744 10 744 27]  ^ self =  ^ result }
     
 end
 module Alloc_Boxed_Impl54_AsMut
@@ -5858,8 +5858,8 @@ module Alloc_Boxed_Impl54_AsMut
   type a
   use prelude.Borrow
   val as_mut [@cfg:stackify] (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 742 31 743 3]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 743 32 744 12]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 743 1 743 18]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 744 10 744 27]  ^ self =  ^ result }
     
 end
 module CreusotContracts_Resolve_Impl0_Resolve_Stub
@@ -10047,14 +10047,14 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 754 6 764 11] result = self }
+    ensures { [#"../red_black_tree.rs" 754 21 764 26] result = self }
     
 end
 module Core_Clone_Clone_Clone
   type self
   use prelude.Borrow
   val clone' [@cfg:stackify] (self : self) : self
-    ensures { [#"../red_black_tree.rs" 754 6 764 11] result = self }
+    ensures { [#"../red_black_tree.rs" 754 21 764 26] result = self }
     
 end
 module RedBlackTree_Impl17

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -1,0 +1,1097 @@
+
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+end
+module Core_Ptr_NonNull_NonNull_Type
+  use prelude.Opaque
+  type t_nonnull 't =
+    | C_NonNull opaque_ptr
+    
+end
+module Core_Marker_PhantomData_Type
+  type t_phantomdata 't =
+    | C_PhantomData
+    
+end
+module Core_Ptr_Unique_Unique_Type
+  use Core_Marker_PhantomData_Type as Core_Marker_PhantomData_Type
+  use Core_Ptr_NonNull_NonNull_Type as Core_Ptr_NonNull_NonNull_Type
+  type t_unique 't =
+    | C_Unique (Core_Ptr_NonNull_NonNull_Type.t_nonnull 't) (Core_Marker_PhantomData_Type.t_phantomdata 't)
+    
+end
+module Alloc_RawVec_RawVec_Type
+  use mach.int.Int
+  use prelude.UIntSize
+  use Core_Ptr_Unique_Unique_Type as Core_Ptr_Unique_Unique_Type
+  type t_rawvec 't 'a =
+    | C_RawVec (Core_Ptr_Unique_Unique_Type.t_unique 't) usize 'a
+    
+end
+module Alloc_Collections_VecDeque_VecDeque_Type
+  use mach.int.Int
+  use prelude.UIntSize
+  use Alloc_RawVec_RawVec_Type as Alloc_RawVec_RawVec_Type
+  type t_vecdeque 't 'a =
+    | C_VecDeque usize usize (Alloc_RawVec_RawVec_Type.t_rawvec 't 'a)
+    
+end
+module Core_Num_Impl12_Max_Stub
+  use mach.int.Int
+  use prelude.UIntSize
+  val constant mAX'  : usize
+end
+module Core_Num_Impl12_Max
+  use mach.int.Int
+  use prelude.UIntSize
+  let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
+    (18446744073709551615 : usize)
+end
+module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub
+  type t
+  type a
+  use seq.Seq
+  use mach.int.UInt64
+  use mach.int.Int
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone Core_Num_Impl12_Max_Stub as Max0
+  function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
+end
+module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface
+  type t
+  type a
+  use seq.Seq
+  use mach.int.UInt64
+  use mach.int.Int
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone Core_Num_Impl12_Max_Stub as Max0
+  function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . Seq.length (shallow_model self) <= UInt64.to_int Max0.mAX'
+end
+module CreusotContracts_Std1_Deque_Impl0_ShallowModel
+  type t
+  type a
+  use seq.Seq
+  use mach.int.UInt64
+  use mach.int.Int
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone Core_Num_Impl12_Max_Stub as Max0
+  function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
+  val shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
+    ensures { result = shallow_model self }
+    
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . Seq.length (shallow_model self) <= UInt64.to_int Max0.mAX'
+end
+module Alloc_Alloc_Global_Type
+  type t_global  =
+    | C_Global
+    
+end
+module Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface
+  type t
+  use seq.Seq
+  use mach.int.Int
+  use prelude.UIntSize
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val with_capacity [@cfg:stackify] (capacity : usize) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
+    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    
+end
+module Alloc_Collections_VecDeque_Impl4_WithCapacity
+  type t
+  use seq.Seq
+  use mach.int.Int
+  use prelude.UIntSize
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val with_capacity [@cfg:stackify] (capacity : usize) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
+    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    
+end
+module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
+  type self
+  type shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Stub
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Interface
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+  val shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_ShallowModel_ShallowModel_Stub as ShallowModel0 with
+    type self = t,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
+    ShallowModel0.shallow_model self
+  val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type
+  type t
+  type a
+  use seq.Seq
+  type shallowModelTy  =
+    Seq.seq t
+end
+module Alloc_Collections_VecDeque_Impl5_IsEmpty_Interface
+  type t
+  type a
+  use seq.Seq
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val is_empty [@cfg:stackify] (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : bool
+    ensures { result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_IsEmpty
+  type t
+  type a
+  use seq.Seq
+  use prelude.Borrow
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val is_empty [@cfg:stackify] (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : bool
+    ensures { result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_Len_Interface
+  type t
+  type a
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Borrow
+  use mach.int.Int
+  use prelude.UIntSize
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val len [@cfg:stackify] (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : usize
+    ensures { UInt64.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_Len
+  type t
+  type a
+  use mach.int.UInt64
+  use seq.Seq
+  use prelude.Borrow
+  use mach.int.Int
+  use prelude.UIntSize
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel_Interface as ShallowModel0 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  val len [@cfg:stackify] (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : usize
+    ensures { UInt64.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    
+end
+module Alloc_Collections_VecDeque_Impl4_New_Interface
+  type t
+  use seq.Seq
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val new [@cfg:stackify] (_1' : ()) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
+    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    
+end
+module Alloc_Collections_VecDeque_Impl4_New
+  type t
+  use seq.Seq
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val new [@cfg:stackify] (_1' : ()) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
+    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    
+end
+module CreusotContracts_Model_Impl3_ShallowModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl3_ShallowModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl3_ShallowModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_ShallowModel_ShallowModel_Stub as ShallowModel0 with
+    type self = t,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
+    ShallowModel0.shallow_model ( * self)
+  val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PopFront_Interface
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use seq_ext.SeqExt
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Stub as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val pop_front [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
+    ensures { match (result) with
+      | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 1 (Seq.length (ShallowModel1.shallow_model self)) /\ ShallowModel1.shallow_model self = Seq.(++) (Seq.singleton t) (ShallowModel0.shallow_model ( ^ self))
+      | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
+      end }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PopFront
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use seq_ext.SeqExt
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Interface as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val pop_front [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
+    ensures { match (result) with
+      | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 1 (Seq.length (ShallowModel1.shallow_model self)) /\ ShallowModel1.shallow_model self = Seq.(++) (Seq.singleton t) (ShallowModel0.shallow_model ( ^ self))
+      | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
+      end }
+    
+end
+module CreusotContracts_Model_DeepModel_DeepModelTy_Type
+  type self
+  type deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel_Stub
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel_Interface
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_DeepModel_DeepModel
+  type self
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = self
+  function deep_model (self : self) : DeepModelTy0.deepModelTy
+  val deep_model (self : self) : DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module CreusotContracts_Model_Impl0_DeepModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  function deep_model (self : t) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_Impl0_DeepModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  function deep_model (self : t) : DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_Impl0_DeepModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
+    type self = t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  function deep_model (self : t) : DeepModelTy0.deepModelTy =
+    DeepModel0.deep_model self
+  val deep_model (self : t) : DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module Core_Option_Impl42_Eq_Interface
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = Core_Option_Option_Type.t_option t
+  clone CreusotContracts_Model_Impl0_DeepModel_Stub as DeepModel0 with
+    type t = Core_Option_Option_Type.t_option t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) (other : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Core_Option_Impl42_Eq
+  type t
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = Core_Option_Option_Type.t_option t
+  clone CreusotContracts_Model_Impl0_DeepModel_Interface as DeepModel0 with
+    type t = Core_Option_Option_Type.t_option t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  val eq [@cfg:stackify] (self : Core_Option_Option_Type.t_option t) (other : Core_Option_Option_Type.t_option t) : bool
+    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PopBack_Interface
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use mach.int.Int
+  use seq_ext.SeqExt
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Stub as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val pop_back [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
+    ensures { match (result) with
+      | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 0 (Seq.length (ShallowModel1.shallow_model self) - 1) /\ ShallowModel1.shallow_model self = Seq.snoc (ShallowModel0.shallow_model ( ^ self)) t
+      | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
+      end }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PopBack
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use mach.int.Int
+  use seq_ext.SeqExt
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Interface as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  val pop_back [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
+    ensures { match (result) with
+      | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 0 (Seq.length (ShallowModel1.shallow_model self) - 1) /\ ShallowModel1.shallow_model self = Seq.snoc (ShallowModel0.shallow_model ( ^ self)) t
+      | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
+      end }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PushFront_Interface
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Stub as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val push_front [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
+    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
+    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PushFront
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  use mach.int.Int
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Interface as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val push_front [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
+    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
+    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PushBack_Interface
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Stub as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val push_back [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
+    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_PushBack
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = t,
+    type a = a
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Interface as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val push_back [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
+    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_Clear_Interface
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val clear [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : ()
+    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
+    
+end
+module Alloc_Collections_VecDeque_Impl5_Clear
+  type t
+  type a
+  use prelude.Borrow
+  use seq.Seq
+  clone Core_Num_Impl12_Max_Stub as Max0
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface as ShallowModel0 with
+    type t = t,
+    type a = a,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  val clear [@cfg:stackify] (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : ()
+    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
+    
+end
+module CreusotContracts_Model_Impl10_DeepModelTy_Type
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  type deepModelTy  =
+    Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+end
+module CreusotContracts_Model_Impl10_DeepModel_Stub
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+end
+module CreusotContracts_Model_Impl10_DeepModel_Interface
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+end
+module CreusotContracts_Model_Impl10_DeepModel
+  type t
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = t
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Model_DeepModel_DeepModel_Stub as DeepModel0 with
+    type self = t,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    
+   =
+    match (self) with
+      | Core_Option_Option_Type.C_Some t -> Core_Option_Option_Type.C_Some (DeepModel0.deep_model t)
+      | Core_Option_Option_Type.C_None -> Core_Option_Option_Type.C_None
+      end
+  val deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
+    ensures { result = deep_model self }
+    
+end
+module CreusotContracts_Logic_Int_Impl12_DeepModelTy_Type
+  use mach.int.Int
+  type deepModelTy  =
+    int
+end
+module CreusotContracts_Logic_Int_Impl12_DeepModel_Stub
+  use mach.int.Int
+  use mach.int.UInt32
+  function deep_model (self : uint32) : int
+end
+module CreusotContracts_Logic_Int_Impl12_DeepModel_Interface
+  use mach.int.Int
+  use mach.int.UInt32
+  function deep_model (self : uint32) : int
+end
+module CreusotContracts_Logic_Int_Impl12_DeepModel
+  use mach.int.Int
+  use mach.int.UInt32
+  function deep_model (self : uint32) : int =
+    UInt32.to_int self
+  val deep_model (self : uint32) : int
+    ensures { result = deep_model self }
+    
+end
+module Vecdeque_TestDeque_Interface
+  val test_deque [@cfg:stackify] [#"../vecdeque.rs" 5 0 5 19] (_1' : ()) : ()
+end
+module Vecdeque_TestDeque
+  use mach.int.Int
+  use mach.int.UInt32
+  use prelude.Borrow
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  let constant promoted0  : Core_Option_Option_Type.t_option uint32 = [@vc:do_not_keep_trace] [@vc:sp]
+    let _1 = Core_Option_Option_Type.C_Some ([#"../vecdeque.rs" 24 37 24 38] (3 : uint32)) in let _0 = _1 in _0
+  let constant promoted1  : Core_Option_Option_Type.t_option uint32 = [@vc:do_not_keep_trace] [@vc:sp]
+    let _1 = Core_Option_Option_Type.C_Some ([#"../vecdeque.rs" 23 38 23 39] (2 : uint32)) in let _0 = _1 in _0
+  let constant promoted2  : Core_Option_Option_Type.t_option uint32 = [@vc:do_not_keep_trace] [@vc:sp]
+    let _1 = Core_Option_Option_Type.C_None in let _0 = _1 in _0
+  let constant promoted3  : Core_Option_Option_Type.t_option uint32 = [@vc:do_not_keep_trace] [@vc:sp]
+    let _1 = Core_Option_Option_Type.C_None in let _0 = _1 in _0
+  use prelude.UIntSize
+  use mach.int.Int
+  clone CreusotContracts_Logic_Int_Impl12_DeepModel as DeepModel2
+  clone CreusotContracts_Logic_Int_Impl12_DeepModelTy_Type as DeepModelTy1
+  clone CreusotContracts_Model_Impl10_DeepModel as DeepModel1 with
+    type t = uint32,
+    type DeepModelTy0.deepModelTy = DeepModelTy1.deepModelTy,
+    function DeepModel0.deep_model = DeepModel2.deep_model
+  clone CreusotContracts_Model_Impl10_DeepModelTy_Type as DeepModelTy0 with
+    type t = uint32,
+    type DeepModelTy0.deepModelTy = DeepModelTy1.deepModelTy
+  clone CreusotContracts_Model_Impl0_DeepModel as DeepModel0 with
+    type t = Core_Option_Option_Type.t_option uint32,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
+    function DeepModel0.deep_model = DeepModel1.deep_model
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
+  clone Core_Num_Impl12_Max as Max0
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModel as ShallowModel0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  clone CreusotContracts_Std1_Deque_Impl0_ShallowModelTy_Type as ShallowModelTy0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global
+  clone CreusotContracts_Model_Impl3_ShallowModel as ShallowModel2 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global),
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model
+  clone CreusotContracts_Model_Impl1_ShallowModel as ShallowModel1 with
+    type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global),
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model
+  clone Alloc_Collections_VecDeque_Impl5_Clear_Interface as Clear0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Alloc_Collections_VecDeque_Impl5_PushBack_Interface as PushBack0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Alloc_Collections_VecDeque_Impl5_PushFront_Interface as PushFront0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Alloc_Collections_VecDeque_Impl5_PopBack_Interface as PopBack0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Core_Option_Impl42_Eq_Interface as Eq0 with
+    type t = uint32,
+    function DeepModel0.deep_model = DeepModel0.deep_model,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
+  clone Alloc_Collections_VecDeque_Impl5_PopFront_Interface as PopFront0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Alloc_Collections_VecDeque_Impl4_New_Interface as New0 with
+    type t = uint32,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  clone Alloc_Collections_VecDeque_Impl5_Len_Interface as Len0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone Alloc_Collections_VecDeque_Impl5_IsEmpty_Interface as IsEmpty0 with
+    type t = uint32,
+    type a = Alloc_Alloc_Global_Type.t_global,
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface as WithCapacity0 with
+    type t = uint32,
+    function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
+    val Max0.mAX' = Max0.mAX'
+  let rec cfg test_deque [@cfg:stackify] [#"../vecdeque.rs" 5 0 5 19] (_1' : ()) : () = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  var deque_1 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _2 : ();
+  var _3 : bool;
+  var _4 : bool;
+  var _5 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _6 : ();
+  var _7 : ();
+  var _8 : bool;
+  var _9 : bool;
+  var _10 : usize;
+  var _11 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _12 : ();
+  var deque_13 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _14 : ();
+  var _15 : bool;
+  var _16 : bool;
+  var _17 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _18 : ();
+  var _19 : ();
+  var _20 : bool;
+  var _21 : bool;
+  var _22 : usize;
+  var _23 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _24 : ();
+  var _25 : ();
+  var _26 : bool;
+  var _27 : bool;
+  var _28 : Core_Option_Option_Type.t_option uint32;
+  var _29 : Core_Option_Option_Type.t_option uint32;
+  var _30 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _31 : Core_Option_Option_Type.t_option uint32;
+  var _32 : Core_Option_Option_Type.t_option uint32;
+  var _33 : ();
+  var _34 : ();
+  var _35 : bool;
+  var _36 : bool;
+  var _37 : Core_Option_Option_Type.t_option uint32;
+  var _38 : Core_Option_Option_Type.t_option uint32;
+  var _39 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _40 : Core_Option_Option_Type.t_option uint32;
+  var _41 : Core_Option_Option_Type.t_option uint32;
+  var _42 : ();
+  var _43 : ();
+  var _44 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _45 : ();
+  var _46 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _47 : ();
+  var _48 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _49 : ();
+  var _50 : bool;
+  var _51 : bool;
+  var _52 : Core_Option_Option_Type.t_option uint32;
+  var _53 : Core_Option_Option_Type.t_option uint32;
+  var _54 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _55 : Core_Option_Option_Type.t_option uint32;
+  var _56 : Core_Option_Option_Type.t_option uint32;
+  var _57 : ();
+  var _58 : ();
+  var _59 : bool;
+  var _60 : bool;
+  var _61 : Core_Option_Option_Type.t_option uint32;
+  var _62 : Core_Option_Option_Type.t_option uint32;
+  var _63 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _64 : Core_Option_Option_Type.t_option uint32;
+  var _65 : Core_Option_Option_Type.t_option uint32;
+  var _66 : ();
+  var _67 : ();
+  var _68 : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
+  var _69 : ();
+  var _70 : bool;
+  var _71 : bool;
+  var _72 : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global);
+  var _73 : ();
+  var _74 : Core_Option_Option_Type.t_option uint32;
+  var _75 : Core_Option_Option_Type.t_option uint32;
+  var _76 : Core_Option_Option_Type.t_option uint32;
+  var _77 : Core_Option_Option_Type.t_option uint32;
+  {
+    goto BB0
+  }
+  BB0 {
+    deque_1 <- ([#"../vecdeque.rs" 6 31 6 57] WithCapacity0.with_capacity ([#"../vecdeque.rs" 6 55 6 56] (5 : usize)));
+    goto BB1
+  }
+  BB1 {
+    _5 <- deque_1;
+    _4 <- ([#"../vecdeque.rs" 8 12 8 28] IsEmpty0.is_empty _5);
+    goto BB2
+  }
+  BB2 {
+    _3 <- not _4;
+    switch (_3)
+      | False -> goto BB4
+      | True -> goto BB3
+      end
+  }
+  BB3 {
+    absurd
+  }
+  BB4 {
+    _2 <- ();
+    _11 <- deque_1;
+    _10 <- ([#"../vecdeque.rs" 9 12 9 23] Len0.len _11);
+    goto BB5
+  }
+  BB5 {
+    _9 <- ([#"../vecdeque.rs" 9 12 9 28] _10 = ([#"../vecdeque.rs" 9 27 9 28] (0 : usize)));
+    _8 <- not _9;
+    switch (_8)
+      | False -> goto BB7
+      | True -> goto BB6
+      end
+  }
+  BB6 {
+    absurd
+  }
+  BB7 {
+    _7 <- ();
+    deque_13 <- ([#"../vecdeque.rs" 11 35 11 50] New0.new ());
+    goto BB8
+  }
+  BB8 {
+    _17 <- deque_13;
+    _16 <- ([#"../vecdeque.rs" 13 12 13 28] IsEmpty0.is_empty _17);
+    goto BB9
+  }
+  BB9 {
+    _15 <- not _16;
+    switch (_15)
+      | False -> goto BB11
+      | True -> goto BB10
+      end
+  }
+  BB10 {
+    absurd
+  }
+  BB11 {
+    _14 <- ();
+    _23 <- deque_13;
+    _22 <- ([#"../vecdeque.rs" 14 12 14 23] Len0.len _23);
+    goto BB12
+  }
+  BB12 {
+    _21 <- ([#"../vecdeque.rs" 14 12 14 28] _22 = ([#"../vecdeque.rs" 14 27 14 28] (0 : usize)));
+    _20 <- not _21;
+    switch (_20)
+      | False -> goto BB14
+      | True -> goto BB13
+      end
+  }
+  BB13 {
+    absurd
+  }
+  BB14 {
+    _19 <- ();
+    _30 <- borrow_mut deque_13;
+    deque_13 <-  ^ _30;
+    _29 <- ([#"../vecdeque.rs" 16 12 16 29] PopFront0.pop_front _30);
+    goto BB15
+  }
+  BB15 {
+    _28 <- _29;
+    _77 <- ([#"../vecdeque.rs" 16 33 16 37] promoted3);
+    _31 <- _77;
+    _27 <- ([#"../vecdeque.rs" 16 12 16 37] Eq0.eq _28 _31);
+    goto BB16
+  }
+  BB16 {
+    _26 <- not _27;
+    switch (_26)
+      | False -> goto BB18
+      | True -> goto BB17
+      end
+  }
+  BB17 {
+    absurd
+  }
+  BB18 {
+    _25 <- ();
+    _39 <- borrow_mut deque_13;
+    deque_13 <-  ^ _39;
+    _38 <- ([#"../vecdeque.rs" 17 12 17 28] PopBack0.pop_back _39);
+    goto BB19
+  }
+  BB19 {
+    _37 <- _38;
+    _76 <- ([#"../vecdeque.rs" 17 32 17 36] promoted2);
+    _40 <- _76;
+    _36 <- ([#"../vecdeque.rs" 17 12 17 36] Eq0.eq _37 _40);
+    goto BB20
+  }
+  BB20 {
+    _35 <- not _36;
+    switch (_35)
+      | False -> goto BB22
+      | True -> goto BB21
+      end
+  }
+  BB21 {
+    absurd
+  }
+  BB22 {
+    _34 <- ();
+    _44 <- borrow_mut deque_13;
+    deque_13 <-  ^ _44;
+    _43 <- ([#"../vecdeque.rs" 19 4 19 23] PushFront0.push_front _44 ([#"../vecdeque.rs" 19 21 19 22] (1 : uint32)));
+    goto BB23
+  }
+  BB23 {
+    _46 <- borrow_mut deque_13;
+    deque_13 <-  ^ _46;
+    _45 <- ([#"../vecdeque.rs" 20 4 20 23] PushFront0.push_front _46 ([#"../vecdeque.rs" 20 21 20 22] (2 : uint32)));
+    goto BB24
+  }
+  BB24 {
+    _48 <- borrow_mut deque_13;
+    deque_13 <-  ^ _48;
+    _47 <- ([#"../vecdeque.rs" 21 4 21 22] PushBack0.push_back _48 ([#"../vecdeque.rs" 21 20 21 21] (3 : uint32)));
+    goto BB25
+  }
+  BB25 {
+    _54 <- borrow_mut deque_13;
+    deque_13 <-  ^ _54;
+    _53 <- ([#"../vecdeque.rs" 23 12 23 29] PopFront0.pop_front _54);
+    goto BB26
+  }
+  BB26 {
+    _52 <- _53;
+    _75 <- ([#"../vecdeque.rs" 23 33 23 40] promoted1);
+    _55 <- _75;
+    _51 <- ([#"../vecdeque.rs" 23 12 23 40] Eq0.eq _52 _55);
+    goto BB27
+  }
+  BB27 {
+    _50 <- not _51;
+    switch (_50)
+      | False -> goto BB29
+      | True -> goto BB28
+      end
+  }
+  BB28 {
+    absurd
+  }
+  BB29 {
+    _49 <- ();
+    _63 <- borrow_mut deque_13;
+    deque_13 <-  ^ _63;
+    _62 <- ([#"../vecdeque.rs" 24 12 24 28] PopBack0.pop_back _63);
+    goto BB30
+  }
+  BB30 {
+    _61 <- _62;
+    _74 <- ([#"../vecdeque.rs" 24 32 24 39] promoted0);
+    _64 <- _74;
+    _60 <- ([#"../vecdeque.rs" 24 12 24 39] Eq0.eq _61 _64);
+    goto BB31
+  }
+  BB31 {
+    _59 <- not _60;
+    switch (_59)
+      | False -> goto BB33
+      | True -> goto BB32
+      end
+  }
+  BB32 {
+    absurd
+  }
+  BB33 {
+    _58 <- ();
+    _68 <- borrow_mut deque_13;
+    deque_13 <-  ^ _68;
+    _67 <- ([#"../vecdeque.rs" 25 4 25 17] Clear0.clear _68);
+    goto BB34
+  }
+  BB34 {
+    _72 <- deque_13;
+    _71 <- ([#"../vecdeque.rs" 26 12 26 28] IsEmpty0.is_empty _72);
+    goto BB35
+  }
+  BB35 {
+    _70 <- not _71;
+    switch (_70)
+      | False -> goto BB37
+      | True -> goto BB36
+      end
+  }
+  BB36 {
+    absurd
+  }
+  BB37 {
+    _69 <- ();
+    _0 <- ();
+    goto BB38
+  }
+  BB38 {
+    goto BB39
+  }
+  BB39 {
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/vecdeque.rs
+++ b/creusot/tests/should_succeed/vecdeque.rs
@@ -1,0 +1,27 @@
+extern crate creusot_contracts;
+
+use std::collections::VecDeque;
+
+pub fn test_deque() {
+    let deque: VecDeque<u32> = VecDeque::with_capacity(5);
+
+    assert!(deque.is_empty());
+    assert!(deque.len() == 0);
+
+    let mut deque: VecDeque<u32> = VecDeque::new();
+
+    assert!(deque.is_empty());
+    assert!(deque.len() == 0);
+
+    assert!(deque.pop_front() == None);
+    assert!(deque.pop_back() == None);
+
+    deque.push_front(1);
+    deque.push_front(2);
+    deque.push_back(3);
+
+    assert!(deque.pop_front() == Some(2));
+    assert!(deque.pop_back() == Some(3));
+    deque.clear();
+    assert!(deque.is_empty());
+}


### PR DESCRIPTION
I added specs for the functions that I thought would be most useful for `VecDeque`. Most of them mirror the specs for `Vec`. Original specs are for `pop_front()` and `push_front()`.