### PR TITLE
Add a "rust-analyzer.rustc.source" setting for vscode's rust-analyzer.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.rustc.source": "discover",
+}


### PR DESCRIPTION
This setting enables rust-analyzer to discover rustc private crates. Cf https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/.E2.9C.94.20How.20to.20get.20rust-analyzer.20in.20vscode.20for.20OOT.20rustc.20plugins