### PR TITLE
partial fix 685

### DIFF
--- a/creusot-contracts-proc/src/invariant.rs
+++ b/creusot-contracts-proc/src/invariant.rs
@@ -153,7 +153,7 @@ fn desugar_for(mut invariants: Vec<Invariant>, f: ExprForLoop) -> TokenStream {
         },
     );
 
-    let elem = Ident::new("i", proc_macro::Span::def_site().into());
+    let elem = Ident::new("__creusot_proc_iter_elem", proc_macro::Span::def_site().into());
 
     quote! { {
         let mut #it = ::std::iter::IntoIterator::into_iter(#iter);

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -1079,7 +1079,7 @@ module C100doors_F
   var _16 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _17 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _18 : isize;
-  var i_19 : usize;
+  var __creusot_proc_iter_elem_19 : usize;
   var _20 : Ghost.ghost_ty (Seq.seq usize);
   var _22 : ();
   var pass_23 : usize;
@@ -1155,15 +1155,15 @@ module C100doors_F
     absurd
   }
   BB10 {
-    i_19 <- Core_Option_Option_Type.some_0 _15;
+    __creusot_proc_iter_elem_19 <- Core_Option_Option_Type.some_0 _15;
     _22 <- ();
-    _20 <- ([#"../100doors.rs" 20 4 20 54] Ghost.new (Seq.(++) (Ghost.inner produced_7) (Seq.singleton i_19)));
+    _20 <- ([#"../100doors.rs" 20 4 20 54] Ghost.new (Seq.(++) (Ghost.inner produced_7) (Seq.singleton __creusot_proc_iter_elem_19)));
     goto BB11
   }
   BB11 {
     produced_7 <- _20;
     _20 <- any Ghost.ghost_ty (Seq.seq usize);
-    pass_23 <- i_19;
+    pass_23 <- __creusot_proc_iter_elem_19;
     door_24 <- pass_23;
     goto BB12
   }

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -1698,7 +1698,7 @@ module Hillel_InsertUnique
   var _32 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _33 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _34 : isize;
-  var i_35 : t;
+  var __creusot_proc_iter_elem_35 : t;
   var _36 : Ghost.ghost_ty (Seq.seq t);
   var _38 : ();
   var e_39 : t;
@@ -1799,11 +1799,11 @@ module Hillel_InsertUnique
     absurd
   }
   BB15 {
-    assume { Resolve6.resolve i_35 };
-    i_35 <- Core_Option_Option_Type.some_0 _31;
+    assume { Resolve6.resolve __creusot_proc_iter_elem_35 };
+    __creusot_proc_iter_elem_35 <- Core_Option_Option_Type.some_0 _31;
     assume { Resolve5.resolve _31 };
     _38 <- ();
-    _36 <- ([#"../hillel.rs" 83 4 83 121] Ghost.new (Seq.(++) (Ghost.inner produced_23) (Seq.singleton i_35)));
+    _36 <- ([#"../hillel.rs" 83 4 83 121] Ghost.new (Seq.(++) (Ghost.inner produced_23) (Seq.singleton __creusot_proc_iter_elem_35)));
     goto BB16
   }
   BB16 {
@@ -1811,8 +1811,8 @@ module Hillel_InsertUnique
     produced_23 <- _36;
     _36 <- any Ghost.ghost_ty (Seq.seq t);
     assume { Resolve6.resolve e_39 };
-    e_39 <- i_35;
-    assume { Resolve6.resolve i_35 };
+    e_39 <- __creusot_proc_iter_elem_35;
+    assume { Resolve6.resolve __creusot_proc_iter_elem_35 };
     assert { [#"../hillel.rs" 85 24 85 55] e_39 = Seq.get (ShallowModel0.shallow_model ( * vec_1)) (Seq.length (Ghost.inner produced_23) - 1) };
     _40 <- ();
     _43 <- e_39;
@@ -2501,7 +2501,7 @@ module Hillel_Unique
   var _29 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _30 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _31 : isize;
-  var i_32 : usize;
+  var __creusot_proc_iter_elem_32 : usize;
   var _33 : Ghost.ghost_ty (Seq.seq usize);
   var _35 : ();
   var i_36 : usize;
@@ -2595,15 +2595,15 @@ module Hillel_Unique
     absurd
   }
   BB14 {
-    i_32 <- Core_Option_Option_Type.some_0 _28;
+    __creusot_proc_iter_elem_32 <- Core_Option_Option_Type.some_0 _28;
     _35 <- ();
-    _33 <- ([#"../hillel.rs" 103 4 103 56] Ghost.new (Seq.(++) (Ghost.inner produced_18) (Seq.singleton i_32)));
+    _33 <- ([#"../hillel.rs" 103 4 103 56] Ghost.new (Seq.(++) (Ghost.inner produced_18) (Seq.singleton __creusot_proc_iter_elem_32)));
     goto BB15
   }
   BB15 {
     produced_18 <- _33;
     _33 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_36 <- i_32;
+    i_36 <- __creusot_proc_iter_elem_32;
     _38 <- i_36;
     _39 <- UIntSize.of_int (Seq.length str_1);
     _40 <- ([#"../hillel.rs" 107 22 107 28] _38 < _39);
@@ -3092,7 +3092,7 @@ module Hillel_Fulcrum
   var _23 : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
   var _24 : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
   var _25 : isize;
-  var i_26 : uint32;
+  var __creusot_proc_iter_elem_26 : uint32;
   var _27 : Ghost.ghost_ty (Seq.seq uint32);
   var _29 : ();
   var x_30 : uint32;
@@ -3115,7 +3115,7 @@ module Hillel_Fulcrum
   var _58 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _59 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _60 : isize;
-  var i_61 : usize;
+  var __creusot_proc_iter_elem_61 : usize;
   var _62 : Ghost.ghost_ty (Seq.seq usize);
   var _64 : ();
   var i_65 : usize;
@@ -3192,15 +3192,15 @@ module Hillel_Fulcrum
     absurd
   }
   BB8 {
-    i_26 <- Core_Option_Option_Type.some_0 _22;
+    __creusot_proc_iter_elem_26 <- Core_Option_Option_Type.some_0 _22;
     _29 <- ();
-    _27 <- ([#"../hillel.rs" 158 4 158 67] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton i_26)));
+    _27 <- ([#"../hillel.rs" 158 4 158 67] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_26)));
     goto BB9
   }
   BB9 {
     produced_13 <- _27;
     _27 <- any Ghost.ghost_ty (Seq.seq uint32);
-    x_30 <- i_26;
+    x_30 <- __creusot_proc_iter_elem_26;
     _31 <- x_30;
     total_6 <- ([#"../hillel.rs" 161 8 161 18] total_6 + _31);
     _21 <- ();
@@ -3255,15 +3255,15 @@ module Hillel_Fulcrum
     absurd
   }
   BB18 {
-    i_61 <- Core_Option_Option_Type.some_0 _57;
+    __creusot_proc_iter_elem_61 <- Core_Option_Option_Type.some_0 _57;
     _64 <- ();
-    _62 <- ([#"../hillel.rs" 170 4 170 63] Ghost.new (Seq.(++) (Ghost.inner produced_46) (Seq.singleton i_61)));
+    _62 <- ([#"../hillel.rs" 170 4 170 63] Ghost.new (Seq.(++) (Ghost.inner produced_46) (Seq.singleton __creusot_proc_iter_elem_61)));
     goto BB19
   }
   BB19 {
     produced_46 <- _62;
     _62 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_65 <- i_61;
+    i_65 <- __creusot_proc_iter_elem_61;
     _67 <- sum_37;
     _69 <- total_6;
     _70 <- sum_37;

--- a/creusot/tests/should_succeed/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/inc_max_repeat.mlcfg
@@ -595,7 +595,7 @@ module IncMaxRepeat_IncMaxRepeat
   var _22 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _23 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _24 : isize;
-  var i_25 : uint32;
+  var __creusot_proc_iter_elem_25 : uint32;
   var _26 : Ghost.ghost_ty (Seq.seq uint32);
   var _28 : ();
   var mc_29 : borrowed uint32;
@@ -678,9 +678,9 @@ module IncMaxRepeat_IncMaxRepeat
     absurd
   }
   BB8 {
-    i_25 <- Core_Option_Option_Type.some_0 _21;
+    __creusot_proc_iter_elem_25 <- Core_Option_Option_Type.some_0 _21;
     _28 <- ();
-    _26 <- ([#"../inc_max_repeat.rs" 16 4 16 97] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_25)));
+    _26 <- ([#"../inc_max_repeat.rs" 16 4 16 97] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_25)));
     goto BB9
   }
   BB9 {

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -741,7 +741,7 @@ module C03StdIterators_SliceIter
   var _21 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _22 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _23 : isize;
-  var i_24 : t;
+  var __creusot_proc_iter_elem_24 : t;
   var _25 : Ghost.ghost_ty (Seq.seq t);
   var _27 : ();
   var _28 : ();
@@ -804,12 +804,12 @@ module C03StdIterators_SliceIter
     absurd
   }
   BB9 {
-    assume { Resolve4.resolve i_24 };
-    i_24 <- Core_Option_Option_Type.some_0 _20;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_24 };
+    __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     assume { Resolve3.resolve _20 };
-    assume { Resolve4.resolve i_24 };
+    assume { Resolve4.resolve __creusot_proc_iter_elem_24 };
     _27 <- ();
-    _25 <- ([#"../03_std_iterators.rs" 8 4 8 45] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_24)));
+    _25 <- ([#"../03_std_iterators.rs" 8 4 8 45] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB10
   }
   BB10 {
@@ -1141,7 +1141,7 @@ module C03StdIterators_VecIter
   var _20 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _21 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _22 : isize;
-  var i_23 : t;
+  var __creusot_proc_iter_elem_23 : t;
   var _24 : Ghost.ghost_ty (Seq.seq t);
   var _26 : ();
   var _27 : ();
@@ -1201,12 +1201,12 @@ module C03StdIterators_VecIter
     absurd
   }
   BB8 {
-    assume { Resolve4.resolve i_23 };
-    i_23 <- Core_Option_Option_Type.some_0 _19;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_23 };
+    __creusot_proc_iter_elem_23 <- Core_Option_Option_Type.some_0 _19;
     assume { Resolve3.resolve _19 };
-    assume { Resolve4.resolve i_23 };
+    assume { Resolve4.resolve __creusot_proc_iter_elem_23 };
     _26 <- ();
-    _24 <- ([#"../03_std_iterators.rs" 19 4 19 45] Ghost.new (Seq.(++) (Ghost.inner produced_11) (Seq.singleton i_23)));
+    _24 <- ([#"../03_std_iterators.rs" 19 4 19 45] Ghost.new (Seq.(++) (Ghost.inner produced_11) (Seq.singleton __creusot_proc_iter_elem_23)));
     goto BB9
   }
   BB9 {
@@ -1822,7 +1822,7 @@ module C03StdIterators_AllZero
   var _21 : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
   var _22 : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
   var _23 : isize;
-  var i_24 : borrowed usize;
+  var __creusot_proc_iter_elem_24 : borrowed usize;
   var _25 : Ghost.ghost_ty (Seq.seq (borrowed usize));
   var _27 : ();
   var x_28 : borrowed usize;
@@ -1890,19 +1890,19 @@ module C03StdIterators_AllZero
     absurd
   }
   BB10 {
-    assume { Resolve4.resolve i_24 };
-    i_24 <- Core_Option_Option_Type.some_0 _20;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_24 };
+    __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     _20 <- (let Core_Option_Option_Type.C_Some a = _20 in Core_Option_Option_Type.C_Some (any borrowed usize));
     _27 <- ();
-    _25 <- ([#"../03_std_iterators.rs" 29 4 29 91] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_24)));
+    _25 <- ([#"../03_std_iterators.rs" 29 4 29 91] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB11
   }
   BB11 {
     produced_12 <- _25;
     _25 <- any Ghost.ghost_ty (Seq.seq (borrowed usize));
     assume { Resolve4.resolve x_28 };
-    x_28 <- i_24;
-    i_24 <- any borrowed usize;
+    x_28 <- __creusot_proc_iter_elem_24;
+    __creusot_proc_iter_elem_24 <- any borrowed usize;
     x_28 <- { x_28 with current = ([#"../03_std_iterators.rs" 31 13 31 14] (0 : usize)) };
     assume { Resolve4.resolve x_28 };
     _19 <- ();
@@ -4503,7 +4503,7 @@ module C03StdIterators_SumRange
   var _21 : borrowed (Core_Ops_Range_Range_Type.t_range isize);
   var _22 : borrowed (Core_Ops_Range_Range_Type.t_range isize);
   var _23 : isize;
-  var i_24 : isize;
+  var __creusot_proc_iter_elem_24 : isize;
   var _25 : Ghost.ghost_ty (Seq.seq isize);
   var _27 : ();
   var _28 : ();
@@ -4558,9 +4558,9 @@ module C03StdIterators_SumRange
     absurd
   }
   BB8 {
-    i_24 <- Core_Option_Option_Type.some_0 _20;
+    __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     _27 <- ();
-    _25 <- ([#"../03_std_iterators.rs" 66 4 66 54] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_24)));
+    _25 <- ([#"../03_std_iterators.rs" 66 4 66 54] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB9
   }
   BB9 {

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -687,7 +687,7 @@ module C08CollectExtend_Extend
   var _23 : borrowed i;
   var _24 : borrowed i;
   var _25 : isize;
-  var i_26 : t;
+  var __creusot_proc_iter_elem_26 : t;
   var _27 : Ghost.ghost_ty (Seq.seq t);
   var _29 : ();
   var x_30 : t;
@@ -768,11 +768,11 @@ module C08CollectExtend_Extend
     absurd
   }
   BB13 {
-    assume { Resolve4.resolve i_26 };
-    i_26 <- Core_Option_Option_Type.some_0 _22;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_26 };
+    __creusot_proc_iter_elem_26 <- Core_Option_Option_Type.some_0 _22;
     _22 <- (let Core_Option_Option_Type.C_Some a = _22 in Core_Option_Option_Type.C_Some (any t));
     _29 <- ();
-    _27 <- ([#"../08_collect_extend.rs" 29 4 29 46] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton i_26)));
+    _27 <- ([#"../08_collect_extend.rs" 29 4 29 46] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_26)));
     goto BB14
   }
   BB14 {
@@ -780,8 +780,8 @@ module C08CollectExtend_Extend
     produced_13 <- _27;
     _27 <- any Ghost.ghost_ty (Seq.seq t);
     assume { Resolve4.resolve x_30 };
-    x_30 <- i_26;
-    i_26 <- any t;
+    x_30 <- __creusot_proc_iter_elem_26;
+    __creusot_proc_iter_elem_26 <- any t;
     _32 <- borrow_mut ( * vec_1);
     vec_1 <- { vec_1 with current = ( ^ _32) };
     assume { Resolve4.resolve _33 };
@@ -999,7 +999,7 @@ module C08CollectExtend_Collect
   var _20 : borrowed i;
   var _21 : borrowed i;
   var _22 : isize;
-  var i_23 : Item0.item;
+  var __creusot_proc_iter_elem_23 : Item0.item;
   var _24 : Ghost.ghost_ty (Seq.seq Item0.item);
   var _26 : ();
   var x_27 : Item0.item;
@@ -1079,11 +1079,11 @@ module C08CollectExtend_Collect
     absurd
   }
   BB14 {
-    assume { Resolve4.resolve i_23 };
-    i_23 <- Core_Option_Option_Type.some_0 _19;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_23 };
+    __creusot_proc_iter_elem_23 <- Core_Option_Option_Type.some_0 _19;
     _19 <- (let Core_Option_Option_Type.C_Some a = _19 in Core_Option_Option_Type.C_Some (any Item0.item));
     _26 <- ();
-    _24 <- ([#"../08_collect_extend.rs" 48 4 48 47] Ghost.new (Seq.(++) (Ghost.inner produced_11) (Seq.singleton i_23)));
+    _24 <- ([#"../08_collect_extend.rs" 48 4 48 47] Ghost.new (Seq.(++) (Ghost.inner produced_11) (Seq.singleton __creusot_proc_iter_elem_23)));
     goto BB15
   }
   BB15 {
@@ -1091,8 +1091,8 @@ module C08CollectExtend_Collect
     produced_11 <- _24;
     _24 <- any Ghost.ghost_ty (Seq.seq Item0.item);
     assume { Resolve4.resolve x_27 };
-    x_27 <- i_23;
-    i_23 <- any Item0.item;
+    x_27 <- __creusot_proc_iter_elem_23;
+    __creusot_proc_iter_elem_23 <- any Item0.item;
     _29 <- borrow_mut res_4;
     res_4 <-  ^ _29;
     assume { Resolve4.resolve _30 };

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -2233,7 +2233,7 @@ module KnapsackFull_Knapsack01Dyn
   var _36 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _37 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _38 : isize;
-  var i_39 : usize;
+  var __creusot_proc_iter_elem_39 : usize;
   var _40 : Ghost.ghost_ty (Seq.seq usize);
   var _42 : ();
   var i_43 : usize;
@@ -2252,7 +2252,7 @@ module KnapsackFull_Knapsack01Dyn
   var _66 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _67 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _68 : isize;
-  var i_69 : usize;
+  var __creusot_proc_iter_elem_69 : usize;
   var _70 : Ghost.ghost_ty (Seq.seq usize);
   var _72 : ();
   var w_73 : usize;
@@ -2418,15 +2418,15 @@ module KnapsackFull_Knapsack01Dyn
     absurd
   }
   BB16 {
-    i_39 <- Core_Option_Option_Type.some_0 _35;
+    __creusot_proc_iter_elem_39 <- Core_Option_Option_Type.some_0 _35;
     _42 <- ();
-    _40 <- ([#"../knapsack_full.rs" 87 4 87 70] Ghost.new (Seq.(++) (Ghost.inner produced_24) (Seq.singleton i_39)));
+    _40 <- ([#"../knapsack_full.rs" 87 4 87 70] Ghost.new (Seq.(++) (Ghost.inner produced_24) (Seq.singleton __creusot_proc_iter_elem_39)));
     goto BB17
   }
   BB17 {
     produced_24 <- _40;
     _40 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_43 <- i_39;
+    i_43 <- __creusot_proc_iter_elem_39;
     _46 <- items_1;
     _47 <- i_43;
     _45 <- ([#"../knapsack_full.rs" 95 18 95 26] Index0.index _46 _47);
@@ -2505,15 +2505,15 @@ module KnapsackFull_Knapsack01Dyn
     absurd
   }
   BB32 {
-    i_69 <- Core_Option_Option_Type.some_0 _65;
+    __creusot_proc_iter_elem_69 <- Core_Option_Option_Type.some_0 _65;
     _72 <- ();
-    _70 <- ([#"../knapsack_full.rs" 97 8 97 75] Ghost.new (Seq.(++) (Ghost.inner produced_54) (Seq.singleton i_69)));
+    _70 <- ([#"../knapsack_full.rs" 97 8 97 75] Ghost.new (Seq.(++) (Ghost.inner produced_54) (Seq.singleton __creusot_proc_iter_elem_69)));
     goto BB33
   }
   BB33 {
     produced_54 <- _70;
     _70 <- any Ghost.ghost_ty (Seq.seq usize);
-    w_73 <- i_69;
+    w_73 <- __creusot_proc_iter_elem_69;
     _76 <- KnapsackFull_Item_Type.item_weight it_44;
     _77 <- w_73;
     _75 <- ([#"../knapsack_full.rs" 110 38 110 51] _76 > _77);

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -1813,7 +1813,7 @@ module SelectionSortGeneric_SelectionSort
   var _25 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _26 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _27 : isize;
-  var i_28 : usize;
+  var __creusot_proc_iter_elem_28 : usize;
   var _29 : Ghost.ghost_ty (Seq.seq usize);
   var _31 : ();
   var i_32 : usize;
@@ -1833,7 +1833,7 @@ module SelectionSortGeneric_SelectionSort
   var _53 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _54 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _55 : isize;
-  var i_56 : usize;
+  var __creusot_proc_iter_elem_56 : usize;
   var _57 : Ghost.ghost_ty (Seq.seq usize);
   var _59 : ();
   var j_60 : usize;
@@ -1917,15 +1917,15 @@ module SelectionSortGeneric_SelectionSort
     absurd
   }
   BB10 {
-    i_28 <- Core_Option_Option_Type.some_0 _24;
+    __creusot_proc_iter_elem_28 <- Core_Option_Option_Type.some_0 _24;
     _31 <- ();
-    _29 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton i_28)));
+    _29 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_28)));
     goto BB11
   }
   BB11 {
     produced_14 <- _29;
     _29 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_32 <- i_28;
+    i_32 <- __creusot_proc_iter_elem_28;
     min_33 <- i_32;
     _38 <- i_32;
     _37 <- ([#"../selection_sort_generic.rs" 42 17 42 24] _38 + ([#"../selection_sort_generic.rs" 42 22 42 23] (1 : usize)));
@@ -1982,15 +1982,15 @@ module SelectionSortGeneric_SelectionSort
     absurd
   }
   BB20 {
-    i_56 <- Core_Option_Option_Type.some_0 _52;
+    __creusot_proc_iter_elem_56 <- Core_Option_Option_Type.some_0 _52;
     _59 <- ();
-    _57 <- ([#"../selection_sort_generic.rs" 40 8 40 133] Ghost.new (Seq.(++) (Ghost.inner produced_44) (Seq.singleton i_56)));
+    _57 <- ([#"../selection_sort_generic.rs" 40 8 40 133] Ghost.new (Seq.(++) (Ghost.inner produced_44) (Seq.singleton __creusot_proc_iter_elem_56)));
     goto BB21
   }
   BB21 {
     produced_44 <- _57;
     _57 <- any Ghost.ghost_ty (Seq.seq usize);
-    j_60 <- i_56;
+    j_60 <- __creusot_proc_iter_elem_56;
     _64 <-  * v_1;
     _65 <- j_60;
     _63 <- ([#"../selection_sort_generic.rs" 43 15 43 19] Index0.index _64 _65);

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -838,7 +838,7 @@ module Sum_SumFirstN
   var _21 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
   var _22 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
   var _23 : isize;
-  var i_24 : uint32;
+  var __creusot_proc_iter_elem_24 : uint32;
   var _25 : Ghost.ghost_ty (Seq.seq uint32);
   var _27 : ();
   var i_28 : uint32;
@@ -898,15 +898,15 @@ module Sum_SumFirstN
     absurd
   }
   BB9 {
-    i_24 <- Core_Option_Option_Type.some_0 _20;
+    __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     _27 <- ();
-    _25 <- ([#"../sum.rs" 8 4 8 78] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_24)));
+    _25 <- ([#"../sum.rs" 8 4 8 78] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB10
   }
   BB10 {
     produced_12 <- _25;
     _25 <- any Ghost.ghost_ty (Seq.seq uint32);
-    i_28 <- i_24;
+    i_28 <- __creusot_proc_iter_elem_24;
     _29 <- i_28;
     sum_4 <- ([#"../sum.rs" 10 8 10 16] sum_4 + _29);
     _19 <- ();

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -634,7 +634,7 @@ module SumOfOdds_ComputeSumOfOdd
   var _22 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _23 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _24 : isize;
-  var i_25 : uint32;
+  var __creusot_proc_iter_elem_25 : uint32;
   var _26 : Ghost.ghost_ty (Seq.seq uint32);
   var _28 : ();
   var i_29 : uint32;
@@ -694,15 +694,15 @@ module SumOfOdds_ComputeSumOfOdd
     absurd
   }
   BB8 {
-    i_25 <- Core_Option_Option_Type.some_0 _21;
+    __creusot_proc_iter_elem_25 <- Core_Option_Option_Type.some_0 _21;
     _28 <- ();
-    _26 <- ([#"../sum_of_odds.rs" 38 4 38 60] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton i_25)));
+    _26 <- ([#"../sum_of_odds.rs" 38 4 38 60] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_25)));
     goto BB9
   }
   BB9 {
     produced_13 <- _26;
     _26 <- any Ghost.ghost_ty (Seq.seq uint32);
-    i_29 <- i_25;
+    i_29 <- __creusot_proc_iter_elem_25;
     assert { [#"../sum_of_odds.rs" 41 12 41 33] let _ = SumOfOddIsSqr0.sum_of_odd_is_sqr (UInt32.to_int i_29) in true };
     _30 <- ();
     _34 <- i_29;

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -1044,7 +1044,7 @@ module C01_AllZero
   var _24 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _25 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _26 : isize;
-  var i_27 : usize;
+  var __creusot_proc_iter_elem_27 : usize;
   var _28 : Ghost.ghost_ty (Seq.seq usize);
   var _30 : ();
   var i_31 : usize;
@@ -1113,15 +1113,15 @@ module C01_AllZero
     absurd
   }
   BB10 {
-    i_27 <- Core_Option_Option_Type.some_0 _23;
+    __creusot_proc_iter_elem_27 <- Core_Option_Option_Type.some_0 _23;
     _30 <- ();
-    _28 <- ([#"../01.rs" 11 4 11 57] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton i_27)));
+    _28 <- ([#"../01.rs" 11 4 11 57] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_27)));
     goto BB11
   }
   BB11 {
     produced_14 <- _28;
     _28 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_31 <- i_27;
+    i_31 <- __creusot_proc_iter_elem_27;
     _33 <- borrow_mut ( * v_1);
     v_1 <- { v_1 with current = ( ^ _33) };
     _34 <- i_31;

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -953,7 +953,7 @@ module C03KnuthShuffle_KnuthShuffle
   var _22 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _23 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _24 : isize;
-  var i_25 : usize;
+  var __creusot_proc_iter_elem_25 : usize;
   var _26 : Ghost.ghost_ty (Seq.seq usize);
   var _28 : ();
   var n_29 : usize;
@@ -1031,15 +1031,15 @@ module C03KnuthShuffle_KnuthShuffle
     absurd
   }
   BB10 {
-    i_25 <- Core_Option_Option_Type.some_0 _21;
+    __creusot_proc_iter_elem_25 <- Core_Option_Option_Type.some_0 _21;
     _28 <- ();
-    _26 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton i_25)));
+    _26 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_25)));
     goto BB11
   }
   BB11 {
     produced_13 <- _26;
     _26 <- any Ghost.ghost_ty (Seq.seq usize);
-    n_29 <- i_25;
+    n_29 <- __creusot_proc_iter_elem_25;
     _32 <-  * v_1;
     _31 <- ([#"../03_knuth_shuffle.rs" 20 20 20 27] Len0.len _32);
     goto BB12

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -2910,7 +2910,7 @@ module C06KnightsTour_Impl1_CountDegree
   var _21 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _22 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _23 : isize;
-  var i_24 : (isize, isize);
+  var __creusot_proc_iter_elem_24 : (isize, isize);
   var _25 : Ghost.ghost_ty (Seq.seq (isize, isize));
   var _27 : ();
   var m_28 : (isize, isize);
@@ -2982,18 +2982,18 @@ module C06KnightsTour_Impl1_CountDegree
     absurd
   }
   BB11 {
-    assume { Resolve2.resolve i_24 };
-    i_24 <- Core_Option_Option_Type.some_0 _20;
+    assume { Resolve2.resolve __creusot_proc_iter_elem_24 };
+    __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     _27 <- ();
-    _25 <- ([#"../06_knights_tour.rs" 73 8 73 53] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton i_24)));
+    _25 <- ([#"../06_knights_tour.rs" 73 8 73 53] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB12
   }
   BB12 {
     produced_12 <- _25;
     _25 <- any Ghost.ghost_ty (Seq.seq (isize, isize));
     assume { Resolve2.resolve m_28 };
-    m_28 <- i_24;
-    assume { Resolve2.resolve i_24 };
+    m_28 <- __creusot_proc_iter_elem_24;
+    assume { Resolve2.resolve __creusot_proc_iter_elem_24 };
     _30 <- p_2;
     _32 <- m_28;
     assume { Resolve2.resolve m_28 };
@@ -3844,7 +3844,7 @@ module C06KnightsTour_Min
   var _19 : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
   var _20 : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
   var _21 : isize;
-  var i_22 : (usize, C06KnightsTour_Point_Type.t_point);
+  var __creusot_proc_iter_elem_22 : (usize, C06KnightsTour_Point_Type.t_point);
   var _23 : Ghost.ghost_ty (Seq.seq (usize, C06KnightsTour_Point_Type.t_point));
   var _25 : ();
   var x_26 : (usize, C06KnightsTour_Point_Type.t_point);
@@ -3909,15 +3909,15 @@ module C06KnightsTour_Min
     absurd
   }
   BB8 {
-    i_22 <- Core_Option_Option_Type.some_0 _18;
+    __creusot_proc_iter_elem_22 <- Core_Option_Option_Type.some_0 _18;
     _25 <- ();
-    _23 <- ([#"../06_knights_tour.rs" 113 4 114 79] Ghost.new (Seq.(++) (Ghost.inner produced_10) (Seq.singleton i_22)));
+    _23 <- ([#"../06_knights_tour.rs" 113 4 114 79] Ghost.new (Seq.(++) (Ghost.inner produced_10) (Seq.singleton __creusot_proc_iter_elem_22)));
     goto BB9
   }
   BB9 {
     produced_10 <- _23;
     _23 <- any Ghost.ghost_ty (Seq.seq (usize, C06KnightsTour_Point_Type.t_point));
-    x_26 <- i_22;
+    x_26 <- __creusot_proc_iter_elem_22;
     switch (min_3)
       | Core_Option_Option_Type.C_None -> goto BB12
       | Core_Option_Option_Type.C_Some _ -> goto BB10
@@ -4421,7 +4421,7 @@ module C06KnightsTour_KnightsTour
   var _41 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _42 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _43 : isize;
-  var i_44 : usize;
+  var __creusot_proc_iter_elem_44 : usize;
   var _45 : Ghost.ghost_ty (Seq.seq usize);
   var _47 : ();
   var step_48 : usize;
@@ -4437,7 +4437,7 @@ module C06KnightsTour_KnightsTour
   var _64 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _65 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _66 : isize;
-  var i_67 : (isize, isize);
+  var __creusot_proc_iter_elem_67 : (isize, isize);
   var _68 : Ghost.ghost_ty (Seq.seq (isize, isize));
   var _70 : ();
   var m_71 : (isize, isize);
@@ -4557,15 +4557,15 @@ module C06KnightsTour_KnightsTour
     absurd
   }
   BB13 {
-    i_44 <- Core_Option_Option_Type.some_0 _40;
+    __creusot_proc_iter_elem_44 <- Core_Option_Option_Type.some_0 _40;
     _47 <- ();
-    _45 <- ([#"../06_knights_tour.rs" 142 4 142 39] Ghost.new (Seq.(++) (Ghost.inner produced_30) (Seq.singleton i_44)));
+    _45 <- ([#"../06_knights_tour.rs" 142 4 142 39] Ghost.new (Seq.(++) (Ghost.inner produced_30) (Seq.singleton __creusot_proc_iter_elem_44)));
     goto BB14
   }
   BB14 {
     produced_30 <- _45;
     _45 <- any Ghost.ghost_ty (Seq.seq usize);
-    step_48 <- i_44;
+    step_48 <- __creusot_proc_iter_elem_44;
     candidates_49 <- ([#"../06_knights_tour.rs" 147 50 147 60] New1.new ());
     goto BB15
   }
@@ -4627,18 +4627,18 @@ module C06KnightsTour_KnightsTour
     absurd
   }
   BB27 {
-    assume { Resolve4.resolve i_67 };
-    i_67 <- Core_Option_Option_Type.some_0 _63;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_67 };
+    __creusot_proc_iter_elem_67 <- Core_Option_Option_Type.some_0 _63;
     _70 <- ();
-    _68 <- ([#"../06_knights_tour.rs" 148 8 149 57] Ghost.new (Seq.(++) (Ghost.inner produced_56) (Seq.singleton i_67)));
+    _68 <- ([#"../06_knights_tour.rs" 148 8 149 57] Ghost.new (Seq.(++) (Ghost.inner produced_56) (Seq.singleton __creusot_proc_iter_elem_67)));
     goto BB28
   }
   BB28 {
     produced_56 <- _68;
     _68 <- any Ghost.ghost_ty (Seq.seq (isize, isize));
     assume { Resolve4.resolve m_71 };
-    m_71 <- i_67;
-    assume { Resolve4.resolve i_67 };
+    m_71 <- __creusot_proc_iter_elem_67;
+    assume { Resolve4.resolve __creusot_proc_iter_elem_67 };
     _73 <- p_9;
     _75 <- m_71;
     assume { Resolve4.resolve m_71 };

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -1503,7 +1503,7 @@ module C08Haystack_Search
   var _28 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _29 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _30 : isize;
-  var i_31 : usize;
+  var __creusot_proc_iter_elem_31 : usize;
   var _32 : Ghost.ghost_ty (Seq.seq usize);
   var _34 : ();
   var i_35 : usize;
@@ -1521,7 +1521,7 @@ module C08Haystack_Search
   var _53 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _54 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _55 : isize;
-  var i_56 : usize;
+  var __creusot_proc_iter_elem_56 : usize;
   var _57 : Ghost.ghost_ty (Seq.seq usize);
   var _59 : ();
   var j_60 : usize;
@@ -1605,15 +1605,15 @@ module C08Haystack_Search
     absurd
   }
   BB11 {
-    i_31 <- Core_Option_Option_Type.some_0 _27;
+    __creusot_proc_iter_elem_31 <- Core_Option_Option_Type.some_0 _27;
     _34 <- ();
-    _32 <- ([#"../08_haystack.rs" 22 4 22 123] Ghost.new (Seq.(++) (Ghost.inner produced_19) (Seq.singleton i_31)));
+    _32 <- ([#"../08_haystack.rs" 22 4 22 123] Ghost.new (Seq.(++) (Ghost.inner produced_19) (Seq.singleton __creusot_proc_iter_elem_31)));
     goto BB12
   }
   BB12 {
     produced_19 <- _32;
     _32 <- any Ghost.ghost_ty (Seq.seq usize);
-    i_35 <- i_31;
+    i_35 <- __creusot_proc_iter_elem_31;
     _41 <- needle_1;
     _40 <- ([#"../08_haystack.rs" 25 20 25 32] Len0.len _41);
     goto BB13
@@ -1663,15 +1663,15 @@ module C08Haystack_Search
     absurd
   }
   BB21 {
-    i_56 <- Core_Option_Option_Type.some_0 _52;
+    __creusot_proc_iter_elem_56 <- Core_Option_Option_Type.some_0 _52;
     _59 <- ();
-    _57 <- ([#"../08_haystack.rs" 24 8 24 82] Ghost.new (Seq.(++) (Ghost.inner produced_45) (Seq.singleton i_56)));
+    _57 <- ([#"../08_haystack.rs" 24 8 24 82] Ghost.new (Seq.(++) (Ghost.inner produced_45) (Seq.singleton __creusot_proc_iter_elem_56)));
     goto BB22
   }
   BB22 {
     produced_45 <- _57;
     _57 <- any Ghost.ghost_ty (Seq.seq usize);
-    j_60 <- i_56;
+    j_60 <- __creusot_proc_iter_elem_56;
     _64 <- needle_1;
     _65 <- j_60;
     _63 <- ([#"../08_haystack.rs" 26 15 26 24] Index0.index _64 _65);


### PR DESCRIPTION
This makes the macro *super hygenic* until I find a proper fix for this issue. 

The underlying cause is that we need to create a substitution when dealing with proof asserts which maps variables into MIR locals, but the method I was using to construct that substitution (debug info) does not allow us to account for the hygiene of bindings.

I'm unsure what the fix will be but evidently this was insufficient. 
