### PR TITLE
First step to mutual recursive predicates

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -7,3 +7,4 @@ pub(crate) mod program;
 pub(crate) mod signature;
 pub(crate) mod term;
 pub(crate) mod traits;
+pub(crate) mod ty;

--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -3,6 +3,7 @@ pub(crate) mod constant;
 pub(crate) mod dependency;
 pub(crate) mod interface;
 pub(crate) mod logic;
+pub(crate) mod place;
 pub(crate) mod program;
 pub(crate) mod signature;
 pub(crate) mod term;

--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -1,3 +1,4 @@
+pub(crate) mod clone_map;
 pub(crate) mod constant;
 pub(crate) mod dependency;
 pub(crate) mod interface;

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -22,9 +22,9 @@ use why3::{
 };
 
 use crate::{
-    backend::{dependency::Dependency, interface},
+    backend::{self, dependency::Dependency, interface, ty::translate_ty_param},
     ctx::{self, *},
-    translation::{traits, ty::translate_ty_param},
+    translation::traits,
     util::{self, get_builtin, ident_of, ident_of_ty, item_name, module_name},
 };
 
@@ -595,7 +595,7 @@ impl<'tcx> CloneMap<'tcx> {
                 DepNode::Type(ty) => {
                     for (nm, sym) in syms.clone() {
                         let ty_name = nm.qname_ident(sym.ident());
-                        let ty = crate::translation::ty::translate_ty(ctx, self, DUMMY_SP, ty);
+                        let ty = backend::ty::translate_ty(ctx, self, DUMMY_SP, ty);
                         clone_subst.push(CloneSubst::Type(ty_name, ty))
                     }
                 }
@@ -717,7 +717,7 @@ pub(crate) fn base_subst<'tcx>(
         let ty = subst[ix];
         if let GenericParamDefKind::Type { .. } = p.kind {
             let ty = ctx.normalize_erasing_regions(param_env, ty.expect_ty());
-            let ty = crate::translation::ty::translate_ty(ctx, names, rustc_span::DUMMY_SP, ty);
+            let ty = backend::ty::translate_ty(ctx, names, rustc_span::DUMMY_SP, ty);
             clone_subst.push(CloneSubst::Type(translate_ty_param(p.name).into(), ty));
         }
     }

--- a/creusot/src/backend/clone_map.rs
+++ b/creusot/src/backend/clone_map.rs
@@ -595,7 +595,7 @@ impl<'tcx> CloneMap<'tcx> {
                 DepNode::Type(ty) => {
                     for (nm, sym) in syms.clone() {
                         let ty_name = nm.qname_ident(sym.ident());
-                        let ty = super::ty::translate_ty(ctx, self, DUMMY_SP, ty);
+                        let ty = crate::translation::ty::translate_ty(ctx, self, DUMMY_SP, ty);
                         clone_subst.push(CloneSubst::Type(ty_name, ty))
                     }
                 }
@@ -717,7 +717,7 @@ pub(crate) fn base_subst<'tcx>(
         let ty = subst[ix];
         if let GenericParamDefKind::Type { .. } = p.kind {
             let ty = ctx.normalize_erasing_regions(param_env, ty.expect_ty());
-            let ty = super::ty::translate_ty(ctx, names, rustc_span::DUMMY_SP, ty);
+            let ty = crate::translation::ty::translate_ty(ctx, names, rustc_span::DUMMY_SP, ty);
             clone_subst.push(CloneSubst::Type(translate_ty_param(p.name).into(), ty));
         }
     }

--- a/creusot/src/backend/constant.rs
+++ b/creusot/src/backend/constant.rs
@@ -3,13 +3,15 @@ use rustc_middle::ty::{self, InternalSubsts};
 use why3::declaration::{Decl, LetDecl, LetKind, Module, ValDecl};
 
 use crate::{
-    clone_map::{CloneMap, CloneSummary},
     ctx::{TranslatedItem, TranslationCtx},
     translation::{constant::from_ty_const, function::closure_generic_decls},
     util::{self, module_name, signature_of},
 };
 
-use super::logic::stub_module;
+use super::{
+    clone_map::{CloneLevel, CloneMap, CloneSummary},
+    logic::stub_module,
+};
 
 impl<'tcx> TranslationCtx<'tcx> {
     pub(crate) fn translate_constant(
@@ -22,7 +24,7 @@ impl<'tcx> TranslationCtx<'tcx> {
             .mk_const(ty::ConstKind::Unevaluated(uneval), self.type_of(def_id).subst_identity());
 
         let res = from_ty_const(self, constant, self.param_env(def_id), self.def_span(def_id));
-        let mut names = CloneMap::new(self.tcx, def_id, crate::clone_map::CloneLevel::Body);
+        let mut names = CloneMap::new(self.tcx, def_id, CloneLevel::Body);
         let res = res.to_why(self, &mut names, None);
         let sig = signature_of(self, &mut names, def_id);
         let mut decls: Vec<_> = closure_generic_decls(self.tcx, def_id).collect();

--- a/creusot/src/backend/interface.rs
+++ b/creusot/src/backend/interface.rs
@@ -1,9 +1,9 @@
+use super::clone_map::CloneMap;
 use crate::{
     backend::{
         logic::spec_axiom,
         program::{closure_aux_defs, closure_type_use},
     },
-    clone_map::CloneMap,
     ctx::*,
     translation::function::closure_generic_decls,
     util,
@@ -15,7 +15,6 @@ use why3::{
     declaration::{Contract, Decl, Module},
     Exp, Ident,
 };
-
 pub(crate) fn interface_for<'tcx>(
     ctx: &mut TranslationCtx<'tcx>,
     def_id: DefId,

--- a/creusot/src/backend/place.rs
+++ b/creusot/src/backend/place.rs
@@ -1,7 +1,7 @@
-use super::LocalIdent;
 use crate::{
     backend::program::uint_to_int,
     ctx::{CloneMap, TranslationCtx},
+    translation::LocalIdent,
 };
 use rustc_middle::{
     mir::{Body, Local, Place},
@@ -227,7 +227,7 @@ pub(crate) fn translate_rplace_inner<'tcx>(
     inner
 }
 
-pub(super) fn translate_local(body: &Body, loc: Local) -> LocalIdent {
+pub(crate) fn translate_local(body: &Body, loc: Local) -> LocalIdent {
     use rustc_middle::mir::VarDebugInfoContents::Place;
     let debug_info: Vec<_> = body
         .var_debug_info

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -1,5 +1,5 @@
+use super::clone_map::{CloneLevel, PreludeModule};
 use crate::{
-    clone_map::{CloneLevel, PreludeModule},
     ctx::{CloneMap, TranslationCtx},
     translation::{
         binop_to_binop,
@@ -22,7 +22,6 @@ use rustc_middle::{
 };
 use rustc_mir_transform::{cleanup_post_borrowck::CleanupPostBorrowck, simplify::SimplifyCfg};
 use rustc_span::DUMMY_SP;
-
 use rustc_type_ir::{IntTy, UintTy};
 use why3::{
     declaration::{self, CfgFunction, Decl, LetDecl, LetKind, Module, Predicate, Use},

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -1,14 +1,15 @@
 use super::clone_map::{CloneLevel, PreludeModule};
 use crate::{
-    backend::ty::{self, closure_accessors, translate_closure_ty, translate_ty},
+    backend::{
+        place,
+        place::translate_rplace_inner,
+        ty::{self, closure_accessors, translate_closure_ty, translate_ty},
+    },
     ctx::{CloneMap, TranslationCtx},
     translation::{
         binop_to_binop,
         fmir::{self, Block, Branches, Expr, RValue, Statement, Terminator},
-        function::{
-            closure_contract, closure_generic_decls, place, place::translate_rplace_inner,
-            promoted, ClosureContract,
-        },
+        function::{closure_contract, closure_generic_decls, promoted, ClosureContract},
         specification::{lower_impure, lower_pure},
         unop_to_unop,
     },

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -1,5 +1,6 @@
 use super::clone_map::{CloneLevel, PreludeModule};
 use crate::{
+    backend::ty::{self, closure_accessors, translate_closure_ty, translate_ty},
     ctx::{CloneMap, TranslationCtx},
     translation::{
         binop_to_binop,
@@ -9,7 +10,6 @@ use crate::{
             promoted, ClosureContract,
         },
         specification::{lower_impure, lower_pure},
-        ty::{self, closure_accessors, translate_closure_ty, translate_ty},
         unop_to_unop,
     },
     util::{self, is_ghost_closure, module_name, signature_of, ItemType},

--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -277,9 +277,10 @@ pub fn to_why<'tcx>(
         statements: vars
             .iter()
             .skip(1)
+            .zip(ctx.sig(def_id).inputs.iter().map(|(s, _, _)| s))
             .take(body.arg_count)
-            .map(|(_, id, _)| {
-                let rhs = id.arg_name();
+            .map(|((_, id, _), arg)| {
+                let rhs = arg.to_string().into();
                 mlcfg::Statement::Assign { lhs: id.ident(), rhs: Exp::impure_var(rhs) }
             })
             .collect(),

--- a/creusot/src/backend/signature.rs
+++ b/creusot/src/backend/signature.rs
@@ -5,8 +5,9 @@ use why3::{
 };
 
 use crate::{
+    backend,
     ctx::{CloneMap, TranslationCtx},
-    translation::{self, specification::PreContract},
+    translation::specification::PreContract,
     util::{ident_of, item_name, why3_attrs, AnonymousParamName, PreSignature},
 };
 
@@ -31,7 +32,7 @@ pub(crate) fn sig_to_why3<'tcx>(
             .into_iter()
             .enumerate()
             .map(|(ix, (id, _, ty))| {
-                let ty = translation::ty::translate_ty(ctx, names, span, ty);
+                let ty = backend::ty::translate_ty(ctx, names, span, ty);
                 let id = if id.is_empty() {
                     format!("{}", AnonymousParamName(ix)).into()
                 } else {
@@ -50,9 +51,8 @@ pub(crate) fn sig_to_why3<'tcx>(
         .and_then(|span| ctx.span_attr(span))
         .map(|attr| attrs.push(attr));
 
-    let retty = names.with_public_clones(|names| {
-        translation::ty::translate_ty(ctx, names, span, pre_sig.output)
-    });
+    let retty = names
+        .with_public_clones(|names| backend::ty::translate_ty(ctx, names, span, pre_sig.output));
     Signature { name, attrs, retty: Some(retty), args, contract }
 }
 

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -1,7 +1,7 @@
 use crate::{
+    backend::ty::{intty_to_ty, translate_ty, uintty_to_ty},
     ctx::*,
     pearlite::{self, Literal, Pattern, Term, TermKind},
-    translation::ty::{intty_to_ty, translate_ty, uintty_to_ty},
     util,
     util::get_builtin,
 };

--- a/creusot/src/backend/traits.rs
+++ b/creusot/src/backend/traits.rs
@@ -1,6 +1,8 @@
-use super::term::lower_pure;
-use crate::{
+use super::{
     clone_map::{CloneLevel, CloneMap, CloneSummary},
+    term::lower_pure,
+};
+use crate::{
     ctx::{ItemType, TranslationCtx},
     translation::{
         function::{all_generic_decls_for, own_generic_decls_for},
@@ -8,9 +10,7 @@ use crate::{
     },
     util::{self, item_name, module_name},
 };
-use rustc_hir::def_id::DefId;
-
-use rustc_hir::def::Namespace;
+use rustc_hir::{def::Namespace, def_id::DefId};
 use why3::declaration::{Decl, Goal, Module, TyDecl};
 
 pub(crate) fn lower_impl<'tcx>(ctx: &mut TranslationCtx<'tcx>, def_id: DefId) -> Module {

--- a/creusot/src/backend/traits.rs
+++ b/creusot/src/backend/traits.rs
@@ -3,11 +3,9 @@ use super::{
     term::lower_pure,
 };
 use crate::{
+    backend,
     ctx::{ItemType, TranslationCtx},
-    translation::{
-        function::{all_generic_decls_for, own_generic_decls_for},
-        ty,
-    },
+    translation::function::{all_generic_decls_for, own_generic_decls_for},
     util::{self, item_name, module_name},
 };
 use rustc_hir::{def::Namespace, def_id::DefId};
@@ -53,7 +51,7 @@ impl<'tcx> TranslationCtx<'tcx> {
                 TyDecl::Alias {
                     ty_name: name.clone(),
                     ty_params: vec![],
-                    alias: ty::translate_ty(self, names, rustc_span::DUMMY_SP, assoc_ty),
+                    alias: backend::ty::translate_ty(self, names, rustc_span::DUMMY_SP, assoc_ty),
                 }
             }),
             rustc_middle::ty::TraitContainer => {

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -7,8 +7,8 @@ use crate::{
     util::{self, get_builtin, item_qname, module_name, PreSignature},
 };
 use indexmap::IndexSet;
-use rustc_hir::{def::Namespace, def_id::DefId};
 use petgraph::{algo::tarjan_scc, graphmap::DiGraphMap};
+use rustc_hir::{def::Namespace, def_id::DefId};
 use rustc_middle::ty::{
     self,
     subst::{InternalSubsts, SubstsRef},

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -1,5 +1,14 @@
+use crate::{
+    ctx::*,
+    translation::{
+        pearlite::{self, Term, TermKind},
+        specification::PreContract,
+    },
+    util::{self, get_builtin, item_qname, module_name, PreSignature},
+};
 use indexmap::IndexSet;
 use rustc_hir::{def::Namespace, def_id::DefId};
+use petgraph::{algo::tarjan_scc, graphmap::DiGraphMap};
 use rustc_middle::ty::{
     self,
     subst::{InternalSubsts, SubstsRef},
@@ -10,17 +19,12 @@ use rustc_type_ir::sty::TyKind::*;
 use std::collections::VecDeque;
 use why3::{
     declaration::{
-        AdtDecl, ConstructorDecl, Contract, Decl, Field, LetDecl, LetKind, Module, Signature, Use,
+        AdtDecl, ConstructorDecl, Contract, Decl, Field, LetDecl, LetKind, Module, Signature,
+        TyDecl, Use,
     },
     exp::{Binder, Exp, Pattern},
-    Ident,
-};
-
-use why3::{declaration::TyDecl, ty::Type as MlT, QName};
-
-use crate::{
-    ctx::*,
-    util::{self, get_builtin, item_qname, module_name, PreSignature},
+    ty::Type as MlT,
+    Ident, QName,
 };
 
 /// When we translate a type declaration, generic parameters should be declared using 't notation:
@@ -223,13 +227,6 @@ pub(crate) fn translate_closure_ty<'tcx>(
 
     TyDecl::Adt { tys: vec![kind] }
 }
-
-use petgraph::{algo::tarjan_scc, graphmap::DiGraphMap};
-
-use super::{
-    pearlite::{self, Term, TermKind},
-    specification::PreContract,
-};
 
 pub(crate) fn ty_binding_group<'tcx>(tcx: TyCtxt<'tcx>, ty_id: DefId) -> IndexSet<DefId> {
     let mut graph = DiGraphMap::<_, ()>::new();

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -6,6 +6,7 @@ use crate::{
         self,
         interface::interface_for,
         program::{translate_closure, translate_function},
+        ty::{self, translate_tydecl, ty_binding_group},
     },
     creusot_items::{self, CreusotItems},
     error::{CrErr, CreusotResult, Error},
@@ -18,7 +19,6 @@ use crate::{
         pearlite::{self, Term},
         specification::{ContractClauses, PurityVisitor},
         traits::{self, TraitImpl},
-        ty::{self, translate_tydecl, ty_binding_group},
     },
     util::{self, item_type, pre_sig_of, PreSignature},
 };

--- a/creusot/src/ctx.rs
+++ b/creusot/src/ctx.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ops::Deref};
 
-pub(crate) use crate::clone_map::*;
+pub(crate) use crate::backend::clone_map::*;
 use crate::{
     backend::{
         self,

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -32,7 +32,6 @@ mod analysis;
 pub(crate) mod backend;
 pub mod callbacks;
 mod cleanup_spec_closures;
-pub(crate) mod clone_map;
 pub(crate) mod creusot_items;
 pub(crate) mod ctx;
 

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -6,7 +6,6 @@ pub(crate) mod function;
 pub(crate) mod pearlite;
 pub(crate) mod specification;
 pub(crate) mod traits;
-pub(crate) mod ty;
 
 use crate::{
     ctx,

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -332,13 +332,6 @@ impl LocalIdent {
         LocalIdent(loc, Some(dbg.name))
     }
 
-    pub(crate) fn arg_name(&self) -> why3::Ident {
-        match &self.1 {
-            None => format!("{:?}'", self.0).into(),
-            Some(h) => ident_of(*h),
-        }
-    }
-
     pub(crate) fn symbol(&self) -> Symbol {
         match &self.1 {
             Some(id) => Symbol::intern(&format!("{}_{}", &*ident_of(*id), self.0.index())),

--- a/creusot/src/translation/function.rs
+++ b/creusot/src/translation/function.rs
@@ -3,6 +3,7 @@ use super::{
     pearlite::{normalize, Term},
 };
 use crate::{
+    backend::place,
     ctx::*,
     fmir::{self, Expr},
     gather_spec_closures::corrected_invariant_names_and_locations,
@@ -37,7 +38,6 @@ use rustc_span::{Span, Symbol, DUMMY_SP};
 use std::rc::Rc;
 use why3::declaration::*;
 
-pub(crate) mod place;
 pub(crate) mod promoted;
 mod statement;
 pub(crate) mod terminator;


### PR DESCRIPTION
Supporting mutual recursive predicates intersects with cleaning up the `CloneMap`. I cleaned up most things so that we only have one dependency on `why3` outside of `backend`, and a trivial one at that. We'll be able to split up multiple crates now.
