### PR TITLE
Ensure we properly overload operators in no_std mode

### DIFF
--- a/creusot/src/translation/specification.rs
+++ b/creusot/src/translation/specification.rs
@@ -281,18 +281,18 @@ pub(crate) fn contract_of<'tcx>(
 pub(crate) fn is_overloaded_item(tcx: TyCtxt, def_id: DefId) -> bool {
     let def_path = tcx.def_path_str(def_id);
 
-    def_path == "std::ops::Index::index"
-        || def_path == "std::convert::Into::into"
-        || def_path == "std::convert::From::from"
-        || def_path == "std::ops::Mul::mul"
-        || def_path == "std::ops::Add::add"
-        || def_path == "std::ops::Sub::sub"
-        || def_path == "std::ops::Div::div"
-        || def_path == "std::ops::Rem::rem"
-        || def_path == "std::ops::Neg::neg"
-        || def_path == "std::boxed::Box::<T>::new"
-        || def_path == "std::ops::Deref::deref"
-        || def_path == "std::clone::Clone::clone"
+    def_path.ends_with("::ops::Index::index")
+        || def_path.ends_with("::convert::Into::into")
+        || def_path.ends_with("::convert::From::from")
+        || def_path.ends_with("::ops::Mul::mul")
+        || def_path.ends_with("::ops::Add::add")
+        || def_path.ends_with("::ops::Sub::sub")
+        || def_path.ends_with("::ops::Div::div")
+        || def_path.ends_with("::ops::Rem::rem")
+        || def_path.ends_with("::ops::Neg::neg")
+        || def_path.ends_with("::boxed::Box::<T>::new")
+        || def_path.ends_with("::ops::Deref::deref")
+        || def_path.ends_with("::clone::Clone::clone")
 }
 
 pub(crate) struct PurityVisitor<'a, 'tcx> {

--- a/creusot/tests/should_succeed/bug/653.mlcfg
+++ b/creusot/tests/should_succeed/bug/653.mlcfg
@@ -1,0 +1,27 @@
+
+module C653_Omg_Interface
+  use prelude.UIntSize
+  use prelude.Int
+  val omg [#"../653.rs" 6 0 6 29] (n : usize) : usize
+    ensures { [#"../653.rs" 5 10 5 38] UIntSize.to_int result = div (UIntSize.to_int n * (UIntSize.to_int n + 1)) 2 }
+    
+end
+module C653_Omg
+  use prelude.Int
+  use prelude.UIntSize
+  let rec cfg omg [#"../653.rs" 6 0 6 29] [@cfg:stackify] [@cfg:subregion_analysis] (n : usize) : usize
+    ensures { [#"../653.rs" 5 10 5 38] UIntSize.to_int result = div (UIntSize.to_int n * (UIntSize.to_int n + 1)) 2 }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : usize;
+  var n_1 : usize;
+  {
+    n_1 <- n;
+    goto BB0
+  }
+  BB0 {
+    _0 <- n_1;
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/bug/653.rs
+++ b/creusot/tests/should_succeed/bug/653.rs
@@ -1,0 +1,8 @@
+#![no_std]
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[ensures(@result == @n * (@n + 1) / 2)]
+pub fn omg(n: usize) -> usize {
+    n
+}


### PR DESCRIPTION
Turns out we were stupidly checking for primitive operators by matching on a path that included `std` which in `no_std`.. doesn't exist. 

Fixes #653 (at least as reported). 

