### PR TITLE
Provide VSCode tasks to work with whycode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build MLCFG",
+            "dependsOn": [
+                "Generate MLCFG",
+                "Reload Session"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Generate MLCFG",
+            "type": "shell",
+            "command": "./mlcfg ${file}",
+            "group": {
+                "kind": "build"
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "options": {
+                "env": {
+                    "OUTPUT_FILE": "${relativeFileDirname}/${fileBasenameNoExtension}.mlcfg"
+                }
+            }
+        },
+        {
+            "label": "Reload Session",
+            "command": "${command:extension.reloadSession}"
+        }
+    ]
+}

--- a/creusot/Cargo.toml
+++ b/creusot/Cargo.toml
@@ -15,7 +15,7 @@ petgraph = "0.6"
 indexmap = { version = "1.7.0", features = ["serde"] }
 toml = "0.5.8"
 why3 = { path = "../why3", features = ["serialize"] }
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 creusot-metadata = { path = "../creusot-metadata" }
 creusot-rustc = { path = "../creusot-rustc" }
 lazy_static = "1.4.0"


### PR DESCRIPTION
Some hacks that provide a rough-ish workflow for using creusot in VSCode. 

This only works for single-file crates (ie the tests). 
Making a version of this that works with `cargo-creusot` is easy though, just call `cargo creusot` instead of `mlcfg`. 


