### PR TITLE
Encode float operators with a dot

### DIFF
--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -345,8 +345,8 @@ impl<'tcx> Expr<'tcx> {
                 Box::new(l.to_why(ctx, names, body)),
                 Box::new(r.to_why(ctx, names, body)),
             ),
-            Expr::UnaryOp(op, arg) => {
-                Exp::UnaryOp(unop_to_unop(op), Box::new(arg.to_why(ctx, names, body)))
+            Expr::UnaryOp(op, ty, arg) => {
+                Exp::UnaryOp(unop_to_unop(ty, op), Box::new(arg.to_why(ctx, names, body)))
             }
             Expr::Constructor(id, subst, args) => {
                 let args = args.into_iter().map(|a| a.to_why(ctx, names, body)).collect();
@@ -454,7 +454,7 @@ impl<'tcx> Expr<'tcx> {
                 l.invalidated_places(places);
                 r.invalidated_places(places)
             }
-            Expr::UnaryOp(_, e) => e.invalidated_places(places),
+            Expr::UnaryOp(_, _, e) => e.invalidated_places(places),
             Expr::Constructor(_, _, es) => es.iter().for_each(|e| e.invalidated_places(places)),
             Expr::Call(_, _, es) => es.iter().for_each(|e| e.invalidated_places(places)),
             Expr::Constant(_) => {}

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::ty::{intty_to_ty, translate_ty, uintty_to_ty},
+    backend::ty::{floatty_to_ty, intty_to_ty, translate_ty, uintty_to_ty},
     ctx::*,
     pearlite::{self, Literal, Pattern, Term, TermKind},
     util,
@@ -392,7 +392,10 @@ pub(crate) fn lower_literal<'tcx>(
             names.insert(id, subst);
             Exp::Tuple(Vec::new())
         }
-        Literal::Float(f) => Constant::Float(f).into(),
+        Literal::Float(f, fty) => {
+            let _why_ty = floatty_to_ty(names, &fty);
+            Constant::Float(f).into()
+        }
         Literal::ZST => Exp::Tuple(Vec::new()),
         Literal::String(string) => Constant::String(string).into(),
     }

--- a/creusot/src/backend/ty.rs
+++ b/creusot/src/backend/ty.rs
@@ -667,7 +667,7 @@ pub(crate) fn uintty_to_ty(names: &mut CloneMap<'_>, ity: &rustc_middle::ty::Uin
     }
 }
 
-fn floatty_to_ty(names: &mut CloneMap<'_>, fty: &rustc_middle::ty::FloatTy) -> MlT {
+pub(crate) fn floatty_to_ty(names: &mut CloneMap<'_>, fty: &rustc_middle::ty::FloatTy) -> MlT {
     use rustc_middle::ty::FloatTy::*;
 
     match fty {

--- a/creusot/src/translation.rs
+++ b/creusot/src/translation.rs
@@ -171,10 +171,34 @@ pub(crate) fn binop_to_binop(ctx: &mut TranslationCtx, ty: Ty, op: mir::BinOp) -
                 BinOp::Eq
             }
         }
-        mir::BinOp::Lt => BinOp::Lt,
-        mir::BinOp::Le => BinOp::Le,
-        mir::BinOp::Gt => BinOp::Gt,
-        mir::BinOp::Ge => BinOp::Ge,
+        mir::BinOp::Lt => {
+            if ty.is_floating_point() {
+                BinOp::FloatLt
+            } else {
+                BinOp::Lt
+            }
+        }
+        mir::BinOp::Le => {
+            if ty.is_floating_point() {
+                BinOp::FloatLe
+            } else {
+                BinOp::Le
+            }
+        }
+        mir::BinOp::Gt => {
+            if ty.is_floating_point() {
+                BinOp::FloatGt
+            } else {
+                BinOp::Gt
+            }
+        }
+        mir::BinOp::Ge => {
+            if ty.is_floating_point() {
+                BinOp::FloatGe
+            } else {
+                BinOp::Ge
+            }
+        }
         mir::BinOp::Ne => BinOp::Ne,
         mir::BinOp::Rem => BinOp::Mod,
         _ => ctx.crash_and_error(
@@ -184,10 +208,16 @@ pub(crate) fn binop_to_binop(ctx: &mut TranslationCtx, ty: Ty, op: mir::BinOp) -
     }
 }
 
-pub(crate) fn unop_to_unop(op: rustc_middle::mir::UnOp) -> why3::exp::UnOp {
+pub(crate) fn unop_to_unop(ty: Ty, op: rustc_middle::mir::UnOp) -> why3::exp::UnOp {
     match op {
         rustc_middle::mir::UnOp::Not => why3::exp::UnOp::Not,
-        rustc_middle::mir::UnOp::Neg => why3::exp::UnOp::Neg,
+        rustc_middle::mir::UnOp::Neg => {
+            if ty.is_floating_point() {
+                why3::exp::UnOp::FloatNeg
+            } else {
+                why3::exp::UnOp::Neg
+            }
+        }
     }
 }
 

--- a/creusot/src/translation/constant.rs
+++ b/creusot/src/translation/constant.rs
@@ -138,7 +138,7 @@ fn try_to_bits<'tcx, C: ToBits<'tcx>>(
             if float.is_nan() {
                 ctx.crash_and_error(span, "NaN is not yet supported")
             } else {
-                Literal::Float(float as f64)
+                Literal::Float(float as f64, FloatTy::F32)
             }
         }
         Float(FloatTy::F64) => {
@@ -147,7 +147,7 @@ fn try_to_bits<'tcx, C: ToBits<'tcx>>(
             if float.is_nan() {
                 ctx.crash_and_error(span, "NaN is not yet supported")
             } else {
-                Literal::Float(float)
+                Literal::Float(float, FloatTy::F32)
             }
         }
         _ if ty.is_unit() => Literal::ZST,

--- a/creusot/src/translation/fmir.rs
+++ b/creusot/src/translation/fmir.rs
@@ -34,7 +34,7 @@ pub enum Expr<'tcx> {
     Move(Place<'tcx>),
     Copy(Place<'tcx>),
     BinOp(BinOp, Ty<'tcx>, Box<Expr<'tcx>>, Box<Expr<'tcx>>),
-    UnaryOp(UnOp, Box<Expr<'tcx>>),
+    UnaryOp(UnOp, Ty<'tcx>, Box<Expr<'tcx>>),
     Constructor(DefId, SubstsRef<'tcx>, Vec<Expr<'tcx>>),
     // Should this be a statement?
     Call(DefId, SubstsRef<'tcx>, Vec<Expr<'tcx>>),

--- a/creusot/src/translation/function/statement.rs
+++ b/creusot/src/translation/function/statement.rs
@@ -130,7 +130,9 @@ impl<'tcx> BodyTranslator<'_, 'tcx> {
                 );
                 Expr::Span(si.span, Box::new(exp))
             }
-            Rvalue::UnaryOp(op, v) => Expr::UnaryOp(*op, Box::new(self.translate_operand(v))),
+            Rvalue::UnaryOp(op, v) => {
+                Expr::UnaryOp(*op, v.ty(self.body, self.tcx), Box::new(self.translate_operand(v)))
+            }
             Rvalue::Aggregate(box kind, ops) => {
                 use rustc_middle::mir::AggregateKind::*;
                 let fields = ops.iter().map(|op| self.translate_operand(op)).collect();

--- a/creusot/src/translation/pearlite.rs
+++ b/creusot/src/translation/pearlite.rs
@@ -35,7 +35,7 @@ use rustc_middle::{
 };
 use rustc_span::{Span, Symbol, DUMMY_SP};
 use rustc_target::abi::VariantIdx;
-use rustc_type_ir::{IntTy, Interner, UintTy};
+use rustc_type_ir::{FloatTy, IntTy, Interner, UintTy};
 
 mod normalize;
 
@@ -175,7 +175,7 @@ pub enum Literal<'tcx> {
     Integer(i128),
     MachSigned(i128, IntTy),
     MachUnsigned(u128, UintTy),
-    Float(f64),
+    Float(f64, FloatTy),
     String(String),
     ZST,
     Function(DefId, SubstsRef<'tcx>),

--- a/creusot/tests/should_succeed/float_ops.mlcfg
+++ b/creusot/tests/should_succeed/float_ops.mlcfg
@@ -1,0 +1,127 @@
+
+module FloatOps_Eq_Interface
+  val eq [#"../float_ops.rs" 5 0 5 19] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 4 10 4 24] result = true }
+    
+end
+module FloatOps_Eq
+  use prelude.Float32
+  let rec cfg eq [#"../float_ops.rs" 5 0 5 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 4 10 4 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 6 4 6 14] ([#"../float_ops.rs" 6 4 6 7] 1.0000000000000000000000000000000000000000000000000000000000000000) .= ([#"../float_ops.rs" 6 11 6 14] 2.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end
+module FloatOps_Lt_Interface
+  val lt [#"../float_ops.rs" 10 0 10 19] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 9 10 9 24] result = true }
+    
+end
+module FloatOps_Lt
+  use prelude.Float32
+  let rec cfg lt [#"../float_ops.rs" 10 0 10 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 9 10 9 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 11 4 11 13] ([#"../float_ops.rs" 11 4 11 7] 1.0000000000000000000000000000000000000000000000000000000000000000) .< ([#"../float_ops.rs" 11 10 11 13] 2.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end
+module FloatOps_Le_Interface
+  val le [#"../float_ops.rs" 15 0 15 19] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 14 10 14 24] result = true }
+    
+end
+module FloatOps_Le
+  use prelude.Float32
+  let rec cfg le [#"../float_ops.rs" 15 0 15 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 14 10 14 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 16 4 16 14] ([#"../float_ops.rs" 16 4 16 7] 1.0000000000000000000000000000000000000000000000000000000000000000) .<= ([#"../float_ops.rs" 16 11 16 14] 2.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end
+module FloatOps_Gt_Interface
+  val gt [#"../float_ops.rs" 20 0 20 19] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 19 10 19 24] result = true }
+    
+end
+module FloatOps_Gt
+  use prelude.Float32
+  let rec cfg gt [#"../float_ops.rs" 20 0 20 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 19 10 19 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 21 4 21 13] ([#"../float_ops.rs" 21 4 21 7] 2.0000000000000000000000000000000000000000000000000000000000000000) .> ([#"../float_ops.rs" 21 10 21 13] 1.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end
+module FloatOps_Ge_Interface
+  val ge [#"../float_ops.rs" 25 0 25 19] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 24 10 24 24] result = true }
+    
+end
+module FloatOps_Ge
+  use prelude.Float32
+  let rec cfg ge [#"../float_ops.rs" 25 0 25 19] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 24 10 24 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 26 4 26 14] ([#"../float_ops.rs" 26 4 26 7] 2.0000000000000000000000000000000000000000000000000000000000000000) .>= ([#"../float_ops.rs" 26 11 26 14] 1.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end
+module FloatOps_Neg_Interface
+  val neg [#"../float_ops.rs" 30 0 30 20] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 29 10 29 24] result = true }
+    
+end
+module FloatOps_Neg
+  use prelude.Float32
+  let rec cfg neg [#"../float_ops.rs" 30 0 30 20] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : bool
+    ensures { [#"../float_ops.rs" 29 10 29 24] result = true }
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : bool;
+  {
+    goto BB0
+  }
+  BB0 {
+    _0 <- ([#"../float_ops.rs" 31 4 31 15] ([#"../float_ops.rs" 31 4 31 8] -2.0000000000000000000000000000000000000000000000000000000000000000) .<= ([#"../float_ops.rs" 31 12 31 15] 1.0000000000000000000000000000000000000000000000000000000000000000));
+    return _0
+  }
+  
+end

--- a/creusot/tests/should_succeed/float_ops.rs
+++ b/creusot/tests/should_succeed/float_ops.rs
@@ -1,0 +1,32 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[ensures(result == true)]
+pub fn eq() -> bool {
+    1.0 == 2.0
+}
+
+#[ensures(result == true)]
+pub fn lt() -> bool {
+    1.0 < 2.0
+}
+
+#[ensures(result == true)]
+pub fn le() -> bool {
+    1.0 <= 2.0
+}
+
+#[ensures(result == true)]
+pub fn gt() -> bool {
+    2.0 > 1.0
+}
+
+#[ensures(result == true)]
+pub fn ge() -> bool {
+    2.0 >= 1.0
+}
+
+#[ensures(result == true)]
+pub fn neg() -> bool {
+    -2.0 <= 1.0
+}

--- a/why3/src/exp.rs
+++ b/why3/src/exp.rs
@@ -25,9 +25,13 @@ pub enum BinOp {
     Eq,
     FloatEq,
     Lt,
+    FloatLt,
     Le,
+    FloatLe,
     Gt,
+    FloatGt,
     Ge,
+    FloatGe,
     Ne,
 }
 
@@ -50,11 +54,15 @@ impl BinOp {
             BinOp::Ne => Infix1,
             BinOp::Ge => Infix1,
             BinOp::Gt => Infix1,
-            BinOp::FloatAdd => Infix4,
-            BinOp::FloatSub => Infix4,
-            BinOp::FloatMul => Infix4,
-            BinOp::FloatDiv => Infix4,
+            BinOp::FloatAdd => Infix5,
+            BinOp::FloatSub => Infix5,
+            BinOp::FloatMul => Infix5,
+            BinOp::FloatDiv => Infix5,
             BinOp::FloatEq => Infix4,
+            BinOp::FloatLt => Infix4,
+            BinOp::FloatLe => Infix4,
+            BinOp::FloatGt => Infix4,
+            BinOp::FloatGe => Infix4,
         }
     }
 
@@ -76,6 +84,7 @@ impl BinOp {
 pub enum UnOp {
     Not,
     Neg,
+    FloatNeg,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -450,6 +459,7 @@ pub(crate) enum Precedence {
     Infix2,   // infix-op level 2 (left-assoc)
     Infix3,   // infix-op level 3 (left-assoc)
     Infix4,   // infix-op level 4 (left-assoc)
+    Infix5,   // infix-op level 5 (left-assoc)
     Prefix,   // prefix-op
     Abs,      // Function abstraction
     App,      // Function application
@@ -478,7 +488,8 @@ impl Precedence {
             Precedence::AtOld => Precedence::Infix2,
             Precedence::Infix2 => Precedence::Infix3,
             Precedence::Infix3 => Precedence::Infix4,
-            Precedence::Infix4 => Precedence::Prefix,
+            Precedence::Infix4 => Precedence::Infix5,
+            Precedence::Infix5 => Precedence::Prefix,
             Precedence::Prefix => Precedence::Abs,
             Precedence::Abs => Precedence::App,
             Precedence::App => Precedence::Brackets,
@@ -526,7 +537,7 @@ impl Exp {
             Exp::IfThenElse(_, _, _) => IfLet,
             Exp::BorrowMut(_) => App,
             Exp::Const(_) => Atom,
-            Exp::UnaryOp(UnOp::Neg, _) => Prefix,
+            Exp::UnaryOp(UnOp::Neg | UnOp::FloatNeg, _) => Prefix,
             Exp::UnaryOp(UnOp::Not, _) => Not,
             Exp::BinaryOp(op, _, _) => op.precedence(),
             Exp::Call(_, _) => App,

--- a/why3/src/exp.rs
+++ b/why3/src/exp.rs
@@ -54,10 +54,10 @@ impl BinOp {
             BinOp::Ne => Infix1,
             BinOp::Ge => Infix1,
             BinOp::Gt => Infix1,
-            BinOp::FloatAdd => Infix5,
-            BinOp::FloatSub => Infix5,
-            BinOp::FloatMul => Infix5,
-            BinOp::FloatDiv => Infix5,
+            BinOp::FloatAdd => Infix4,
+            BinOp::FloatSub => Infix4,
+            BinOp::FloatMul => Infix4,
+            BinOp::FloatDiv => Infix4,
             BinOp::FloatEq => Infix4,
             BinOp::FloatLt => Infix4,
             BinOp::FloatLe => Infix4,
@@ -459,7 +459,6 @@ pub(crate) enum Precedence {
     Infix2,   // infix-op level 2 (left-assoc)
     Infix3,   // infix-op level 3 (left-assoc)
     Infix4,   // infix-op level 4 (left-assoc)
-    Infix5,   // infix-op level 5 (left-assoc)
     Prefix,   // prefix-op
     Abs,      // Function abstraction
     App,      // Function application
@@ -488,8 +487,7 @@ impl Precedence {
             Precedence::AtOld => Precedence::Infix2,
             Precedence::Infix2 => Precedence::Infix3,
             Precedence::Infix3 => Precedence::Infix4,
-            Precedence::Infix4 => Precedence::Infix5,
-            Precedence::Infix5 => Precedence::Prefix,
+            Precedence::Infix4 => Precedence::Prefix,
             Precedence::Prefix => Precedence::Abs,
             Precedence::Abs => Precedence::App,
             Precedence::App => Precedence::Brackets,

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -668,6 +668,7 @@ impl Print for Exp {
             }
 
             Exp::UnaryOp(UnOp::Neg, box op) => alloc.text("- ").append(op.pretty(alloc, env)),
+            Exp::UnaryOp(UnOp::FloatNeg, box op) => alloc.text(".- ").append(op.pretty(alloc, env)),
             Exp::BinaryOp(op, box l, box r) => match self.associativity() {
                 Some(AssocDir::Left) => parens!(alloc, env, self, l),
                 Some(AssocDir::Right) | None => parens!(alloc, env, self.precedence().next(), l),
@@ -990,6 +991,10 @@ fn bin_op_to_string(op: &BinOp) -> &str {
         FloatMul => ".*",
         FloatDiv => "./",
         FloatEq => ".=",
+        FloatLt => ".<",
+        FloatLe => ".<=",
+        FloatGt => ".>",
+        FloatGe => ".>=",
     }
 }
 


### PR DESCRIPTION
I noticed some of the float operators were missing while working on [this](https://github.com/xldenis/creusot/discussions/735). I got the syntax for operators from here https://why3.lri.fr/stdlib/ieee_float.html. 

I added a test, but not sure if that's how it should be tested. I tried it locally and it worked.