### PR TITLE
Stop using `features = contracts` to toggle creusot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,9 @@ To add contracts to your programs you will need to use the `creusot-contracts` c
 [dependencies]
 creusot-contracts = { path = "/path/to/creusot/creusot-contracts" }
 ```
-and enabling the `contracts` feature through running with `cargo creusot`.
-When that feature is enabled `rustc` cannot successfully compile your programs, so we recommend adding a feature to your program which conditionally enables the `contracts` feature like so:
 
-```toml
-# Cargo.toml
-
-[features]
-contracts = ["creusot-contracts/contracts"]
-```
+Adding this dependency will make the contract macros available in your code. These macros will erase themselves when compiled with `rustc`.
+To add Creusot-only trait implementations or code, you can use `cfg(creusot)` to toggle.
 
 ## Proving in Why3
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To add contracts to your programs you will need to use the `creusot-contracts` c
 [dependencies]
 creusot-contracts = { path = "/path/to/creusot/creusot-contracts" }
 ```
-and enabling the `contracts` feature through running with `cargo creusot -- --features=contracts`.
+and enabling the `contracts` feature through running with `cargo creusot`.
 When that feature is enabled `rustc` cannot successfully compile your programs, so we recommend adding a feature to your program which conditionally enables the `contracts` feature like so:
 
 ```toml

--- a/creusot-contracts/src/ghost.rs
+++ b/creusot-contracts/src/ghost.rs
@@ -1,6 +1,6 @@
 use crate::{std::ops::Deref, *};
 
-#[cfg_attr(feature = "contracts", creusot::builtins = "prelude.Ghost.ghost_ty")]
+#[cfg_attr(creusot, creusot::builtins = "prelude.Ghost.ghost_ty")]
 pub struct Ghost<T>(std::marker::PhantomData<T>)
 where
     T: ?Sized;

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -14,50 +14,62 @@ extern crate self as creusot_contracts;
 #[cfg(creusot)]
 mod macros {
     /// A pre-condition of a function or trait item
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::requires;
 
     /// A post-condition of a function or trait item
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::ensures;
 
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::ghost;
 
     /// A loop invariant
     /// The first argument should be a name for the invariant
     /// The second argument is the Pearlite expression for the loop invariant
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::invariant;
 
     /// Declares a trait item as being a law which is autoloaded as soon another
     /// trait item is used in a function
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::law;
 
     /// Declare a function as being a logical function, this declaration must be pure and
     /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
     /// use logical operations and syntax with the help of the [pearlite] macro.
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::logic;
 
     /// Declare a function as being a logical function, this declaration must be pure and
     /// total. It cannot be called from Rust programs as it is *ghost*, in exchange it can
     /// use logical operations and syntax with the help of the [pearlite] macro.
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::predicate;
 
     /// Inserts a *logical* assertion into the code. This assertion will not be checked at runtime
     /// but only during proofs. However, it has access to the ghost context and can use logical operations
     /// and syntax.
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::proof_assert;
 
     /// Instructs Pearlite to ignore the body of a declaration, assuming any contract the declaration has is
     /// valid.
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::trusted;
 
     /// Declares a variant for a function, this is primarily used in combination with logical functions
     /// The variant must be an expression which returns a type implementing [WellFounded]
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::variant;
 
     /// Enables Pearlite syntax, granting access to Pearlite specific operators and syntax
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::pearlite;
 
     /// Allows specifications to be attached to functions coming from external crates
     /// TODO: Document syntax
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::extern_spec;
 
     /// Allows specifying both a pre- and post-condition in a single statement.
@@ -66,6 +78,7 @@ mod macros {
     ///
     /// Generates a `requires` and `ensures` clause in the shape of the input expression, with
     /// `mut` replaced by `*` in the `requires` and `^` in the ensures.
+    #[cfg_attr(feature = "contracts", deprecated("the `contracts` feature is no longer needed. Use `cfg(creusot)` instead to toggle behavior"))]
     pub use creusot_contracts_proc::maintains;
 }
 

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(
-    feature = "contracts",
+    creusot,
     feature(unsized_locals, fn_traits, min_specialization),
     allow(incomplete_features),
     feature(slice_take),
@@ -7,11 +7,11 @@
 )]
 #![cfg_attr(feature = "typechecker", feature(rustc_private), feature(box_patterns, box_syntax))]
 #![feature(step_trait, allocator_api, unboxed_closures, tuple_trait)]
-#![cfg_attr(not(feature = "contracts"), feature(rustc_attrs))]
+#![cfg_attr(not(creusot), feature(rustc_attrs))]
 
 extern crate self as creusot_contracts;
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 mod macros {
     /// A pre-condition of a function or trait item
     pub use creusot_contracts_proc::requires;
@@ -69,7 +69,7 @@ mod macros {
     pub use creusot_contracts_proc::maintains;
 }
 
-#[cfg(not(feature = "contracts"))]
+#[cfg(not(creusot))]
 mod macros {
     /// A pre-condition of a function or trait item
     pub use creusot_contracts_dummy::requires;
@@ -127,19 +127,19 @@ mod macros {
     pub use creusot_contracts_dummy::maintains;
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 #[path = "stubs.rs"]
 pub mod __stubs;
 
 pub mod logic;
 
-#[cfg_attr(not(feature = "contracts"), allow(unused))]
+#[cfg_attr(not(creusot), allow(unused))]
 pub mod std;
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 pub mod ghost;
 
-#[cfg(not(feature = "contracts"))]
+#[cfg(not(creusot))]
 pub mod ghost {
     pub struct Ghost<T>(std::marker::PhantomData<T>)
     where

--- a/creusot-contracts/src/logic.rs
+++ b/creusot-contracts/src/logic.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "contracts"), allow(unused_imports))]
+#![cfg_attr(not(creusot), allow(unused_imports))]
 
 mod fset;
 mod int;

--- a/creusot-contracts/src/logic/fset.rs
+++ b/creusot-contracts/src/logic/fset.rs
@@ -1,10 +1,10 @@
 use crate::*;
 
-#[cfg_attr(feature = "contracts", creusot::builtins = "set.Fset.fset")]
+#[cfg_attr(creusot, creusot::builtins = "set.Fset.fset")]
 pub struct FSet<T: ?Sized>(std::marker::PhantomData<T>);
 
 impl<T: ?Sized> FSet<T> {
-    #[cfg(feature = "contracts")]
+    #[cfg(creusot)]
     #[trusted]
     #[creusot::builtins = "set.Fset.empty"]
     pub const EMPTY: Self = { FSet(std::marker::PhantomData) };

--- a/creusot-contracts/src/logic/int.rs
+++ b/creusot-contracts/src/logic/int.rs
@@ -3,11 +3,7 @@ use crate::{
     *,
 };
 
-#[cfg_attr(
-    creusot,
-    rustc_diagnostic_item = "creusot_int",
-    creusot::builtins = "prelude.Int.int"
-)]
+#[cfg_attr(creusot, rustc_diagnostic_item = "creusot_int", creusot::builtins = "prelude.Int.int")]
 pub struct Int(*mut ());
 
 impl Int {

--- a/creusot-contracts/src/logic/int.rs
+++ b/creusot-contracts/src/logic/int.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 #[cfg_attr(
-    feature = "contracts",
+    creusot,
     rustc_diagnostic_item = "creusot_int",
     creusot::builtins = "prelude.Int.int"
 )]
@@ -92,7 +92,7 @@ mach_int!(i64, "prelude.Int64");
 mach_int!(i128, "prelude.Int128");
 mach_int!(isize, "prelude.IntSize");
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Add<Int> for Int {
     type Output = Int;
     #[creusot::no_translate]
@@ -102,7 +102,7 @@ impl Add<Int> for Int {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Sub<Int> for Int {
     type Output = Int;
     #[creusot::no_translate]
@@ -112,7 +112,7 @@ impl Sub<Int> for Int {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Mul<Int> for Int {
     type Output = Int;
     #[creusot::no_translate]
@@ -122,7 +122,7 @@ impl Mul<Int> for Int {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Div<Int> for Int {
     type Output = Int;
     #[creusot::no_translate]
@@ -132,7 +132,7 @@ impl Div<Int> for Int {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Rem<Int> for Int {
     type Output = Int;
     #[creusot::no_translate]
@@ -142,7 +142,7 @@ impl Rem<Int> for Int {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl Neg for Int {
     type Output = Int;
     #[creusot::no_translate]

--- a/creusot-contracts/src/logic/mapping.rs
+++ b/creusot-contracts/src/logic/mapping.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[cfg_attr(feature = "contracts", creusot::builtins = "map.Map.map")]
+#[cfg_attr(creusot, creusot::builtins = "map.Map.map")]
 pub struct Mapping<A, B>(std::marker::PhantomData<(A, B)>);
 
 impl<A, B> Mapping<A, B> {
@@ -25,7 +25,7 @@ impl<A, B> Mapping<A, B> {
         absurd
     }
 
-    #[cfg_attr(feature = "contracts", creusot::no_translate)]
+    #[cfg_attr(creusot, creusot::no_translate)]
     #[trusted]
     #[logic]
     #[creusot::builtins = "prelude.Mapping.from_fn"]

--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -1,10 +1,10 @@
 use crate::{std::ops::Index, *};
 
-#[cfg_attr(feature = "contracts", creusot::builtins = "seq.Seq.seq")]
+#[cfg_attr(creusot, creusot::builtins = "seq.Seq.seq")]
 pub struct Seq<T: ?Sized>(std::marker::PhantomData<T>);
 
 impl<T> Seq<T> {
-    #[cfg(feature = "contracts")]
+    #[cfg(creusot)]
     #[trusted]
     #[creusot::builtins = "seq.Seq.empty"]
     pub const EMPTY: Self = { Seq(std::marker::PhantomData) };
@@ -124,7 +124,7 @@ impl<T> Seq<T> {
 // Relies on the fact we don't enforce that implementations of traits are of
 // the same function type as the trait signature.. When this is addressed
 // the following instance will error.
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl<T> std::ops::Index<Int> for Seq<T> {
     type Output = T;
 

--- a/creusot-contracts/src/logic/set.rs
+++ b/creusot-contracts/src/logic/set.rs
@@ -1,10 +1,10 @@
 use crate::*;
 
-#[cfg_attr(feature = "contracts", creusot::builtins = "set.Set.set")]
+#[cfg_attr(creusot, creusot::builtins = "set.Set.set")]
 pub struct Set<T: ?Sized>(std::marker::PhantomData<T>);
 
 impl<T: ?Sized> Set<T> {
-    #[cfg(feature = "contracts")]
+    #[cfg(creusot)]
     #[trusted]
     #[creusot::builtins = "set.Set.empty"]
     pub const EMPTY: Self = { Set(std::marker::PhantomData) };

--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 use ::std::alloc::Allocator;
 
 /// The shallow model of a type is typically used to specify a data
@@ -55,7 +55,7 @@ impl<T: ShallowModel + ?Sized> ShallowModel for &mut T {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl<T: DeepModel + ?Sized, A: Allocator> DeepModel for Box<T, A> {
     type DeepModelTy = T::DeepModelTy;
     #[logic]
@@ -64,7 +64,7 @@ impl<T: DeepModel + ?Sized, A: Allocator> DeepModel for Box<T, A> {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 impl<T: ShallowModel + ?Sized, A: Allocator> ShallowModel for Box<T, A> {
     type ShallowModelTy = T::ShallowModelTy;
     #[logic]

--- a/creusot-contracts/src/resolve.rs
+++ b/creusot-contracts/src/resolve.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[cfg_attr(feature = "contracts", rustc_diagnostic_item = "creusot_resolve")]
+#[cfg_attr(creusot, rustc_diagnostic_item = "creusot_resolve")]
 #[trusted]
 pub trait Resolve {
     #[predicate]
@@ -24,7 +24,7 @@ impl<T: ?Sized> Resolve for &mut T {
     }
 }
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 #[trusted]
 impl<T> Resolve for T {
     #[predicate]

--- a/creusot-contracts/src/std/clone.rs
+++ b/creusot-contracts/src/std/clone.rs
@@ -1,7 +1,7 @@
 use crate::*;
 pub use ::std::clone::*;
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 pub use creusot_contracts_proc::Clone;
 
 extern_spec! {

--- a/creusot-contracts/src/std/cmp.rs
+++ b/creusot-contracts/src/std/cmp.rs
@@ -1,7 +1,7 @@
 use crate::{logic::OrdLogic, *};
 pub use ::std::cmp::*;
 
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 pub use creusot_contracts_proc::PartialEq;
 
 extern_spec! {

--- a/creusot-contracts/src/std/fmt.rs
+++ b/creusot-contracts/src/std/fmt.rs
@@ -1,5 +1,5 @@
 use crate::*;
-#[cfg(feature = "contracts")]
+#[cfg(creusot)]
 use ::std::fmt::{ArgumentV1, Arguments, Debug, Formatter};
 
 extern_spec! {

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -420,7 +420,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 506 56 506 89] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 533 24 534 29] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -505,7 +505,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 503 86 504 5] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 529 16 529 52] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -527,7 +527,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 504 40 505 10] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 530 23 531 11] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -540,7 +540,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 504 40 505 10] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 530 23 531 11] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -559,7 +559,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 507 5 507 52] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 535 8 538 12] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -572,7 +572,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 507 5 507 52] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 535 8 538 12] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -588,7 +588,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 508 89 509 31] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 542 3 542 36] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -610,7 +610,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 510 34 511 20] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 543 16 547 14] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -623,7 +623,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 510 34 511 20] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 543 16 547 14] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -639,7 +639,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 514 43 515 33] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 549 41 549 77] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -661,7 +661,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 515 68 516 47] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 550 23 551 26] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -674,7 +674,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 515 68 516 47] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 550 23 551 26] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -689,7 +689,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 517 65 518 24] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 552 3 552 34] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -700,7 +700,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 517 65 518 24] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 552 3 552 34] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -715,7 +715,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 519 27 519 44] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 519 62 519 79] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 519 96 520 2] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 86 552 103] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 553 10 553 27] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 44 554 12] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -724,11 +724,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {[#"../red_black_tree.rs" 519 27 519 44] CmpLog0.cmp_log x y = o}
-    requires {[#"../red_black_tree.rs" 519 62 519 79] CmpLog0.cmp_log y z = o}
+    requires {[#"../red_black_tree.rs" 552 86 552 103] CmpLog0.cmp_log x y = o}
+    requires {[#"../red_black_tree.rs" 553 10 553 27] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 519 27 519 44] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 519 62 519 79] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 519 96 520 2] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 86 552 103] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 553 10 553 27] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 44 554 12] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -743,7 +743,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 521 41 522 26] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 522 43 523 23] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 96 555 28] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 556 0 556 33] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -752,10 +752,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 521 41 522 26] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../red_black_tree.rs" 554 96 555 28] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 521 41 522 26] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 522 43 523 23] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 96 555 28] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 556 0 556 33] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -770,7 +770,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 524 5 525 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 525 20 525 50] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 98 557 25] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 42 557 72] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -779,10 +779,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 524 5 525 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../red_black_tree.rs" 556 98 557 25] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 524 5 525 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 525 20 525 50] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 98 557 25] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 42 557 72] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -797,7 +797,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 526 26 527 31] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 558 31 559 28] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -808,7 +808,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 526 26 527 31] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 558 31 559 28] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Stub
   type k
@@ -4970,7 +4970,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 805 11 809 6] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 847 49 847 108] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl16_InsertRec_Interface
@@ -5822,8 +5822,8 @@ module Alloc_Boxed_Impl55_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 754 25 754 42]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 758 4 758 21]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 788 7 788 24]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 789 6 789 23]  ^ self =  ^ result }
     
 end
 module CreusotContracts_Resolve_Impl0_Resolve_Stub

--- a/creusot/tests/ui.rs
+++ b/creusot/tests/ui.rs
@@ -30,7 +30,7 @@ fn main() {
             temp_file.as_os_str(),
             "--output-file=/dev/null".as_ref(),
         ])
-        .args(&["--", "--package", "creusot-contracts", "--features=contracts"])
+        .args(&["--", "--package", "creusot-contracts"])
         .env("CREUSOT_CONTINUE", "true");
 
     if !metadata_file.status().expect("could not dump metadata for `creusot_contracts`").success() {


### PR DESCRIPTION
This stops using `features=contracts` to toggle creusot code. I'm not sure how I can warn about this though...
