### PR TITLE
Add postfix model operator

### DIFF
--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -358,7 +358,9 @@ fn escape_self_in_term(t: &mut Term) {
             escape_self_in_term(expr);
         }
         Term::Final(TermFinal { term, .. }) => escape_self_in_term(term),
-        Term::Model(TermModel { term, .. }) => escape_self_in_term(term),
+        Term::Model(TermModel { term, .. }) | Term::ModelPost(TermModelPost { term, .. }) => {
+            escape_self_in_term(term)
+        }
         Term::LogEq(TermLogEq { lhs, rhs, .. }) => {
             escape_self_in_term(lhs);
             escape_self_in_term(rhs)

--- a/creusot-contracts-proc/src/extern_spec.rs
+++ b/creusot-contracts-proc/src/extern_spec.rs
@@ -358,9 +358,7 @@ fn escape_self_in_term(t: &mut Term) {
             escape_self_in_term(expr);
         }
         Term::Final(TermFinal { term, .. }) => escape_self_in_term(term),
-        Term::Model(TermModel { term, .. }) | Term::ModelPost(TermModelPost { term, .. }) => {
-            escape_self_in_term(term)
-        }
+        Term::Model(TermModel { term, .. }) => escape_self_in_term(term),
         Term::LogEq(TermLogEq { lhs, rhs, .. }) => {
             escape_self_in_term(lhs);
             escape_self_in_term(rhs)

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -191,6 +191,10 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
             })
         }
         RT::Model(TermModel { term, .. }) | RT::ModelPost(TermModelPost { term, .. }) => {
+            let term = match &**term {
+                RT::Paren(TermParen { expr, .. }) => &expr,
+                _ => &*term,
+            };
             let term = encode_term(term)?;
             Ok(quote! {
                 ::creusot_contracts::model::ShallowModel::shallow_model(#term)

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -190,7 +190,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 * ::creusot_contracts::__stubs::fin(#term)
             })
         }
-        RT::Model(TermModel { term, .. }) | RT::ModelPost(TermModelPost { term, .. }) => {
+        RT::Model(TermModel { term, .. }) => {
             let term = match &**term {
                 RT::Paren(TermParen { expr, .. }) => &expr,
                 _ => &*term,

--- a/creusot-contracts-proc/src/pretyping.rs
+++ b/creusot-contracts-proc/src/pretyping.rs
@@ -190,7 +190,7 @@ pub fn encode_term(term: &RT) -> Result<TokenStream, EncodeError> {
                 * ::creusot_contracts::__stubs::fin(#term)
             })
         }
-        RT::Model(TermModel { term, .. }) => {
+        RT::Model(TermModel { term, .. }) | RT::ModelPost(TermModelPost { term, .. }) => {
             let term = encode_term(term)?;
             Ok(quote! {
                 ::creusot_contracts::model::ShallowModel::shallow_model(#term)

--- a/creusot-contracts/src/logic/int.rs
+++ b/creusot-contracts/src/logic/int.rs
@@ -68,7 +68,7 @@ macro_rules! mach_int {
             type DeepModelTy = Int;
             #[logic]
             fn deep_model(self) -> Self::DeepModelTy {
-                pearlite! { @self }
+                pearlite! { self@ }
             }
         }
     };

--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -95,7 +95,7 @@ impl<T: DeepModel, const N: usize> DeepModel for [T; N] {
     // TODO
     // #[ensures(result.len() == @N)]
     #[ensures(self.shallow_model().len() == result.len())]
-    #[ensures(forall<i: _> 0 <= i && i < result.len() ==> result[i] == (@self)[i].deep_model())]
+    #[ensures(forall<i: _> 0 <= i && i < result.len() ==> result[i] == self@[i].deep_model())]
     fn deep_model(self) -> Self::DeepModelTy {
         pearlite! { absurd }
     }

--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -80,7 +80,7 @@ impl<T, const N: usize> ShallowModel for [T; N] {
     #[trusted]
     #[creusot::builtins = "prelude.Slice.id"]
     // TODO:
-    // #[ensures(result.len() == @N)]
+    // #[ensures(result.len() == N@)]
     // Warning: #[ensures] and #[trusted] are incompatible, so this might require
     fn shallow_model(self) -> Self::ShallowModelTy {
         pearlite! { absurd }
@@ -93,7 +93,7 @@ impl<T: DeepModel, const N: usize> DeepModel for [T; N] {
     #[logic]
     #[trusted]
     // TODO
-    // #[ensures(result.len() == @N)]
+    // #[ensures(result.len() == N@)]
     #[ensures(self.shallow_model().len() == result.len())]
     #[ensures(forall<i: _> 0 <= i && i < result.len() ==> result[i] == self@[i].deep_model())]
     fn deep_model(self) -> Self::DeepModelTy {

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -43,30 +43,30 @@ extern_spec! {
                 #[ensures(result == (self@.len() == 0))]
                 fn is_empty(&self) -> bool;
 
-                #[ensures((@^self).len() == 0)]
+                #[ensures(((^self)@).len() == 0)]
                 fn clear(&mut self);
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == self@.subsequence(1, self@.len()) &&
-                        self@ == Seq::singleton(t).concat(@^self),
+                        (^self)@ == self@.subsequence(1, self@.len()) &&
+                        self@ == Seq::singleton(t).concat((^self)@),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_front(&mut self) -> Option<T>;
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == self@.subsequence(0, self@.len() - 1) &&
-                        self@ == (@^self).push(t),
+                        (^self)@ == self@.subsequence(0, self@.len() - 1) &&
+                        self@ == ((^self)@).push(t),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_back(&mut self) -> Option<T>;
 
-                #[ensures((@^self).len() == self@.len() + 1)]
-                #[ensures((@^self) == Seq::singleton(value).concat(self@))]
+                #[ensures(((^self)@).len() == self@.len() + 1)]
+                #[ensures(((^self)@) == Seq::singleton(value).concat(self@))]
                 fn push_front(&mut self, value: T);
 
-                #[ensures(@^self == self@.push(value))]
+                #[ensures((^self)@ == self@.push(value))]
                 fn push_back(&mut self, value: T);
             }
         }

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -19,7 +19,7 @@ impl<T: DeepModel, A: Allocator> DeepModel for VecDeque<T, A> {
     #[trusted]
     #[ensures(self.shallow_model().len() == result.len())]
     #[ensures(forall<i: Int> 0 <= i && i < self.shallow_model().len()
-              ==> result[i] == (@self)[i].deep_model())]
+              ==> result[i] == self@[i].deep_model())]
     fn deep_model(self) -> Self::DeepModelTy {
         pearlite! { absurd }
     }
@@ -29,18 +29,18 @@ extern_spec! {
     mod std {
         mod collections {
             impl<T> VecDeque<T> {
-                #[ensures((@result).len() == 0)]
+                #[ensures(result@.len() == 0)]
                 fn new() -> Self;
 
-                #[ensures((@result).len() == 0)]
+                #[ensures(result@.len() == 0)]
                 fn with_capacity(capacity: usize) -> Self;
             }
 
             impl<T, A: Allocator> VecDeque<T, A> {
-                #[ensures(@result == (@self).len())]
+                #[ensures(@result == self@.len())]
                 fn len(&self) -> usize;
 
-                #[ensures(result == ((@self).len() == 0))]
+                #[ensures(result == (self@.len() == 0))]
                 fn is_empty(&self) -> bool;
 
                 #[ensures((@^self).len() == 0)]
@@ -48,25 +48,25 @@ extern_spec! {
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == (@self).subsequence(1, (@self).len()) &&
+                        @^self == self@.subsequence(1, self@.len()) &&
                         @self == Seq::singleton(t).concat(@^self),
-                    None => *self == ^self && (@self).len() == 0
+                    None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_front(&mut self) -> Option<T>;
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == (@self).subsequence(0, (@self).len() - 1) &&
+                        @^self == self@.subsequence(0, self@.len() - 1) &&
                         @self == (@^self).push(t),
-                    None => *self == ^self && (@self).len() == 0
+                    None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_back(&mut self) -> Option<T>;
 
-                #[ensures((@^self).len() == (@self).len() + 1)]
+                #[ensures((@^self).len() == self@.len() + 1)]
                 #[ensures((@^self) == Seq::singleton(value).concat(@self))]
                 fn push_front(&mut self, value: T);
 
-                #[ensures(@^self == (@self).push(value))]
+                #[ensures(@^self == self@.push(value))]
                 fn push_back(&mut self, value: T);
             }
         }

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -6,7 +6,7 @@ impl<T, A: Allocator> ShallowModel for VecDeque<T, A> {
 
     #[logic]
     #[trusted]
-    #[ensures(result.len() <= @usize::MAX)]
+    #[ensures(result.len() <= usize::MAX@)]
     fn shallow_model(self) -> Seq<T> {
         pearlite! { absurd }
     }

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -43,7 +43,7 @@ extern_spec! {
                 #[ensures(result == (self@.len() == 0))]
                 fn is_empty(&self) -> bool;
 
-                #[ensures(((^self)@).len() == 0)]
+                #[ensures((^self)@.len() == 0)]
                 fn clear(&mut self);
 
                 #[ensures(match result {
@@ -57,13 +57,13 @@ extern_spec! {
                 #[ensures(match result {
                     Some(t) =>
                         (^self)@ == self@.subsequence(0, self@.len() - 1) &&
-                        self@ == ((^self)@).push(t),
+                        self@ == (^self)@.push(t),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_back(&mut self) -> Option<T>;
 
-                #[ensures(((^self)@).len() == self@.len() + 1)]
-                #[ensures(((^self)@) == Seq::singleton(value).concat(self@))]
+                #[ensures((^self)@.len() == self@.len() + 1)]
+                #[ensures((^self)@ == Seq::singleton(value).concat(self@))]
                 fn push_front(&mut self, value: T);
 
                 #[ensures((^self)@ == self@.push(value))]

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -37,7 +37,7 @@ extern_spec! {
             }
 
             impl<T, A: Allocator> VecDeque<T, A> {
-                #[ensures(@result == self@.len())]
+                #[ensures(result@ == self@.len())]
                 fn len(&self) -> usize;
 
                 #[ensures(result == (self@.len() == 0))]
@@ -49,7 +49,7 @@ extern_spec! {
                 #[ensures(match result {
                     Some(t) =>
                         @^self == self@.subsequence(1, self@.len()) &&
-                        @self == Seq::singleton(t).concat(@^self),
+                        self@ == Seq::singleton(t).concat(@^self),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_front(&mut self) -> Option<T>;
@@ -57,13 +57,13 @@ extern_spec! {
                 #[ensures(match result {
                     Some(t) =>
                         @^self == self@.subsequence(0, self@.len() - 1) &&
-                        @self == (@^self).push(t),
+                        self@ == (@^self).push(t),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop_back(&mut self) -> Option<T>;
 
                 #[ensures((@^self).len() == self@.len() + 1)]
-                #[ensures((@^self) == Seq::singleton(value).concat(@self))]
+                #[ensures((@^self) == Seq::singleton(value).concat(self@))]
                 fn push_front(&mut self, value: T);
 
                 #[ensures(@^self == self@.push(value))]

--- a/creusot-contracts/src/std/iter.rs
+++ b/creusot-contracts/src/std/iter.rs
@@ -88,10 +88,10 @@ extern_spec! {
                 })]
                 fn next(&mut self) -> Option<Self::Item>;
 
-                #[ensures(result.iter() == self && result.n() == @n)]
+                #[ensures(result.iter() == self && result.n() == n@)]
                 fn skip(self, n: usize) -> Skip<Self>;
 
-                #[ensures(result.iter() == self && result.n() == @n)]
+                #[ensures(result.iter() == self && result.n() == n@)]
                 fn take(self, n: usize) -> Take<Self>;
 
                 #[ensures(result.iter() == self)]
@@ -137,10 +137,10 @@ extern_spec! {
 
             fn empty<T>() -> Empty<T>;
 
-            #[ensures(@result == Some(value))]
+            #[ensures(result@ == Some(value))]
             fn once<T>(value: T) -> Once<T>;
 
-            #[ensures(@result == elt)]
+            #[ensures(result@ == elt)]
             fn repeat<T: Clone>(elt: T) -> Repeat<T>;
         }
     }

--- a/creusot-contracts/src/std/iter/enumerate.rs
+++ b/creusot-contracts/src/std/iter/enumerate.rs
@@ -58,7 +58,7 @@ where
             visited.len() == o.n() - self.n()
             && exists<s: Seq<I::Item>> self.iter().produces(s, o.iter())
                 && visited.len() == s.len()
-                && forall<i: Int> 0 <= i && i < s.len() ==> @visited[i].0 == self.n() + i && visited[i].1 == s[i]
+                && forall<i: Int> 0 <= i && i < s.len() ==> visited[i].0@ == self.n() + i && visited[i].1 == s[i]
         }
     }
 

--- a/creusot-contracts/src/std/iter/enumerate.rs
+++ b/creusot-contracts/src/std/iter/enumerate.rs
@@ -37,7 +37,7 @@ impl<I: Invariant + Iterator> Invariant for Enumerate<I> {
     fn invariant(self) -> bool {
         pearlite! {
             self.iter().invariant()
-            && (forall<s: Seq<I::Item>, i: I> self.iter().produces(s, i) ==> self.n() + s.len() < @std::usize::MAX)
+            && (forall<s: Seq<I::Item>, i: I> self.iter().produces(s, i) ==> self.n() + s.len() < std::usize::MAX@)
             && (forall<i: &mut I> i.completed() ==> i.produces(Seq::EMPTY, ^i))
         }
     }

--- a/creusot-contracts/src/std/iter/once.rs
+++ b/creusot-contracts/src/std/iter/once.rs
@@ -15,7 +15,7 @@ impl<T> Invariant for Once<T> {}
 impl<T> Iterator for Once<T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { @*self == None && self.resolve() }
+        pearlite! { (*self)@ == None && self.resolve() }
     }
 
     #[predicate]

--- a/creusot-contracts/src/std/iter/once.rs
+++ b/creusot-contracts/src/std/iter/once.rs
@@ -22,7 +22,7 @@ impl<T> Iterator for Once<T> {
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             visited == Seq::EMPTY && self == o ||
-            exists<e: Self::Item> @self == Some(e) && visited == Seq::singleton(e) && @o == None
+            exists<e: Self::Item> self@ == Some(e) && visited == Seq::singleton(e) && o@ == None
         }
     }
 

--- a/creusot-contracts/src/std/iter/repeat.rs
+++ b/creusot-contracts/src/std/iter/repeat.rs
@@ -22,7 +22,7 @@ impl<T: Clone> Iterator for Repeat<T> {
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             self == o &&
-            forall<i: Int> 0 <= i && i < visited.len() ==> visited[i] == @self
+            forall<i: Int> 0 <= i && i < visited.len() ==> visited[i] == self@
         }
     }
 

--- a/creusot-contracts/src/std/iter/skip.rs
+++ b/creusot-contracts/src/std/iter/skip.rs
@@ -17,7 +17,7 @@ impl<I> SkipExt<I> for Skip<I> {
 
     #[logic]
     #[trusted]
-    #[ensures(result >= 0 && result <= @usize::MAX)]
+    #[ensures(result >= 0 && result <= usize::MAX@)]
     fn n(self) -> Int {
         pearlite! { absurd }
     }

--- a/creusot-contracts/src/std/iter/take.rs
+++ b/creusot-contracts/src/std/iter/take.rs
@@ -27,7 +27,7 @@ impl<I> TakeExt<I> for Take<I> {
 
     #[logic]
     #[trusted]
-    #[ensures(result >= 0 && result <= @usize::MAX)]
+    #[ensures(result >= 0 && result <= usize::MAX@)]
     fn n(self) -> Int {
         pearlite! { absurd }
     }

--- a/creusot-contracts/src/std/num.rs
+++ b/creusot-contracts/src/std/num.rs
@@ -163,13 +163,13 @@ macro_rules! spec_abs_diff {
         extern_spec! {
             impl $unsigned {
                 #[allow(dead_code)]
-                #[ensures(@result == (@self).abs_diff(@other))]
+                #[ensures(@result == self@.abs_diff(@other))]
                 fn abs_diff(self, other: $unsigned) -> $unsigned;
             }
 
             impl $signed {
                 #[allow(dead_code)]
-                #[ensures(@result == (@self).abs_diff(@other))]
+                #[ensures(@result == self@.abs_diff(@other))]
                 fn abs_diff(self, other: $signed) -> $unsigned;
             }
         }

--- a/creusot-contracts/src/std/num.rs
+++ b/creusot-contracts/src/std/num.rs
@@ -44,9 +44,9 @@ macro_rules! spec_type {
                 // Panics if the divisor is zero
                 #[requires(rhs@ != 0)]
                 // Returns `self` if the division overflows
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> @result.0 == self@)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result.0@ == self@)]
                 // Else, returns the result of the division
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) || @result.0 == self@ / rhs@)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result.0@ == self@ / rhs@)]
                 // Overflow only occurs when computing `$type::MIN / -1`
                 #[ensures(result.1 == (self@ == @$type::MIN && rhs@ == -1))]
                 fn overflowing_div(self, rhs: $type) -> ($type, bool);
@@ -126,12 +126,12 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns result converted to `$type`
                 #[ensures(
-                    @result.0 == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
+                    result.0@ == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
                 )]
                 // Returns the result if it is in range
                 #[ensures(
                     (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
-                    ==> @result.0 == (self@ $op rhs@)
+                    ==> result.0@ == (self@ $op rhs@)
                 )]
                 // Returns the result shifted by a multiple of the type's range if it is out of
                 // range. For addition and subtraction, `k` (qualified over below) will always be 1
@@ -139,12 +139,12 @@ macro_rules! spec_op_common {
                 #[ensures(
                     (self@ $op rhs@) < @$type::MIN
                     ==> exists<k: Int> k > 0
-                        && @result.0 == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
+                        && result.0@ == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 #[ensures(
                     (self@ $op rhs@) > @$type::MAX
                     ==> exists<k: Int> k > 0
-                        && @result.0 == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
+                        && result.0@ == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 // Overflow occurred iff the result is out of range
                 #[ensures(

--- a/creusot-contracts/src/std/num.rs
+++ b/creusot-contracts/src/std/num.rs
@@ -17,7 +17,7 @@ macro_rules! spec_type {
             impl $type {
                 #[allow(dead_code)]
                 // Returns `None` iff the divisor is zero or the division overflows
-                #[ensures((result == None) == (rhs@ == 0 || (self@ == @$type::MIN && rhs@ == -1)))]
+                #[ensures((result == None) == (rhs@ == 0 || (self@ == $type::MIN@ && rhs@ == -1)))]
                 // Else, returns the result of the division
                 #[ensures(forall<r: $type> result == Some(r) ==> r@ == self@ / rhs@)]
                 fn checked_div(self, rhs: $type) -> Option<$type>;
@@ -26,29 +26,29 @@ macro_rules! spec_type {
                 // Panics if the divisor is zero
                 #[requires(rhs@ != 0)]
                 // Returns `self` if the division overflows
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result@ == self@)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) ==> result@ == self@)]
                 // Else, returns the result of the division
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result@ == self@ / rhs@)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) || result@ == self@ / rhs@)]
                 fn wrapping_div(self, rhs: $type) -> $type;
 
                 #[allow(dead_code)]
                 // Panics if the divisor is zero
                 #[requires(rhs@ != 0)]
                 // Returns `$type::MIN` if the division overflows
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result@ == @$type::MIN)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) ==> result@ == $type::MIN@)]
                 // Else, returns the result of the division
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result@ == self@ / rhs@)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) || result@ == self@ / rhs@)]
                 fn saturating_div(self, rhs: $type) -> $type;
 
                 #[allow(dead_code)]
                 // Panics if the divisor is zero
                 #[requires(rhs@ != 0)]
                 // Returns `self` if the division overflows
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result.0@ == self@)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) ==> result.0@ == self@)]
                 // Else, returns the result of the division
-                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result.0@ == self@ / rhs@)]
+                #[ensures((self@ == $type::MIN@ && rhs@ == -1) || result.0@ == self@ / rhs@)]
                 // Overflow only occurs when computing `$type::MIN / -1`
-                #[ensures(result.1 == (self@ == @$type::MIN && rhs@ == -1))]
+                #[ensures(result.1 == (self@ == $type::MIN@ && rhs@ == -1))]
                 fn overflowing_div(self, rhs: $type) -> ($type, bool);
             }
         }
@@ -76,7 +76,7 @@ macro_rules! spec_op_common {
                 // Returns `None` iff the result is out of range
                 #[ensures(
                     (result == None)
-                    == ((self@ $op rhs@) < @$type::MIN || (self@ $op rhs@) > @$type::MAX)
+                    == ((self@ $op rhs@) < $type::MIN@ || (self@ $op rhs@) > $type::MAX@)
                 )]
                 // Returns `Some(result)` if the result is in range
                 #[ensures(forall<r: $type> result == Some(r) ==> r@ == (self@ $op rhs@))]
@@ -86,25 +86,25 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns result converted to `$type`
                 #[ensures(
-                    result@ == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
+                    result@ == (self@ $op rhs@).rem_euclid(2.pow($type::BITS@)) + $type::MIN@
                 )]
                 // Returns the result if it is in range
                 #[ensures(
-                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    (self@ $op rhs@) >= $type::MIN@ && (self@ $op rhs@) <= $type::MAX@
                     ==> result@ == (self@ $op rhs@)
                 )]
                 // Returns the result shifted by a multiple of the type's range if it is out of
                 // range. For addition and subtraction, `k` (qualified over below) will always be 1
                 // or -1, but the verifier is able to deduce that.
                 #[ensures(
-                    (self@ $op rhs@) < @$type::MIN
+                    (self@ $op rhs@) < $type::MIN@
                     ==> exists<k: Int> k > 0
-                        && result@ == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
+                        && result@ == (self@ $op rhs@) + k * ($type::MAX@ - $type::MIN@ + 1)
                 )]
                 #[ensures(
-                    (self@ $op rhs@) > @$type::MAX
+                    (self@ $op rhs@) > $type::MAX@
                     ==> exists<k: Int> k > 0
-                        && result@ == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
+                        && result@ == (self@ $op rhs@) - k * ($type::MAX@ - $type::MIN@ + 1)
                 )]
                 fn $wrapping(self, rhs: $type) -> $type;
 
@@ -113,12 +113,12 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns the result if it is in range
                 #[ensures(
-                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    (self@ $op rhs@) >= $type::MIN@ && (self@ $op rhs@) <= $type::MAX@
                     ==> result@ == (self@ $op rhs@)
                 )]
                 // Returns the nearest bound if the result is out of range
-                #[ensures((self@ $op rhs@) < @$type::MIN ==> result@ == @$type::MIN)]
-                #[ensures((self@ $op rhs@) > @$type::MAX ==> result@ == @$type::MAX)]
+                #[ensures((self@ $op rhs@) < $type::MIN@ ==> result@ == $type::MIN@)]
+                #[ensures((self@ $op rhs@) > $type::MAX@ ==> result@ == $type::MAX@)]
                 fn $saturating(self, rhs: $type) -> $type;
 
                 // Overflowing: performs the operation on `Int` and converts back to `$type`, and
@@ -126,29 +126,29 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns result converted to `$type`
                 #[ensures(
-                    result.0@ == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
+                    result.0@ == (self@ $op rhs@).rem_euclid(2.pow($type::BITS@)) + $type::MIN@
                 )]
                 // Returns the result if it is in range
                 #[ensures(
-                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    (self@ $op rhs@) >= $type::MIN@ && (self@ $op rhs@) <= $type::MAX@
                     ==> result.0@ == (self@ $op rhs@)
                 )]
                 // Returns the result shifted by a multiple of the type's range if it is out of
                 // range. For addition and subtraction, `k` (qualified over below) will always be 1
                 // or -1, but the verifier is able to deduce that.
                 #[ensures(
-                    (self@ $op rhs@) < @$type::MIN
+                    (self@ $op rhs@) < $type::MIN@
                     ==> exists<k: Int> k > 0
-                        && result.0@ == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
+                        && result.0@ == (self@ $op rhs@) + k * ($type::MAX@ - $type::MIN@ + 1)
                 )]
                 #[ensures(
-                    (self@ $op rhs@) > @$type::MAX
+                    (self@ $op rhs@) > $type::MAX@
                     ==> exists<k: Int> k > 0
-                        && result.0@ == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
+                        && result.0@ == (self@ $op rhs@) - k * ($type::MAX@ - $type::MIN@ + 1)
                 )]
                 // Overflow occurred iff the result is out of range
                 #[ensures(
-                    result.1 == ((self@ $op rhs@) < @$type::MIN || (self@ $op rhs@) > @$type::MAX)
+                    result.1 == ((self@ $op rhs@) < $type::MIN@ || (self@ $op rhs@) > $type::MAX@)
                 )]
                 fn $overflowing(self, rhs: $type) -> ($type, bool);
             }

--- a/creusot-contracts/src/std/num.rs
+++ b/creusot-contracts/src/std/num.rs
@@ -17,38 +17,38 @@ macro_rules! spec_type {
             impl $type {
                 #[allow(dead_code)]
                 // Returns `None` iff the divisor is zero or the division overflows
-                #[ensures((result == None) == (@rhs == 0 || (@self == @$type::MIN && @rhs == -1)))]
+                #[ensures((result == None) == (rhs@ == 0 || (self@ == @$type::MIN && rhs@ == -1)))]
                 // Else, returns the result of the division
-                #[ensures(forall<r: $type> result == Some(r) ==> @r == @self / @rhs)]
+                #[ensures(forall<r: $type> result == Some(r) ==> r@ == self@ / rhs@)]
                 fn checked_div(self, rhs: $type) -> Option<$type>;
 
                 #[allow(dead_code)]
                 // Panics if the divisor is zero
-                #[requires(@rhs != 0)]
+                #[requires(rhs@ != 0)]
                 // Returns `self` if the division overflows
-                #[ensures((@self == @$type::MIN && @rhs == -1) ==> @result == @self)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result@ == self@)]
                 // Else, returns the result of the division
-                #[ensures((@self == @$type::MIN && @rhs == -1) || @result == @self / @rhs)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result@ == self@ / rhs@)]
                 fn wrapping_div(self, rhs: $type) -> $type;
 
                 #[allow(dead_code)]
                 // Panics if the divisor is zero
-                #[requires(@rhs != 0)]
+                #[requires(rhs@ != 0)]
                 // Returns `$type::MIN` if the division overflows
-                #[ensures((@self == @$type::MIN && @rhs == -1) ==> @result == @$type::MIN)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> result@ == @$type::MIN)]
                 // Else, returns the result of the division
-                #[ensures((@self == @$type::MIN && @rhs == -1) || @result == @self / @rhs)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) || result@ == self@ / rhs@)]
                 fn saturating_div(self, rhs: $type) -> $type;
 
                 #[allow(dead_code)]
                 // Panics if the divisor is zero
-                #[requires(@rhs != 0)]
+                #[requires(rhs@ != 0)]
                 // Returns `self` if the division overflows
-                #[ensures((@self == @$type::MIN && @rhs == -1) ==> @result.0 == @self)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) ==> @result.0 == self@)]
                 // Else, returns the result of the division
-                #[ensures((@self == @$type::MIN && @rhs == -1) || @result.0 == @self / @rhs)]
+                #[ensures((self@ == @$type::MIN && rhs@ == -1) || @result.0 == self@ / rhs@)]
                 // Overflow only occurs when computing `$type::MIN / -1`
-                #[ensures(result.1 == (@self == @$type::MIN && @rhs == -1))]
+                #[ensures(result.1 == (self@ == @$type::MIN && rhs@ == -1))]
                 fn overflowing_div(self, rhs: $type) -> ($type, bool);
             }
         }
@@ -76,35 +76,35 @@ macro_rules! spec_op_common {
                 // Returns `None` iff the result is out of range
                 #[ensures(
                     (result == None)
-                    == ((@self $op @rhs) < @$type::MIN || (@self $op @rhs) > @$type::MAX)
+                    == ((self@ $op rhs@) < @$type::MIN || (self@ $op rhs@) > @$type::MAX)
                 )]
                 // Returns `Some(result)` if the result is in range
-                #[ensures(forall<r: $type> result == Some(r) ==> @r == (@self $op @rhs))]
+                #[ensures(forall<r: $type> result == Some(r) ==> r@ == (self@ $op rhs@))]
                 fn $checked(self, rhs: $type) -> Option<$type>;
 
                 // Wrapping: performs the operation on `Int` and converts back to `$type`
                 #[allow(dead_code)]
                 // Returns result converted to `$type`
                 #[ensures(
-                    @result == (@self $op @rhs).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
+                    result@ == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
                 )]
                 // Returns the result if it is in range
                 #[ensures(
-                    (@self $op @rhs) >= @$type::MIN && (@self $op @rhs) <= @$type::MAX
-                    ==> @result == (@self $op @rhs)
+                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    ==> result@ == (self@ $op rhs@)
                 )]
                 // Returns the result shifted by a multiple of the type's range if it is out of
                 // range. For addition and subtraction, `k` (qualified over below) will always be 1
                 // or -1, but the verifier is able to deduce that.
                 #[ensures(
-                    (@self $op @rhs) < @$type::MIN
+                    (self@ $op rhs@) < @$type::MIN
                     ==> exists<k: Int> k > 0
-                        && @result == (@self $op @rhs) + k * (@$type::MAX - @$type::MIN + 1)
+                        && result@ == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 #[ensures(
-                    (@self $op @rhs) > @$type::MAX
+                    (self@ $op rhs@) > @$type::MAX
                     ==> exists<k: Int> k > 0
-                        && @result == (@self $op @rhs) - k * (@$type::MAX - @$type::MIN + 1)
+                        && result@ == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 fn $wrapping(self, rhs: $type) -> $type;
 
@@ -113,12 +113,12 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns the result if it is in range
                 #[ensures(
-                    (@self $op @rhs) >= @$type::MIN && (@self $op @rhs) <= @$type::MAX
-                    ==> @result == (@self $op @rhs)
+                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    ==> result@ == (self@ $op rhs@)
                 )]
                 // Returns the nearest bound if the result is out of range
-                #[ensures((@self $op @rhs) < @$type::MIN ==> @result == @$type::MIN)]
-                #[ensures((@self $op @rhs) > @$type::MAX ==> @result == @$type::MAX)]
+                #[ensures((self@ $op rhs@) < @$type::MIN ==> result@ == @$type::MIN)]
+                #[ensures((self@ $op rhs@) > @$type::MAX ==> result@ == @$type::MAX)]
                 fn $saturating(self, rhs: $type) -> $type;
 
                 // Overflowing: performs the operation on `Int` and converts back to `$type`, and
@@ -126,29 +126,29 @@ macro_rules! spec_op_common {
                 #[allow(dead_code)]
                 // Returns result converted to `$type`
                 #[ensures(
-                    @result.0 == (@self $op @rhs).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
+                    @result.0 == (self@ $op rhs@).rem_euclid(2.pow(@$type::BITS)) + @$type::MIN
                 )]
                 // Returns the result if it is in range
                 #[ensures(
-                    (@self $op @rhs) >= @$type::MIN && (@self $op @rhs) <= @$type::MAX
-                    ==> @result.0 == (@self $op @rhs)
+                    (self@ $op rhs@) >= @$type::MIN && (self@ $op rhs@) <= @$type::MAX
+                    ==> @result.0 == (self@ $op rhs@)
                 )]
                 // Returns the result shifted by a multiple of the type's range if it is out of
                 // range. For addition and subtraction, `k` (qualified over below) will always be 1
                 // or -1, but the verifier is able to deduce that.
                 #[ensures(
-                    (@self $op @rhs) < @$type::MIN
+                    (self@ $op rhs@) < @$type::MIN
                     ==> exists<k: Int> k > 0
-                        && @result.0 == (@self $op @rhs) + k * (@$type::MAX - @$type::MIN + 1)
+                        && @result.0 == (self@ $op rhs@) + k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 #[ensures(
-                    (@self $op @rhs) > @$type::MAX
+                    (self@ $op rhs@) > @$type::MAX
                     ==> exists<k: Int> k > 0
-                        && @result.0 == (@self $op @rhs) - k * (@$type::MAX - @$type::MIN + 1)
+                        && @result.0 == (self@ $op rhs@) - k * (@$type::MAX - @$type::MIN + 1)
                 )]
                 // Overflow occurred iff the result is out of range
                 #[ensures(
-                    result.1 == ((@self $op @rhs) < @$type::MIN || (@self $op @rhs) > @$type::MAX)
+                    result.1 == ((self@ $op rhs@) < @$type::MIN || (self@ $op rhs@) > @$type::MAX)
                 )]
                 fn $overflowing(self, rhs: $type) -> ($type, bool);
             }
@@ -163,13 +163,13 @@ macro_rules! spec_abs_diff {
         extern_spec! {
             impl $unsigned {
                 #[allow(dead_code)]
-                #[ensures(@result == self@.abs_diff(@other))]
+                #[ensures(result@ == self@.abs_diff(other@))]
                 fn abs_diff(self, other: $unsigned) -> $unsigned;
             }
 
             impl $signed {
                 #[allow(dead_code)]
-                #[ensures(@result == self@.abs_diff(@other))]
+                #[ensures(result@ == self@.abs_diff(other@))]
                 fn abs_diff(self, other: $signed) -> $unsigned;
             }
         }

--- a/creusot-contracts/src/std/option.rs
+++ b/creusot-contracts/src/std/option.rs
@@ -129,7 +129,7 @@ impl<T> Iterator for IntoIter<T> {
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             visited == Seq::EMPTY && self == o ||
-            exists<e: Self::Item> @self == Some(e) && visited == Seq::singleton(e) && @o == None
+            exists<e: Self::Item> self@ == Some(e) && visited == Seq::singleton(e) && o@ == None
         }
     }
 
@@ -152,7 +152,7 @@ impl<T> IntoIterator for Option<T> {
 
     #[predicate]
     fn into_iter_post(self, res: Self::IntoIter) -> bool {
-        pearlite! { self == @res }
+        pearlite! { self == res@ }
     }
 }
 
@@ -178,7 +178,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             visited == Seq::EMPTY && self == o ||
-            exists<e: Self::Item> @self == Some(e) && visited == Seq::singleton(e) && @o == None
+            exists<e: Self::Item> self@ == Some(e) && visited == Seq::singleton(e) && o@ == None
         }
     }
 
@@ -202,8 +202,8 @@ impl<'a, T> IntoIterator for &'a Option<T> {
     #[predicate]
     fn into_iter_post(self, res: Self::IntoIter) -> bool {
         pearlite! {
-            (*self == None ==> @res == None) &&
-            (*self == None || exists<r: &T> @res == Some(r) && *self == Some(*r))
+            (*self == None ==> res@ == None) &&
+            (*self == None || exists<r: &T> res@ == Some(r) && *self == Some(*r))
         }
     }
 }
@@ -230,7 +230,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             visited == Seq::EMPTY && self == o ||
-            exists<e: Self::Item> @self == Some(e) && visited == Seq::singleton(e) && @o == None
+            exists<e: Self::Item> self@ == Some(e) && visited == Seq::singleton(e) && o@ == None
         }
     }
 
@@ -254,8 +254,8 @@ impl<'a, T> IntoIterator for &'a mut Option<T> {
     #[predicate]
     fn into_iter_post(self, res: Self::IntoIter) -> bool {
         pearlite! {
-            (*self == None ==> @res == None && ^self == None) &&
-            (*self == None || exists<r: &mut T> @res == Some(r) && *self == Some(*r) && ^self == Some(^r))
+            (*self == None ==> res@ == None && ^self == None) &&
+            (*self == None || exists<r: &mut T> res@ == Some(r) && *self == Some(*r) && ^self == Some(^r))
         }
     }
 }

--- a/creusot-contracts/src/std/option.rs
+++ b/creusot-contracts/src/std/option.rs
@@ -122,7 +122,7 @@ impl<T> Invariant for IntoIter<T> {}
 impl<T> Iterator for IntoIter<T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { @*self == None && self.resolve() }
+        pearlite! { (*self)@ == None && self.resolve() }
     }
 
     #[predicate]
@@ -171,7 +171,7 @@ impl<'a, T> Invariant for Iter<'a, T> {}
 impl<'a, T> Iterator for Iter<'a, T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { @*self == None && self.resolve() }
+        pearlite! { (*self)@ == None && self.resolve() }
     }
 
     #[predicate]
@@ -223,7 +223,7 @@ impl<'a, T> Invariant for IterMut<'a, T> {}
 impl<'a, T> Iterator for IterMut<'a, T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { @*self == None && self.resolve() }
+        pearlite! { (*self)@ == None && self.resolve() }
     }
 
     #[predicate]

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -67,7 +67,7 @@ impl<T> SliceExt<T> for [T] {
     #[trusted]
     #[ensures(result.len() == self@.len())]
     #[ensures(forall<i : _> 0 <= i && i < result.len() ==> *result[i] == self@[i])]
-    #[ensures(forall<i : _> 0 <= i && i < result.len() ==> ^result[i] == ((^self)@)[i])]
+    #[ensures(forall<i : _> 0 <= i && i < result.len() ==> ^result[i] == (^self)@[i])]
     fn to_mut_seq(&mut self) -> Seq<&mut T> {
         pearlite! { absurd }
     }
@@ -212,7 +212,7 @@ extern_spec! {
 
         #[requires(i@ < self@.len())]
         #[requires(j@ < self@.len())]
-        #[ensures(((^self)@).exchange(self@, i@, j@))]
+        #[ensures((^self)@.exchange(self@, i@, j@))]
         fn swap(&mut self, i: usize, j: usize);
 
         #[ensures(ix.in_bounds(self@) ==> exists<r: _> result == Some(r) && ix.has_value(self_@, *r))]
@@ -222,21 +222,21 @@ extern_spec! {
         #[requires(mid@ <= self@.len())]
         #[ensures({
             let (l,r) = result;  let sl = self@.len();
-            (((^self)@).len() == sl) &&
+            ((^self)@.len() == sl) &&
             self@.subsequence(0, mid@).ext_eq(l@) &&
             self@.subsequence(mid@, sl).ext_eq(r@) &&
-            ((^self)@).subsequence(0, mid@).ext_eq((^l)@) &&
-            ((^self)@).subsequence(mid@, sl).ext_eq((^r)@)
+            (^self)@.subsequence(0, mid@).ext_eq((^l)@) &&
+            (^self)@.subsequence(mid@, sl).ext_eq((^r)@)
         })]
         fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
 
         #[ensures(result == None ==> self@.len() == 0 && ^self == *self && self@ == Seq::EMPTY)]
         #[ensures(forall<first: &mut T, tail: &mut [T]>
                   result == Some((first, tail))
-                && *first == self@[0] && ^first == ((^self)@)[0]
-                && self@.len() > 0 && ((^self)@).len() > 0
+                && *first == self@[0] && ^first == (^self)@[0]
+                && self@.len() > 0 && (^self)@.len() > 0
                 && tail@ == self@.tail()
-                && (^tail)@ == ((^self)@).tail())]
+                && (^tail)@ == (^self)@.tail())]
         fn split_first_mut(&mut self) -> Option<(&mut T, &mut [T])>;
 
         #[ensures(match result {
@@ -288,7 +288,7 @@ extern_spec! {
        #[ensures(ix.has_value(self@, *result))]
        #[ensures(ix.has_value((^self)@, ^result))]
        #[ensures(ix.resolve_elswhere(self@, (^self)@))]
-       #[ensures(((^self)@).len() == self@.len())]
+       #[ensures((^self)@.len() == self@.len())]
         fn index_mut(&mut self, ix: I) -> &mut <[T] as Index<I>>::Output;
     }
 
@@ -365,7 +365,7 @@ impl<'a, T> ShallowModel for IterMut<'a, T> {
 
     #[logic]
     #[trusted]
-    #[ensures(((^result)@).len() == ((*result)@).len())]
+    #[ensures((^result)@.len() == (*result)@.len())]
     fn shallow_model(self) -> Self::ShallowModelTy {
         absurd
     }

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -241,13 +241,13 @@ extern_spec! {
 
         #[ensures(match result {
             Some(r) => {
-                * r == (@**self)[0] &&
-                ^ r == (@^*self)[0] &&
-                (@**self).len() > 0 && // ^*s.len == **s.len ? (i dont think so)
-                (@^*self).len() > 0 &&
-                (@*^self).ext_eq((@**self).tail()) && (@^^self).ext_eq((@^*self).tail())
+                * r == (**self)@[0] &&
+                ^ r == (^*self)@[0] &&
+                (**self)@.len() > 0 && // ^*s.len == **s.len ? (i dont think so)
+                (^*self)@.len() > 0 &&
+                (*^self)@.ext_eq((**self)@.tail()) && (^^self)@.ext_eq((^*self)@.tail())
             }
-            None => ^self == * self && (@**self).len() == 0
+            None => ^self == * self && (**self)@.len() == 0
         })]
         fn take_first_mut<'a>(self_: &mut &'a mut [T]) -> Option<&'a mut T>;
 
@@ -339,7 +339,7 @@ impl<'a, T> Invariant for Iter<'a, T> {}
 impl<'a, T> Iterator for Iter<'a, T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { self.resolve() && @*self@ == Seq::EMPTY }
+        pearlite! { self.resolve() && (*self@)@ == Seq::EMPTY }
     }
 
     #[predicate]
@@ -384,14 +384,14 @@ impl<'a, T> Invariant for IterMut<'a, T> {
     #[creusot::ignore_type_invariant]
     fn invariant(self) -> bool {
         // Property that is always true but we must carry around..
-        pearlite! { (@^self@).len() == (@*self@).len() }
+        pearlite! { (^self@)@.len() == (*self@)@.len() }
     }
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { self.resolve() && @*self@ == Seq::EMPTY }
+        pearlite! { self.resolve() && (*self@)@ == Seq::EMPTY }
     }
 
     #[predicate]

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -14,7 +14,7 @@ impl<T> ShallowModel for [T] {
     // We define this as trusted because builtins and ensures are incompatible
     #[logic]
     #[trusted]
-    #[ensures(result.len() <= @usize::MAX)]
+    #[ensures(result.len() <= usize::MAX@)]
     #[ensures(result == slice_model(self))]
     fn shallow_model(self) -> Self::ShallowModelTy {
         pearlite! { absurd }

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -43,7 +43,7 @@ fn slice_model<T>(_: [T]) -> Seq<T> {
 impl<T> Default for &mut [T] {
     #[predicate]
     fn is_default(self) -> bool {
-        pearlite! { self@ == Seq::EMPTY && @^self == Seq::EMPTY }
+        pearlite! { self@ == Seq::EMPTY && (^self)@ == Seq::EMPTY }
     }
 }
 
@@ -67,7 +67,7 @@ impl<T> SliceExt<T> for [T] {
     #[trusted]
     #[ensures(result.len() == self@.len())]
     #[ensures(forall<i : _> 0 <= i && i < result.len() ==> *result[i] == self@[i])]
-    #[ensures(forall<i : _> 0 <= i && i < result.len() ==> ^result[i] == (@^self)[i])]
+    #[ensures(forall<i : _> 0 <= i && i < result.len() ==> ^result[i] == ((^self)@)[i])]
     fn to_mut_seq(&mut self) -> Seq<&mut T> {
         pearlite! { absurd }
     }
@@ -212,7 +212,7 @@ extern_spec! {
 
         #[requires(i@ < self@.len())]
         #[requires(j@ < self@.len())]
-        #[ensures((@^self).exchange(self@, i@, j@))]
+        #[ensures(((^self)@).exchange(self@, i@, j@))]
         fn swap(&mut self, i: usize, j: usize);
 
         #[ensures(ix.in_bounds(self@) ==> exists<r: _> result == Some(r) && ix.has_value(self_@, *r))]
@@ -222,21 +222,21 @@ extern_spec! {
         #[requires(mid@ <= self@.len())]
         #[ensures({
             let (l,r) = result;  let sl = self@.len();
-            ((@^self).len() == sl) &&
+            (((^self)@).len() == sl) &&
             self@.subsequence(0, mid@).ext_eq(l@) &&
             self@.subsequence(mid@, sl).ext_eq(r@) &&
-            (@^self).subsequence(0, mid@).ext_eq(@^l) &&
-            (@^self).subsequence(mid@, sl).ext_eq(@^r)
+            ((^self)@).subsequence(0, mid@).ext_eq((^l)@) &&
+            ((^self)@).subsequence(mid@, sl).ext_eq((^r)@)
         })]
         fn split_at_mut(&mut self, mid: usize) -> (&mut [T], &mut [T]);
 
         #[ensures(result == None ==> self@.len() == 0 && ^self == *self && self@ == Seq::EMPTY)]
         #[ensures(forall<first: &mut T, tail: &mut [T]>
                   result == Some((first, tail))
-                && *first == self@[0] && ^first == (@^self)[0]
-                && self@.len() > 0 && (@^self).len() > 0
+                && *first == self@[0] && ^first == ((^self)@)[0]
+                && self@.len() > 0 && ((^self)@).len() > 0
                 && tail@ == self@.tail()
-                && @^tail == (@^self).tail())]
+                && (^tail)@ == ((^self)@).tail())]
         fn split_first_mut(&mut self) -> Option<(&mut T, &mut [T])>;
 
         #[ensures(match result {
@@ -286,9 +286,9 @@ extern_spec! {
         where I : SliceIndex<[T]> {
        #[requires(ix.in_bounds(self@))]
        #[ensures(ix.has_value(self@, *result))]
-       #[ensures(ix.has_value(@^self, ^result))]
-       #[ensures(ix.resolve_elswhere(self@, @^self))]
-       #[ensures((@^self).len() == self@.len())]
+       #[ensures(ix.has_value((^self)@, ^result))]
+       #[ensures(ix.resolve_elswhere(self@, (^self)@))]
+       #[ensures(((^self)@).len() == self@.len())]
         fn index_mut(&mut self, ix: I) -> &mut <[T] as Index<I>>::Output;
     }
 
@@ -365,7 +365,7 @@ impl<'a, T> ShallowModel for IterMut<'a, T> {
 
     #[logic]
     #[trusted]
-    #[ensures((@^result).len() == (@*result).len())]
+    #[ensures(((^result)@).len() == ((*result)@).len())]
     fn shallow_model(self) -> Self::ShallowModelTy {
         absurd
     }

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -118,18 +118,18 @@ impl<T> SliceIndex<[T]> for usize {
 impl<T> SliceIndex<[T]> for Range<usize> {
     #[predicate]
     fn in_bounds(self, seq: Seq<T>) -> bool {
-        pearlite! { @self.start <= @self.end && @self.end <= seq.len() }
+        pearlite! { self.start@ <= self.end@ && self.end@ <= seq.len() }
     }
 
     #[predicate]
     fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
-        pearlite! { seq.subsequence(@self.start, @self.end) == out@ }
+        pearlite! { seq.subsequence(self.start@, self.end@) == out@ }
     }
 
     #[predicate]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
         pearlite! {
-            forall<i : Int> 0 <= i && (i < @self.start || @self.end <= i) && i < old.len()
+            forall<i : Int> 0 <= i && (i < self.start@ || self.end@ <= i) && i < old.len()
             ==> old[i] == fin[i]
         }
     }
@@ -138,35 +138,35 @@ impl<T> SliceIndex<[T]> for Range<usize> {
 impl<T> SliceIndex<[T]> for RangeTo<usize> {
     #[predicate]
     fn in_bounds(self, seq: Seq<T>) -> bool {
-        pearlite! { @self.end <= seq.len() }
+        pearlite! { self.end@ <= seq.len() }
     }
 
     #[predicate]
     fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
-        pearlite! { seq.subsequence(0, @self.end) == out@ }
+        pearlite! { seq.subsequence(0, self.end@) == out@ }
     }
 
     #[predicate]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
-        pearlite! { forall<i : Int> @self.end <= i && i < old.len() ==> old[i] == fin[i] }
+        pearlite! { forall<i : Int> self.end@ <= i && i < old.len() ==> old[i] == fin[i] }
     }
 }
 
 impl<T> SliceIndex<[T]> for RangeFrom<usize> {
     #[predicate]
     fn in_bounds(self, seq: Seq<T>) -> bool {
-        pearlite! { @self.start <= seq.len() }
+        pearlite! { self.start@ <= seq.len() }
     }
 
     #[predicate]
     fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
-        pearlite! { seq.subsequence(@self.start, seq.len()) == out@ }
+        pearlite! { seq.subsequence(self.start@, seq.len()) == out@ }
     }
 
     #[predicate]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
         pearlite! {
-            forall<i : Int> 0 <= i && i < @self.start && i < old.len() ==> old[i] == fin[i]
+            forall<i : Int> 0 <= i && i < self.start@ && i < old.len() ==> old[i] == fin[i]
         }
     }
 }
@@ -191,17 +191,17 @@ impl<T> SliceIndex<[T]> for RangeFull {
 impl<T> SliceIndex<[T]> for RangeToInclusive<usize> {
     #[predicate]
     fn in_bounds(self, seq: Seq<T>) -> bool {
-        pearlite! { @self.end < seq.len() }
+        pearlite! { self.end@ < seq.len() }
     }
 
     #[predicate]
     fn has_value(self, seq: Seq<T>, out: [T]) -> bool {
-        pearlite! { seq.subsequence(0, @self.end + 1) == out@ }
+        pearlite! { seq.subsequence(0, self.end@ + 1) == out@ }
     }
 
     #[predicate]
     fn resolve_elswhere(self, old: Seq<T>, fin: Seq<T>) -> bool {
-        pearlite! { forall<i : Int> @self.end < i && i < old.len() ==> old[i] == fin[i] }
+        pearlite! { forall<i : Int> self.end@ < i && i < old.len() ==> old[i] == fin[i] }
     }
 }
 

--- a/creusot-contracts/src/std/time.rs
+++ b/creusot-contracts/src/std/time.rs
@@ -73,93 +73,93 @@ extern_spec! {
     mod std {
         mod time {
             impl Duration {
-                #[requires(@secs + nanos_to_secs(@nanos) <= @u64::MAX)]
-                #[ensures(@result == secs_to_nanos(@secs) + @nanos )]
+                #[requires(secs@ + nanos_to_secs(nanos@) <= @u64::MAX)]
+                #[ensures(result@ == secs_to_nanos(secs@) + nanos@ )]
                 fn new(secs: u64, nanos: u32) -> Duration;
 
-                #[ensures(@result == secs_to_nanos(@secs))]
+                #[ensures(result@ == secs_to_nanos(secs@))]
                 fn from_secs(secs: u64) -> Duration;
 
-                #[ensures(@result == (@millis * 1_000_000))]
+                #[ensures(result@ == (millis@ * 1_000_000))]
                 fn from_millis(millis: u64) -> Duration;
 
-                #[ensures(@result == (@micros * 1_000))]
+                #[ensures(result@ == (micros@ * 1_000))]
                 fn from_micros(micros: u64) -> Duration;
 
-                #[ensures(@result == @nanos)]
+                #[ensures(result@ == nanos@)]
                 fn from_nanos(nanos: u64) -> Duration;
 
-                #[ensures(@self == 0 ==> result == true)]
-                #[ensures(@self != 0 ==> result == false)]
+                #[ensures(self@ == 0 ==> result == true)]
+                #[ensures(self@ != 0 ==> result == false)]
                 fn is_zero(&self) -> bool;
 
-                #[ensures(@result == nanos_to_secs(@self))]
+                #[ensures(result@ == nanos_to_secs(self@))]
                 fn as_secs(&self) -> u64;
 
-                #[ensures(@result == nanos_to_millis(@self) % 1_000)]
+                #[ensures(result@ == nanos_to_millis(self@) % 1_000)]
                 #[ensures(result < 1_000_u32)]
                 fn subsec_millis(&self) -> u32;
 
-                #[ensures(@result == nanos_to_micros(@self) % 1_000_000)]
+                #[ensures(result@ == nanos_to_micros(self@) % 1_000_000)]
                 #[ensures(result < 1_000_000_u32)]
                 fn subsec_micros(&self) -> u32;
 
-                #[ensures(@result == (@self % 1_000_000_000))]
+                #[ensures(result@ == (self@ % 1_000_000_000))]
                 #[ensures(result < 1_000_000_000_u32)]
                 fn subsec_nanos(&self) -> u32;
 
-                #[ensures(@result == nanos_to_millis(@self))]
+                #[ensures(result@ == nanos_to_millis(self@))]
                 fn as_millis(&self) -> u128;
 
-                #[ensures(@result == nanos_to_micros(@self))]
+                #[ensures(result@ == nanos_to_micros(self@))]
                 fn as_micros(&self) -> u128;
 
-                #[ensures(@result == @self)]
-                #[ensures(@result <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+                #[ensures(result@ == self@)]
+                #[ensures(result@ <= secs_to_nanos(@u64::MAX) + 999_999_999)]
                 fn as_nanos(&self) -> u128;
 
-                #[ensures(nanos_to_secs(@self + @rhs) > @u64::MAX ==> result == None)]
-                #[ensures(nanos_to_secs(@self + @rhs) <= @u64::MAX ==> result.deep_model() == Some(@self + @rhs))]
+                #[ensures(nanos_to_secs(self@ + rhs@) > @u64::MAX ==> result == None)]
+                #[ensures(nanos_to_secs(self@ + rhs@) <= @u64::MAX ==> result.deep_model() == Some(self@ + rhs@))]
                 fn checked_add(self, rhs: Duration) -> Option<Duration>;
 
-                #[ensures(@self - @rhs < 0 ==> result == None)]
-                #[ensures(@self - @rhs >= 0 ==> result.deep_model() == Some(@self - @rhs))]
+                #[ensures(self@ - rhs@ < 0 ==> result == None)]
+                #[ensures(self@ - rhs@ >= 0 ==> result.deep_model() == Some(self@ - rhs@))]
                 fn checked_sub(self, rhs: Duration) -> Option<Duration>;
 
-                #[ensures(nanos_to_secs(@self * @rhs) > @u64::MAX ==> result == None)]
-                #[ensures(nanos_to_secs(@self * @rhs) <= @u64::MAX ==> result.deep_model() == Some(@self * @rhs))]
+                #[ensures(nanos_to_secs(self@ * rhs@) > @u64::MAX ==> result == None)]
+                #[ensures(nanos_to_secs(self@ * rhs@) <= @u64::MAX ==> result.deep_model() == Some(self@ * rhs@))]
                 fn checked_mul(self, rhs: u32) -> Option<Duration>;
 
                 #[ensures(rhs == 0u32 ==> result == None)]
-                #[ensures(rhs != 0u32 ==> result.deep_model() == Some(@self / @rhs))]
+                #[ensures(rhs != 0u32 ==> result.deep_model() == Some(self@ / rhs@))]
                 fn checked_div(self, rhs: u32) -> Option<Duration>;
             }
 
             impl Instant {
-                #[ensures(@result >= 0)]
+                #[ensures(result@ >= 0)]
                 fn now() -> Instant;
 
-                #[ensures(@result >= 0)]
+                #[ensures(result@ >= 0)]
                 fn elapsed(&self) -> Duration;
 
-                #[ensures(@self > @earlier ==> @result > 0)]
-                #[ensures(@self <= @earlier ==> @result == 0)]
+                #[ensures(self@ > earlier@ ==> result@ > 0)]
+                #[ensures(self@ <= earlier@ ==> result@ == 0)]
                 fn duration_since(&self, earlier: Instant) -> Duration;
 
-                #[ensures(@self >= @earlier ==> result != None)]
-                #[ensures(@self < @earlier ==> result == None)]
+                #[ensures(self@ >= earlier@ ==> result != None)]
+                #[ensures(self@ < earlier@ ==> result == None)]
                 fn checked_duration_since(&self, earlier: Instant) -> Option<Duration>;
 
-                #[ensures(@self > @earlier ==> @result > 0)]
-                #[ensures(@self <= @earlier ==> @result == 0)]
+                #[ensures(self@ > earlier@ ==> result@ > 0)]
+                #[ensures(self@ <= earlier@ ==> result@ == 0)]
                 fn saturating_duration_since(&self, earlier: Instant) -> Duration;
 
-                #[ensures(@duration == 0 ==> result.deep_model() == Some(@self))]
-                #[ensures(@duration > 0 && result != None ==> Some(@self) < result.deep_model())]
+                #[ensures(duration@ == 0 ==> result.deep_model() == Some(self@))]
+                #[ensures(duration@ > 0 && result != None ==> Some(self@) < result.deep_model())]
                 fn checked_add(&self, duration: Duration) -> Option<Instant>;
 
-                #[ensures(@duration == 0 ==> result.deep_model() == Some(@self))]
-                #[ensures(@duration > 0 && result != None ==> Some(@self) > result.deep_model())]
+                #[ensures(duration@ == 0 ==> result.deep_model() == Some(self@))]
+                #[ensures(duration@ > 0 && result != None ==> Some(self@) > result.deep_model())]
                 fn checked_sub(&self, duration: Duration) -> Option<Instant>;
             }
         }
@@ -168,32 +168,32 @@ extern_spec! {
 
 extern_spec! {
     impl Add<Duration> for Duration {
-        #[requires(@self + @rhs <= secs_to_nanos(@u64::MAX) + 999_999_999)]
-        #[ensures(@self + @rhs == @result)]
+        #[requires(self@ + rhs@ <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+        #[ensures(self@ + rhs@ == result@)]
         fn add(self, rhs: Duration) -> Duration;
     }
 
     impl Sub<Duration> for Duration {
-        #[requires(@self - @rhs >= 0)]
-        #[ensures(@self - @rhs == @result)]
+        #[requires(self@ - rhs@ >= 0)]
+        #[ensures(self@ - rhs@ == result@)]
         fn sub(self, rhs: Duration) -> Duration;
     }
 
     impl Add<Duration> for Instant {
-        #[ensures(@rhs == 0 ==> @self == @result)]
-        #[ensures(@rhs > 0 ==> @self < @result)]
+        #[ensures(rhs@ == 0 ==> self@ == result@)]
+        #[ensures(rhs@ > 0 ==> self@ < result@)]
         fn add(self, rhs: Duration) -> Instant;
     }
 
     impl Sub<Duration> for Instant {
-        #[ensures(@rhs == 0 ==> @self == @result)]
-        #[ensures(@rhs > 0 ==> @self > @result)]
+        #[ensures(rhs@ == 0 ==> self@ == result@)]
+        #[ensures(rhs@ > 0 ==> self@ > result@)]
         fn sub(self, rhs: Duration) -> Instant;
     }
 
     impl Sub<Instant> for Instant {
-        #[ensures(@self > @other ==> @result > 0)]
-        #[ensures(@self <= @other ==> @result == 0)]
+        #[ensures(self@ > other@ ==> result@ > 0)]
+        #[ensures(self@ <= other@ ==> result@ == 0)]
         fn sub(self, other: Instant) -> Duration;
     }
 }

--- a/creusot-contracts/src/std/time.rs
+++ b/creusot-contracts/src/std/time.rs
@@ -9,7 +9,7 @@ impl ShallowModel for Duration {
 
     #[logic]
     #[trusted]
-    #[ensures(result >= 0 && result <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+    #[ensures(result >= 0 && result <= secs_to_nanos(u64::MAX@) + 999_999_999)]
     fn shallow_model(self) -> Self::ShallowModelTy {
         pearlite! { absurd }
     }
@@ -20,7 +20,7 @@ impl DeepModel for Duration {
 
     #[logic]
     #[trusted]
-    #[ensures(result >= 0 && result <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+    #[ensures(result >= 0 && result <= secs_to_nanos(u64::MAX@) + 999_999_999)]
     #[ensures(result == self.shallow_model())]
     fn deep_model(self) -> Self::DeepModelTy {
         pearlite! { absurd }
@@ -73,7 +73,7 @@ extern_spec! {
     mod std {
         mod time {
             impl Duration {
-                #[requires(secs@ + nanos_to_secs(nanos@) <= @u64::MAX)]
+                #[requires(secs@ + nanos_to_secs(nanos@) <= u64::MAX@)]
                 #[ensures(result@ == secs_to_nanos(secs@) + nanos@ )]
                 fn new(secs: u64, nanos: u32) -> Duration;
 
@@ -115,19 +115,19 @@ extern_spec! {
                 fn as_micros(&self) -> u128;
 
                 #[ensures(result@ == self@)]
-                #[ensures(result@ <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+                #[ensures(result@ <= secs_to_nanos(u64::MAX@) + 999_999_999)]
                 fn as_nanos(&self) -> u128;
 
-                #[ensures(nanos_to_secs(self@ + rhs@) > @u64::MAX ==> result == None)]
-                #[ensures(nanos_to_secs(self@ + rhs@) <= @u64::MAX ==> result.deep_model() == Some(self@ + rhs@))]
+                #[ensures(nanos_to_secs(self@ + rhs@) > u64::MAX@ ==> result == None)]
+                #[ensures(nanos_to_secs(self@ + rhs@) <= u64::MAX@ ==> result.deep_model() == Some(self@ + rhs@))]
                 fn checked_add(self, rhs: Duration) -> Option<Duration>;
 
                 #[ensures(self@ - rhs@ < 0 ==> result == None)]
                 #[ensures(self@ - rhs@ >= 0 ==> result.deep_model() == Some(self@ - rhs@))]
                 fn checked_sub(self, rhs: Duration) -> Option<Duration>;
 
-                #[ensures(nanos_to_secs(self@ * rhs@) > @u64::MAX ==> result == None)]
-                #[ensures(nanos_to_secs(self@ * rhs@) <= @u64::MAX ==> result.deep_model() == Some(self@ * rhs@))]
+                #[ensures(nanos_to_secs(self@ * rhs@) > u64::MAX@ ==> result == None)]
+                #[ensures(nanos_to_secs(self@ * rhs@) <= u64::MAX@ ==> result.deep_model() == Some(self@ * rhs@))]
                 fn checked_mul(self, rhs: u32) -> Option<Duration>;
 
                 #[ensures(rhs == 0u32 ==> result == None)]
@@ -168,7 +168,7 @@ extern_spec! {
 
 extern_spec! {
     impl Add<Duration> for Duration {
-        #[requires(self@ + rhs@ <= secs_to_nanos(@u64::MAX) + 999_999_999)]
+        #[requires(self@ + rhs@ <= secs_to_nanos(u64::MAX@) + 999_999_999)]
         #[ensures(self@ + rhs@ == result@)]
         fn add(self, rhs: Duration) -> Duration;
     }

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -62,51 +62,51 @@ extern_spec! {
                 #[ensures(result@ == self@.len())]
                 fn len(&self) -> usize;
 
-                #[ensures(@^self == self@.push(v))]
+                #[ensures((^self)@ == self@.push(v))]
                 fn push(&mut self, v: T);
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == self@.subsequence(0, self@.len() - 1) &&
-                        self@ == (@^self).push(t),
+                        (^self)@ == self@.subsequence(0, self@.len() - 1) &&
+                        self@ == ((^self)@).push(t),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop(&mut self) -> Option<T>;
 
                 #[requires(ix@ < self@.len())]
                 #[ensures(result == self@[ix@])]
-                #[ensures(@^self == self@.subsequence(0, ix@).concat(self@.subsequence(ix@ + 1, self@.len())))]
-                #[ensures((@^self).len() == self@.len() - 1)]
+                #[ensures((^self)@ == self@.subsequence(0, ix@).concat(self@.subsequence(ix@ + 1, self@.len())))]
+                #[ensures(((^self)@).len() == self@.len() - 1)]
                 fn remove(&mut self, ix: usize) -> T;
 
-                #[ensures((@^self).len() == self@.len() + 1)]
-                #[ensures(forall<i: Int> 0 <= i && i < index@ ==> (@^self)[i] == self@[i])]
-                #[ensures((@^self)[index@] == element)]
-                #[ensures(forall<i: Int> index@ < i && i < (@^self).len() ==> (@^self)[i] == self@[i - 1])]
+                #[ensures(((^self)@).len() == self@.len() + 1)]
+                #[ensures(forall<i: Int> 0 <= i && i < index@ ==> ((^self)@)[i] == self@[i])]
+                #[ensures(((^self)@)[index@] == element)]
+                #[ensures(forall<i: Int> index@ < i && i < ((^self)@).len() ==> ((^self)@)[i] == self@[i - 1])]
                 fn insert(&mut self, index: usize, element: T);
 
                 #[ensures(result@ >= self@.len())]
                 fn capacity(&self) -> usize;
 
-                #[ensures(@^self == self@)]
+                #[ensures((^self)@ == self@)]
                 fn reserve(&mut self, additional: usize);
 
-                #[ensures(@^self == self@)]
+                #[ensures((^self)@ == self@)]
                 fn reserve_exact(&mut self, additional: usize);
 
-                #[ensures(@^self == self@)]
+                #[ensures((^self)@ == self@)]
                 fn shrink_to_fit(&mut self);
 
-                #[ensures(@^self == self@)]
+                #[ensures((^self)@ == self@)]
                 fn shrink_to(&mut self, min_capacity: usize);
 
-                #[ensures((@^self).len() == 0)]
+                #[ensures(((^self)@).len() == 0)]
                 fn clear(&mut self);
             }
 
             impl<T, A : Allocator> Extend<T> for Vec<T, A> {
                 #[ensures(exists<done_ : &mut I, prod: Seq<I::Item>>
-                    done_.completed() && iter.produces(prod, *done_) && @^self == self@.concat(prod)
+                    done_.completed() && iter.produces(prod, *done_) && (^self)@ == self@.concat(prod)
                 )]
                 fn extend<I>(&mut self, iter: I)
                 where
@@ -117,9 +117,9 @@ extern_spec! {
             impl<T, I : SliceIndex<[T]>, A : Allocator> IndexMut<I> for Vec<T, A> {
                 #[requires(ix.in_bounds(self@))]
                 #[ensures(ix.has_value(self@, *result))]
-                #[ensures(ix.has_value(@^self, ^result))]
-                #[ensures(ix.resolve_elswhere(self@, @^self))]
-                #[ensures((@^self).len() == self@.len())]
+                #[ensures(ix.has_value((^self)@, ^result))]
+                #[ensures(ix.resolve_elswhere(self@, (^self)@))]
+                #[ensures(((^self)@).len() == self@.len())]
                 fn index_mut(&mut self, ix: I) -> &mut <Vec<T, A> as Index<I>>::Output;
             }
 
@@ -136,7 +136,7 @@ extern_spec! {
 
             impl<T, A : Allocator> DerefMut for Vec<T, A> {
                 #[ensures(result@ == self@)]
-                #[ensures(@^result == @^self)]
+                #[ensures((^result)@ == (^self)@)]
                 fn deref_mut(&mut self) -> &mut [T];
             }
 

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -167,7 +167,7 @@ impl<T, A: Allocator> IntoIterator for &Vec<T, A> {
 
     #[predicate]
     fn into_iter_post(self, res: Self::IntoIter) -> bool {
-        pearlite! { self@ == @res@ }
+        pearlite! { self@ == res@@ }
     }
 }
 
@@ -179,7 +179,7 @@ impl<T, A: Allocator> IntoIterator for &mut Vec<T, A> {
 
     #[predicate]
     fn into_iter_post(self, res: Self::IntoIter) -> bool {
-        pearlite! { self@ == @res@ }
+        pearlite! { self@ == res@@ }
     }
 }
 

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -27,7 +27,7 @@ impl<T: DeepModel, A: Allocator> DeepModel for Vec<T, A> {
     #[trusted]
     #[ensures(self.shallow_model().len() == result.len())]
     #[ensures(forall<i: Int> 0 <= i && i < self.shallow_model().len()
-              ==> result[i] == (@self)[i].deep_model())]
+              ==> result[i] == self@[i].deep_model())]
     fn deep_model(self) -> Self::DeepModelTy {
         pearlite! { absurd }
     }
@@ -44,7 +44,7 @@ impl<T> Default for Vec<T> {
 impl<T> Resolve for Vec<T> {
     #[predicate]
     fn resolve(self) -> bool {
-        pearlite! { forall<i : Int> 0 <= i && i < (@self).len() ==> (@self)[i].resolve() }
+        pearlite! { forall<i : Int> 0 <= i && i < self@.len() ==> self@[i].resolve() }
     }
 }
 
@@ -52,40 +52,40 @@ extern_spec! {
     mod std {
         mod vec {
             impl<T> Vec<T> {
-                #[ensures((@result).len() == 0)]
+                #[ensures(result@.len() == 0)]
                 fn new() -> Vec<T>;
 
-                #[ensures((@result).len() == 0)]
+                #[ensures(result@.len() == 0)]
                 fn with_capacity(capacity: usize) -> Vec<T>;
             }
             impl<T, A : Allocator> Vec<T, A> {
-                #[ensures(@result == (@self).len())]
+                #[ensures(@result == self@.len())]
                 fn len(&self) -> usize;
 
-                #[ensures(@^self == (@self).push(v))]
+                #[ensures(@^self == self@.push(v))]
                 fn push(&mut self, v: T);
 
                 #[ensures(match result {
                     Some(t) =>
-                        @^self == (@self).subsequence(0, (@self).len() - 1) &&
+                        @^self == self@.subsequence(0, self@.len() - 1) &&
                         @self == (@^self).push(t),
-                    None => *self == ^self && (@self).len() == 0
+                    None => *self == ^self && self@.len() == 0
                 })]
                 fn pop(&mut self) -> Option<T>;
 
-                #[requires(@ix < (@self).len())]
-                #[ensures(result == (@self)[@ix])]
-                #[ensures(@^self == (@self).subsequence(0, @ix).concat((@self).subsequence(@ix + 1, (@self).len())))]
-                #[ensures((@^self).len() == (@self).len() - 1)]
+                #[requires(@ix < self@.len())]
+                #[ensures(result == self@[@ix])]
+                #[ensures(@^self == self@.subsequence(0, @ix).concat(self@.subsequence(@ix + 1, self@.len())))]
+                #[ensures((@^self).len() == self@.len() - 1)]
                 fn remove(&mut self, ix: usize) -> T;
 
-                #[ensures((@^self).len() == (@self).len() + 1)]
-                #[ensures(forall<i: Int> 0 <= i && i < @index ==> (@^self)[i] == (@self)[i])]
+                #[ensures((@^self).len() == self@.len() + 1)]
+                #[ensures(forall<i: Int> 0 <= i && i < @index ==> (@^self)[i] == self@[i])]
                 #[ensures((@^self)[@index] == element)]
-                #[ensures(forall<i: Int> @index < i && i < (@^self).len() ==> (@^self)[i] == (@self)[i - 1])]
+                #[ensures(forall<i: Int> @index < i && i < (@^self).len() ==> (@^self)[i] == self@[i - 1])]
                 fn insert(&mut self, index: usize, element: T);
 
-                #[ensures(@result >= (@self).len())]
+                #[ensures(@result >= self@.len())]
                 fn capacity(&self) -> usize;
 
                 #[ensures(@^self == @self)]
@@ -106,7 +106,7 @@ extern_spec! {
 
             impl<T, A : Allocator> Extend<T> for Vec<T, A> {
                 #[ensures(exists<done_ : &mut I, prod: Seq<I::Item>>
-                    done_.completed() && iter.produces(prod, *done_) && @^self == (@self).concat(prod)
+                    done_.completed() && iter.produces(prod, *done_) && @^self == self@.concat(prod)
                 )]
                 fn extend<I>(&mut self, iter: I)
                 where
@@ -119,7 +119,7 @@ extern_spec! {
                 #[ensures(ix.has_value(@self, *result))]
                 #[ensures(ix.has_value(@^self, ^result))]
                 #[ensures(ix.resolve_elswhere(@self, @^self))]
-                #[ensures((@^self).len() == (@self).len())]
+                #[ensures((@^self).len() == self@.len())]
                 fn index_mut(&mut self, ix: I) -> &mut <Vec<T, A> as Index<I>>::Output;
             }
 
@@ -140,8 +140,8 @@ extern_spec! {
                 fn deref_mut(&mut self) -> &mut [T];
             }
 
-            #[ensures((@result).len() == @n)]
-            #[ensures(forall<i : Int> 0 <= i && i < @n ==> (@result)[i] == elem)]
+            #[ensures(result@.len() == @n)]
+            #[ensures(forall<i : Int> 0 <= i && i < @n ==> result@[i] == elem)]
             fn from_elem<T : Clone>(elem : T, n : usize) -> Vec<T>;
         }
     }
@@ -197,7 +197,7 @@ impl<T, A: Allocator> ShallowModel for std::vec::IntoIter<T, A> {
 impl<T, A: Allocator> Resolve for std::vec::IntoIter<T, A> {
     #[predicate]
     fn resolve(self) -> bool {
-        pearlite! { forall<i: Int> 0 <= i && i < (@self).len() ==> (@self)[i].resolve() }
+        pearlite! { forall<i: Int> 0 <= i && i < self@.len() ==> self@[i].resolve() }
     }
 }
 

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -68,7 +68,7 @@ extern_spec! {
                 #[ensures(match result {
                     Some(t) =>
                         (^self)@ == self@.subsequence(0, self@.len() - 1) &&
-                        self@ == ((^self)@).push(t),
+                        self@ == (^self)@.push(t),
                     None => *self == ^self && self@.len() == 0
                 })]
                 fn pop(&mut self) -> Option<T>;
@@ -76,13 +76,13 @@ extern_spec! {
                 #[requires(ix@ < self@.len())]
                 #[ensures(result == self@[ix@])]
                 #[ensures((^self)@ == self@.subsequence(0, ix@).concat(self@.subsequence(ix@ + 1, self@.len())))]
-                #[ensures(((^self)@).len() == self@.len() - 1)]
+                #[ensures((^self)@.len() == self@.len() - 1)]
                 fn remove(&mut self, ix: usize) -> T;
 
-                #[ensures(((^self)@).len() == self@.len() + 1)]
-                #[ensures(forall<i: Int> 0 <= i && i < index@ ==> ((^self)@)[i] == self@[i])]
-                #[ensures(((^self)@)[index@] == element)]
-                #[ensures(forall<i: Int> index@ < i && i < ((^self)@).len() ==> ((^self)@)[i] == self@[i - 1])]
+                #[ensures((^self)@.len() == self@.len() + 1)]
+                #[ensures(forall<i: Int> 0 <= i && i < index@ ==> (^self)@[i] == self@[i])]
+                #[ensures((^self)@[index@] == element)]
+                #[ensures(forall<i: Int> index@ < i && i < (^self)@.len() ==> (^self)@[i] == self@[i - 1])]
                 fn insert(&mut self, index: usize, element: T);
 
                 #[ensures(result@ >= self@.len())]
@@ -100,7 +100,7 @@ extern_spec! {
                 #[ensures((^self)@ == self@)]
                 fn shrink_to(&mut self, min_capacity: usize);
 
-                #[ensures(((^self)@).len() == 0)]
+                #[ensures((^self)@.len() == 0)]
                 fn clear(&mut self);
             }
 
@@ -119,7 +119,7 @@ extern_spec! {
                 #[ensures(ix.has_value(self@, *result))]
                 #[ensures(ix.has_value((^self)@, ^result))]
                 #[ensures(ix.resolve_elswhere(self@, (^self)@))]
-                #[ensures(((^self)@).len() == self@.len())]
+                #[ensures((^self)@.len() == self@.len())]
                 fn index_mut(&mut self, ix: I) -> &mut <Vec<T, A> as Index<I>>::Output;
             }
 

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -14,7 +14,7 @@ impl<T, A: Allocator> ShallowModel for Vec<T, A> {
 
     #[logic]
     #[trusted]
-    #[ensures(result.len() <= @usize::MAX)]
+    #[ensures(result.len() <= usize::MAX@)]
     fn shallow_model(self) -> Seq<T> {
         pearlite! { absurd }
     }

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -248,7 +248,7 @@ module C01ResolveUnsoundness_MakeVecOfSize_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val make_vec_of_size [#"../01_resolve_unsoundness.rs" 9 0 9 46] (n : usize) : Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../01_resolve_unsoundness.rs" 8 10 8 31] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../01_resolve_unsoundness.rs" 8 10 8 29] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
     
 end
 module C01ResolveUnsoundness_MakeVecOfSize
@@ -287,7 +287,7 @@ module C01ResolveUnsoundness_MakeVecOfSize
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
   let rec cfg make_vec_of_size [#"../01_resolve_unsoundness.rs" 9 0 9 46] [@cfg:stackify] [@cfg:subregion_analysis] (n : usize) : Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../01_resolve_unsoundness.rs" 8 10 8 31] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../01_resolve_unsoundness.rs" 8 10 8 29] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global);

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.rs
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.rs
@@ -5,7 +5,7 @@ use creusot_contracts::*;
 // This program exhibited a bug where we resolve the borrow of `push`, causing
 // us to prove an invalid loop invariant
 // This program should not prove.
-#[ensures(result@.len() == @n)]
+#[ensures(result@.len() == n@)]
 pub fn make_vec_of_size(n: usize) -> Vec<bool> {
     let mut out: Vec<bool> = Vec::new();
     let mut i = 0;

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.rs
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.rs
@@ -5,7 +5,7 @@ use creusot_contracts::*;
 // This program exhibited a bug where we resolve the borrow of `push`, causing
 // us to prove an invalid loop invariant
 // This program should not prove.
-#[ensures((@result).len() == @n)]
+#[ensures(result@.len() == @n)]
 pub fn make_vec_of_size(n: usize) -> Vec<bool> {
     let mut out: Vec<bool> = Vec::new();
     let mut i = 0;

--- a/creusot/tests/should_fail/impure_functions.rs
+++ b/creusot/tests/should_fail/impure_functions.rs
@@ -3,7 +3,7 @@ use creusot_contracts::{logic::*, *};
 
 #[logic]
 fn x<T>(v: &Vec<T>) -> Int {
-    pearlite! { @v.len() }
+    pearlite! { v.len()@ }
 }
 
 fn y() {

--- a/creusot/tests/should_fail/impure_functions.stderr
+++ b/creusot/tests/should_fail/impure_functions.stderr
@@ -1,8 +1,8 @@
 error[creusot]: called impure program function in logical context "std::vec::Vec::<T, A>::len"
- --> impure_functions.rs:6:20
+ --> impure_functions.rs:6:19
   |
-6 |     pearlite! { @v.len() }
-  |                    ^^^
+6 |     pearlite! { v.len()@ }
+  |                   ^^^
 
 error[creusot]: called logical function in impure context "x"
   --> impure_functions.rs:10:13

--- a/creusot/tests/should_fail/traits/17_impl_refinement.rs
+++ b/creusot/tests/should_fail/traits/17_impl_refinement.rs
@@ -4,13 +4,13 @@ use creusot_contracts::*;
 // Verifies that implementations can refine the contract of their encompassing trait
 
 trait Tr {
-    #[ensures(@result >= 10)]
+    #[ensures(result@ >= 10)]
     fn my_function(&self) -> usize;
 }
 
 impl Tr for () {
     #[requires(true)]
-    #[ensures(@result >= 15)]
+    #[ensures(result@ >= 15)]
     fn my_function(&self) -> usize {
         20
     }
@@ -18,13 +18,13 @@ impl Tr for () {
 
 trait ReqFalse {
     #[logic]
-    #[requires(@x >= 10)]
+    #[requires(x@ >= 10)]
     fn need_false(x: u64) -> ();
 }
 
 impl ReqFalse for () {
     // This should not prove
     #[logic]
-    #[requires(@y >= 15)]
+    #[requires(y@ >= 15)]
     fn need_false(y: u64) {}
 }

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -1045,17 +1045,17 @@ module C100doors_F
   }
   BB1 {
     _3 <- Core_Ops_Range_Range_Type.C_Range ([#"../100doors.rs" 21 16 21 17] (1 : usize)) ([#"../100doors.rs" 21 19 21 22] (101 : usize));
-    iter_2 <- ([#"../100doors.rs" 20 4 20 54] IntoIter0.into_iter _3);
+    iter_2 <- ([#"../100doors.rs" 20 4 20 52] IntoIter0.into_iter _3);
     goto BB2
   }
   BB2 {
     _6 <- ();
-    iter_old_4 <- ([#"../100doors.rs" 20 4 20 54] Ghost.new iter_2);
+    iter_old_4 <- ([#"../100doors.rs" 20 4 20 52] Ghost.new iter_2);
     goto BB3
   }
   BB3 {
     _10 <- ();
-    produced_7 <- ([#"../100doors.rs" 20 4 20 54] Ghost.new (Seq.empty ));
+    produced_7 <- ([#"../100doors.rs" 20 4 20 52] Ghost.new (Seq.empty ));
     goto BB4
   }
   BB4 {
@@ -1065,15 +1065,15 @@ module C100doors_F
     goto BB6
   }
   BB6 {
-    invariant type_invariant { [#"../100doors.rs" 20 4 20 54] Invariant0.invariant' iter_2 };
-    invariant structural { [#"../100doors.rs" 20 4 20 54] Produces0.produces (Ghost.inner iter_old_4) (Ghost.inner produced_7) iter_2 };
-    invariant door_size { [#"../100doors.rs" 20 27 20 52] Seq.length (ShallowModel0.shallow_model door_open_1) = 100 };
+    invariant type_invariant { [#"../100doors.rs" 20 4 20 52] Invariant0.invariant' iter_2 };
+    invariant structural { [#"../100doors.rs" 20 4 20 52] Produces0.produces (Ghost.inner iter_old_4) (Ghost.inner produced_7) iter_2 };
+    invariant door_size { [#"../100doors.rs" 20 27 20 50] Seq.length (ShallowModel0.shallow_model door_open_1) = 100 };
     _17 <- borrow_mut iter_2;
     iter_2 <-  ^ _17;
     _16 <- borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _16) };
     assume { Resolve0.resolve _17 };
-    _15 <- ([#"../100doors.rs" 20 4 20 54] Next0.next _16);
+    _15 <- ([#"../100doors.rs" 20 4 20 52] Next0.next _16);
     goto BB7
   }
   BB7 {
@@ -1094,7 +1094,7 @@ module C100doors_F
   BB10 {
     __creusot_proc_iter_elem_19 <- Core_Option_Option_Type.some_0 _15;
     _22 <- ();
-    _20 <- ([#"../100doors.rs" 20 4 20 54] Ghost.new (Seq.(++) (Ghost.inner produced_7) (Seq.singleton __creusot_proc_iter_elem_19)));
+    _20 <- ([#"../100doors.rs" 20 4 20 52] Ghost.new (Seq.(++) (Ghost.inner produced_7) (Seq.singleton __creusot_proc_iter_elem_19)));
     goto BB11
   }
   BB11 {
@@ -1109,7 +1109,7 @@ module C100doors_F
   }
   BB13 {
     invariant loop_bounds { [#"../100doors.rs" 23 32 23 66] 1 <= UIntSize.to_int door_24 /\ UIntSize.to_int door_24 <= 100 + UIntSize.to_int pass_23 };
-    invariant door_size { [#"../100doors.rs" 24 31 24 56] Seq.length (ShallowModel0.shallow_model door_open_1) = 100 };
+    invariant door_size { [#"../100doors.rs" 24 31 24 54] Seq.length (ShallowModel0.shallow_model door_open_1) = 100 };
     _28 <- door_24;
     _27 <- ([#"../100doors.rs" 25 14 25 25] _28 <= ([#"../100doors.rs" 25 22 25 25] (100 : usize)));
     switch (_27)

--- a/creusot/tests/should_succeed/100doors.rs
+++ b/creusot/tests/should_succeed/100doors.rs
@@ -20,7 +20,7 @@ pub fn f() {
     #[invariant(door_size, door_open@.len() == 100)]
     for pass in 1..101 {
         let mut door: usize = pass;
-        #[invariant(loop_bounds,1 <= @door && @door <= 100 + @pass)]
+        #[invariant(loop_bounds,1 <= door@ && door@ <= 100 + pass@)]
         #[invariant(door_size, door_open@.len() == 100)]
         while door <= 100 {
             door_open[door - 1] = !door_open[door - 1];

--- a/creusot/tests/should_succeed/100doors.rs
+++ b/creusot/tests/should_succeed/100doors.rs
@@ -17,11 +17,11 @@ use creusot_contracts::{vec, *};
 
 pub fn f() {
     let mut door_open: Vec<bool> = vec![false; 100];
-    #[invariant(door_size, (@door_open).len() == 100)]
+    #[invariant(door_size, door_open@.len() == 100)]
     for pass in 1..101 {
         let mut door: usize = pass;
         #[invariant(loop_bounds,1 <= @door && @door <= 100 + @pass)]
-        #[invariant(door_size, (@door_open).len() == 100)]
+        #[invariant(door_size, door_open@.len() == 100)]
         while door <= 100 {
             door_open[door - 1] = !door_open[door - 1];
             door += pass;

--- a/creusot/tests/should_succeed/binary_search.rs
+++ b/creusot/tests/should_succeed/binary_search.rs
@@ -40,14 +40,14 @@ impl<T> List<T> {
         }
     }
 
-    #[requires(@ix < self.len_logic())]
-    #[ensures(Some(*result) == self.get(@ix))]
+    #[requires(ix@ < self.len_logic())]
+    #[ensures(Some(*result) == self.get(ix@))]
     fn index(&self, mut ix: usize) -> &T {
         let orig_ix = ix;
         let mut l = self;
 
-        #[invariant(ix_valid, @ix < l.len_logic())]
-        #[invariant(res_get, self.get(@orig_ix) == l.get(@ix))]
+        #[invariant(ix_valid, ix@ < l.len_logic())]
+        #[invariant(res_get, self.get(orig_ix@) == l.get(ix@))]
         while let Cons(t, ls) = l {
             if ix > 0 {
                 l = &*ls;
@@ -62,11 +62,11 @@ impl<T> List<T> {
     // Temporary until support for usize::MAX is added
     #[requires(self.len_logic() <= 1_000_000)]
     #[ensures(result >= 0usize)]
-    #[ensures(@result == self.len_logic())]
+    #[ensures(result@ == self.len_logic())]
     fn len(&self) -> usize {
         let mut len: usize = 0;
         let mut l = self;
-        #[invariant(len_valid, @len + l.len_logic() == self.len_logic())]
+        #[invariant(len_valid, len@ + l.len_logic() == self.len_logic())]
         while let Cons(_, ls) = l {
             len += 1;
             l = ls;
@@ -101,11 +101,11 @@ impl List<u32> {
 
 #[requires(arr.len_logic() <= 1_000_000)]
 #[requires(arr.is_sorted())]
-#[ensures(forall<x:usize> result == Ok(x) ==> arr.get(@x) == Some(elem))]
+#[ensures(forall<x:usize> result == Ok(x) ==> arr.get(x@) == Some(elem))]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> 0 <= @i && @i < @x ==> arr.get_default(@i, 0u32) <= elem)]
+    forall<i:usize> 0 <= i@ && i@ < x@ ==> arr.get_default(i@, 0u32) <= elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> @x < @i && @i < arr.len_logic() ==> elem < arr.get_default(@i, 0u32))]
+    forall<i:usize> x@ < i@ && i@ < arr.len_logic() ==> elem < arr.get_default(i@, 0u32))]
 pub fn binary_search(arr: &List<u32>, elem: u32) -> Result<usize, usize> {
     if arr.len() == 0 {
         return Err(0);
@@ -113,9 +113,9 @@ pub fn binary_search(arr: &List<u32>, elem: u32) -> Result<usize, usize> {
     let mut size = arr.len();
     let mut base = 0;
 
-    #[invariant(size_valid, 0 < @size && @size + @base <= (arr).len_logic())]
-    #[invariant(lower_b, forall<i : usize> i < base ==> (arr).get_default(@i, 0u32) <= elem)]
-    #[invariant(lower_b, forall<i : usize> @base + @size < @i && @i < (arr).len_logic() ==> elem < (arr).get_default(@i, 0u32))]
+    #[invariant(size_valid, 0 < size@ && size@ + base@ <= (arr).len_logic())]
+    #[invariant(lower_b, forall<i : usize> i < base ==> (arr).get_default(i@, 0u32) <= elem)]
+    #[invariant(lower_b, forall<i : usize> base@ + size@ < i@ && i@ < (arr).len_logic() ==> elem < (arr).get_default(i@, 0u32))]
     while size > 1 {
         let half = size / 2;
         let mid = base + half;

--- a/creusot/tests/should_succeed/bug/173.rs
+++ b/creusot/tests/should_succeed/bug/173.rs
@@ -2,13 +2,13 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-// #[requires(0 < @n && @n < 10000)]
+// #[requires(0 < n@ && n@ < 10000)]
 // fn knapsack01_dyn<Name>(n: usize) {
 //     let i: usize = 0;
 
 //     let mut w = 1;
 
-//     #[invariant(i_items_len, @i < @n)]
+//     #[invariant(i_items_len, i@ < n@)]
 //     while w <= n {
 //         w += 1
 //     }
@@ -18,7 +18,7 @@ use creusot_contracts::*;
 
 pub fn test_233() {
     let x = 17;
-    proof_assert!( @x == 17 );
+    proof_assert!( x@ == 17 );
     let x = 42;
-    proof_assert!( @x == 42 );
+    proof_assert!( x@ == 42 );
 }

--- a/creusot/tests/should_succeed/bug/181_ident.rs
+++ b/creusot/tests/should_succeed/bug/181_ident.rs
@@ -13,7 +13,7 @@ pub fn max_int(a: Int, b: Int) -> Int {
 }
 
 #[trusted]
-#[ensures(@result == max_int(@a, @b))]
+#[ensures(result@ == max_int(a@, b@))]
 pub fn max_usize(a: usize, b: usize) -> usize {
     if a < b {
         b

--- a/creusot/tests/should_succeed/bug/206.rs
+++ b/creusot/tests/should_succeed/bug/206.rs
@@ -5,7 +5,7 @@ use creusot_contracts::*;
 pub struct A(Vec<usize>);
 
 #[logic]
-#[ensures(@a.0 == @a.0)]
+#[ensures(a.0@ == a.0@)]
 fn u2(a: A) {}
 
 #[logic]

--- a/creusot/tests/should_succeed/bug/463.rs
+++ b/creusot/tests/should_succeed/bug/463.rs
@@ -2,10 +2,10 @@ extern crate creusot_contracts;
 use creusot_contracts::*;
 pub fn test() {
     let c = {
-        #[requires(@x < 1000)]
-        #[ensures(@result == @x + 1)]
+        #[requires(x@ < 1000)]
+        #[ensures(result@ == x@ + 1)]
         |x: usize| x + 1
     };
     let y = c(2);
-    proof_assert!(@y == 3)
+    proof_assert!(y@ == 3)
 }

--- a/creusot/tests/should_succeed/bug/486.mlcfg
+++ b/creusot/tests/should_succeed/bug/486.mlcfg
@@ -15,7 +15,7 @@ module C486_Test_Interface
   use prelude.Int
   use C486_HasMutRef_Type as C486_HasMutRef_Type
   val test [#"../486.rs" 7 0 7 34] (x : C486_HasMutRef_Type.t_hasmutref uint32) : ()
-    ensures { [#"../486.rs" 6 10 6 20] UInt32.to_int ( ^ C486_HasMutRef_Type.hasmutref_0 x) = 5 }
+    ensures { [#"../486.rs" 6 10 6 22] UInt32.to_int ( ^ C486_HasMutRef_Type.hasmutref_0 x) = 5 }
     
 end
 module C486_Test
@@ -24,7 +24,7 @@ module C486_Test
   use prelude.Borrow
   use C486_HasMutRef_Type as C486_HasMutRef_Type
   let rec cfg test [#"../486.rs" 7 0 7 34] [@cfg:stackify] [@cfg:subregion_analysis] (x : C486_HasMutRef_Type.t_hasmutref uint32) : ()
-    ensures { [#"../486.rs" 6 10 6 20] UInt32.to_int ( ^ C486_HasMutRef_Type.hasmutref_0 x) = 5 }
+    ensures { [#"../486.rs" 6 10 6 22] UInt32.to_int ( ^ C486_HasMutRef_Type.hasmutref_0 x) = 5 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/bug/486.rs
+++ b/creusot/tests/should_succeed/bug/486.rs
@@ -3,7 +3,7 @@ use creusot_contracts::*;
 
 pub struct HasMutRef<'a, T>(&'a mut T);
 
-#[ensures(@^x.0 == 5)]
+#[ensures((^x.0)@ == 5)]
 pub fn test(x: HasMutRef<'_, u32>) {
     *x.0 = 5
 }

--- a/creusot/tests/should_succeed/bug/653.rs
+++ b/creusot/tests/should_succeed/bug/653.rs
@@ -2,7 +2,7 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[ensures(@result == @n * (@n + 1) / 2)]
+#[ensures(result@ == n@ * (n@ + 1) / 2)]
 pub fn omg(n: usize) -> usize {
     n
 }

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -238,7 +238,7 @@ module TwoPhase_Test_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val test [#"../two_phase.rs" 6 0 6 31] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../two_phase.rs" 5 10 5 42] UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) (Seq.length (ShallowModel1.shallow_model v))) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../two_phase.rs" 5 10 5 38] UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) (Seq.length (ShallowModel1.shallow_model v))) = Seq.length (ShallowModel1.shallow_model v) }
     
 end
 module TwoPhase_Test
@@ -276,7 +276,7 @@ module TwoPhase_Test
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
   let rec cfg test [#"../two_phase.rs" 6 0 6 31] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../two_phase.rs" 5 10 5 42] UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) (Seq.length (ShallowModel1.shallow_model v))) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../two_phase.rs" 5 10 5 38] UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) (Seq.length (ShallowModel1.shallow_model v))) = Seq.length (ShallowModel1.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/bug/two_phase.rs
+++ b/creusot/tests/should_succeed/bug/two_phase.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[ensures(@(^v)@[v@.len()] == v@.len())]
+#[ensures((^v)@[v@.len()]@ == v@.len())]
 pub fn test(v: &mut Vec<usize>) {
     v.push(v.len());
 }

--- a/creusot/tests/should_succeed/bug/two_phase.rs
+++ b/creusot/tests/should_succeed/bug/two_phase.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[ensures(@((^v)@)[v@.len()] == v@.len())]
+#[ensures(@(^v)@[v@.len()] == v@.len())]
 pub fn test(v: &mut Vec<usize>) {
     v.push(v.len());
 }

--- a/creusot/tests/should_succeed/bug/two_phase.rs
+++ b/creusot/tests/should_succeed/bug/two_phase.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[ensures(@(@^v)[(@v).len()] == (@v).len())]
+#[ensures(@(@^v)[v@.len()] == v@.len())]
 pub fn test(v: &mut Vec<usize>) {
     v.push(v.len());
 }

--- a/creusot/tests/should_succeed/bug/two_phase.rs
+++ b/creusot/tests/should_succeed/bug/two_phase.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[ensures(@(@^v)[v@.len()] == v@.len())]
+#[ensures(@((^v)@)[v@.len()] == v@.len())]
 pub fn test(v: &mut Vec<usize>) {
     v.push(v.len());
 }

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -564,7 +564,7 @@ module C02_FibMemo_Interface
   clone C02_FibCell_Stub as FibCell0
   val fib_memo [#"../02.rs" 89 0 89 50] (mem : Alloc_Vec_Vec_Type.t_vec (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib)) (Alloc_Alloc_Global_Type.t_global)) (i : usize) : usize
     requires {[#"../02.rs" 85 11 85 25] FibCell0.fib_cell mem}
-    requires {[#"../02.rs" 86 11 86 28] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model mem)}
+    requires {[#"../02.rs" 86 11 86 26] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model mem)}
     requires {[#"../02.rs" 88 11 88 19] UIntSize.to_int i <= 63}
     ensures { [#"../02.rs" 87 10 87 28] UIntSize.to_int result = Fib0.fib (UIntSize.to_int i) }
     
@@ -626,7 +626,7 @@ module C02_FibMemo
     val Max0.mAX' = Max0.mAX'
   let rec cfg fib_memo [#"../02.rs" 89 0 89 50] [@cfg:stackify] [@cfg:subregion_analysis] (mem : Alloc_Vec_Vec_Type.t_vec (C02_Cell_Type.t_cell (Core_Option_Option_Type.t_option usize) (C02_Fib_Type.t_fib)) (Alloc_Alloc_Global_Type.t_global)) (i : usize) : usize
     requires {[#"../02.rs" 85 11 85 25] FibCell0.fib_cell mem}
-    requires {[#"../02.rs" 86 11 86 28] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model mem)}
+    requires {[#"../02.rs" 86 11 86 26] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model mem)}
     requires {[#"../02.rs" 88 11 88 19] UIntSize.to_int i <= 63}
     ensures { [#"../02.rs" 87 10 87 28] UIntSize.to_int result = Fib1.fib (UIntSize.to_int i) }
     

--- a/creusot/tests/should_succeed/cell/02.rs
+++ b/creusot/tests/should_succeed/cell/02.rs
@@ -55,7 +55,7 @@ pub fn lemma_fib_bound(i: Int) {
 
 #[trusted]
 #[logic]
-#[ensures(2.pow(63) < @0xffff_ffff_ffff_ffffusize)]
+#[ensures(2.pow(63) < 0xffff_ffff_ffff_ffffusize@)]
 pub fn lemma_max_int() {}
 
 pub struct Fib {
@@ -67,7 +67,7 @@ impl Inv<Option<usize>> for Fib {
         pearlite! {
             match v {
                 None => true,
-                Some(i) => @i == fib(@self.ix)
+                Some(i) => i@ == fib(@self.ix)
             }
         }
     }
@@ -83,9 +83,9 @@ fn fib_cell(v: FibCache) -> bool {
 }
 
 #[requires(fib_cell(*mem))]
-#[requires(@i < mem@.len())]
-#[ensures(@result == fib(@i))]
-#[requires(@i <= 63)]
+#[requires(i@ < mem@.len())]
+#[ensures(result@ == fib(i@))]
+#[requires(i@ <= 63)]
 pub fn fib_memo(mem: &FibCache, i: usize) -> usize {
     match mem[i].get() {
         Some(v) => v,
@@ -99,7 +99,7 @@ pub fn fib_memo(mem: &FibCache, i: usize) -> usize {
                 ghost! { lemma_fib_bound };
                 fib_memo(mem, i - 1) + fib_memo(mem, i - 2)
             };
-            proof_assert! { @fib_i == fib(@i)};
+            proof_assert! { fib_i@ == fib(i@)};
             mem[i].set(Some(fib_i));
             fib_i
         }

--- a/creusot/tests/should_succeed/cell/02.rs
+++ b/creusot/tests/should_succeed/cell/02.rs
@@ -78,12 +78,12 @@ pub type FibCache = Vec<Cell<Option<usize>, Fib>>;
 #[predicate]
 fn fib_cell(v: FibCache) -> bool {
     pearlite! {
-        forall<i : Int> @(@v)[i].ghost_inv.ix == i
+        forall<i : Int> @v@[i].ghost_inv.ix == i
     }
 }
 
 #[requires(fib_cell(*mem))]
-#[requires(@i < (@mem).len())]
+#[requires(@i < mem@.len())]
 #[ensures(@result == fib(@i))]
 #[requires(@i <= 63)]
 pub fn fib_memo(mem: &FibCache, i: usize) -> usize {

--- a/creusot/tests/should_succeed/cell/02.rs
+++ b/creusot/tests/should_succeed/cell/02.rs
@@ -67,7 +67,7 @@ impl Inv<Option<usize>> for Fib {
         pearlite! {
             match v {
                 None => true,
-                Some(i) => i@ == fib(@self.ix)
+                Some(i) => i@ == fib(self.ix@)
             }
         }
     }
@@ -78,7 +78,7 @@ pub type FibCache = Vec<Cell<Option<usize>, Fib>>;
 #[predicate]
 fn fib_cell(v: FibCache) -> bool {
     pearlite! {
-        forall<i : Int> @v@[i].ghost_inv.ix == i
+        forall<i : Int> v@[i].ghost_inv.ix@ == i
     }
 }
 

--- a/creusot/tests/should_succeed/checked_ops.rs
+++ b/creusot/tests/should_succeed/checked_ops.rs
@@ -19,7 +19,7 @@ pub fn test_u8_add_example() {
 }
 
 /// Tests addition of `u8`s in a general overflowing case
-#[requires(@a != 0)]
+#[requires(a@ != 0)]
 pub fn test_u8_add_overflow(a: u8) {
     assert!(255u8.checked_add(a).is_none());
     assert!(255u8.wrapping_add(a) == a - 1);
@@ -30,7 +30,7 @@ pub fn test_u8_add_overflow(a: u8) {
 
 /// Tests that the verifier is able to deduce a stricter postcondition for wrapping addition of
 /// `u8`s
-#[ensures(@result == @a + @b || @result == @a + @b - 256)]
+#[ensures(result@ == a@ + b@ || result@ == a@ + b@ - 256)]
 pub fn test_u8_wrapping_add(a: u8, b: u8) -> u8 {
     a.wrapping_add(b)
 }
@@ -59,7 +59,7 @@ pub fn test_u8_sub_example() {
 }
 
 /// Tests subtraction of `u8`s in a general overflowing case
-#[requires(@a != 0)]
+#[requires(a@ != 0)]
 pub fn test_u8_sub_overflow(a: u8) {
     assert!(0u8.checked_sub(a).is_none());
     assert!(0u8.wrapping_sub(a) == 255 - a + 1);
@@ -70,7 +70,7 @@ pub fn test_u8_sub_overflow(a: u8) {
 
 /// Tests that the verifier is able to deduce a stricter postcondition for wrapping subtraction of
 /// `u8`s
-#[ensures(@result == @a - @b || @result == @a - @b + 256)]
+#[ensures(result@ == a@ - b@ || result@ == a@ - b@ + 256)]
 pub fn test_u8_wrapping_sub(a: u8, b: u8) -> u8 {
     a.wrapping_sub(b)
 }
@@ -124,7 +124,7 @@ pub fn test_u8_div_example() {
 }
 
 /// Tests that division of `u8`s never overflows
-#[requires(@b != 0)]
+#[requires(b@ != 0)]
 pub fn test_u8_div_no_overflow(a: u8, b: u8) {
     assert!(a.checked_div(b).unwrap() == a / b);
     assert!(a.wrapping_div(b) == a / b);
@@ -161,7 +161,7 @@ pub fn test_i8_add_example() {
 }
 
 /// Tests addition of `i8`s in a general overflowing case, for positive `a`
-#[requires(@a > 0)]
+#[requires(a@ > 0)]
 pub fn test_i8_add_overflow_pos(a: i8) {
     assert!(127i8.checked_add(a).is_none());
     assert!(127i8.wrapping_add(a) == a - 127 - 2);
@@ -171,7 +171,7 @@ pub fn test_i8_add_overflow_pos(a: i8) {
 }
 
 /// Tests addition of `i8`s in a general overflowing case, for negative `a`
-#[requires(@a < 0)]
+#[requires(a@ < 0)]
 pub fn test_i8_add_overflow_neg(a: i8) {
     assert!((-128i8).checked_add(a).is_none());
     assert!((-128i8).wrapping_add(a) == a + 127 + 1);
@@ -182,7 +182,7 @@ pub fn test_i8_add_overflow_neg(a: i8) {
 
 /// Tests that the verifier is able to deduce a stricter postcondition for wrapping addition of
 /// `i8`s
-#[ensures(@result == @a + @b || @result == @a + @b - 256 || @result == @a + @b + 256)]
+#[ensures(result@ == a@ + b@ || result@ == a@ + b@ - 256 || result@ == a@ + b@ + 256)]
 pub fn test_i8_wrapping_add(a: i8, b: i8) -> i8 {
     a.wrapping_add(b)
 }
@@ -216,7 +216,7 @@ pub fn test_i8_sub_example() {
 }
 
 /// Tests subtraction of `i8`s in a general overflowing case, for positive `a`
-#[requires(@a > 0)]
+#[requires(a@ > 0)]
 pub fn test_i8_sub_overflow_pos(a: i8) {
     assert!((-128i8).checked_sub(a).is_none());
     assert!((-128i8).wrapping_sub(a) == 127 - a + 1);
@@ -226,7 +226,7 @@ pub fn test_i8_sub_overflow_pos(a: i8) {
 }
 
 /// Tests subtraction of `i8`s in a general overflowing case, for negative `a`
-#[requires(@a < 0)]
+#[requires(a@ < 0)]
 pub fn test_i8_sub_overflow_neg(a: i8) {
     assert!(127i8.checked_sub(a).is_none());
     assert!(127i8.wrapping_sub(a) == -(2 + a) - 127);
@@ -237,7 +237,7 @@ pub fn test_i8_sub_overflow_neg(a: i8) {
 
 /// Tests that the verifier is able to deduce a stricter postcondition for wrapping subtraction of
 /// `i8`s
-#[ensures(@result == @a - @b || @result == @a - @b + 256 || @result == @a - @b - 256)]
+#[ensures(result@ == a@ - b@ || result@ == a@ - b@ + 256 || result@ == a@ - b@ - 256)]
 pub fn test_i8_wrapping_sub(a: i8, b: i8) -> i8 {
     a.wrapping_sub(b)
 }
@@ -309,7 +309,7 @@ pub fn test_i8_div_example() {
 }
 
 /// Tests that division of `i8`s never overflows, except for the one special case
-#[requires(@b != 0 && (@a != -128 || @b != -1))]
+#[requires(b@ != 0 && (a@ != -128 || b@ != -1))]
 pub fn test_i8_div_no_overflow(a: i8, b: i8) {
     assert!(a.checked_div(b).unwrap() == a / b);
     assert!(a.wrapping_div(b) == a / b);

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.rs
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.rs
@@ -1,11 +1,11 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[requires(@x == 100_000)]
+#[requires(x@ == 100_000)]
 pub fn test_fnmut(mut x: u32) {
     let mut c = {
-        #[requires(@x < 1_000_000)]
-        #[ensures(@x == @old(x) + 1)]
+        #[requires(x@ < 1_000_000)]
+        #[ensures(x@ == @old(x) + 1)]
         || {
             x += 1;
             5
@@ -14,5 +14,5 @@ pub fn test_fnmut(mut x: u32) {
     c();
     c();
 
-    proof_assert! { @x == 100_002};
+    proof_assert! { x@ == 100_002};
 }

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.rs
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.rs
@@ -5,7 +5,7 @@ use creusot_contracts::*;
 pub fn test_fnmut(mut x: u32) {
     let mut c = {
         #[requires(x@ < 1_000_000)]
-        #[ensures(x@ == @old(x) + 1)]
+        #[ensures(x@ == old(x)@ + 1)]
         || {
             x += 1;
             5

--- a/creusot/tests/should_succeed/duration.rs
+++ b/creusot/tests/should_succeed/duration.rs
@@ -6,22 +6,22 @@ use std::time::Duration;
 
 pub fn test_duration() {
     let zero = Duration::new(0, 0);
-    proof_assert!(@zero == 0);
+    proof_assert!(zero@ == 0);
     assert!(zero.as_nanos() == 0);
 
     let max = Duration::new(u64::MAX, 999_999_999);
 
     let d_secs = Duration::from_secs(1);
-    proof_assert!(@d_secs == 1_000_000_000);
+    proof_assert!(d_secs@ == 1_000_000_000);
 
     let d_millis = Duration::from_millis(1);
-    proof_assert!(@d_millis == 1_000_000);
+    proof_assert!(d_millis@ == 1_000_000);
 
     let d_micros = Duration::from_micros(1);
-    proof_assert!(@d_micros == 1_000);
+    proof_assert!(d_micros@ == 1_000);
 
     let d_nanos = Duration::from_nanos(1);
-    proof_assert!(@d_nanos == 1);
+    proof_assert!(d_nanos@ == 1);
 
     assert!(zero.is_zero());
     assert!(!d_secs.is_zero());
@@ -49,6 +49,6 @@ pub fn test_duration() {
 
     let sum = d_millis + d_micros;
     let difference = d_millis - d_micros;
-    proof_assert!(@sum == 1_001_000);
-    proof_assert!(@difference == 999000);
+    proof_assert!(sum@ == 1_001_000);
+    proof_assert!(difference@ == 999000);
 }

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -802,7 +802,7 @@ module FilterPositive_M
     goto BB3
   }
   BB3 {
-    invariant loop_bound { [#"../filter_positive.rs" 85 28 85 44] UIntSize.to_int i_4 <= Seq.length (ShallowModel0.shallow_model t_1) };
+    invariant loop_bound { [#"../filter_positive.rs" 85 28 85 42] UIntSize.to_int i_4 <= Seq.length (ShallowModel0.shallow_model t_1) };
     invariant count_bound { [#"../filter_positive.rs" 86 29 86 41] UIntSize.to_int count_3 <= UIntSize.to_int i_4 };
     invariant num { [#"../filter_positive.rs" 87 21 87 50] UIntSize.to_int count_3 = NumOfPos0.num_of_pos 0 (UIntSize.to_int i_4) (ShallowModel0.shallow_model t_1) };
     _11 <- i_4;
@@ -864,7 +864,7 @@ module FilterPositive_M
   }
   BB14 {
     invariant num { [#"../filter_positive.rs" 99 21 99 50] UIntSize.to_int count_3 = NumOfPos0.num_of_pos 0 (UIntSize.to_int i_4) (ShallowModel0.shallow_model t_1) };
-    invariant ulength { [#"../filter_positive.rs" 100 25 100 66] Seq.length (ShallowModel0.shallow_model u_23) = NumOfPos0.num_of_pos 0 (Seq.length (ShallowModel0.shallow_model t_1)) (ShallowModel0.shallow_model t_1) };
+    invariant ulength { [#"../filter_positive.rs" 100 25 100 62] Seq.length (ShallowModel0.shallow_model u_23) = NumOfPos0.num_of_pos 0 (Seq.length (ShallowModel0.shallow_model t_1)) (ShallowModel0.shallow_model t_1) };
     _29 <- i_4;
     _31 <- t_1;
     _30 <- ([#"../filter_positive.rs" 102 14 102 21] Len0.len _31);
@@ -897,7 +897,7 @@ module FilterPositive_M
   }
   BB19 {
     _38 <- ();
-    assert { [#"../filter_positive.rs" 110 16 110 65] let _ = LemmaNumOfPosIncreasing0.lemma_num_of_pos_increasing 0 (UIntSize.to_int i_4 + 1) (Seq.length (ShallowModel0.shallow_model t_1)) (ShallowModel0.shallow_model t_1) in UIntSize.to_int count_3 < Seq.length (ShallowModel0.shallow_model u_23) };
+    assert { [#"../filter_positive.rs" 110 16 110 63] let _ = LemmaNumOfPosIncreasing0.lemma_num_of_pos_increasing 0 (UIntSize.to_int i_4 + 1) (Seq.length (ShallowModel0.shallow_model t_1)) (ShallowModel0.shallow_model t_1) in UIntSize.to_int count_3 < Seq.length (ShallowModel0.shallow_model u_23) };
     goto BB20
   }
   BB20 {

--- a/creusot/tests/should_succeed/filter_positive.rs
+++ b/creusot/tests/should_succeed/filter_positive.rs
@@ -82,10 +82,10 @@ fn lemma_num_of_pos_strictly_increasing(i: Int, t: Seq<i32>) {}
 pub fn m(t: Vec<i32>) -> Vec<i32> {
     let mut count: usize = 0;
     let mut i: usize = 0;
-    #[invariant(loop_bound, @i <= t@.len())]
-    #[invariant(count_bound, @count <= @i)]
-    #[invariant(num, @count == num_of_pos(0,@i,@t))]
-    //#[variant(t@.len() - @i)]
+    #[invariant(loop_bound, i@ <= t@.len())]
+    #[invariant(count_bound, count@ <= i@)]
+    #[invariant(num, count@ == num_of_pos(0,i@,t@))]
+    //#[variant(t@.len() - i@)]
     while i < t.len() {
         if t[i] > 0 {
             count += 1
@@ -96,19 +96,19 @@ pub fn m(t: Vec<i32>) -> Vec<i32> {
     count = 0;
 
     i = 0;
-    #[invariant(num, @count == num_of_pos(0,@i,@t))]
-    #[invariant(ulength, u@.len() == num_of_pos(0,t@.len(),@t))]
-    //#[variant(t@.len() - @i)]
+    #[invariant(num, count@ == num_of_pos(0,i@,t@))]
+    #[invariant(ulength, u@.len() == num_of_pos(0,t@.len(),t@))]
+    //#[variant(t@.len() - i@)]
     while i < t.len() {
         if t[i] > 0 {
             // the tricky assertions, that needs lemmas
             proof_assert! {
-                lemma_num_of_pos_strictly_increasing(@i,@u);
-                num_of_pos(0,@i,@t) < num_of_pos(0,@i+1,@t)
+                lemma_num_of_pos_strictly_increasing(i@,u@);
+                num_of_pos(0,i@,t@) < num_of_pos(0,i@+1,t@)
             };
             proof_assert! {
-                lemma_num_of_pos_increasing(0,@i+1,t@.len(),@t);
-                @count < u@.len()
+                lemma_num_of_pos_increasing(0,i@+1,t@.len(),t@);
+                count@ < u@.len()
             };
             u[count] = t[i];
             count += 1;

--- a/creusot/tests/should_succeed/filter_positive.rs
+++ b/creusot/tests/should_succeed/filter_positive.rs
@@ -37,7 +37,7 @@ use creusot_contracts::{
 fn num_of_pos(i: Int, j: Int, t: Seq<i32>) -> Int {
     pearlite! {
         if i >= j { 0 } else {
-            if @t[j-1] > 0 {
+            if t[j-1]@ > 0 {
                 num_of_pos(i,j-1,t) + 1
             } else {
                 num_of_pos(i,j-1,t)
@@ -74,7 +74,7 @@ fn lemma_num_of_pos_increasing(i: Int, j: Int, k: Int, t: Seq<i32>) {
 // is met
 #[logic]
 #[requires(0 <= i && i < t.len())]
-#[requires(@t[i] > 0)]
+#[requires(t[i]@ > 0)]
 #[ensures(num_of_pos(0,i,t) < num_of_pos(0,i+1,t))]
 fn lemma_num_of_pos_strictly_increasing(i: Int, t: Seq<i32>) {}
 

--- a/creusot/tests/should_succeed/filter_positive.rs
+++ b/creusot/tests/should_succeed/filter_positive.rs
@@ -82,10 +82,10 @@ fn lemma_num_of_pos_strictly_increasing(i: Int, t: Seq<i32>) {}
 pub fn m(t: Vec<i32>) -> Vec<i32> {
     let mut count: usize = 0;
     let mut i: usize = 0;
-    #[invariant(loop_bound, @i <= (@t).len())]
+    #[invariant(loop_bound, @i <= t@.len())]
     #[invariant(count_bound, @count <= @i)]
     #[invariant(num, @count == num_of_pos(0,@i,@t))]
-    //#[variant((@t).len() - @i)]
+    //#[variant(t@.len() - @i)]
     while i < t.len() {
         if t[i] > 0 {
             count += 1
@@ -97,8 +97,8 @@ pub fn m(t: Vec<i32>) -> Vec<i32> {
 
     i = 0;
     #[invariant(num, @count == num_of_pos(0,@i,@t))]
-    #[invariant(ulength, (@u).len() == num_of_pos(0,(@t).len(),@t))]
-    //#[variant((@t).len() - @i)]
+    #[invariant(ulength, u@.len() == num_of_pos(0,t@.len(),@t))]
+    //#[variant(t@.len() - @i)]
     while i < t.len() {
         if t[i] > 0 {
             // the tricky assertions, that needs lemmas
@@ -107,8 +107,8 @@ pub fn m(t: Vec<i32>) -> Vec<i32> {
                 num_of_pos(0,@i,@t) < num_of_pos(0,@i+1,@t)
             };
             proof_assert! {
-                lemma_num_of_pos_increasing(0,@i+1,(@t).len(),@t);
-                @count < (@u).len()
+                lemma_num_of_pos_increasing(0,@i+1,t@.len(),@t);
+                @count < u@.len()
             };
             u[count] = t[i];
             count += 1;

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -408,7 +408,7 @@ module Hashmap_Impl4_BucketIx
   function bucket_ix [#"../hashmap.rs" 86 4 86 48] (self : Hashmap_MyHashMap_Type.t_myhashmap k v) (k : DeepModelTy0.deepModelTy) : int
     
    =
-    [#"../hashmap.rs" 87 20 87 68] EuclideanDivision.mod (HashLog0.hash_log k) (Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets self)))
+    [#"../hashmap.rs" 87 20 87 66] EuclideanDivision.mod (HashLog0.hash_log k) (Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets self)))
   val bucket_ix [#"../hashmap.rs" 86 4 86 48] (self : Hashmap_MyHashMap_Type.t_myhashmap k v) (k : DeepModelTy0.deepModelTy) : int
     ensures { result = bucket_ix self k }
     
@@ -456,7 +456,7 @@ module Hashmap_Impl4_Bucket
   function bucket [#"../hashmap.rs" 81 4 81 54] (self : Hashmap_MyHashMap_Type.t_myhashmap k v) (k : DeepModelTy0.deepModelTy) : Hashmap_List_Type.t_list (k, v)
     
    =
-    [#"../hashmap.rs" 82 8 82 56] Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets self)) (BucketIx0.bucket_ix self k)
+    [#"../hashmap.rs" 82 8 82 54] Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets self)) (BucketIx0.bucket_ix self k)
   val bucket [#"../hashmap.rs" 81 4 81 54] (self : Hashmap_MyHashMap_Type.t_myhashmap k v) (k : DeepModelTy0.deepModelTy) : Hashmap_List_Type.t_list (k, v)
     ensures { result = bucket self k }
     
@@ -647,7 +647,7 @@ module Hashmap_Impl5_New_Interface
   val new [#"../hashmap.rs" 95 4 95 46] (size : usize) : Hashmap_MyHashMap_Type.t_myhashmap k v
     requires {[#"../hashmap.rs" 92 15 92 24] 0 < UIntSize.to_int size}
     ensures { [#"../hashmap.rs" 93 14 93 34] HashmapInv0.hashmap_inv result }
-    ensures { [#"../hashmap.rs" 94 4 94 66] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
+    ensures { [#"../hashmap.rs" 94 4 94 64] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
     
 end
 module Hashmap_Impl5_New
@@ -728,7 +728,7 @@ module Hashmap_Impl5_New
   let rec cfg new [#"../hashmap.rs" 95 4 95 46] [@cfg:stackify] [@cfg:subregion_analysis] (size : usize) : Hashmap_MyHashMap_Type.t_myhashmap k v
     requires {[#"../hashmap.rs" 92 15 92 24] 0 < UIntSize.to_int size}
     ensures { [#"../hashmap.rs" 93 14 93 34] HashmapInv0.hashmap_inv result }
-    ensures { [#"../hashmap.rs" 94 4 94 66] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
+    ensures { [#"../hashmap.rs" 94 4 94 64] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Hashmap_MyHashMap_Type.t_myhashmap k v;
@@ -1150,7 +1150,7 @@ module Hashmap_Impl5_Add_Interface
   val add [#"../hashmap.rs" 103 4 103 41] (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) (key : k) (val' : v) : ()
     requires {[#"../hashmap.rs" 100 15 100 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 101 14 101 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 102 4 102 126] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
+    ensures { [#"../hashmap.rs" 102 4 102 124] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
       Core_Option_Option_Type.C_Some val'
     else
       Map.get (ShallowModel1.shallow_model self) i
@@ -1301,7 +1301,7 @@ module Hashmap_Impl5_Add
   let rec cfg add [#"../hashmap.rs" 103 4 103 41] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) (key : k) (val' : v) : ()
     requires {[#"../hashmap.rs" 100 15 100 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 101 14 101 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 102 4 102 126] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
+    ensures { [#"../hashmap.rs" 102 4 102 124] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
       Core_Option_Option_Type.C_Some val'
     else
       Map.get (ShallowModel1.shallow_model self) i
@@ -1893,10 +1893,10 @@ module Hashmap_Impl5_Resize_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val resize [#"../hashmap.rs" 159 4 159 24] (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : ()
-    requires {[#"../hashmap.rs" 154 15 154 43] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self))) < 1000}
+    requires {[#"../hashmap.rs" 154 15 154 41] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self))) < 1000}
     requires {[#"../hashmap.rs" 155 15 155 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 156 14 156 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 157 4 157 76] forall k : DeepModelTy0.deepModelTy . Map.get (ShallowModel1.shallow_model ( ^ self)) k = Map.get (ShallowModel2.shallow_model self) k }
+    ensures { [#"../hashmap.rs" 157 4 157 74] forall k : DeepModelTy0.deepModelTy . Map.get (ShallowModel1.shallow_model ( ^ self)) k = Map.get (ShallowModel2.shallow_model self) k }
     
 end
 module Hashmap_Impl5_Resize
@@ -2047,10 +2047,10 @@ module Hashmap_Impl5_Resize
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
   let rec cfg resize [#"../hashmap.rs" 159 4 159 24] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) : ()
-    requires {[#"../hashmap.rs" 154 15 154 43] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self))) < 1000}
+    requires {[#"../hashmap.rs" 154 15 154 41] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self))) < 1000}
     requires {[#"../hashmap.rs" 155 15 155 36] HashmapInv0.hashmap_inv ( * self)}
     ensures { [#"../hashmap.rs" 156 14 156 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 157 4 157 76] forall k : DeepModelTy0.deepModelTy . Map.get (ShallowModel1.shallow_model ( ^ self)) k = Map.get (ShallowModel2.shallow_model self) k }
+    ensures { [#"../hashmap.rs" 157 4 157 74] forall k : DeepModelTy0.deepModelTy . Map.get (ShallowModel1.shallow_model ( ^ self)) k = Map.get (ShallowModel2.shallow_model self) k }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -2123,13 +2123,13 @@ module Hashmap_Impl5_Resize
     goto BB6
   }
   BB6 {
-    invariant seen { [#"../hashmap.rs" 164 8 164 121] forall k : DeepModelTy0.deepModelTy . BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k < UIntSize.to_int i_13 -> Map.get (ShallowModel3.shallow_model old_self_6) k = Map.get (ShallowModel1.shallow_model new_9) k };
-    invariant unseen { [#"../hashmap.rs" 164 8 164 121] forall k : DeepModelTy0.deepModelTy . UIntSize.to_int i_13 <= BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k /\ BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k <= Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) -> Map.get (ShallowModel1.shallow_model new_9) k = Core_Option_Option_Type.C_None };
-    invariant rest { [#"../hashmap.rs" 164 8 164 121] forall j : int . UIntSize.to_int i_13 <= j /\ j < Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) -> Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) j = Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) j };
+    invariant seen { [#"../hashmap.rs" 164 8 164 117] forall k : DeepModelTy0.deepModelTy . BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k < UIntSize.to_int i_13 -> Map.get (ShallowModel3.shallow_model old_self_6) k = Map.get (ShallowModel1.shallow_model new_9) k };
+    invariant unseen { [#"../hashmap.rs" 164 8 164 117] forall k : DeepModelTy0.deepModelTy . UIntSize.to_int i_13 <= BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k /\ BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k <= Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) -> Map.get (ShallowModel1.shallow_model new_9) k = Core_Option_Option_Type.C_None };
+    invariant rest { [#"../hashmap.rs" 164 8 164 117] forall j : int . UIntSize.to_int i_13 <= j /\ j < Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) -> Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) j = Seq.get (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) j };
     invariant a { [#"../hashmap.rs" 170 23 170 40] HashmapInv0.hashmap_inv new_9 };
     invariant p { [#"../hashmap.rs" 171 23 171 49]  ^ Ghost.inner old_self_6 =  ^ self_1 };
-    invariant l { [#"../hashmap.rs" 172 23 172 73] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) = Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) };
-    invariant z { [#"../hashmap.rs" 173 23 173 50] UIntSize.to_int i_13 <= Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) };
+    invariant l { [#"../hashmap.rs" 172 23 172 69] Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * Ghost.inner old_self_6))) = Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) };
+    invariant z { [#"../hashmap.rs" 173 23 173 48] UIntSize.to_int i_13 <= Seq.length (ShallowModel0.shallow_model (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1))) };
     _24 <- i_13;
     _26 <- Hashmap_MyHashMap_Type.myhashmap_buckets ( * self_1);
     _25 <- ([#"../hashmap.rs" 174 18 174 36] Len0.len _26);
@@ -2233,7 +2233,7 @@ module Hashmap_Impl5_Resize
   BB22 {
     assume { Resolve1.resolve l_27 };
     _34 <- ();
-    assert { [#"../hashmap.rs" 190 12 190 125] forall k : DeepModelTy0.deepModelTy . BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k = UIntSize.to_int i_13 -> Map.get (ShallowModel3.shallow_model old_self_6) k = Map.get (ShallowModel1.shallow_model new_9) k };
+    assert { [#"../hashmap.rs" 190 12 190 121] forall k : DeepModelTy0.deepModelTy . BucketIx0.bucket_ix ( * Ghost.inner old_self_6) k = UIntSize.to_int i_13 -> Map.get (ShallowModel3.shallow_model old_self_6) k = Map.get (ShallowModel1.shallow_model new_9) k };
     goto BB24
   }
   BB23 {

--- a/creusot/tests/should_succeed/hashmap.rs
+++ b/creusot/tests/should_succeed/hashmap.rs
@@ -99,7 +99,7 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
 
     #[requires((*self).hashmap_inv())]
     #[ensures((^self).hashmap_inv())]
-    #[ensures(forall<i: K::DeepModelTy> ((^self)@).get(i) == (if i == key.deep_model() { Some(val) } else { self@.get(i) } ))]
+    #[ensures(forall<i: K::DeepModelTy> (^self)@.get(i) == (if i == key.deep_model() { Some(val) } else { self@.get(i) } ))]
     pub fn add(&mut self, key: K, val: V) {
         use List::*;
         let old_self = ghost! { self };
@@ -154,7 +154,7 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
     #[requires((@self.buckets).len() < 1000)]
     #[requires((*self).hashmap_inv())]
     #[ensures((^self).hashmap_inv())]
-    #[ensures(forall<k : K::DeepModelTy> ((^self)@).get(k) == self@.get(k))] // lets prove the extensional version for now
+    #[ensures(forall<k : K::DeepModelTy> (^self)@.get(k) == self@.get(k))] // lets prove the extensional version for now
     #[allow(dead_code)]
     fn resize(&mut self) {
         let old_self = ghost! { self };

--- a/creusot/tests/should_succeed/hashmap.rs
+++ b/creusot/tests/should_succeed/hashmap.rs
@@ -79,12 +79,12 @@ impl<K: Hash, V> ShallowModel for MyHashMap<K, V> {
 impl<K: Hash, V> MyHashMap<K, V> {
     #[logic]
     fn bucket(self, k: K::DeepModelTy) -> List<(K, V)> {
-        pearlite! { (self.buckets@)[self.bucket_ix(k)] }
+        pearlite! { self.buckets@[self.bucket_ix(k)] }
     }
 
     #[logic]
     fn bucket_ix(self, k: K::DeepModelTy) -> Int {
-        pearlite! { K::hash_log(k).rem_euclid((self.buckets@).len()) }
+        pearlite! { K::hash_log(k).rem_euclid(self.buckets@.len()) }
     }
 }
 
@@ -151,7 +151,7 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
     }
 
     // TODO: Cleanup.
-    #[requires((self.buckets@).len() < 1000)]
+    #[requires(self.buckets@.len() < 1000)]
     #[requires((*self).hashmap_inv())]
     #[ensures((^self).hashmap_inv())]
     #[ensures(forall<k : K::DeepModelTy> (^self)@.get(k) == self@.get(k))] // lets prove the extensional version for now
@@ -164,20 +164,20 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
         #[invariant(seen, forall<k : K::DeepModelTy> old_self.bucket_ix(k) < i@ ==> old_self@.get(k) == new@.get(k))]
         #[invariant(unseen, forall<k : K::DeepModelTy>
             i@ <=   old_self.bucket_ix(k) &&
-                    old_self.bucket_ix(k) <= (old_self.buckets@).len() ==> new@.get(k) == None
+                    old_self.bucket_ix(k) <= old_self.buckets@.len() ==> new@.get(k) == None
         )]
-        #[invariant(rest, forall<j : Int> i@ <= j && j < (old_self.buckets@).len() ==> (self.buckets@)[j] == (old_self.buckets@)[j])]
+        #[invariant(rest, forall<j : Int> i@ <= j && j < old_self.buckets@.len() ==> self.buckets@[j] == old_self.buckets@[j])]
         #[invariant(a, new.hashmap_inv())]
         #[invariant(p, ^old_self.inner() == ^self)]
-        #[invariant(l, (old_self.buckets@).len() == (self.buckets@).len())]
-        #[invariant(z, i@ <= (self.buckets@).len())]
+        #[invariant(l, old_self.buckets@.len() == self.buckets@.len())]
+        #[invariant(z, i@ <= self.buckets@.len())]
         while i < self.buckets.len() {
             let mut l: List<_> = std::mem::replace(&mut self.buckets[i], List::Nil);
 
             #[invariant(a, new.hashmap_inv())]
             #[invariant(x, forall<k : K::DeepModelTy> old_self.bucket_ix(k) < i@ ==> old_self@.get(k) == new@.get(k))]
             #[invariant(x, forall<k : K::DeepModelTy>
-                i@ < old_self.bucket_ix(k) && old_self.bucket_ix(k) <= (old_self.buckets@).len()  ==> new@.get(k) == None
+                i@ < old_self.bucket_ix(k) && old_self.bucket_ix(k) <= old_self.buckets@.len()  ==> new@.get(k) == None
             )]
             #[invariant(zzz, forall<k : K::DeepModelTy> old_self.bucket_ix(k) == i@ ==>
                         old_self@.get(k) == match l.get(k) { None => new@.get(k), Some(v) => Some(v) })]
@@ -206,8 +206,8 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
     #[predicate]
     fn hashmap_inv(&self) -> bool {
         pearlite! {
-            0 < (self.buckets@).len() &&
-            forall<i : _> 0 <= i && i < (self.buckets@).len() ==> self.good_bucket((self.buckets@)[i], i) && (self.buckets@)[i].no_double_binding()
+            0 < self.buckets@.len() &&
+            forall<i : _> 0 <= i && i < self.buckets@.len() ==> self.good_bucket(self.buckets@[i], i) && self.buckets@[i].no_double_binding()
         }
     }
 }

--- a/creusot/tests/should_succeed/hashmap.rs
+++ b/creusot/tests/should_succeed/hashmap.rs
@@ -99,7 +99,7 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
 
     #[requires((*self).hashmap_inv())]
     #[ensures((^self).hashmap_inv())]
-    #[ensures(forall<i: K::DeepModelTy> (@^self).get(i) == (if i == key.deep_model() { Some(val) } else { self@.get(i) } ))]
+    #[ensures(forall<i: K::DeepModelTy> ((^self)@).get(i) == (if i == key.deep_model() { Some(val) } else { self@.get(i) } ))]
     pub fn add(&mut self, key: K, val: V) {
         use List::*;
         let old_self = ghost! { self };
@@ -154,7 +154,7 @@ impl<K: Hash + Copy + Eq + DeepModel, V: Copy> MyHashMap<K, V> {
     #[requires((@self.buckets).len() < 1000)]
     #[requires((*self).hashmap_inv())]
     #[ensures((^self).hashmap_inv())]
-    #[ensures(forall<k : K::DeepModelTy> (@^self).get(k) == self@.get(k))] // lets prove the extensional version for now
+    #[ensures(forall<k : K::DeepModelTy> ((^self)@).get(k) == self@.get(k))] // lets prove the extensional version for now
     #[allow(dead_code)]
     fn resize(&mut self) {
         let old_self = ghost! { self };

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -1220,10 +1220,10 @@ module HeapsortGeneric_SiftDown_Interface
   val sift_down [#"../heapsort_generic.rs" 41 0 43 29] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (start : usize) (end' : usize) : ()
     requires {[#"../heapsort_generic.rs" 31 11 31 54] HeapFrag0.heap_frag (DeepModel0.deep_model v) (UIntSize.to_int start + 1) (UIntSize.to_int end')}
     requires {[#"../heapsort_generic.rs" 32 11 32 24] UIntSize.to_int start < UIntSize.to_int end'}
-    requires {[#"../heapsort_generic.rs" 33 11 33 29] UIntSize.to_int end' <= Seq.length (ShallowModel0.shallow_model v)}
+    requires {[#"../heapsort_generic.rs" 33 11 33 27] UIntSize.to_int end' <= Seq.length (ShallowModel0.shallow_model v)}
     ensures { [#"../heapsort_generic.rs" 34 10 34 52] HeapFrag0.heap_frag (DeepModel1.deep_model ( ^ v)) (UIntSize.to_int start) (UIntSize.to_int end') }
-    ensures { [#"../heapsort_generic.rs" 35 10 35 34] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
-    ensures { [#"../heapsort_generic.rs" 36 0 37 47] forall i : int . 0 <= i /\ i < UIntSize.to_int start \/ UIntSize.to_int end' <= i /\ i < Seq.length (ShallowModel0.shallow_model v) -> Seq.get (ShallowModel0.shallow_model v) i = Seq.get (ShallowModel1.shallow_model ( ^ v)) i }
+    ensures { [#"../heapsort_generic.rs" 35 0 35 36] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
+    ensures { [#"../heapsort_generic.rs" 36 0 37 45] forall i : int . 0 <= i /\ i < UIntSize.to_int start \/ UIntSize.to_int end' <= i /\ i < Seq.length (ShallowModel0.shallow_model v) -> Seq.get (ShallowModel0.shallow_model v) i = Seq.get (ShallowModel1.shallow_model ( ^ v)) i }
     ensures { [#"../heapsort_generic.rs" 38 0 40 80] forall m : DeepModelTy0.deepModelTy . (forall j : int . UIntSize.to_int start <= j /\ j < UIntSize.to_int end' -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v) j) m) -> (forall j : int . UIntSize.to_int start <= j /\ j < UIntSize.to_int end' -> LeLog0.le_log (Seq.get (DeepModel1.deep_model ( ^ v)) j) m) }
     
 end
@@ -1396,10 +1396,10 @@ module HeapsortGeneric_SiftDown
   let rec cfg sift_down [#"../heapsort_generic.rs" 41 0 43 29] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (start : usize) (end' : usize) : ()
     requires {[#"../heapsort_generic.rs" 31 11 31 54] HeapFrag0.heap_frag (DeepModel0.deep_model v) (UIntSize.to_int start + 1) (UIntSize.to_int end')}
     requires {[#"../heapsort_generic.rs" 32 11 32 24] UIntSize.to_int start < UIntSize.to_int end'}
-    requires {[#"../heapsort_generic.rs" 33 11 33 29] UIntSize.to_int end' <= Seq.length (ShallowModel0.shallow_model v)}
+    requires {[#"../heapsort_generic.rs" 33 11 33 27] UIntSize.to_int end' <= Seq.length (ShallowModel0.shallow_model v)}
     ensures { [#"../heapsort_generic.rs" 34 10 34 52] HeapFrag0.heap_frag (DeepModel1.deep_model ( ^ v)) (UIntSize.to_int start) (UIntSize.to_int end') }
-    ensures { [#"../heapsort_generic.rs" 35 10 35 34] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
-    ensures { [#"../heapsort_generic.rs" 36 0 37 47] forall i : int . 0 <= i /\ i < UIntSize.to_int start \/ UIntSize.to_int end' <= i /\ i < Seq.length (ShallowModel0.shallow_model v) -> Seq.get (ShallowModel0.shallow_model v) i = Seq.get (ShallowModel1.shallow_model ( ^ v)) i }
+    ensures { [#"../heapsort_generic.rs" 35 0 35 36] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
+    ensures { [#"../heapsort_generic.rs" 36 0 37 45] forall i : int . 0 <= i /\ i < UIntSize.to_int start \/ UIntSize.to_int end' <= i /\ i < Seq.length (ShallowModel0.shallow_model v) -> Seq.get (ShallowModel0.shallow_model v) i = Seq.get (ShallowModel1.shallow_model ( ^ v)) i }
     ensures { [#"../heapsort_generic.rs" 38 0 40 80] forall m : DeepModelTy0.deepModelTy . (forall j : int . UIntSize.to_int start <= j /\ j < UIntSize.to_int end' -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v) j) m) -> (forall j : int . UIntSize.to_int start <= j /\ j < UIntSize.to_int end' -> LeLog0.le_log (Seq.get (DeepModel1.deep_model ( ^ v)) j) m) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -1472,13 +1472,13 @@ module HeapsortGeneric_SiftDown
     goto BB2
   }
   BB2 {
-    invariant permutation { [#"../heapsort_generic.rs" 48 29 48 56] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_11) };
+    invariant permutation { [#"../heapsort_generic.rs" 48 4 48 56] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_11) };
     invariant i_bounds { [#"../heapsort_generic.rs" 49 26 49 51] UIntSize.to_int start_2 <= UIntSize.to_int i_14 /\ UIntSize.to_int i_14 < UIntSize.to_int end'_3 };
-    invariant unchanged { [#"../heapsort_generic.rs" 48 4 48 58] forall j : int . 0 <= j /\ j < UIntSize.to_int start_2 \/ UIntSize.to_int end'_3 <= j /\ j < Seq.length (ShallowModel0.shallow_model v_1) -> Seq.get (ShallowModel2.shallow_model old_v_11) j = Seq.get (ShallowModel0.shallow_model v_1) j };
-    invariant keep_bound { [#"../heapsort_generic.rs" 48 4 48 58] forall m : DeepModelTy0.deepModelTy . (forall j : int . UIntSize.to_int start_2 <= j /\ j < UIntSize.to_int end'_3 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model (Ghost.inner old_v_11)) j) m) -> (forall j : int . UIntSize.to_int start_2 <= j /\ j < UIntSize.to_int end'_3 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) j) m) };
-    invariant heap { [#"../heapsort_generic.rs" 48 4 48 58] forall j : int . UIntSize.to_int start_2 <= Parent0.parent j /\ j < UIntSize.to_int end'_3 /\ UIntSize.to_int i_14 <> Parent0.parent j -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) j) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent j)) };
-    invariant hole_left { [#"../heapsort_generic.rs" 48 4 48 58] let c = 2 * UIntSize.to_int i_14 + 1 in c < UIntSize.to_int end'_3 /\ UIntSize.to_int start_2 <= Parent0.parent (UIntSize.to_int i_14) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) c) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent (Parent0.parent c))) };
-    invariant hole_right { [#"../heapsort_generic.rs" 48 4 48 58] let c = 2 * UIntSize.to_int i_14 + 2 in c < UIntSize.to_int end'_3 /\ UIntSize.to_int start_2 <= Parent0.parent (UIntSize.to_int i_14) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) c) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent (Parent0.parent c))) };
+    invariant unchanged { [#"../heapsort_generic.rs" 48 4 48 56] forall j : int . 0 <= j /\ j < UIntSize.to_int start_2 \/ UIntSize.to_int end'_3 <= j /\ j < Seq.length (ShallowModel0.shallow_model v_1) -> Seq.get (ShallowModel2.shallow_model old_v_11) j = Seq.get (ShallowModel0.shallow_model v_1) j };
+    invariant keep_bound { [#"../heapsort_generic.rs" 48 4 48 56] forall m : DeepModelTy0.deepModelTy . (forall j : int . UIntSize.to_int start_2 <= j /\ j < UIntSize.to_int end'_3 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model (Ghost.inner old_v_11)) j) m) -> (forall j : int . UIntSize.to_int start_2 <= j /\ j < UIntSize.to_int end'_3 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) j) m) };
+    invariant heap { [#"../heapsort_generic.rs" 48 4 48 56] forall j : int . UIntSize.to_int start_2 <= Parent0.parent j /\ j < UIntSize.to_int end'_3 /\ UIntSize.to_int i_14 <> Parent0.parent j -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) j) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent j)) };
+    invariant hole_left { [#"../heapsort_generic.rs" 48 4 48 56] let c = 2 * UIntSize.to_int i_14 + 1 in c < UIntSize.to_int end'_3 /\ UIntSize.to_int start_2 <= Parent0.parent (UIntSize.to_int i_14) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) c) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent (Parent0.parent c))) };
+    invariant hole_right { [#"../heapsort_generic.rs" 48 4 48 56] let c = 2 * UIntSize.to_int i_14 + 2 in c < UIntSize.to_int end'_3 /\ UIntSize.to_int start_2 <= Parent0.parent (UIntSize.to_int i_14) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v_1) c) (Seq.get (DeepModel0.deep_model v_1) (Parent0.parent (Parent0.parent c))) };
     _26 <- i_14;
     _28 <- end'_3;
     _29 <- ([#"../heapsort_generic.rs" 60 16 60 23] ([#"../heapsort_generic.rs" 60 22 60 23] (2 : usize)) = ([#"../heapsort_generic.rs" 60 16 60 23] (0 : usize)));
@@ -1725,9 +1725,9 @@ module HeapsortGeneric_HeapSort_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val heap_sort [#"../heapsort_generic.rs" 93 0 95 29] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    requires {[#"../heapsort_generic.rs" 90 11 90 42] Seq.length (ShallowModel0.shallow_model v) < div (UIntSize.to_int Max0.mAX') 2}
+    requires {[#"../heapsort_generic.rs" 90 11 90 40] Seq.length (ShallowModel0.shallow_model v) < div (UIntSize.to_int Max0.mAX') 2}
     ensures { [#"../heapsort_generic.rs" 91 10 91 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../heapsort_generic.rs" 92 10 92 34] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
+    ensures { [#"../heapsort_generic.rs" 92 0 92 36] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
     
 end
 module HeapsortGeneric_HeapSort
@@ -1894,9 +1894,9 @@ module HeapsortGeneric_HeapSort
     predicate SortedRange0.sorted_range = SortedRange0.sorted_range
   clone Core_Usize_Max as Max0
   let rec cfg heap_sort [#"../heapsort_generic.rs" 93 0 95 29] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    requires {[#"../heapsort_generic.rs" 90 11 90 42] Seq.length (ShallowModel0.shallow_model v) < div (UIntSize.to_int Max0.mAX') 2}
+    requires {[#"../heapsort_generic.rs" 90 11 90 40] Seq.length (ShallowModel0.shallow_model v) < div (UIntSize.to_int Max0.mAX') 2}
     ensures { [#"../heapsort_generic.rs" 91 10 91 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../heapsort_generic.rs" 92 10 92 34] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
+    ensures { [#"../heapsort_generic.rs" 92 0 92 36] PermutationOf0.permutation_of (ShallowModel1.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1959,9 +1959,9 @@ module HeapsortGeneric_HeapSort
     goto BB4
   }
   BB4 {
-    invariant permutation { [#"../heapsort_generic.rs" 100 29 100 56] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_5) };
-    invariant heap { [#"../heapsort_generic.rs" 101 22 101 67] HeapFrag0.heap_frag (DeepModel1.deep_model v_1) (UIntSize.to_int start_8) (Seq.length (ShallowModel0.shallow_model v_1)) };
-    invariant start_bound { [#"../heapsort_generic.rs" 102 29 102 51] UIntSize.to_int start_8 <= div (Seq.length (ShallowModel0.shallow_model v_1)) 2 };
+    invariant permutation { [#"../heapsort_generic.rs" 100 4 100 56] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_5) };
+    invariant heap { [#"../heapsort_generic.rs" 101 22 101 65] HeapFrag0.heap_frag (DeepModel1.deep_model v_1) (UIntSize.to_int start_8) (Seq.length (ShallowModel0.shallow_model v_1)) };
+    invariant start_bound { [#"../heapsort_generic.rs" 102 29 102 49] UIntSize.to_int start_8 <= div (Seq.length (ShallowModel0.shallow_model v_1)) 2 };
     _18 <- start_8;
     _17 <- ([#"../heapsort_generic.rs" 103 10 103 19] _18 > ([#"../heapsort_generic.rs" 103 18 103 19] (0 : usize)));
     switch (_17)
@@ -1996,11 +1996,11 @@ module HeapsortGeneric_HeapSort
     goto BB10
   }
   BB10 {
-    invariant end_bound { [#"../heapsort_generic.rs" 109 27 109 45] UIntSize.to_int end'_27 <= Seq.length (ShallowModel0.shallow_model v_1) };
-    invariant permutation { [#"../heapsort_generic.rs" 110 29 110 56] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_5) };
+    invariant end_bound { [#"../heapsort_generic.rs" 109 27 109 43] UIntSize.to_int end'_27 <= Seq.length (ShallowModel0.shallow_model v_1) };
+    invariant permutation { [#"../heapsort_generic.rs" 109 4 109 45] PermutationOf0.permutation_of (ShallowModel0.shallow_model v_1) (ShallowModel2.shallow_model old_v_5) };
     invariant heap { [#"../heapsort_generic.rs" 111 22 111 56] HeapFrag0.heap_frag (DeepModel1.deep_model v_1) 0 (UIntSize.to_int end'_27) };
-    invariant sorted { [#"../heapsort_generic.rs" 112 24 112 70] SortedRange0.sorted_range (DeepModel1.deep_model v_1) (UIntSize.to_int end'_27) (Seq.length (ShallowModel0.shallow_model v_1)) };
-    invariant heap_le { [#"../heapsort_generic.rs" 109 4 109 47] forall j : int . forall i : int . 0 <= i /\ i < UIntSize.to_int end'_27 /\ UIntSize.to_int end'_27 <= j /\ j < Seq.length (ShallowModel0.shallow_model v_1) -> LeLog0.le_log (Seq.get (DeepModel1.deep_model v_1) i) (Seq.get (DeepModel1.deep_model v_1) j) };
+    invariant sorted { [#"../heapsort_generic.rs" 112 24 112 68] SortedRange0.sorted_range (DeepModel1.deep_model v_1) (UIntSize.to_int end'_27) (Seq.length (ShallowModel0.shallow_model v_1)) };
+    invariant heap_le { [#"../heapsort_generic.rs" 109 4 109 45] forall j : int . forall i : int . 0 <= i /\ i < UIntSize.to_int end'_27 /\ UIntSize.to_int end'_27 <= j /\ j < Seq.length (ShallowModel0.shallow_model v_1) -> LeLog0.le_log (Seq.get (DeepModel1.deep_model v_1) i) (Seq.get (DeepModel1.deep_model v_1) j) };
     _35 <- end'_27;
     _34 <- ([#"../heapsort_generic.rs" 115 10 115 17] _35 > ([#"../heapsort_generic.rs" 115 16 115 17] (1 : usize)));
     switch (_34)

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -87,7 +87,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
     }
 }
 
-#[requires(v@.len() < @std::usize::MAX/2)]
+#[requires(v@.len() < std::usize::MAX@/2)]
 #[ensures(sorted((^v).deep_model()))]
 #[ensures((^v)@.permutation_of(v@))]
 pub fn heap_sort<T: Ord + DeepModel>(v: &mut Vec<T>)

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -28,16 +28,16 @@ fn heap_frag_max<T: OrdLogic>(s: Seq<T>, i: Int, end: Int) {
     }
 }
 
-#[requires(heap_frag(v.deep_model(), @start + 1, @end))]
-#[requires(@start < @end)]
-#[requires(@end <= v@.len())]
-#[ensures(heap_frag((^v).deep_model(), @start, @end))]
-#[ensures((@^v).permutation_of(@v))]
-#[ensures(forall<i: Int> 0 <= i && i < @start || @end <= i && i < v@.len()
+#[requires(heap_frag(v.deep_model(), start@ + 1, end@))]
+#[requires(start@ < end@)]
+#[requires(end@ <= v@.len())]
+#[ensures(heap_frag((^v).deep_model(), start@, end@))]
+#[ensures((@^v).permutation_of(v@))]
+#[ensures(forall<i: Int> 0 <= i && i < start@ || end@ <= i && i < v@.len()
                       ==> v@[i] == (@^v)[i])]
 #[ensures(forall<m: T::DeepModelTy>
-          (forall<j: Int> @start <= j && j < @end ==> v.deep_model()[j] <= m) ==>
-          forall<j: Int> @start <= j && j < @end ==> (^v).deep_model()[j] <= m)]
+          (forall<j: Int> start@ <= j && j < end@ ==> v.deep_model()[j] <= m) ==>
+          forall<j: Int> start@ <= j && j < end@ ==> (^v).deep_model()[j] <= m)]
 fn sift_down<T: Ord + DeepModel>(v: &mut Vec<T>, start: usize, end: usize)
 where
     T::DeepModelTy: OrdLogic,
@@ -45,17 +45,17 @@ where
     let old_v = ghost! { v };
     let mut i = start;
 
-    #[invariant(permutation, v@.permutation_of(@old_v))]
-    #[invariant(i_bounds, @start <= @i && @i < @end)]
-    #[invariant(unchanged, forall<j: Int> 0 <= j && j < @start || @end <= j && j < v@.len()
+    #[invariant(permutation, v@.permutation_of(old_v@))]
+    #[invariant(i_bounds, start@ <= i@ && i@ < end@)]
+    #[invariant(unchanged, forall<j: Int> 0 <= j && j < start@ || end@ <= j && j < v@.len()
                               ==> old_v@[j] == v@[j])]
     #[invariant(keep_bound, forall<m: T::DeepModelTy>
-          (forall<j: Int> @start <= j && j < @end ==> old_v.deep_model()[j] <= m) ==>
-          forall<j: Int> @start <= j && j < @end ==> v.deep_model()[j] <= m)]
-    #[invariant(heap, forall<j: Int> @start <= parent(j) && j < @end && @i != parent(j) ==>
+          (forall<j: Int> start@ <= j && j < end@ ==> old_v.deep_model()[j] <= m) ==>
+          forall<j: Int> start@ <= j && j < end@ ==> v.deep_model()[j] <= m)]
+    #[invariant(heap, forall<j: Int> start@ <= parent(j) && j < end@ && i@ != parent(j) ==>
             v.deep_model()[j] <= v.deep_model()[parent(j)])]
-    #[invariant(hole_left,  {let c = 2*@i+1; c < @end && @start <= parent(@i) ==> v.deep_model()[c] <= v.deep_model()[parent(parent(c))]})]
-    #[invariant(hole_right, {let c = 2*@i+2; c < @end && @start <= parent(@i) ==> v.deep_model()[c] <= v.deep_model()[parent(parent(c))]})]
+    #[invariant(hole_left,  {let c = 2*i@+1; c < end@ && start@ <= parent(i@) ==> v.deep_model()[c] <= v.deep_model()[parent(parent(c))]})]
+    #[invariant(hole_right, {let c = 2*i@+2; c < end@ && start@ <= parent(i@) ==> v.deep_model()[c] <= v.deep_model()[parent(parent(c))]})]
     loop {
         if i >= end / 2 {
             return;
@@ -89,7 +89,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 
 #[requires(v@.len() < @std::usize::MAX/2)]
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(@v))]
+#[ensures((@^v).permutation_of(v@))]
 pub fn heap_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,
@@ -97,27 +97,27 @@ where
     let old_v = ghost! { v };
 
     let mut start = v.len() / 2;
-    #[invariant(permutation, v@.permutation_of(@old_v))]
-    #[invariant(heap, heap_frag(v.deep_model(), @start, v@.len()))]
-    #[invariant(start_bound, @start <= v@.len()/2)]
+    #[invariant(permutation, v@.permutation_of(old_v@))]
+    #[invariant(heap, heap_frag(v.deep_model(), start@, v@.len()))]
+    #[invariant(start_bound, start@ <= v@.len()/2)]
     while start > 0 {
         start -= 1;
         sift_down(v, start, v.len());
     }
 
     let mut end = v.len();
-    #[invariant(end_bound, @end <= v@.len())]
-    #[invariant(permutation, v@.permutation_of(@old_v))]
-    #[invariant(heap, heap_frag(v.deep_model(), 0, @end))]
-    #[invariant(sorted, sorted_range(v.deep_model(), @end, v@.len()))]
-    #[invariant(heap_le, forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < v@.len() ==>
+    #[invariant(end_bound, end@ <= v@.len())]
+    #[invariant(permutation, v@.permutation_of(old_v@))]
+    #[invariant(heap, heap_frag(v.deep_model(), 0, end@))]
+    #[invariant(sorted, sorted_range(v.deep_model(), end@, v@.len()))]
+    #[invariant(heap_le, forall<i : Int, j : Int> 0 <= i && i < end@ && end@ <= j && j < v@.len() ==>
                             v.deep_model()[i] <= v.deep_model()[j])]
     while end > 1 {
         end -= 1;
         v.swap(0, end);
         proof_assert! {
-            heap_frag_max(v.deep_model(), 0/*dummy*/, @end);
-            forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < v@.len() ==>
+            heap_frag_max(v.deep_model(), 0/*dummy*/, end@);
+            forall<i : Int, j : Int> 0 <= i && i < end@ && end@ <= j && j < v@.len() ==>
                         v.deep_model()[i] <= v.deep_model()[j]
         };
         sift_down(v, 0, end);

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -32,9 +32,9 @@ fn heap_frag_max<T: OrdLogic>(s: Seq<T>, i: Int, end: Int) {
 #[requires(start@ < end@)]
 #[requires(end@ <= v@.len())]
 #[ensures(heap_frag((^v).deep_model(), start@, end@))]
-#[ensures((@^v).permutation_of(v@))]
+#[ensures(((^v)@).permutation_of(v@))]
 #[ensures(forall<i: Int> 0 <= i && i < start@ || end@ <= i && i < v@.len()
-                      ==> v@[i] == (@^v)[i])]
+                      ==> v@[i] == ((^v)@)[i])]
 #[ensures(forall<m: T::DeepModelTy>
           (forall<j: Int> start@ <= j && j < end@ ==> v.deep_model()[j] <= m) ==>
           forall<j: Int> start@ <= j && j < end@ ==> (^v).deep_model()[j] <= m)]
@@ -89,7 +89,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 
 #[requires(v@.len() < @std::usize::MAX/2)]
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(v@))]
+#[ensures(((^v)@).permutation_of(v@))]
 pub fn heap_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -30,11 +30,11 @@ fn heap_frag_max<T: OrdLogic>(s: Seq<T>, i: Int, end: Int) {
 
 #[requires(heap_frag(v.deep_model(), @start + 1, @end))]
 #[requires(@start < @end)]
-#[requires(@end <= (@v).len())]
+#[requires(@end <= v@.len())]
 #[ensures(heap_frag((^v).deep_model(), @start, @end))]
 #[ensures((@^v).permutation_of(@v))]
-#[ensures(forall<i: Int> 0 <= i && i < @start || @end <= i && i < (@v).len()
-                      ==> (@v)[i] == (@^v)[i])]
+#[ensures(forall<i: Int> 0 <= i && i < @start || @end <= i && i < v@.len()
+                      ==> v@[i] == (@^v)[i])]
 #[ensures(forall<m: T::DeepModelTy>
           (forall<j: Int> @start <= j && j < @end ==> v.deep_model()[j] <= m) ==>
           forall<j: Int> @start <= j && j < @end ==> (^v).deep_model()[j] <= m)]
@@ -45,10 +45,10 @@ where
     let old_v = ghost! { v };
     let mut i = start;
 
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
     #[invariant(i_bounds, @start <= @i && @i < @end)]
-    #[invariant(unchanged, forall<j: Int> 0 <= j && j < @start || @end <= j && j < (@v).len()
-                              ==> (@old_v)[j] == (@v)[j])]
+    #[invariant(unchanged, forall<j: Int> 0 <= j && j < @start || @end <= j && j < v@.len()
+                              ==> old_v@[j] == v@[j])]
     #[invariant(keep_bound, forall<m: T::DeepModelTy>
           (forall<j: Int> @start <= j && j < @end ==> old_v.deep_model()[j] <= m) ==>
           forall<j: Int> @start <= j && j < @end ==> v.deep_model()[j] <= m)]
@@ -87,7 +87,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
     }
 }
 
-#[requires((@v).len() < @std::usize::MAX/2)]
+#[requires(v@.len() < @std::usize::MAX/2)]
 #[ensures(sorted((^v).deep_model()))]
 #[ensures((@^v).permutation_of(@v))]
 pub fn heap_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
@@ -97,27 +97,27 @@ where
     let old_v = ghost! { v };
 
     let mut start = v.len() / 2;
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
-    #[invariant(heap, heap_frag(v.deep_model(), @start, (@v).len()))]
-    #[invariant(start_bound, @start <= (@v).len()/2)]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
+    #[invariant(heap, heap_frag(v.deep_model(), @start, v@.len()))]
+    #[invariant(start_bound, @start <= v@.len()/2)]
     while start > 0 {
         start -= 1;
         sift_down(v, start, v.len());
     }
 
     let mut end = v.len();
-    #[invariant(end_bound, @end <= (@v).len())]
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
+    #[invariant(end_bound, @end <= v@.len())]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
     #[invariant(heap, heap_frag(v.deep_model(), 0, @end))]
-    #[invariant(sorted, sorted_range(v.deep_model(), @end, (@v).len()))]
-    #[invariant(heap_le, forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < (@v).len() ==>
+    #[invariant(sorted, sorted_range(v.deep_model(), @end, v@.len()))]
+    #[invariant(heap_le, forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < v@.len() ==>
                             v.deep_model()[i] <= v.deep_model()[j])]
     while end > 1 {
         end -= 1;
         v.swap(0, end);
         proof_assert! {
             heap_frag_max(v.deep_model(), 0/*dummy*/, @end);
-            forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < (@v).len() ==>
+            forall<i : Int, j : Int> 0 <= i && i < @end && @end <= j && j < v@.len() ==>
                         v.deep_model()[i] <= v.deep_model()[j]
         };
         sift_down(v, 0, end);

--- a/creusot/tests/should_succeed/heapsort_generic.rs
+++ b/creusot/tests/should_succeed/heapsort_generic.rs
@@ -32,9 +32,9 @@ fn heap_frag_max<T: OrdLogic>(s: Seq<T>, i: Int, end: Int) {
 #[requires(start@ < end@)]
 #[requires(end@ <= v@.len())]
 #[ensures(heap_frag((^v).deep_model(), start@, end@))]
-#[ensures(((^v)@).permutation_of(v@))]
+#[ensures((^v)@.permutation_of(v@))]
 #[ensures(forall<i: Int> 0 <= i && i < start@ || end@ <= i && i < v@.len()
-                      ==> v@[i] == ((^v)@)[i])]
+                      ==> v@[i] == (^v)@[i])]
 #[ensures(forall<m: T::DeepModelTy>
           (forall<j: Int> start@ <= j && j < end@ ==> v.deep_model()[j] <= m) ==>
           forall<j: Int> start@ <= j && j < end@ ==> (^v).deep_model()[j] <= m)]
@@ -89,7 +89,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 
 #[requires(v@.len() < @std::usize::MAX/2)]
 #[ensures(sorted((^v).deep_model()))]
-#[ensures(((^v)@).permutation_of(v@))]
+#[ensures((^v)@.permutation_of(v@))]
 pub fn heap_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -282,12 +282,12 @@ module Hillel_RightPad_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val right_pad [#"../hillel.rs" 16 0 16 59] (str : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (len : usize) (pad : t) : ()
-    ensures { [#"../hillel.rs" 10 10 10 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 11 10 11 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 12 0 12 66] UIntSize.to_int len <= Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 13 0 13 57] UIntSize.to_int len > Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len }
-    ensures { [#"../hillel.rs" 14 0 14 81] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = Seq.get (ShallowModel1.shallow_model str) i }
-    ensures { [#"../hillel.rs" 15 0 15 78] forall i : int . Seq.length (ShallowModel1.shallow_model str) <= i /\ i < UIntSize.to_int len -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 10 10 10 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 11 10 11 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 12 0 12 62] UIntSize.to_int len <= Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 13 0 13 55] UIntSize.to_int len > Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len }
+    ensures { [#"../hillel.rs" 14 0 14 77] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = Seq.get (ShallowModel1.shallow_model str) i }
+    ensures { [#"../hillel.rs" 15 0 15 76] forall i : int . Seq.length (ShallowModel1.shallow_model str) <= i /\ i < UIntSize.to_int len -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
     
 end
 module Hillel_RightPad
@@ -337,12 +337,12 @@ module Hillel_RightPad
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   let rec cfg right_pad [#"../hillel.rs" 16 0 16 59] [@cfg:stackify] [@cfg:subregion_analysis] (str : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (len : usize) (pad : t) : ()
-    ensures { [#"../hillel.rs" 10 10 10 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 11 10 11 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 12 0 12 66] UIntSize.to_int len <= Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 13 0 13 57] UIntSize.to_int len > Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len }
-    ensures { [#"../hillel.rs" 14 0 14 81] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = Seq.get (ShallowModel1.shallow_model str) i }
-    ensures { [#"../hillel.rs" 15 0 15 78] forall i : int . Seq.length (ShallowModel1.shallow_model str) <= i /\ i < UIntSize.to_int len -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 10 10 10 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 11 10 11 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 12 0 12 62] UIntSize.to_int len <= Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 13 0 13 55] UIntSize.to_int len > Seq.length (ShallowModel1.shallow_model str) -> Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len }
+    ensures { [#"../hillel.rs" 14 0 14 77] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = Seq.get (ShallowModel1.shallow_model str) i }
+    ensures { [#"../hillel.rs" 15 0 15 76] forall i : int . Seq.length (ShallowModel1.shallow_model str) <= i /\ i < UIntSize.to_int len -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -377,11 +377,11 @@ module Hillel_RightPad
     goto BB2
   }
   BB2 {
-    invariant old_str_bound { [#"../hillel.rs" 19 31 19 63] Seq.length (ShallowModel2.shallow_model old_str_10) <= Seq.length (ShallowModel1.shallow_model str_1) };
-    invariant len_bound { [#"../hillel.rs" 19 4 19 65] Seq.length (ShallowModel2.shallow_model old_str_10) < UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) <= UIntSize.to_int len_2 };
-    invariant len_bound { [#"../hillel.rs" 19 4 19 65] Seq.length (ShallowModel1.shallow_model str_1) > UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) = Seq.length (ShallowModel2.shallow_model old_str_10) };
-    invariant old_elem { [#"../hillel.rs" 19 4 19 65] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model old_str_10) -> Seq.get (ShallowModel1.shallow_model str_1) i = Seq.get (ShallowModel2.shallow_model old_str_10) i };
-    invariant pad_elem { [#"../hillel.rs" 19 4 19 65] forall i : int . Seq.length (ShallowModel2.shallow_model old_str_10) <= i /\ i < Seq.length (ShallowModel1.shallow_model str_1) -> Seq.get (ShallowModel1.shallow_model str_1) i = pad_3 };
+    invariant old_str_bound { [#"../hillel.rs" 19 31 19 59] Seq.length (ShallowModel2.shallow_model old_str_10) <= Seq.length (ShallowModel1.shallow_model str_1) };
+    invariant len_bound { [#"../hillel.rs" 19 4 19 61] Seq.length (ShallowModel2.shallow_model old_str_10) < UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) <= UIntSize.to_int len_2 };
+    invariant len_bound { [#"../hillel.rs" 19 4 19 61] Seq.length (ShallowModel1.shallow_model str_1) > UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) = Seq.length (ShallowModel2.shallow_model old_str_10) };
+    invariant old_elem { [#"../hillel.rs" 19 4 19 61] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model old_str_10) -> Seq.get (ShallowModel1.shallow_model str_1) i = Seq.get (ShallowModel2.shallow_model old_str_10) i };
+    invariant pad_elem { [#"../hillel.rs" 19 4 19 61] forall i : int . Seq.length (ShallowModel2.shallow_model old_str_10) <= i /\ i < Seq.length (ShallowModel1.shallow_model str_1) -> Seq.get (ShallowModel1.shallow_model str_1) i = pad_3 };
     _21 <-  * str_1;
     _20 <- ([#"../hillel.rs" 24 10 24 19] Len0.len _21);
     goto BB3
@@ -477,10 +477,10 @@ module Hillel_LeftPad_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val left_pad [#"../hillel.rs" 33 0 33 58] (str : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (len : usize) (pad : t) : ()
-    ensures { [#"../hillel.rs" 29 10 29 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 30 10 30 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 31 0 31 93] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
-    ensures { [#"../hillel.rs" 32 0 32 114] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) (i + (Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str))) = Seq.get (ShallowModel1.shallow_model str) i }
+    ensures { [#"../hillel.rs" 29 10 29 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 30 10 30 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 31 0 31 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 32 0 32 108] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) (i + (Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str))) = Seq.get (ShallowModel1.shallow_model str) i }
     
 end
 module Hillel_LeftPad
@@ -540,10 +540,10 @@ module Hillel_LeftPad
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
   let rec cfg left_pad [#"../hillel.rs" 33 0 33 58] [@cfg:stackify] [@cfg:subregion_analysis] (str : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (len : usize) (pad : t) : ()
-    ensures { [#"../hillel.rs" 29 10 29 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 30 10 30 64] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
-    ensures { [#"../hillel.rs" 31 0 31 93] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
-    ensures { [#"../hillel.rs" 32 0 32 114] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) (i + (Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str))) = Seq.get (ShallowModel1.shallow_model str) i }
+    ensures { [#"../hillel.rs" 29 10 29 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) >= UIntSize.to_int len /\ Seq.length (ShallowModel0.shallow_model ( ^ str)) >= Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 30 10 30 62] Seq.length (ShallowModel0.shallow_model ( ^ str)) = UIntSize.to_int len \/ Seq.length (ShallowModel0.shallow_model ( ^ str)) = Seq.length (ShallowModel1.shallow_model str) }
+    ensures { [#"../hillel.rs" 31 0 31 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) i = pad }
+    ensures { [#"../hillel.rs" 32 0 32 108] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model str) -> Seq.get (ShallowModel0.shallow_model ( ^ str)) (i + (Seq.length (ShallowModel0.shallow_model ( ^ str)) - Seq.length (ShallowModel1.shallow_model str))) = Seq.get (ShallowModel1.shallow_model str) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -587,12 +587,12 @@ module Hillel_LeftPad
     goto BB3
   }
   BB3 {
-    invariant old_str_bound { [#"../hillel.rs" 37 31 37 63] Seq.length (ShallowModel2.shallow_model old_str_8) <= Seq.length (ShallowModel1.shallow_model str_1) };
-    invariant len_bound { [#"../hillel.rs" 37 4 37 65] Seq.length (ShallowModel2.shallow_model old_str_8) < UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) <= UIntSize.to_int len_2 };
-    invariant len_bound { [#"../hillel.rs" 37 4 37 65] Seq.length (ShallowModel1.shallow_model str_1) > UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) = Seq.length (ShallowModel2.shallow_model old_str_8) };
-    invariant count { [#"../hillel.rs" 40 23 40 60] ShallowModel3.shallow_model c_11 = Seq.length (ShallowModel1.shallow_model str_1) - Seq.length (ShallowModel2.shallow_model old_str_8) };
-    invariant old_elem { [#"../hillel.rs" 37 4 37 65] forall i : int . ShallowModel3.shallow_model c_11 <= i /\ i < Seq.length (ShallowModel1.shallow_model str_1) -> Seq.get (ShallowModel1.shallow_model str_1) i = Seq.get (ShallowModel2.shallow_model old_str_8) (i - ShallowModel3.shallow_model c_11) };
-    invariant pad_elem { [#"../hillel.rs" 37 4 37 65] forall i : int . 0 <= i /\ i < ShallowModel3.shallow_model c_11 -> Seq.get (ShallowModel1.shallow_model str_1) i = pad_3 };
+    invariant old_str_bound { [#"../hillel.rs" 37 31 37 59] Seq.length (ShallowModel2.shallow_model old_str_8) <= Seq.length (ShallowModel1.shallow_model str_1) };
+    invariant len_bound { [#"../hillel.rs" 37 4 37 61] Seq.length (ShallowModel2.shallow_model old_str_8) < UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) <= UIntSize.to_int len_2 };
+    invariant len_bound { [#"../hillel.rs" 37 4 37 61] Seq.length (ShallowModel1.shallow_model str_1) > UIntSize.to_int len_2 -> Seq.length (ShallowModel1.shallow_model str_1) = Seq.length (ShallowModel2.shallow_model old_str_8) };
+    invariant count { [#"../hillel.rs" 40 23 40 56] ShallowModel3.shallow_model c_11 = Seq.length (ShallowModel1.shallow_model str_1) - Seq.length (ShallowModel2.shallow_model old_str_8) };
+    invariant old_elem { [#"../hillel.rs" 37 4 37 61] forall i : int . ShallowModel3.shallow_model c_11 <= i /\ i < Seq.length (ShallowModel1.shallow_model str_1) -> Seq.get (ShallowModel1.shallow_model str_1) i = Seq.get (ShallowModel2.shallow_model old_str_8) (i - ShallowModel3.shallow_model c_11) };
+    invariant pad_elem { [#"../hillel.rs" 37 4 37 61] forall i : int . 0 <= i /\ i < ShallowModel3.shallow_model c_11 -> Seq.get (ShallowModel1.shallow_model str_1) i = pad_3 };
     _24 <-  * str_1;
     _23 <- ([#"../hillel.rs" 43 10 43 19] Len0.len _24);
     goto BB4
@@ -2399,7 +2399,7 @@ module Hillel_Unique
   BB12 {
     assume { Resolve1.resolve str_1 };
     _10 <- ();
-    assert { [#"../hillel.rs" 112 20 112 97] IsSubset0.is_subset (SeqExt.subsequence (DeepModel1.deep_model str_1) 0 (Seq.length (ShallowModel0.shallow_model str_1))) (DeepModel0.deep_model unique_5) };
+    assert { [#"../hillel.rs" 112 20 112 95] IsSubset0.is_subset (SeqExt.subsequence (DeepModel1.deep_model str_1) 0 (Seq.length (ShallowModel0.shallow_model str_1))) (DeepModel0.deep_model unique_5) };
     goto BB19
   }
   BB13 {
@@ -2451,7 +2451,7 @@ module Hillel_Unique
   }
   BB19 {
     _50 <- ();
-    assert { [#"../hillel.rs" 113 20 113 90] Seq.(==) (SeqExt.subsequence (DeepModel1.deep_model str_1) 0 (Seq.length (ShallowModel0.shallow_model str_1))) (DeepModel1.deep_model str_1) };
+    assert { [#"../hillel.rs" 113 20 113 88] Seq.(==) (SeqExt.subsequence (DeepModel1.deep_model str_1) 0 (Seq.length (ShallowModel0.shallow_model str_1))) (DeepModel1.deep_model str_1) };
     _52 <- ();
     assume { Resolve2.resolve _0 };
     _0 <- unique_5;
@@ -2725,10 +2725,10 @@ module Hillel_Fulcrum_Interface
     type t = seq uint32,
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32
   val fulcrum [#"../hillel.rs" 155 0 155 30] (s : seq uint32) : usize
-    requires {[#"../hillel.rs" 151 11 151 47] SumRange0.sum_range (ShallowModel0.shallow_model s) 0 (Seq.length (ShallowModel0.shallow_model s)) <= 1000}
-    requires {[#"../hillel.rs" 152 11 152 25] Seq.length (ShallowModel0.shallow_model s) > 0}
-    ensures { [#"../hillel.rs" 153 10 153 46] 0 <= UIntSize.to_int result /\ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model s) }
-    ensures { [#"../hillel.rs" 154 0 154 90] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> Score0.score (ShallowModel0.shallow_model s) (UIntSize.to_int result) <= Score0.score (ShallowModel0.shallow_model s) i }
+    requires {[#"../hillel.rs" 151 11 151 45] SumRange0.sum_range (ShallowModel0.shallow_model s) 0 (Seq.length (ShallowModel0.shallow_model s)) <= 1000}
+    requires {[#"../hillel.rs" 152 11 152 23] Seq.length (ShallowModel0.shallow_model s) > 0}
+    ensures { [#"../hillel.rs" 153 10 153 44] 0 <= UIntSize.to_int result /\ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model s) }
+    ensures { [#"../hillel.rs" 154 0 154 88] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> Score0.score (ShallowModel0.shallow_model s) (UIntSize.to_int result) <= Score0.score (ShallowModel0.shallow_model s) i }
     
 end
 module Hillel_Fulcrum
@@ -2863,10 +2863,10 @@ module Hillel_Fulcrum
     function AbsDiff0.abs_diff = AbsDiff1.abs_diff,
     axiom .
   let rec cfg fulcrum [#"../hillel.rs" 155 0 155 30] [@cfg:stackify] [@cfg:subregion_analysis] (s : seq uint32) : usize
-    requires {[#"../hillel.rs" 151 11 151 47] SumRange0.sum_range (ShallowModel0.shallow_model s) 0 (Seq.length (ShallowModel0.shallow_model s)) <= 1000}
-    requires {[#"../hillel.rs" 152 11 152 25] Seq.length (ShallowModel0.shallow_model s) > 0}
-    ensures { [#"../hillel.rs" 153 10 153 46] 0 <= UIntSize.to_int result /\ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model s) }
-    ensures { [#"../hillel.rs" 154 0 154 90] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> Score0.score (ShallowModel0.shallow_model s) (UIntSize.to_int result) <= Score0.score (ShallowModel0.shallow_model s) i }
+    requires {[#"../hillel.rs" 151 11 151 45] SumRange0.sum_range (ShallowModel0.shallow_model s) 0 (Seq.length (ShallowModel0.shallow_model s)) <= 1000}
+    requires {[#"../hillel.rs" 152 11 152 23] Seq.length (ShallowModel0.shallow_model s) > 0}
+    ensures { [#"../hillel.rs" 153 10 153 44] 0 <= UIntSize.to_int result /\ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model s) }
+    ensures { [#"../hillel.rs" 154 0 154 88] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> Score0.score (ShallowModel0.shallow_model s) (UIntSize.to_int result) <= Score0.score (ShallowModel0.shallow_model s) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -2954,7 +2954,7 @@ module Hillel_Fulcrum
     invariant type_invariant { [#"../hillel.rs" 158 4 158 67] Invariant0.invariant' iter_8 };
     invariant structural { [#"../hillel.rs" 158 4 158 67] Produces0.produces (Ghost.inner iter_old_10) (Ghost.inner produced_13) iter_8 };
     invariant total { [#"../hillel.rs" 158 23 158 65] UInt32.to_int total_6 = SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (Ghost.inner produced_13)) };
-    invariant total_bound { [#"../hillel.rs" 159 29 159 67] UInt32.to_int total_6 <= SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (ShallowModel0.shallow_model s_1)) };
+    invariant total_bound { [#"../hillel.rs" 159 29 159 65] UInt32.to_int total_6 <= SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (ShallowModel0.shallow_model s_1)) };
     _24 <- borrow_mut iter_8;
     iter_8 <-  ^ _24;
     _23 <- borrow_mut ( * _24);
@@ -2971,7 +2971,7 @@ module Hillel_Fulcrum
   }
   BB6 {
     _7 <- ();
-    assert { [#"../hillel.rs" 164 20 164 58] UInt32.to_int total_6 = SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (ShallowModel0.shallow_model s_1)) };
+    assert { [#"../hillel.rs" 164 20 164 56] UInt32.to_int total_6 = SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (ShallowModel0.shallow_model s_1)) };
     _33 <- ();
     min_i_35 <- ([#"../hillel.rs" 166 27 166 28] (0 : usize));
     min_dist_36 <- total_6;
@@ -3021,7 +3021,7 @@ module Hillel_Fulcrum
     invariant structural { [#"../hillel.rs" 170 4 170 63] Produces1.produces (Ghost.inner iter_old_43) (Ghost.inner produced_46) iter_39 };
     invariant sum { [#"../hillel.rs" 170 21 170 61] UInt32.to_int sum_37 = SumRange0.sum_range (ShallowModel0.shallow_model s_1) 0 (Seq.length (Ghost.inner produced_46)) };
     invariant sum_bound { [#"../hillel.rs" 171 27 171 41] UInt32.to_int sum_37 <= UInt32.to_int total_6 };
-    invariant min_i_bound { [#"../hillel.rs" 172 29 172 76] UIntSize.to_int min_i_35 <= Seq.length (Ghost.inner produced_46) /\ UIntSize.to_int min_i_35 < Seq.length (ShallowModel0.shallow_model s_1) };
+    invariant min_i_bound { [#"../hillel.rs" 172 29 172 74] UIntSize.to_int min_i_35 <= Seq.length (Ghost.inner produced_46) /\ UIntSize.to_int min_i_35 < Seq.length (ShallowModel0.shallow_model s_1) };
     invariant min_dist { [#"../hillel.rs" 173 26 173 56] UInt32.to_int min_dist_36 = Score0.score (ShallowModel0.shallow_model s_1) (UIntSize.to_int min_i_35) };
     invariant min_i_min { [#"../hillel.rs" 170 4 170 63] forall j : int . 0 <= j /\ j < Seq.length (Ghost.inner produced_46) -> Score0.score (ShallowModel0.shallow_model s_1) (UIntSize.to_int min_i_35) <= Score0.score (ShallowModel0.shallow_model s_1) j };
     _59 <- borrow_mut iter_39;

--- a/creusot/tests/should_succeed/hillel.rs
+++ b/creusot/tests/should_succeed/hillel.rs
@@ -7,12 +7,12 @@ use creusot_contracts::{
     *,
 };
 
-#[ensures((@^str).len() >= len@ && (@^str).len() >= str@.len())]
-#[ensures((@^str).len() == len@ || (@^str).len() == str@.len())]
-#[ensures(len@ <= str@.len() ==> (@^str).len() == str@.len())]
-#[ensures(len@ > str@.len() ==> (@^str).len() == len@)]
-#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (@^str)[i] == str@[i])]
-#[ensures(forall<i: Int> str@.len() <= i && i < len@ ==> (@^str)[i] == pad)]
+#[ensures(((^str)@).len() >= len@ && ((^str)@).len() >= str@.len())]
+#[ensures(((^str)@).len() == len@ || ((^str)@).len() == str@.len())]
+#[ensures(len@ <= str@.len() ==> ((^str)@).len() == str@.len())]
+#[ensures(len@ > str@.len() ==> ((^str)@).len() == len@)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> ((^str)@)[i] == str@[i])]
+#[ensures(forall<i: Int> str@.len() <= i && i < len@ ==> ((^str)@)[i] == pad)]
 fn right_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
 
@@ -26,10 +26,10 @@ fn right_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     }
 }
 
-#[ensures((@^str).len() >= len@ && (@^str).len() >= str@.len())]
-#[ensures((@^str).len() == len@ || (@^str).len() == str@.len())]
-#[ensures(forall<i: Int> 0 <= i && i < ((@^str).len() - str@.len()) ==> (@^str)[i] == pad)]
-#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (@^str)[i + ((@^str).len() - str@.len())] == str@[i])]
+#[ensures(((^str)@).len() >= len@ && ((^str)@).len() >= str@.len())]
+#[ensures(((^str)@).len() == len@ || ((^str)@).len() == str@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < (((^str)@).len() - str@.len()) ==> ((^str)@)[i] == pad)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> ((^str)@)[i + (((^str)@).len() - str@.len())] == str@[i])]
 fn left_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
     let mut c: Ghost<usize> = ghost! { 0 };
@@ -82,7 +82,7 @@ fn insert_unique<T: Eq + DeepModel>(vec: &mut Vec<T>, elem: T) {
 
     #[invariant(not_elem, forall<j: Int> 0 <= j && j < produced.len() ==> produced[j].deep_model() != elem.deep_model())]
     for e in vec.iter() {
-        proof_assert! { *e == (@*vec)[produced.len()-1] };
+        proof_assert! { *e == ((*vec)@)[produced.len()-1] };
         if e == &elem {
             proof_assert! { contains(vec.deep_model(), elem.deep_model()) };
             return;

--- a/creusot/tests/should_succeed/hillel.rs
+++ b/creusot/tests/should_succeed/hillel.rs
@@ -7,39 +7,39 @@ use creusot_contracts::{
     *,
 };
 
-#[ensures((@^str).len() >= @len && (@^str).len() >= (@str).len())]
-#[ensures((@^str).len() == @len || (@^str).len() == (@str).len())]
-#[ensures(@len <= (@str).len() ==> (@^str).len() == (@str).len())]
-#[ensures(@len > (@str).len() ==> (@^str).len() == @len)]
-#[ensures(forall<i: Int> 0 <= i && i < (@str).len() ==> (@^str)[i] == (@str)[i])]
-#[ensures(forall<i: Int> (@str).len() <= i && i < @len ==> (@^str)[i] == pad)]
+#[ensures((@^str).len() >= @len && (@^str).len() >= str@.len())]
+#[ensures((@^str).len() == @len || (@^str).len() == str@.len())]
+#[ensures(@len <= str@.len() ==> (@^str).len() == str@.len())]
+#[ensures(@len > str@.len() ==> (@^str).len() == @len)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (@^str)[i] == str@[i])]
+#[ensures(forall<i: Int> str@.len() <= i && i < @len ==> (@^str)[i] == pad)]
 fn right_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
 
-    #[invariant(old_str_bound, (@old_str).len() <= (@str).len())]
-    #[invariant(len_bound, (@old_str).len() < @len ==> (@str).len() <= @len)]
-    #[invariant(len_bound, (@str).len() > @len ==> (@str).len() == (@old_str).len())]
-    #[invariant(old_elem, forall<i: Int> 0 <= i && i < (@old_str).len() ==> (@str)[i] == (@old_str)[i])]
-    #[invariant(pad_elem, forall<i: Int> (@old_str).len() <= i && i < (@str).len() ==> (@str)[i] == pad)]
+    #[invariant(old_str_bound, old_str@.len() <= str@.len())]
+    #[invariant(len_bound, old_str@.len() < @len ==> str@.len() <= @len)]
+    #[invariant(len_bound, str@.len() > @len ==> str@.len() == old_str@.len())]
+    #[invariant(old_elem, forall<i: Int> 0 <= i && i < old_str@.len() ==> str@[i] == old_str@[i])]
+    #[invariant(pad_elem, forall<i: Int> old_str@.len() <= i && i < str@.len() ==> str@[i] == pad)]
     while str.len() < len {
         str.push(pad);
     }
 }
 
-#[ensures((@^str).len() >= @len && (@^str).len() >= (@str).len())]
-#[ensures((@^str).len() == @len || (@^str).len() == (@str).len())]
-#[ensures(forall<i: Int> 0 <= i && i < ((@^str).len() - (@str).len()) ==> (@^str)[i] == pad)]
-#[ensures(forall<i: Int> 0 <= i && i < (@str).len() ==> (@^str)[i + ((@^str).len() - (@str).len())] == (@str)[i])]
+#[ensures((@^str).len() >= @len && (@^str).len() >= str@.len())]
+#[ensures((@^str).len() == @len || (@^str).len() == str@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < ((@^str).len() - str@.len()) ==> (@^str)[i] == pad)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (@^str)[i + ((@^str).len() - str@.len())] == str@[i])]
 fn left_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
     let mut c: Ghost<usize> = ghost! { 0 };
 
-    #[invariant(old_str_bound, (@old_str).len() <= (@str).len())]
-    #[invariant(len_bound, (@old_str).len() < @len ==> (@str).len() <= @len)]
-    #[invariant(len_bound, (@str).len() > @len ==> (@str).len() == (@old_str).len())]
-    #[invariant(count, @c == (@str).len() - (@old_str).len())]
-    #[invariant(old_elem, forall<i: Int> @c <= i && i < (@str).len() ==> (@str)[i] == (@old_str)[i - @c])]
-    #[invariant(pad_elem, forall<i: Int> 0 <= i && i < @c ==> (@str)[i] == pad)]
+    #[invariant(old_str_bound, old_str@.len() <= str@.len())]
+    #[invariant(len_bound, old_str@.len() < @len ==> str@.len() <= @len)]
+    #[invariant(len_bound, str@.len() > @len ==> str@.len() == old_str@.len())]
+    #[invariant(count, @c == str@.len() - old_str@.len())]
+    #[invariant(old_elem, forall<i: Int> @c <= i && i < str@.len() ==> str@[i] == old_str@[i - @c])]
+    #[invariant(pad_elem, forall<i: Int> 0 <= i && i < @c ==> str@[i] == pad)]
     while str.len() < len {
         str.insert(0, pad);
         c = ghost! { 1 + c.inner() };
@@ -109,8 +109,8 @@ fn unique<T: Eq + DeepModel + Copy>(str: &[T]) -> Vec<T> {
         sub_str = ghost! { sub_str.push(elem) };
     }
 
-    proof_assert! { is_subset(str.deep_model().subsequence(0, (@str).len()), unique.deep_model()) }
-    proof_assert! { str.deep_model().subsequence(0, (@str).len()).ext_eq(str.deep_model()) }
+    proof_assert! { is_subset(str.deep_model().subsequence(0, str@.len()), unique.deep_model()) }
+    proof_assert! { str.deep_model().subsequence(0, str@.len()).ext_eq(str.deep_model()) }
     unique
 }
 
@@ -148,20 +148,20 @@ fn score(seq: Seq<u32>, i: Int) -> Int {
 // Fulcrum. Given a sequence of integers, returns the index i that minimizes
 // |sum(seq[..i]) - sum(seq[i..])|. Does this in O(n) time and O(n) memory.
 // Hard
-#[requires(sum_range(@s, 0, (@s).len()) <= 1000)]
-#[requires((@s).len() > 0)]
-#[ensures(0 <= @result && @result < (@s).len())]
-#[ensures(forall<i: Int> 0 <= i && i < (@s).len() ==> score(@s, @result) <= score(@s, i))]
+#[requires(sum_range(@s, 0, s@.len()) <= 1000)]
+#[requires(s@.len() > 0)]
+#[ensures(0 <= @result && @result < s@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < s@.len() ==> score(@s, @result) <= score(@s, i))]
 fn fulcrum(s: &[u32]) -> usize {
     let mut total: u32 = 0;
 
     #[invariant(total, @total == sum_range(@s, 0, produced.len()))]
-    #[invariant(total_bound, @total <= sum_range(@s, 0, (@s).len()))]
+    #[invariant(total_bound, @total <= sum_range(@s, 0, s@.len()))]
     for &x in s {
         total += x;
     }
 
-    proof_assert! { @total == sum_range(@s, 0, (@s).len()) };
+    proof_assert! { @total == sum_range(@s, 0, s@.len()) };
 
     let mut min_i: usize = 0;
     let mut min_dist: u32 = total;
@@ -169,7 +169,7 @@ fn fulcrum(s: &[u32]) -> usize {
     let mut sum: u32 = 0;
     #[invariant(sum, @sum == sum_range(@s, 0, produced.len()))]
     #[invariant(sum_bound, @sum <= @total)]
-    #[invariant(min_i_bound, @min_i <= produced.len() && @min_i < (@s).len())]
+    #[invariant(min_i_bound, @min_i <= produced.len() && @min_i < s@.len())]
     #[invariant(min_dist, @min_dist == score(@s, @min_i))]
     #[invariant(min_i_min, forall<j: Int> 0 <= j && j < produced.len() ==> score(@s, @min_i) <= score(@s, j))]
     for i in 0..s.len() {

--- a/creusot/tests/should_succeed/hillel.rs
+++ b/creusot/tests/should_succeed/hillel.rs
@@ -120,7 +120,7 @@ fn unique<T: Eq + DeepModel + Copy>(str: &[T]) -> Vec<T> {
 #[ensures(result >= 0)]
 fn sum_range(seq: Seq<u32>, from: Int, to: Int) -> Int {
     if to - from > 0 {
-        pearlite! { @seq[from] + sum_range(seq, from + 1, to) }
+        pearlite! { seq[from]@ + sum_range(seq, from + 1, to) }
     } else {
         0
     }

--- a/creusot/tests/should_succeed/hillel.rs
+++ b/creusot/tests/should_succeed/hillel.rs
@@ -7,12 +7,12 @@ use creusot_contracts::{
     *,
 };
 
-#[ensures(((^str)@).len() >= len@ && ((^str)@).len() >= str@.len())]
-#[ensures(((^str)@).len() == len@ || ((^str)@).len() == str@.len())]
-#[ensures(len@ <= str@.len() ==> ((^str)@).len() == str@.len())]
-#[ensures(len@ > str@.len() ==> ((^str)@).len() == len@)]
-#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> ((^str)@)[i] == str@[i])]
-#[ensures(forall<i: Int> str@.len() <= i && i < len@ ==> ((^str)@)[i] == pad)]
+#[ensures((^str)@.len() >= len@ && (^str)@.len() >= str@.len())]
+#[ensures((^str)@.len() == len@ || (^str)@.len() == str@.len())]
+#[ensures(len@ <= str@.len() ==> (^str)@.len() == str@.len())]
+#[ensures(len@ > str@.len() ==> (^str)@.len() == len@)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (^str)@[i] == str@[i])]
+#[ensures(forall<i: Int> str@.len() <= i && i < len@ ==> (^str)@[i] == pad)]
 fn right_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
 
@@ -26,10 +26,10 @@ fn right_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     }
 }
 
-#[ensures(((^str)@).len() >= len@ && ((^str)@).len() >= str@.len())]
-#[ensures(((^str)@).len() == len@ || ((^str)@).len() == str@.len())]
-#[ensures(forall<i: Int> 0 <= i && i < (((^str)@).len() - str@.len()) ==> ((^str)@)[i] == pad)]
-#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> ((^str)@)[i + (((^str)@).len() - str@.len())] == str@[i])]
+#[ensures((^str)@.len() >= len@ && (^str)@.len() >= str@.len())]
+#[ensures((^str)@.len() == len@ || (^str)@.len() == str@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < ((^str)@.len() - str@.len()) ==> (^str)@[i] == pad)]
+#[ensures(forall<i: Int> 0 <= i && i < str@.len() ==> (^str)@[i + ((^str)@.len() - str@.len())] == str@[i])]
 fn left_pad<T: Copy>(str: &mut Vec<T>, len: usize, pad: T) {
     let old_str = ghost! { str };
     let mut c: Ghost<usize> = ghost! { 0 };
@@ -82,7 +82,7 @@ fn insert_unique<T: Eq + DeepModel>(vec: &mut Vec<T>, elem: T) {
 
     #[invariant(not_elem, forall<j: Int> 0 <= j && j < produced.len() ==> produced[j].deep_model() != elem.deep_model())]
     for e in vec.iter() {
-        proof_assert! { *e == ((*vec)@)[produced.len()-1] };
+        proof_assert! { *e == (*vec)@[produced.len()-1] };
         if e == &elem {
             proof_assert! { contains(vec.deep_model(), elem.deep_model()) };
             return;

--- a/creusot/tests/should_succeed/inc_max_repeat.rs
+++ b/creusot/tests/should_succeed/inc_max_repeat.rs
@@ -13,8 +13,8 @@ fn take_max<'a>(ma: &'a mut u32, mb: &'a mut u32) -> &'a mut u32 {
 
 #[requires(a <= 1_000_000u32 && b <= 1_000_000u32 && n <= 1_000_000u32)]
 pub fn inc_max_repeat(mut a: u32, mut b: u32, n: u32) {
-    #[invariant(val_bound, @a <= 1_000_000 + produced.len() && @b <= 1_000_000 + produced.len())]
-    #[invariant(diff_bound, @a >= @b + produced.len() || @b >= @a + produced.len()) ]
+    #[invariant(val_bound, a@ <= 1_000_000 + produced.len() && b@ <= 1_000_000 + produced.len())]
+    #[invariant(diff_bound, a@ >= b@ + produced.len() || b@ >= a@ + produced.len()) ]
     for _ in 0..n {
         let mc = take_max(&mut a, &mut b);
         *mc += 1;

--- a/creusot/tests/should_succeed/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/inc_some_2_list.mlcfg
@@ -284,7 +284,7 @@ module IncSome2List_Impl0_TakeSomeRest_Interface
     type ShallowModelTy0.shallowModelTy = int
   clone IncSome2List_Impl0_Sum_Stub as Sum0
   val take_some_rest [#"../inc_some_2_list.rs" 54 4 54 57] (self : borrowed (IncSome2List_List_Type.t_list)) : (borrowed uint32, borrowed (IncSome2List_List_Type.t_list))
-    ensures { [#"../inc_some_2_list.rs" 50 14 51 70] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { [#"../inc_some_2_list.rs" 50 14 51 72] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     ensures { [#"../inc_some_2_list.rs" 52 14 52 37] ShallowModel0.shallow_model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { [#"../inc_some_2_list.rs" 53 14 53 42] Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     
@@ -316,7 +316,7 @@ module IncSome2List_Impl0_TakeSomeRest
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg take_some_rest [#"../inc_some_2_list.rs" 54 4 54 57] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (IncSome2List_List_Type.t_list)) : (borrowed uint32, borrowed (IncSome2List_List_Type.t_list))
-    ensures { [#"../inc_some_2_list.rs" 50 14 51 70] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { [#"../inc_some_2_list.rs" 50 14 51 72] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     ensures { [#"../inc_some_2_list.rs" 52 14 52 37] ShallowModel0.shallow_model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { [#"../inc_some_2_list.rs" 53 14 53 42] Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     

--- a/creusot/tests/should_succeed/inc_some_2_list.rs
+++ b/creusot/tests/should_succeed/inc_some_2_list.rs
@@ -21,7 +21,7 @@ impl List {
     fn sum(self) -> Int {
         pearlite! {
             match self {
-                Cons(a, l) => @a + l.sum(),
+                Cons(a, l) => a@ + l.sum(),
                 Nil => 0,
             }
         }
@@ -39,7 +39,7 @@ impl List {
     }
 
     #[requires(self.sum() <= 1_000_000)]
-    #[ensures(@result == self.sum())]
+    #[ensures(result@ == self.sum())]
     fn sum_x(&self) -> u32 {
         match self {
             Cons(a, l) => *a + l.sum_x(),
@@ -66,7 +66,7 @@ impl List {
     }
 }
 
-#[requires(l.sum() + @j + @k <= 1_000_000)]
+#[requires(l.sum() + j@ + k@ <= 1_000_000)]
 pub fn inc_some_2_list(mut l: List, j: u32, k: u32) {
     let sum0 = l.sum_x();
     let (ma, ml) = l.take_some_rest();

--- a/creusot/tests/should_succeed/inc_some_2_list.rs
+++ b/creusot/tests/should_succeed/inc_some_2_list.rs
@@ -48,7 +48,7 @@ impl List {
     }
 
     #[ensures((^self).sum() - self.sum() ==
-        @^result.0 + (^result.1).sum() - result.0@ - (*result.1).sum())]
+        (^result.0)@ + (^result.1).sum() - result.0@ - (*result.1).sum())]
     #[ensures(result.0@ <= self.sum())]
     #[ensures(result.1.sum() <= self.sum())]
     fn take_some_rest(&mut self) -> (&mut u32, &mut List) {

--- a/creusot/tests/should_succeed/inc_some_2_list.rs
+++ b/creusot/tests/should_succeed/inc_some_2_list.rs
@@ -48,8 +48,8 @@ impl List {
     }
 
     #[ensures((^self).sum() - self.sum() ==
-        @^result.0 + (^result.1).sum() - @result.0 - (*result.1).sum())]
-    #[ensures(@result.0 <= self.sum())]
+        @^result.0 + (^result.1).sum() - result.0@ - (*result.1).sum())]
+    #[ensures(result.0@ <= self.sum())]
     #[ensures(result.1.sum() <= self.sum())]
     fn take_some_rest(&mut self) -> (&mut u32, &mut List) {
         match self {

--- a/creusot/tests/should_succeed/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/inc_some_2_tree.mlcfg
@@ -306,7 +306,7 @@ module IncSome2Tree_Impl0_TakeSomeRest_Interface
     type ShallowModelTy0.shallowModelTy = int
   clone IncSome2Tree_Impl0_Sum_Stub as Sum0
   val take_some_rest [#"../inc_some_2_tree.rs" 63 4 63 57] (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) : (borrowed uint32, borrowed (IncSome2Tree_Tree_Type.t_tree))
-    ensures { [#"../inc_some_2_tree.rs" 59 14 60 70] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { [#"../inc_some_2_tree.rs" 59 14 60 72] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     ensures { [#"../inc_some_2_tree.rs" 61 14 61 37] ShallowModel0.shallow_model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { [#"../inc_some_2_tree.rs" 62 14 62 42] Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     
@@ -337,7 +337,7 @@ module IncSome2Tree_Impl0_TakeSomeRest
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg take_some_rest [#"../inc_some_2_tree.rs" 63 4 63 57] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (IncSome2Tree_Tree_Type.t_tree)) : (borrowed uint32, borrowed (IncSome2Tree_Tree_Type.t_tree))
-    ensures { [#"../inc_some_2_tree.rs" 59 14 60 70] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
+    ensures { [#"../inc_some_2_tree.rs" 59 14 60 72] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ (let (a, _) = result in a)) + Sum0.sum ( ^ (let (_, a) = result in a)) - ShallowModel0.shallow_model (let (a, _) = result in a) - Sum0.sum ( * (let (_, a) = result in a)) }
     ensures { [#"../inc_some_2_tree.rs" 61 14 61 37] ShallowModel0.shallow_model (let (a, _) = result in a) <= Sum0.sum ( * self) }
     ensures { [#"../inc_some_2_tree.rs" 62 14 62 42] Sum0.sum ( * (let (_, a) = result in a)) <= Sum0.sum ( * self) }
     

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -57,8 +57,8 @@ impl Tree {
     }
 
     #[ensures((^self).sum() - self.sum() ==
-        @^result.0 + (^result.1).sum() - @result.0 - (*result.1).sum())]
-    #[ensures(@result.0 <= self.sum())]
+        @^result.0 + (^result.1).sum() - result.0@ - (*result.1).sum())]
+    #[ensures(result.0@ <= self.sum())]
     #[ensures(result.1.sum() <= self.sum())]
     fn take_some_rest(&mut self) -> (&mut u32, &mut Tree) {
         match self {

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -57,7 +57,7 @@ impl Tree {
     }
 
     #[ensures((^self).sum() - self.sum() ==
-        @^result.0 + (^result.1).sum() - result.0@ - (*result.1).sum())]
+        (^result.0)@ + (^result.1).sum() - result.0@ - (*result.1).sum())]
     #[ensures(result.0@ <= self.sum())]
     #[ensures(result.1.sum() <= self.sum())]
     fn take_some_rest(&mut self) -> (&mut u32, &mut Tree) {

--- a/creusot/tests/should_succeed/inc_some_2_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_2_tree.rs
@@ -21,7 +21,7 @@ impl Tree {
     fn sum(self) -> Int {
         pearlite! {
             match self {
-                Node(tl, a, tr) => tl.sum() + @a + tr.sum(),
+                Node(tl, a, tr) => tl.sum() + a@ + tr.sum(),
                 Leaf => 0,
             }
         }
@@ -41,7 +41,7 @@ impl Tree {
     }
 
     #[requires(self.sum() <= 1_000_000)]
-    #[ensures(@result == self.sum())]
+    #[ensures(result@ == self.sum())]
     fn sum_x(&self) -> u32 {
         match self {
             Node(tl, a, tr) => {
@@ -81,7 +81,7 @@ impl Tree {
     }
 }
 
-#[requires(t.sum() + @j + @k <= 1_000_000)]
+#[requires(t.sum() + j@ + k@ <= 1_000_000)]
 pub fn inc_some_2_tree(mut t: Tree, j: u32, k: u32) {
     let sum0 = t.sum_x();
     let (ma, mt) = t.take_some_rest();

--- a/creusot/tests/should_succeed/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/inc_some_list.mlcfg
@@ -284,7 +284,7 @@ module IncSomeList_Impl0_TakeSome_Interface
     type ShallowModelTy0.shallowModelTy = int
   clone IncSomeList_Impl0_Sum_Stub as Sum0
   val take_some [#"../inc_some_list.rs" 51 4 51 39] (self : borrowed (IncSomeList_List_Type.t_list)) : borrowed uint32
-    ensures { [#"../inc_some_list.rs" 49 14 49 62] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
+    ensures { [#"../inc_some_list.rs" 49 14 49 64] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
     ensures { [#"../inc_some_list.rs" 50 14 50 35] ShallowModel0.shallow_model result <= Sum0.sum ( * self) }
     
 end
@@ -315,7 +315,7 @@ module IncSomeList_Impl0_TakeSome
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg take_some [#"../inc_some_list.rs" 51 4 51 39] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (IncSomeList_List_Type.t_list)) : borrowed uint32
-    ensures { [#"../inc_some_list.rs" 49 14 49 62] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
+    ensures { [#"../inc_some_list.rs" 49 14 49 64] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
     ensures { [#"../inc_some_list.rs" 50 14 50 35] ShallowModel0.shallow_model result <= Sum0.sum ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]

--- a/creusot/tests/should_succeed/inc_some_list.rs
+++ b/creusot/tests/should_succeed/inc_some_list.rs
@@ -46,7 +46,7 @@ impl List {
         }
     }
 
-    #[ensures((^self).sum() - self.sum() == @^result - result@)]
+    #[ensures((^self).sum() - self.sum() == (^result)@ - result@)]
     #[ensures(result@ <= self.sum())]
     fn take_some(&mut self) -> &mut u32 {
         match self {

--- a/creusot/tests/should_succeed/inc_some_list.rs
+++ b/creusot/tests/should_succeed/inc_some_list.rs
@@ -21,7 +21,7 @@ impl List {
     fn sum(self) -> Int {
         pearlite! {
             match self {
-                Cons(a, l) => @a + l.sum(),
+                Cons(a, l) => a@ + l.sum(),
                 Nil => 0,
             }
         }
@@ -38,7 +38,7 @@ impl List {
     }
 
     #[requires(self.sum() <= 1_000_000)]
-    #[ensures(@result == self.sum())]
+    #[ensures(result@ == self.sum())]
     fn sum_x(&self) -> u32 {
         match self {
             Cons(a, l) => *a + l.sum_x(),
@@ -46,8 +46,8 @@ impl List {
         }
     }
 
-    #[ensures((^self).sum() - self.sum() == @^result - @result)]
-    #[ensures(@result <= self.sum())]
+    #[ensures((^self).sum() - self.sum() == @^result - result@)]
+    #[ensures(result@ <= self.sum())]
     fn take_some(&mut self) -> &mut u32 {
         match self {
             Cons(ma, ml) => {
@@ -63,7 +63,7 @@ impl List {
     }
 }
 
-#[requires(l.sum() + @k <= 1_000_000)]
+#[requires(l.sum() + k@ <= 1_000_000)]
 pub fn inc_some_list(mut l: List, k: u32) {
     let sum0 = l.sum_x();
     let ma = l.take_some();

--- a/creusot/tests/should_succeed/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/inc_some_tree.mlcfg
@@ -306,7 +306,7 @@ module IncSomeTree_Impl0_TakeSome_Interface
     type ShallowModelTy0.shallowModelTy = int
   clone IncSomeTree_Impl0_Sum_Stub as Sum0
   val take_some [#"../inc_some_tree.rs" 61 4 61 39] (self : borrowed (IncSomeTree_Tree_Type.t_tree)) : borrowed uint32
-    ensures { [#"../inc_some_tree.rs" 59 14 59 62] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
+    ensures { [#"../inc_some_tree.rs" 59 14 59 64] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
     ensures { [#"../inc_some_tree.rs" 60 14 60 35] ShallowModel0.shallow_model result <= Sum0.sum ( * self) }
     
 end
@@ -336,7 +336,7 @@ module IncSomeTree_Impl0_TakeSome
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg take_some [#"../inc_some_tree.rs" 61 4 61 39] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (IncSomeTree_Tree_Type.t_tree)) : borrowed uint32
-    ensures { [#"../inc_some_tree.rs" 59 14 59 62] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
+    ensures { [#"../inc_some_tree.rs" 59 14 59 64] Sum0.sum ( ^ self) - Sum0.sum ( * self) = UInt32.to_int ( ^ result) - ShallowModel0.shallow_model result }
     ensures { [#"../inc_some_tree.rs" 60 14 60 35] ShallowModel0.shallow_model result <= Sum0.sum ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]

--- a/creusot/tests/should_succeed/inc_some_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_tree.rs
@@ -21,7 +21,7 @@ impl Tree {
     fn sum(self) -> Int {
         pearlite! {
             match self {
-                Node(tl, a, tr) => tl.sum() + @a + tr.sum(),
+                Node(tl, a, tr) => tl.sum() + a@ + tr.sum(),
                 Leaf => 0,
             }
         }
@@ -41,7 +41,7 @@ impl Tree {
     }
 
     #[requires(self.sum() <= 1_000_000)]
-    #[ensures(@result == self.sum())]
+    #[ensures(result@ == self.sum())]
     fn sum_x(&self) -> u32 {
         match self {
             Node(tl, a, tr) => {
@@ -56,8 +56,8 @@ impl Tree {
         }
     }
 
-    #[ensures((^self).sum() - self.sum() == @^result - @result)]
-    #[ensures(@result <= self.sum())]
+    #[ensures((^self).sum() - self.sum() == @^result - result@)]
+    #[ensures(result@ <= self.sum())]
     fn take_some(&mut self) -> &mut u32 {
         match self {
             Node(mtl, ma, mtr) => {
@@ -79,7 +79,7 @@ impl Tree {
     }
 }
 
-#[requires(t.sum() + @k <= 1_000_000)]
+#[requires(t.sum() + k@ <= 1_000_000)]
 pub fn inc_some_tree(mut t: Tree, k: u32) {
     let sum0 = t.sum_x();
     let ma = t.take_some();

--- a/creusot/tests/should_succeed/inc_some_tree.rs
+++ b/creusot/tests/should_succeed/inc_some_tree.rs
@@ -56,7 +56,7 @@ impl Tree {
         }
     }
 
-    #[ensures((^self).sum() - self.sum() == @^result - result@)]
+    #[ensures((^self).sum() - self.sum() == (^result)@ - result@)]
     #[ensures(result@ <= self.sum())]
     fn take_some(&mut self) -> &mut u32 {
         match self {

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -248,7 +248,7 @@ module IndexRange_CreateArr_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val create_arr [#"../index_range.rs" 14 0 14 27] (_1' : ()) : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../index_range.rs" 7 4 12 25] Seq.length (ShallowModel0.shallow_model result) = 5 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 0) = 0 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 1) = 1 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 2) = 2 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 3) = 3 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 4) = 4 }
+    ensures { [#"../index_range.rs" 7 4 12 23] Seq.length (ShallowModel0.shallow_model result) = 5 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 0) = 0 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 1) = 1 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 2) = 2 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 3) = 3 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 4) = 4 }
     
 end
 module IndexRange_CreateArr
@@ -287,7 +287,7 @@ module IndexRange_CreateArr
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
   let rec cfg create_arr [#"../index_range.rs" 14 0 14 27] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../index_range.rs" 7 4 12 25] Seq.length (ShallowModel0.shallow_model result) = 5 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 0) = 0 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 1) = 1 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 2) = 2 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 3) = 3 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 4) = 4 }
+    ensures { [#"../index_range.rs" 7 4 12 23] Seq.length (ShallowModel0.shallow_model result) = 5 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 0) = 0 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 1) = 1 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 2) = 2 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 3) = 3 /\ Int32.to_int (Seq.get (ShallowModel0.shallow_model result) 4) = 4 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global);

--- a/creusot/tests/should_succeed/index_range.rs
+++ b/creusot/tests/should_succeed/index_range.rs
@@ -5,11 +5,11 @@ use creusot_contracts::*;
 /// Creates a test array, vector of `[0, 1, 2, 3, 4]`
 #[ensures(
     result@.len() == 5
-    && @result@[0] == 0
-    && @result@[1] == 1
-    && @result@[2] == 2
-    && @result@[3] == 3
-    && @result@[4] == 4
+    && result@[0]@ == 0
+    && result@[1]@ == 1
+    && result@[2]@ == 2
+    && result@[3]@ == 3
+    && result@[4]@ == 4
 )]
 fn create_arr() -> Vec<i32> {
     let mut arr = Vec::new();

--- a/creusot/tests/should_succeed/index_range.rs
+++ b/creusot/tests/should_succeed/index_range.rs
@@ -4,12 +4,12 @@ use creusot_contracts::*;
 
 /// Creates a test array, vector of `[0, 1, 2, 3, 4]`
 #[ensures(
-    (@result).len() == 5
-    && @(@result)[0] == 0
-    && @(@result)[1] == 1
-    && @(@result)[2] == 2
-    && @(@result)[3] == 3
-    && @(@result)[4] == 4
+    result@.len() == 5
+    && @result@[0] == 0
+    && @result@[1] == 1
+    && @result@[2] == 2
+    && @result@[3] == 3
+    && @result@[4] == 4
 )]
 fn create_arr() -> Vec<i32> {
     let mut arr = Vec::new();

--- a/creusot/tests/should_succeed/instant.rs
+++ b/creusot/tests/should_succeed/instant.rs
@@ -13,14 +13,14 @@ pub fn test_instant() {
     assert!(instant + zero_dur == instant);
     let three_seconds = Duration::from_secs(3);
     let greater_instant = instant + three_seconds;
-    proof_assert!(@instant < @greater_instant);
+    proof_assert!(instant@ < greater_instant@);
     let even_greater_instant = greater_instant + three_seconds;
-    proof_assert!(@instant < @even_greater_instant);
+    proof_assert!(instant@ < even_greater_instant@);
 
     assert!(instant.checked_sub(zero_dur).unwrap() == instant);
     assert!(instant - zero_dur == instant);
     let lesser_instant = instant - three_seconds;
-    proof_assert!(@instant > @lesser_instant);
+    proof_assert!(instant@ > lesser_instant@);
     assert!(instant - instant == zero_dur);
     assert!(instant - greater_instant == zero_dur);
     assert!(greater_instant - instant > zero_dur);

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -142,8 +142,8 @@ module IteNormalize_Impl0_Get_Interface
     type t = IteNormalize_BTreeMap_Type.t_btreemap k v,
     type ShallowModelTy0.shallowModelTy = Map.map DeepModelTy0.deepModelTy (Core_Option_Option_Type.t_option v)
   val get [#"../ite_normalize.rs" 19 4 21 15] (self : IteNormalize_BTreeMap_Type.t_btreemap k v) (key : k) : Core_Option_Option_Type.t_option v
-    ensures { [#"../ite_normalize.rs" 17 4 17 72] result = Core_Option_Option_Type.C_None -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_None }
-    ensures { [#"../ite_normalize.rs" 18 4 18 93] forall v : v . result = Core_Option_Option_Type.C_Some v -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_Some v }
+    ensures { [#"../ite_normalize.rs" 17 4 17 70] result = Core_Option_Option_Type.C_None -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_None }
+    ensures { [#"../ite_normalize.rs" 18 4 18 91] forall v : v . result = Core_Option_Option_Type.C_Some v -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_Some v }
     
 end
 module IteNormalize_Impl2_ShallowModel_Stub
@@ -231,7 +231,7 @@ module IteNormalize_Impl0_Insert_Interface
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val insert [#"../ite_normalize.rs" 28 4 30 15] (self : borrowed (IteNormalize_BTreeMap_Type.t_btreemap k v)) (key : k) (value : v) : Core_Option_Option_Type.t_option v
-    ensures { [#"../ite_normalize.rs" 27 4 27 127] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
+    ensures { [#"../ite_normalize.rs" 27 4 27 125] forall i : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
       Core_Option_Option_Type.C_Some value
     else
       Map.get (ShallowModel1.shallow_model self) i
@@ -991,7 +991,7 @@ module IteNormalize_Impl5_SimplifyHelper_Interface
   clone IteNormalize_Impl5_IsNormalized_Stub as IsNormalized0
   val simplify_helper [#"../ite_normalize.rs" 188 4 188 66] (self : IteNormalize_Expr_Type.t_expr) (state : IteNormalize_BTreeMap_Type.t_btreemap usize bool) : IteNormalize_Expr_Type.t_expr
     requires {[#"../ite_normalize.rs" 184 15 184 35] IsNormalized0.is_normalized self}
-    ensures { [#"../ite_normalize.rs" 185 4 185 109] forall i : usize . (exists v : bool . Map.get (ShallowModel0.shallow_model state) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v) -> DoesNotContain0.does_not_contain result i }
+    ensures { [#"../ite_normalize.rs" 185 4 185 107] forall i : usize . (exists v : bool . Map.get (ShallowModel0.shallow_model state) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v) -> DoesNotContain0.does_not_contain result i }
     ensures { [#"../ite_normalize.rs" 186 14 186 36] IsSimplified0.is_simplified result }
     
 end
@@ -1045,7 +1045,7 @@ module IteNormalize_Impl5_SimplifyHelper
   clone IteNormalize_Impl5_IsNormalized as IsNormalized0
   let rec cfg simplify_helper [#"../ite_normalize.rs" 188 4 188 66] [@cfg:stackify] [@cfg:subregion_analysis] (self : IteNormalize_Expr_Type.t_expr) (state : IteNormalize_BTreeMap_Type.t_btreemap usize bool) : IteNormalize_Expr_Type.t_expr
     requires {[#"../ite_normalize.rs" 184 15 184 35] IsNormalized0.is_normalized self}
-    ensures { [#"../ite_normalize.rs" 185 4 185 109] forall i : usize . (exists v : bool . Map.get (ShallowModel0.shallow_model state) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v) -> DoesNotContain0.does_not_contain result i }
+    ensures { [#"../ite_normalize.rs" 185 4 185 107] forall i : usize . (exists v : bool . Map.get (ShallowModel0.shallow_model state) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v) -> DoesNotContain0.does_not_contain result i }
     ensures { [#"../ite_normalize.rs" 186 14 186 36] IsSimplified0.is_simplified result }
     variant {[#"../ite_normalize.rs" 187 14 187 18] self}
     

--- a/creusot/tests/should_succeed/ite_normalize.rs
+++ b/creusot/tests/should_succeed/ite_normalize.rs
@@ -182,7 +182,7 @@ impl Expr {
     }
 
     #[requires(self.is_normalized())]
-    #[ensures(forall<i: usize> (exists<v: bool> state@.get(@i) == Some(v)) ==> result.does_not_contain(i))]
+    #[ensures(forall<i: usize> (exists<v: bool> state@.get(i@) == Some(v)) ==> result.does_not_contain(i))]
     #[ensures(result.is_simplified())]
     #[variant(self)]
     fn simplify_helper(self, state: BTreeMap<usize, bool>) -> Self {

--- a/creusot/tests/should_succeed/ite_normalize.rs
+++ b/creusot/tests/should_succeed/ite_normalize.rs
@@ -24,7 +24,7 @@ impl<K: DeepModel, V> BTreeMap<K, V> {
     }
 
     #[trusted]
-    #[ensures(forall<i: K::DeepModelTy> (@^self).get(i) == (if i == key.deep_model() { Some(value) } else { self@.get(i) }))]
+    #[ensures(forall<i: K::DeepModelTy> ((^self)@).get(i) == (if i == key.deep_model() { Some(value) } else { self@.get(i) }))]
     fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord,

--- a/creusot/tests/should_succeed/ite_normalize.rs
+++ b/creusot/tests/should_succeed/ite_normalize.rs
@@ -24,7 +24,7 @@ impl<K: DeepModel, V> BTreeMap<K, V> {
     }
 
     #[trusted]
-    #[ensures(forall<i: K::DeepModelTy> ((^self)@).get(i) == (if i == key.deep_model() { Some(value) } else { self@.get(i) }))]
+    #[ensures(forall<i: K::DeepModelTy> (^self)@.get(i) == (if i == key.deep_model() { Some(value) } else { self@.get(i) }))]
     fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord,

--- a/creusot/tests/should_succeed/ite_normalize.rs
+++ b/creusot/tests/should_succeed/ite_normalize.rs
@@ -14,8 +14,8 @@ impl<K: DeepModel, V> BTreeMap<K, V> {
     }
 
     #[trusted]
-    #[ensures(result == None ==> (@self).get(key.deep_model()) == None)]
-    #[ensures(forall<v: &V> result == Some(v) ==> (@self).get(key.deep_model()) == Some(*v))]
+    #[ensures(result == None ==> self@.get(key.deep_model()) == None)]
+    #[ensures(forall<v: &V> result == Some(v) ==> self@.get(key.deep_model()) == Some(*v))]
     fn get<'a>(&'a self, key: &'a K) -> Option<&'a V>
     where
         K: Ord,
@@ -24,7 +24,7 @@ impl<K: DeepModel, V> BTreeMap<K, V> {
     }
 
     #[trusted]
-    #[ensures(forall<i: K::DeepModelTy> (@^self).get(i) == (if i == key.deep_model() { Some(value) } else { (@self).get(i) }))]
+    #[ensures(forall<i: K::DeepModelTy> (@^self).get(i) == (if i == key.deep_model() { Some(value) } else { self@.get(i) }))]
     fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord,
@@ -182,7 +182,7 @@ impl Expr {
     }
 
     #[requires(self.is_normalized())]
-    #[ensures(forall<i: usize> (exists<v: bool> (@state).get(@i) == Some(v)) ==> result.does_not_contain(i))]
+    #[ensures(forall<i: usize> (exists<v: bool> state@.get(@i) == Some(v)) ==> result.does_not_contain(i))]
     #[ensures(result.is_simplified())]
     #[variant(self)]
     fn simplify_helper(self, state: BTreeMap<usize, bool>) -> Self {

--- a/creusot/tests/should_succeed/iterators/01_range.rs
+++ b/creusot/tests/should_succeed/iterators/01_range.rs
@@ -70,7 +70,7 @@ impl Range {
     }
 }
 
-#[requires(@n >= 0)]
+#[requires(n@ >= 0)]
 #[ensures(result == n)]
 pub fn sum_range(n: isize) -> isize {
     let mut i = 0;
@@ -79,7 +79,7 @@ pub fn sum_range(n: isize) -> isize {
     let mut produced = ghost! { Seq::EMPTY };
     #[invariant(type_invariant, it.invariant())]
     #[invariant(structural, iter_old.produces(produced.inner(), it))]
-    #[invariant(user, @i == produced.len() && i <= n)]
+    #[invariant(user, i@ == produced.len() && i <= n)]
     loop {
         match it.next() {
             Some(x) => {

--- a/creusot/tests/should_succeed/iterators/01_range.rs
+++ b/creusot/tests/should_succeed/iterators/01_range.rs
@@ -32,7 +32,7 @@ impl Iterator for Range {
         pearlite! {
             self.end == o.end && self.start <= o.start
             && (visited.len() > 0 ==> o.start <= o.end)
-            && visited.len() == o.start@ - @self.start
+            && visited.len() == o.start@ - self.start@
             && forall<i : Int> 0 <= i && i < visited.len() ==>
                 visited[i]@ == self.start@ + i
         }

--- a/creusot/tests/should_succeed/iterators/01_range.rs
+++ b/creusot/tests/should_succeed/iterators/01_range.rs
@@ -32,9 +32,9 @@ impl Iterator for Range {
         pearlite! {
             self.end == o.end && self.start <= o.start
             && (visited.len() > 0 ==> o.start <= o.end)
-            && visited.len() == @o.start - @self.start
+            && visited.len() == o.start@ - @self.start
             && forall<i : Int> 0 <= i && i < visited.len() ==>
-                @visited[i] == @self.start + i
+                visited[i]@ == self.start@ + i
         }
     }
 

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -181,7 +181,7 @@ module C02IterMut_Impl1_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = C02IterMut_IterMut_Type.t_itermut t
   predicate completed [#"../02_iter_mut.rs" 29 4 29 35] (self : borrowed (C02IterMut_IterMut_Type.t_itermut t)) =
-    [#"../02_iter_mut.rs" 30 20 30 70] Resolve0.resolve self /\ Seq.(==) (ShallowModel0.shallow_model (C02IterMut_IterMut_Type.itermut_inner ( * self))) (Seq.empty )
+    [#"../02_iter_mut.rs" 30 8 30 70] Resolve0.resolve self /\ Seq.(==) (ShallowModel0.shallow_model (C02IterMut_IterMut_Type.itermut_inner ( * self))) (Seq.empty )
   val completed [#"../02_iter_mut.rs" 29 4 29 35] (self : borrowed (C02IterMut_IterMut_Type.t_itermut t)) : bool
     ensures { result = completed self }
     
@@ -1028,8 +1028,8 @@ module C02IterMut_IterMut_Interface
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val iter_mut [#"../02_iter_mut.rs" 67 0 67 55] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : C02IterMut_IterMut_Type.t_itermut t
     ensures { [#"../02_iter_mut.rs" 64 10 64 29] ShallowModel0.shallow_model (C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel1.shallow_model v }
-    ensures { [#"../02_iter_mut.rs" 65 10 65 31] ShallowModel2.shallow_model ( ^ C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel3.shallow_model ( ^ v) }
-    ensures { [#"../02_iter_mut.rs" 66 10 66 35] Seq.length (ShallowModel3.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_iter_mut.rs" 65 10 65 35] ShallowModel2.shallow_model ( ^ C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel3.shallow_model ( ^ v) }
+    ensures { [#"../02_iter_mut.rs" 66 10 66 33] Seq.length (ShallowModel3.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
     ensures { [#"../02_iter_mut.rs" 67 41 67 55] Invariant0.invariant' result }
     
 end
@@ -1091,8 +1091,8 @@ module C02IterMut_IterMut
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
   let rec cfg iter_mut [#"../02_iter_mut.rs" 67 0 67 55] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : C02IterMut_IterMut_Type.t_itermut t
     ensures { [#"../02_iter_mut.rs" 64 10 64 29] ShallowModel0.shallow_model (C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel1.shallow_model v }
-    ensures { [#"../02_iter_mut.rs" 65 10 65 31] ShallowModel2.shallow_model ( ^ C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel3.shallow_model ( ^ v) }
-    ensures { [#"../02_iter_mut.rs" 66 10 66 35] Seq.length (ShallowModel3.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_iter_mut.rs" 65 10 65 35] ShallowModel2.shallow_model ( ^ C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel3.shallow_model ( ^ v) }
+    ensures { [#"../02_iter_mut.rs" 66 10 66 33] Seq.length (ShallowModel3.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
     ensures { [#"../02_iter_mut.rs" 67 41 67 55] Invariant0.invariant' result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -1145,8 +1145,8 @@ module C02IterMut_AllZero_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val all_zero [#"../02_iter_mut.rs" 73 0 73 35] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../02_iter_mut.rs" 71 10 71 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../02_iter_mut.rs" 72 0 72 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
+    ensures { [#"../02_iter_mut.rs" 71 10 71 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_iter_mut.rs" 72 0 72 67] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
     
 end
 module C02IterMut_AllZero
@@ -1238,8 +1238,8 @@ module C02IterMut_AllZero
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
   let rec cfg all_zero [#"../02_iter_mut.rs" 73 0 73 35] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../02_iter_mut.rs" 71 10 71 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../02_iter_mut.rs" 72 0 72 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
+    ensures { [#"../02_iter_mut.rs" 71 10 71 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_iter_mut.rs" 72 0 72 67] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -61,7 +61,7 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-#[ensures(@result.inner == @v)]
+#[ensures(@result.inner == v@)]
 #[ensures(@^result.inner == @^v)]
 #[ensures((@^v).len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -18,7 +18,7 @@ impl<'a, T> Invariant for IterMut<'a, T> {
     #[predicate]
     fn invariant(self) -> bool {
         // Property that is always true but we must carry around..
-        pearlite! { (@^self.inner).len() == (@*self.inner).len() }
+        pearlite! { (^self.inner)@.len() == (*self.inner)@.len() }
     }
 }
 
@@ -62,7 +62,7 @@ impl<'a, T> IterMut<'a, T> {
 }
 
 #[ensures(result.inner@ == v@)]
-#[ensures(@^result.inner == (^v)@)]
+#[ensures((^result.inner)@ == (^v)@)]
 #[ensures((^v)@.len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {
     IterMut { inner: &mut v[..] }
@@ -76,7 +76,7 @@ pub fn all_zero(v: &mut Vec<usize>) {
     let mut produced = ghost! { Seq::EMPTY };
     #[invariant(type_invariant, it.invariant())]
     #[invariant(structural, iter_old.produces(produced.inner(), it))]
-    #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
+    #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> (^produced[i])@ == 0)]
     loop {
         match it.next() {
             Some(x) => {

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -27,7 +27,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { self.resolve() && (self.inner@).ext_eq(Seq::EMPTY) }
+        pearlite! { self.resolve() && self.inner@.ext_eq(Seq::EMPTY) }
     }
 
     #[predicate]

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -62,14 +62,14 @@ impl<'a, T> IterMut<'a, T> {
 }
 
 #[ensures(@result.inner == v@)]
-#[ensures(@^result.inner == @^v)]
-#[ensures((@^v).len() == v@.len())]
+#[ensures(@^result.inner == (^v)@)]
+#[ensures(((^v)@).len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {
     IterMut { inner: &mut v[..] }
 }
 
-#[ensures((@^v).len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(@^v)[i] == 0)]
+#[ensures(((^v)@).len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @((^v)@)[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     let mut it = iter_mut(v).into_iter();
     let iter_old = ghost! { it };

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -69,7 +69,7 @@ fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {
 }
 
 #[ensures((^v)@.len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(^v)@[i] == 0)]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> (^v)@[i]@ == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     let mut it = iter_mut(v).into_iter();
     let iter_old = ghost! { it };

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -63,13 +63,13 @@ impl<'a, T> IterMut<'a, T> {
 
 #[ensures(@result.inner == @v)]
 #[ensures(@^result.inner == @^v)]
-#[ensures((@^v).len() == (@v).len())]
+#[ensures((@^v).len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {
     IterMut { inner: &mut v[..] }
 }
 
-#[ensures((@^v).len() == (@v).len())]
-#[ensures(forall<i : _> 0 <= i && i < (@v).len() ==> @(@^v)[i] == 0)]
+#[ensures((@^v).len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(@^v)[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     let mut it = iter_mut(v).into_iter();
     let iter_old = ghost! { it };

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -27,7 +27,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[predicate]
     fn completed(&mut self) -> bool {
-        pearlite! { self.resolve() && (@self.inner).ext_eq(Seq::EMPTY) }
+        pearlite! { self.resolve() && (self.inner@).ext_eq(Seq::EMPTY) }
     }
 
     #[predicate]
@@ -61,7 +61,7 @@ impl<'a, T> IterMut<'a, T> {
     }
 }
 
-#[ensures(@result.inner == v@)]
+#[ensures(result.inner@ == v@)]
 #[ensures(@^result.inner == (^v)@)]
 #[ensures((^v)@.len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -63,13 +63,13 @@ impl<'a, T> IterMut<'a, T> {
 
 #[ensures(@result.inner == v@)]
 #[ensures(@^result.inner == (^v)@)]
-#[ensures(((^v)@).len() == v@.len())]
+#[ensures((^v)@.len() == v@.len())]
 fn iter_mut<'a, T>(v: &'a mut Vec<T>) -> IterMut<'a, T> {
     IterMut { inner: &mut v[..] }
 }
 
-#[ensures(((^v)@).len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @((^v)@)[i] == 0)]
+#[ensures((^v)@.len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(^v)@[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     let mut it = iter_mut(v).into_iter();
     let iter_old = ghost! { it };

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -586,8 +586,8 @@ module C03StdIterators_SliceIter_Interface
     type t = seq t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val slice_iter [#"../03_std_iterators.rs" 6 0 6 42] (slice : seq t) : usize
-    requires {[#"../03_std_iterators.rs" 4 11 4 32] Seq.length (ShallowModel0.shallow_model slice) < 1000}
-    ensures { [#"../03_std_iterators.rs" 5 10 5 35] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model slice) }
+    requires {[#"../03_std_iterators.rs" 4 11 4 30] Seq.length (ShallowModel0.shallow_model slice) < 1000}
+    ensures { [#"../03_std_iterators.rs" 5 10 5 33] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model slice) }
     
 end
 module C03StdIterators_SliceIter
@@ -679,8 +679,8 @@ module C03StdIterators_SliceIter
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = seq t
   let rec cfg slice_iter [#"../03_std_iterators.rs" 6 0 6 42] [@cfg:stackify] [@cfg:subregion_analysis] (slice : seq t) : usize
-    requires {[#"../03_std_iterators.rs" 4 11 4 32] Seq.length (ShallowModel0.shallow_model slice) < 1000}
-    ensures { [#"../03_std_iterators.rs" 5 10 5 35] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model slice) }
+    requires {[#"../03_std_iterators.rs" 4 11 4 30] Seq.length (ShallowModel0.shallow_model slice) < 1000}
+    ensures { [#"../03_std_iterators.rs" 5 10 5 33] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model slice) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -941,8 +941,8 @@ module C03StdIterators_VecIter_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val vec_iter [#"../03_std_iterators.rs" 17 0 17 41] (vec : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : usize
-    requires {[#"../03_std_iterators.rs" 15 11 15 30] Seq.length (ShallowModel0.shallow_model vec) < 1000}
-    ensures { [#"../03_std_iterators.rs" 16 10 16 33] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model vec) }
+    requires {[#"../03_std_iterators.rs" 15 11 15 28] Seq.length (ShallowModel0.shallow_model vec) < 1000}
+    ensures { [#"../03_std_iterators.rs" 16 10 16 31] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model vec) }
     
 end
 module C03StdIterators_VecIter
@@ -1047,8 +1047,8 @@ module C03StdIterators_VecIter
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   let rec cfg vec_iter [#"../03_std_iterators.rs" 17 0 17 41] [@cfg:stackify] [@cfg:subregion_analysis] (vec : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : usize
-    requires {[#"../03_std_iterators.rs" 15 11 15 30] Seq.length (ShallowModel0.shallow_model vec) < 1000}
-    ensures { [#"../03_std_iterators.rs" 16 10 16 33] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model vec) }
+    requires {[#"../03_std_iterators.rs" 15 11 15 28] Seq.length (ShallowModel0.shallow_model vec) < 1000}
+    ensures { [#"../03_std_iterators.rs" 16 10 16 31] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model vec) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -1565,8 +1565,8 @@ module C03StdIterators_AllZero_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val all_zero [#"../03_std_iterators.rs" 28 0 28 35] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../03_std_iterators.rs" 26 10 26 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
+    ensures { [#"../03_std_iterators.rs" 26 10 26 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../03_std_iterators.rs" 27 0 27 67] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
     
 end
 module C03StdIterators_AllZero
@@ -1685,8 +1685,8 @@ module C03StdIterators_AllZero
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
   let rec cfg all_zero [#"../03_std_iterators.rs" 28 0 28 35] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../03_std_iterators.rs" 26 10 26 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../03_std_iterators.rs" 27 0 27 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
+    ensures { [#"../03_std_iterators.rs" 26 10 26 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../03_std_iterators.rs" 27 0 27 67] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> UIntSize.to_int (Seq.get (ShallowModel0.shallow_model ( ^ v)) i) = 0 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1729,32 +1729,32 @@ module C03StdIterators_AllZero
     goto BB2
   }
   BB2 {
-    iter_4 <- ([#"../03_std_iterators.rs" 29 4 29 91] IntoIter0.into_iter _5);
+    iter_4 <- ([#"../03_std_iterators.rs" 29 4 29 93] IntoIter0.into_iter _5);
     goto BB3
   }
   BB3 {
     _11 <- ();
-    iter_old_9 <- ([#"../03_std_iterators.rs" 29 4 29 91] Ghost.new iter_4);
+    iter_old_9 <- ([#"../03_std_iterators.rs" 29 4 29 93] Ghost.new iter_4);
     goto BB4
   }
   BB4 {
     _15 <- ();
-    produced_12 <- ([#"../03_std_iterators.rs" 29 4 29 91] Ghost.new (Seq.empty ));
+    produced_12 <- ([#"../03_std_iterators.rs" 29 4 29 93] Ghost.new (Seq.empty ));
     goto BB5
   }
   BB5 {
     goto BB6
   }
   BB6 {
-    invariant type_invariant { [#"../03_std_iterators.rs" 29 4 29 91] Invariant0.invariant' iter_4 };
-    invariant structural { [#"../03_std_iterators.rs" 29 4 29 91] Produces0.produces (Ghost.inner iter_old_9) (Ghost.inner produced_12) iter_4 };
-    invariant user { [#"../03_std_iterators.rs" 29 4 29 91] forall i : int . 0 <= i /\ i < Seq.length (Ghost.inner produced_12) -> UIntSize.to_int ( ^ Seq.get (Ghost.inner produced_12) i) = 0 };
+    invariant type_invariant { [#"../03_std_iterators.rs" 29 4 29 93] Invariant0.invariant' iter_4 };
+    invariant structural { [#"../03_std_iterators.rs" 29 4 29 93] Produces0.produces (Ghost.inner iter_old_9) (Ghost.inner produced_12) iter_4 };
+    invariant user { [#"../03_std_iterators.rs" 29 4 29 93] forall i : int . 0 <= i /\ i < Seq.length (Ghost.inner produced_12) -> UIntSize.to_int ( ^ Seq.get (Ghost.inner produced_12) i) = 0 };
     _22 <- borrow_mut iter_4;
     iter_4 <-  ^ _22;
     _21 <- borrow_mut ( * _22);
     _22 <- { _22 with current = ( ^ _21) };
     assume { Resolve2.resolve _22 };
-    _20 <- ([#"../03_std_iterators.rs" 29 4 29 91] Next0.next _21);
+    _20 <- ([#"../03_std_iterators.rs" 29 4 29 93] Next0.next _21);
     goto BB7
   }
   BB7 {
@@ -1777,7 +1777,7 @@ module C03StdIterators_AllZero
     __creusot_proc_iter_elem_24 <- Core_Option_Option_Type.some_0 _20;
     _20 <- (let Core_Option_Option_Type.C_Some a = _20 in Core_Option_Option_Type.C_Some (any borrowed usize));
     _27 <- ();
-    _25 <- ([#"../03_std_iterators.rs" 29 4 29 91] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
+    _25 <- ([#"../03_std_iterators.rs" 29 4 29 93] Ghost.new (Seq.(++) (Ghost.inner produced_12) (Seq.singleton __creusot_proc_iter_elem_24)));
     goto BB11
   }
   BB11 {
@@ -3976,17 +3976,17 @@ module C03StdIterators_Counter
     goto BB4
   }
   BB4 {
-    assert { [#"../03_std_iterators.rs" 56 20 56 44] Seq.length (ShallowModel0.shallow_model x_3) = Seq.length (ShallowModel0.shallow_model v_1) };
+    assert { [#"../03_std_iterators.rs" 56 20 56 40] Seq.length (ShallowModel0.shallow_model x_3) = Seq.length (ShallowModel0.shallow_model v_1) };
     goto BB5
   }
   BB5 {
     _11 <- ();
-    assert { [#"../03_std_iterators.rs" 57 20 57 35] Seq.(==) (ShallowModel0.shallow_model x_3) (ShallowModel0.shallow_model v_1) };
+    assert { [#"../03_std_iterators.rs" 57 4 57 35] Seq.(==) (ShallowModel0.shallow_model x_3) (ShallowModel0.shallow_model v_1) };
     goto BB6
   }
   BB6 {
     _13 <- ();
-    assert { [#"../03_std_iterators.rs" 58 20 58 38] UIntSize.to_int cnt_2 = Seq.length (ShallowModel0.shallow_model x_3) };
+    assert { [#"../03_std_iterators.rs" 58 20 58 36] UIntSize.to_int cnt_2 = Seq.length (ShallowModel0.shallow_model x_3) };
     goto BB7
   }
   BB7 {

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -24,7 +24,7 @@ pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
 }
 
 #[ensures((^v)@.len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(^v)@[i] == 0)]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> (^v)@[i]@ == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
     for x in v.iter_mut() {
@@ -45,7 +45,7 @@ pub fn counter(v: Vec<u32>) {
         .iter()
         .map_inv(
             #[requires(cnt@ == (*_prod).len() && cnt < usize::MAX)]
-            #[ensures(cnt@ == @old(cnt) + 1 && cnt@ == (*_prod).len() + 1 && result == *x)]
+            #[ensures(cnt@ == old(cnt)@ + 1 && cnt@ == (*_prod).len() + 1 && result == *x)]
             |x, _prod| {
                 cnt += 1;
                 *x

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -23,8 +23,8 @@ pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
     i
 }
 
-#[ensures((@^v).len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(@^v)[i] == 0)]
+#[ensures(((^v)@).len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @((^v)@)[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
     for x in v.iter_mut() {

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -23,8 +23,8 @@ pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
     i
 }
 
-#[ensures(((^v)@).len() == v@.len())]
-#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @((^v)@)[i] == 0)]
+#[ensures((^v)@.len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(^v)@[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
     for x in v.iter_mut() {

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -2,10 +2,10 @@ extern crate creusot_contracts;
 use creusot_contracts::{logic::Int, std::iter::*, *};
 
 #[requires(slice@.len() < 1000)]
-#[ensures(@result == slice@.len())]
+#[ensures(result@ == slice@.len())]
 pub fn slice_iter<T>(slice: &[T]) -> usize {
     let mut i = 0;
-    #[invariant(dummy, @i == produced.len())]
+    #[invariant(dummy, i@ == produced.len())]
     for _ in slice.iter() {
         i += 1;
     }
@@ -13,10 +13,10 @@ pub fn slice_iter<T>(slice: &[T]) -> usize {
 }
 
 #[requires(vec@.len() < 1000)]
-#[ensures(@result == vec@.len())]
+#[ensures(result@ == vec@.len())]
 pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
     let mut i = 0;
-    #[invariant(dummy, @i == produced.len())]
+    #[invariant(dummy, i@ == produced.len())]
     for _ in vec {
         i += 1;
     }
@@ -44,8 +44,8 @@ pub fn counter(v: Vec<u32>) {
     let x: Vec<u32> = v
         .iter()
         .map_inv(
-            #[requires(@cnt == (*_prod).len() && cnt < usize::MAX)]
-            #[ensures(@cnt == @old(cnt) + 1 && @cnt == (*_prod).len() + 1 && result == *x)]
+            #[requires(cnt@ == (*_prod).len() && cnt < usize::MAX)]
+            #[ensures(cnt@ == @old(cnt) + 1 && cnt@ == (*_prod).len() + 1 && result == *x)]
             |x, _prod| {
                 cnt += 1;
                 *x
@@ -54,15 +54,15 @@ pub fn counter(v: Vec<u32>) {
         .collect();
 
     proof_assert! { x@.len() == v@.len() };
-    proof_assert! { x@.ext_eq(@v) };
-    proof_assert! { @cnt == x@.len() };
+    proof_assert! { x@.ext_eq(v@) };
+    proof_assert! { cnt@ == x@.len() };
 }
 
-#[requires(@n >= 0)]
+#[requires(n@ >= 0)]
 #[ensures(result == n)]
 pub fn sum_range(n: isize) -> isize {
     let mut i = 0;
-    #[invariant(user, @i == produced.len() && i <= n)]
+    #[invariant(user, i@ == produced.len() && i <= n)]
     for _ in 0..n {
         i += 1;
     }

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -26,7 +26,7 @@ pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
 #[ensures((^v)@.len() == v@.len())]
 #[ensures(forall<i : _> 0 <= i && i < v@.len() ==> (^v)@[i]@ == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
-    #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
+    #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> (^produced[i])@ == 0)]
     for x in v.iter_mut() {
         *x = 0;
     }

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.rs
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.rs
@@ -1,8 +1,8 @@
 extern crate creusot_contracts;
 use creusot_contracts::{logic::Int, std::iter::*, *};
 
-#[requires((@slice).len() < 1000)]
-#[ensures(@result == (@slice).len())]
+#[requires(slice@.len() < 1000)]
+#[ensures(@result == slice@.len())]
 pub fn slice_iter<T>(slice: &[T]) -> usize {
     let mut i = 0;
     #[invariant(dummy, @i == produced.len())]
@@ -12,8 +12,8 @@ pub fn slice_iter<T>(slice: &[T]) -> usize {
     i
 }
 
-#[requires((@vec).len() < 1000)]
-#[ensures(@result == (@vec).len())]
+#[requires(vec@.len() < 1000)]
+#[ensures(@result == vec@.len())]
 pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
     let mut i = 0;
     #[invariant(dummy, @i == produced.len())]
@@ -23,8 +23,8 @@ pub fn vec_iter<T>(vec: &Vec<T>) -> usize {
     i
 }
 
-#[ensures((@^v).len() == (@v).len())]
-#[ensures(forall<i : _> 0 <= i && i < (@v).len() ==> @(@^v)[i] == 0)]
+#[ensures((@^v).len() == v@.len())]
+#[ensures(forall<i : _> 0 <= i && i < v@.len() ==> @(@^v)[i] == 0)]
 pub fn all_zero(v: &mut Vec<usize>) {
     #[invariant(user, forall<i : Int> 0 <= i && i < produced.len() ==> @^produced[i] == 0)]
     for x in v.iter_mut() {
@@ -53,9 +53,9 @@ pub fn counter(v: Vec<u32>) {
         )
         .collect();
 
-    proof_assert! { (@x).len() == (@v).len() };
-    proof_assert! { (@x).ext_eq(@v) };
-    proof_assert! { @cnt == (@x).len() };
+    proof_assert! { x@.len() == v@.len() };
+    proof_assert! { x@.ext_eq(@v) };
+    proof_assert! { @cnt == x@.len() };
 }
 
 #[requires(@n >= 0)]

--- a/creusot/tests/should_succeed/iterators/04_skip.rs
+++ b/creusot/tests/should_succeed/iterators/04_skip.rs
@@ -32,7 +32,7 @@ where
         pearlite! {
             @(^self).n == 0 &&
             exists<s: Seq<Self::Item>, i: &mut I>
-                s.len() <= @self.n &&
+                s.len() <= self.n@ &&
                 self.iter.produces(s, *i) &&
                 (forall<i: Int> 0 <= i && i < s.len() ==> s[i].resolve()) &&
                 i.completed() &&
@@ -44,9 +44,9 @@ where
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
             visited == Seq::EMPTY && self == o ||
-            @o.n == 0 && visited.len() > 0 &&
+            o.n@ == 0 && visited.len() > 0 &&
             exists<s: Seq<Self::Item>>
-                s.len() == @self.n &&
+                s.len() == self.n@ &&
                 self.iter.produces(s.concat(visited), o.iter) &&
                 forall<i: Int> 0 <= i && i < s.len() ==> s[i].resolve()
         }
@@ -70,7 +70,7 @@ where
         let old_self = ghost! { self };
         let mut n = std::mem::take(&mut self.n);
         let mut skipped = ghost! { Seq::EMPTY };
-        #[invariant(skipped_len, skipped.len() + n@ == @old_self.n)]
+        #[invariant(skipped_len, skipped.len() + n@ == old_self.n@)]
         #[invariant(produces, old_self.iter.produces(skipped.inner(), self.iter))]
         #[invariant(skipped_resolve, forall<i: Int> 0 <= i && i < skipped.len() ==> skipped[i].resolve())]
         #[invariant(n_0, @(*self).n == 0)]

--- a/creusot/tests/should_succeed/iterators/04_skip.rs
+++ b/creusot/tests/should_succeed/iterators/04_skip.rs
@@ -70,7 +70,7 @@ where
         let old_self = ghost! { self };
         let mut n = std::mem::take(&mut self.n);
         let mut skipped = ghost! { Seq::EMPTY };
-        #[invariant(skipped_len, skipped.len() + @n == @old_self.n)]
+        #[invariant(skipped_len, skipped.len() + n@ == @old_self.n)]
         #[invariant(produces, old_self.iter.produces(skipped.inner(), self.iter))]
         #[invariant(skipped_resolve, forall<i: Int> 0 <= i && i < skipped.len() ==> skipped[i].resolve())]
         #[invariant(n_0, @(*self).n == 0)]

--- a/creusot/tests/should_succeed/iterators/04_skip.rs
+++ b/creusot/tests/should_succeed/iterators/04_skip.rs
@@ -30,7 +30,7 @@ where
     #[predicate]
     fn completed(&mut self) -> bool {
         pearlite! {
-            @(^self).n == 0 &&
+            (^self).n@ == 0 &&
             exists<s: Seq<Self::Item>, i: &mut I>
                 s.len() <= self.n@ &&
                 self.iter.produces(s, *i) &&
@@ -73,7 +73,7 @@ where
         #[invariant(skipped_len, skipped.len() + n@ == old_self.n@)]
         #[invariant(produces, old_self.iter.produces(skipped.inner(), self.iter))]
         #[invariant(skipped_resolve, forall<i: Int> 0 <= i && i < skipped.len() ==> skipped[i].resolve())]
-        #[invariant(n_0, @(*self).n == 0)]
+        #[invariant(n_0, (*self).n@ == 0)]
         #[invariant(inv, self.invariant())]
         loop {
             let r = self.iter.next();

--- a/creusot/tests/should_succeed/iterators/05_take.rs
+++ b/creusot/tests/should_succeed/iterators/05_take.rs
@@ -20,8 +20,8 @@ where
     #[predicate]
     fn completed(&mut self) -> bool {
         pearlite! {
-            @(*self).n == 0 && self.resolve() ||
-            @(*self).n > 0 && @(*self).n == @(^self).n + 1 && self.iter.completed()
+            (*self).n@ == 0 && self.resolve() ||
+            (*self).n@ > 0 && (*self).n@ == (^self).n@ + 1 && self.iter.completed()
         }
     }
 

--- a/creusot/tests/should_succeed/iterators/05_take.rs
+++ b/creusot/tests/should_succeed/iterators/05_take.rs
@@ -28,7 +28,7 @@ where
     #[predicate]
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
-            @self.n == @o.n + visited.len() && self.iter.produces(visited, o.iter)
+            self.n@ == o.n@ + visited.len() && self.iter.produces(visited, o.iter)
         }
     }
 

--- a/creusot/tests/should_succeed/iterators/06_map_precond.rs
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.rs
@@ -207,7 +207,7 @@ pub fn counter<I: Iterator<Item = u32>>(iter: I) {
     map(
         iter,
         #[requires(cnt@ == (*_prod).len() && cnt < usize::MAX)]
-        #[ensures(cnt@ == @old(cnt) + 1)]
+        #[ensures(cnt@ == old(cnt)@ + 1)]
         |x, _prod: Ghost<Seq<_>>| {
             cnt += 1;
             x

--- a/creusot/tests/should_succeed/iterators/06_map_precond.rs
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.rs
@@ -188,8 +188,8 @@ pub fn identity<I: Iterator>(iter: I) {
 pub fn increment<I: Iterator<Item = u32>>(iter: I) {
     let i = map(
         iter,
-        #[requires(@x <= 15)]
-        #[ensures(@result == @x+1)]
+        #[requires(x@ <= 15)]
+        #[ensures(result@ == x@+1)]
         |x: u32, _| x + 1,
     );
 
@@ -206,8 +206,8 @@ pub fn counter<I: Iterator<Item = u32>>(iter: I) {
     let mut cnt = 0;
     map(
         iter,
-        #[requires(@cnt == (*_prod).len() && cnt < usize::MAX)]
-        #[ensures(@cnt == @old(cnt) + 1)]
+        #[requires(cnt@ == (*_prod).len() && cnt < usize::MAX)]
+        #[ensures(cnt@ == @old(cnt) + 1)]
         |x, _prod: Ghost<Seq<_>>| {
             cnt += 1;
             x

--- a/creusot/tests/should_succeed/iterators/06_map_precond.rs
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.rs
@@ -201,7 +201,7 @@ pub fn increment<I: Iterator<Item = u32>>(iter: I) {
 
 #[requires(iter.invariant())]
 #[requires(forall<done_ : &mut I> done_.completed() ==> (^done_).invariant() ==> forall<next : I, steps: Seq<_>> (^done_).produces(steps, next) ==> steps == Seq::EMPTY && ^done_ == next)]
-#[requires(forall<prod : _, fin: I> fin.invariant() ==> iter.produces(prod, fin) ==> prod.len() <= @usize::MAX)]
+#[requires(forall<prod : _, fin: I> fin.invariant() ==> iter.produces(prod, fin) ==> prod.len() <= usize::MAX@)]
 pub fn counter<I: Iterator<Item = u32>>(iter: I) {
     let mut cnt = 0;
     map(

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -768,7 +768,7 @@ module C08CollectExtend_Extend
     invariant structural { [#"../08_collect_extend.rs" 28 4 28 44] Produces0.produces (Ghost.inner iter_old_9) (Ghost.inner produced_12) iter_7 };
     invariant iter_inv { [#"../08_collect_extend.rs" 28 26 28 42] Invariant0.invariant' iter_7 };
     invariant vec_proph { [#"../08_collect_extend.rs" 29 27 29 44]  ^ Ghost.inner old_vec_4 =  ^ vec_1 };
-    invariant vec { [#"../08_collect_extend.rs" 30 21 30 64] Seq.(==) (ShallowModel1.shallow_model vec_1) (Seq.(++) (ShallowModel2.shallow_model old_vec_4) (Ghost.inner produced_12)) };
+    invariant vec { [#"../08_collect_extend.rs" 28 4 28 44] Seq.(==) (ShallowModel1.shallow_model vec_1) (Seq.(++) (ShallowModel2.shallow_model old_vec_4) (Ghost.inner produced_12)) };
     _24 <- borrow_mut iter_7;
     iter_7 <-  ^ _24;
     _23 <- borrow_mut ( * _24);
@@ -1086,7 +1086,7 @@ module C08CollectExtend_Collect
     invariant type_invariant { [#"../08_collect_extend.rs" 47 4 47 44] Invariant0.invariant' iter_5 };
     invariant structural { [#"../08_collect_extend.rs" 47 4 47 44] Produces0.produces (Ghost.inner iter_old_7) (Ghost.inner produced_10) iter_5 };
     invariant iter_inv { [#"../08_collect_extend.rs" 47 26 47 42] Invariant0.invariant' iter_5 };
-    invariant vec { [#"../08_collect_extend.rs" 48 21 48 45] Seq.(==) (ShallowModel0.shallow_model res_3) (Ghost.inner produced_10) };
+    invariant vec { [#"../08_collect_extend.rs" 47 4 47 44] Seq.(==) (ShallowModel0.shallow_model res_3) (Ghost.inner produced_10) };
     _21 <- borrow_mut iter_5;
     iter_5 <-  ^ _21;
     _20 <- borrow_mut ( * _21);
@@ -1666,7 +1666,7 @@ module C08CollectExtend_ExtendIndex
     goto BB4
   }
   BB4 {
-    assert { [#"../08_collect_extend.rs" 60 20 60 57] Seq.(==) (ShallowModel0.shallow_model v1_1) (Seq.(++) (ShallowModel1.shallow_model oldv1_3) (ShallowModel1.shallow_model oldv2_7)) };
+    assert { [#"../08_collect_extend.rs" 60 4 60 55] Seq.(==) (ShallowModel0.shallow_model v1_1) (Seq.(++) (ShallowModel1.shallow_model oldv1_3) (ShallowModel1.shallow_model oldv2_7)) };
     goto BB5
   }
   BB5 {
@@ -1772,7 +1772,7 @@ module C08CollectExtend_CollectExample
     goto BB2
   }
   BB2 {
-    assert { [#"../08_collect_extend.rs" 67 4 67 80] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v_3) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model v_3) i) = i };
+    assert { [#"../08_collect_extend.rs" 67 4 67 76] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v_3) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model v_3) i) = i };
     goto BB3
   }
   BB3 {

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.rs
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.rs
@@ -21,13 +21,13 @@ use creusot_contracts::{
 // Here we prove the specific instance of `extend` for `Vec<T>`.
 #[ensures(
   exists<done_ : &mut I, prod: Seq<_>>
-    done_.completed() && iter.produces(prod, *done_) && @^vec == (@vec).concat(prod)
+    done_.completed() && iter.produces(prod, *done_) && @^vec == vec@.concat(prod)
 )]
 pub fn extend<T, I: Iterator<Item = T> + Invariant>(vec: &mut Vec<T>, iter: I) {
     let old_vec = ghost! { vec };
     #[invariant(iter_inv, iter.invariant())]
     #[invariant(vec_proph, ^*old_vec == ^vec)]
-    #[invariant(vec, (@vec).ext_eq((@old_vec).concat(*produced)))]
+    #[invariant(vec, vec@.ext_eq(old_vec@.concat(*produced)))]
     for x in iter {
         vec.push(x);
     }
@@ -45,7 +45,7 @@ pub fn collect<I: Iterator>(iter: I) -> Vec<I::Item> {
     let mut res = Vec::new();
 
     #[invariant(iter_inv, iter.invariant())]
-    #[invariant(vec, (@res).ext_eq(*produced))]
+    #[invariant(vec, res@.ext_eq(*produced))]
     for x in iter {
         res.push(x);
     }
@@ -57,12 +57,12 @@ pub fn extend_index(mut v1: Vec<u32>, v2: Vec<u32>) {
     let oldv2 = ghost! { *v2 };
     extend(&mut v1, v2.into_iter());
 
-    proof_assert! { (@v1).ext_eq((@oldv1).concat(@oldv2)) };
+    proof_assert! { v1@.ext_eq(oldv1@.concat(@oldv2)) };
 }
 
 #[requires(forall<prod : Seq<u32>, fin: I> iter.produces(prod, fin) ==> forall<i : _> 0 <= i && i < prod.len() ==> @prod[i] == i)]
 pub fn collect_example<I: Iterator<Item = u32>>(iter: I) {
     let v: Vec<u32> = collect(iter);
 
-    proof_assert! { forall<i : Int> 0 <= i && i < (@v).len() ==> @(@v)[i] == i };
+    proof_assert! { forall<i : Int> 0 <= i && i < v@.len() ==> @v@[i] == i };
 }

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.rs
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.rs
@@ -21,7 +21,7 @@ use creusot_contracts::{
 // Here we prove the specific instance of `extend` for `Vec<T>`.
 #[ensures(
   exists<done_ : &mut I, prod: Seq<_>>
-    done_.completed() && iter.produces(prod, *done_) && @^vec == vec@.concat(prod)
+    done_.completed() && iter.produces(prod, *done_) && (^vec)@ == vec@.concat(prod)
 )]
 pub fn extend<T, I: Iterator<Item = T> + Invariant>(vec: &mut Vec<T>, iter: I) {
     let old_vec = ghost! { vec };

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.rs
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.rs
@@ -39,7 +39,7 @@ pub fn extend<T, I: Iterator<Item = T> + Invariant>(vec: &mut Vec<T>, iter: I) {
 //  We prove the specific instance for vector
 #[ensures(
   exists<done_ : &mut I, prod: Seq<_>>
-    done_.completed() && iter.produces(prod, *done_) && @result == prod
+    done_.completed() && iter.produces(prod, *done_) && result@ == prod
 )]
 pub fn collect<I: Iterator>(iter: I) -> Vec<I::Item> {
     let mut res = Vec::new();
@@ -57,7 +57,7 @@ pub fn extend_index(mut v1: Vec<u32>, v2: Vec<u32>) {
     let oldv2 = ghost! { *v2 };
     extend(&mut v1, v2.into_iter());
 
-    proof_assert! { v1@.ext_eq(oldv1@.concat(@oldv2)) };
+    proof_assert! { v1@.ext_eq(oldv1@.concat(oldv2@)) };
 }
 
 #[requires(forall<prod : Seq<u32>, fin: I> iter.produces(prod, fin) ==> forall<i : _> 0 <= i && i < prod.len() ==> @prod[i] == i)]

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.rs
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.rs
@@ -60,9 +60,9 @@ pub fn extend_index(mut v1: Vec<u32>, v2: Vec<u32>) {
     proof_assert! { v1@.ext_eq(oldv1@.concat(oldv2@)) };
 }
 
-#[requires(forall<prod : Seq<u32>, fin: I> iter.produces(prod, fin) ==> forall<i : _> 0 <= i && i < prod.len() ==> @prod[i] == i)]
+#[requires(forall<prod : Seq<u32>, fin: I> iter.produces(prod, fin) ==> forall<i : _> 0 <= i && i < prod.len() ==> prod[i]@ == i)]
 pub fn collect_example<I: Iterator<Item = u32>>(iter: I) {
     let v: Vec<u32> = collect(iter);
 
-    proof_assert! { forall<i : Int> 0 <= i && i < v@.len() ==> @v@[i] == i };
+    proof_assert! { forall<i : Int> 0 <= i && i < v@.len() ==> v@[i]@ == i };
 }

--- a/creusot/tests/should_succeed/iterators/15_enumerate.rs
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.rs
@@ -25,10 +25,10 @@ where
     #[predicate]
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
-            visited.len() == @o.count - @self.count
+            visited.len() == o.count@ - @self.count
             && exists<s: Seq<I::Item>> self.iter.produces(s, o.iter)
                 && visited.len() == s.len()
-                && forall<i: Int> 0 <= i && i < s.len() ==> @visited[i].0 == @self.count + i && visited[i].1 == s[i]
+                && forall<i: Int> 0 <= i && i < s.len() ==> visited[i].0@ == self.count@ + i && visited[i].1 == s[i]
         }
     }
 
@@ -66,7 +66,7 @@ where
     fn invariant(self) -> bool {
         pearlite! {
             self.iter.invariant()
-            && (forall<s: Seq<I::Item>, i: I> self.iter.produces(s, i) ==> @self.count + s.len() < @std::usize::MAX)
+            && (forall<s: Seq<I::Item>, i: I> self.iter.produces(s, i) ==> self.count@ + s.len() < @std::usize::MAX)
             && (forall<i: &mut I> i.completed() ==> i.produces(Seq::EMPTY, ^i))
         }
     }

--- a/creusot/tests/should_succeed/iterators/15_enumerate.rs
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.rs
@@ -25,7 +25,7 @@ where
     #[predicate]
     fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool {
         pearlite! {
-            visited.len() == o.count@ - @self.count
+            visited.len() == o.count@ - self.count@
             && exists<s: Seq<I::Item>> self.iter.produces(s, o.iter)
                 && visited.len() == s.len()
                 && forall<i: Int> 0 <= i && i < s.len() ==> visited[i].0@ == self.count@ + i && visited[i].1 == s[i]

--- a/creusot/tests/should_succeed/iterators/15_enumerate.rs
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.rs
@@ -66,14 +66,14 @@ where
     fn invariant(self) -> bool {
         pearlite! {
             self.iter.invariant()
-            && (forall<s: Seq<I::Item>, i: I> self.iter.produces(s, i) ==> self.count@ + s.len() < @std::usize::MAX)
+            && (forall<s: Seq<I::Item>, i: I> self.iter.produces(s, i) ==> self.count@ + s.len() < std::usize::MAX@)
             && (forall<i: &mut I> i.completed() ==> i.produces(Seq::EMPTY, ^i))
         }
     }
 }
 
 #[requires(forall<i: &mut I> i.completed() ==> i.produces(Seq::EMPTY, ^i))]
-#[requires(forall<s: Seq<I::Item>, i: I> iter.produces(s, i) ==> s.len() < @std::usize::MAX)]
+#[requires(forall<s: Seq<I::Item>, i: I> iter.produces(s, i) ==> s.len() < std::usize::MAX@)]
 pub fn enumerate<I: Iterator>(iter: I) -> Enumerate<I> {
     Enumerate { iter, count: 0 }
 }

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -5,7 +5,7 @@ module Knapsack_Max_Interface
   use prelude.Int
   val max [#"../knapsack.rs" 15 0 15 35] (a : usize) (b : usize) : usize
     requires {[#"../knapsack.rs" 13 11 13 15] true}
-    ensures { [#"../knapsack.rs" 14 10 14 33] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../knapsack.rs" 14 10 14 31] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module Knapsack_Max
@@ -14,7 +14,7 @@ module Knapsack_Max
   use int.MinMax
   let rec cfg max [#"../knapsack.rs" 15 0 15 35] [@cfg:stackify] [@cfg:subregion_analysis] (a : usize) (b : usize) : usize
     requires {[#"../knapsack.rs" 13 11 13 15] true}
-    ensures { [#"../knapsack.rs" 14 10 14 33] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../knapsack.rs" 14 10 14 31] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -698,9 +698,9 @@ module Knapsack_Knapsack01Dyn_Interface
     type t = Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq (Knapsack_Item_Type.t_item name)
   val knapsack01_dyn [#"../knapsack.rs" 48 0 48 91] (items : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) (max_weight : usize) : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)
-    requires {[#"../knapsack.rs" 45 11 45 36] Seq.length (ShallowModel0.shallow_model items) < 10000000}
+    requires {[#"../knapsack.rs" 45 11 45 34] Seq.length (ShallowModel0.shallow_model items) < 10000000}
     requires {[#"../knapsack.rs" 46 11 46 33] UIntSize.to_int max_weight < 10000000}
-    requires {[#"../knapsack.rs" 47 0 47 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (Knapsack_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
+    requires {[#"../knapsack.rs" 47 0 47 87] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (Knapsack_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
     
 end
 module Knapsack_Knapsack01Dyn
@@ -872,9 +872,9 @@ module Knapsack_Knapsack01Dyn
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     val Max0.mAX' = Max1.mAX'
   let rec cfg knapsack01_dyn [#"../knapsack.rs" 48 0 48 91] [@cfg:stackify] [@cfg:subregion_analysis] (items : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) (max_weight : usize) : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)
-    requires {[#"../knapsack.rs" 45 11 45 36] Seq.length (ShallowModel0.shallow_model items) < 10000000}
+    requires {[#"../knapsack.rs" 45 11 45 34] Seq.length (ShallowModel0.shallow_model items) < 10000000}
     requires {[#"../knapsack.rs" 46 11 46 33] UIntSize.to_int max_weight < 10000000}
-    requires {[#"../knapsack.rs" 47 0 47 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (Knapsack_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
+    requires {[#"../knapsack.rs" 47 0 47 87] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (Knapsack_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global);
@@ -1018,10 +1018,10 @@ module Knapsack_Knapsack01Dyn
     goto BB8
   }
   BB8 {
-    invariant items_len { [#"../knapsack.rs" 52 27 52 68] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel1.shallow_model best_value_6) };
-    invariant weight_len { [#"../knapsack.rs" 52 4 52 70] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model best_value_6) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) i)) };
-    invariant best_value { [#"../knapsack.rs" 52 4 52 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_13 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
-    invariant best_value_bounds { [#"../knapsack.rs" 52 4 52 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) <= 10000000 * ii };
+    invariant items_len { [#"../knapsack.rs" 52 27 52 64] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel1.shallow_model best_value_6) };
+    invariant weight_len { [#"../knapsack.rs" 52 4 52 66] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model best_value_6) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) i)) };
+    invariant best_value { [#"../knapsack.rs" 52 4 52 66] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_13 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
+    invariant best_value_bounds { [#"../knapsack.rs" 52 4 52 66] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) <= 10000000 * ii };
     _21 <- i_13;
     _23 <- items_1;
     _22 <- ([#"../knapsack.rs" 59 14 59 25] Len0.len _23);
@@ -1062,11 +1062,11 @@ module Knapsack_Knapsack01Dyn
     goto BB17
   }
   BB17 {
-    invariant items_len2 { [#"../knapsack.rs" 66 32 66 73] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel1.shallow_model best_value_6) };
-    invariant weight_len2 { [#"../knapsack.rs" 66 8 66 75] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model best_value_6) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) i)) };
-    invariant best_value2 { [#"../knapsack.rs" 66 8 66 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_13 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
-    invariant best_value2 { [#"../knapsack.rs" 66 8 66 75] forall ww : int . 0 <= ww /\ ww <= UIntSize.to_int w_28 - 1 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) (UIntSize.to_int i_13 + 1))) ww) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int i_13 + 1) ww };
-    invariant best_value_bounds { [#"../knapsack.rs" 66 8 66 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) <= 10000000 * ii };
+    invariant items_len2 { [#"../knapsack.rs" 66 32 66 69] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel1.shallow_model best_value_6) };
+    invariant weight_len2 { [#"../knapsack.rs" 66 8 66 71] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model best_value_6) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) i)) };
+    invariant best_value2 { [#"../knapsack.rs" 66 8 66 71] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_13 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
+    invariant best_value2 { [#"../knapsack.rs" 66 8 66 71] forall ww : int . 0 <= ww /\ ww <= UIntSize.to_int w_28 - 1 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) (UIntSize.to_int i_13 + 1))) ww) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int i_13 + 1) ww };
+    invariant best_value_bounds { [#"../knapsack.rs" 66 8 66 71] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel2.shallow_model (Seq.get (ShallowModel1.shallow_model best_value_6) ii)) ww) <= 10000000 * ii };
     _36 <- w_28;
     _37 <- max_weight_2;
     _35 <- ([#"../knapsack.rs" 76 14 76 29] _36 <= _37);
@@ -1188,7 +1188,7 @@ module Knapsack_Knapsack01Dyn
     goto BB36
   }
   BB36 {
-    invariant j_items_len { [#"../knapsack.rs" 91 29 91 49] UIntSize.to_int j_83 <= Seq.length (ShallowModel0.shallow_model items_1) };
+    invariant j_items_len { [#"../knapsack.rs" 91 29 91 47] UIntSize.to_int j_83 <= Seq.length (ShallowModel0.shallow_model items_1) };
     invariant left_weight_le_max { [#"../knapsack.rs" 92 36 92 63] UIntSize.to_int left_weight_82 <= UIntSize.to_int max_weight_2 };
     _89 <- j_83;
     _88 <- ([#"../knapsack.rs" 93 10 93 15] ([#"../knapsack.rs" 93 10 93 11] (0 : usize)) < _89);

--- a/creusot/tests/should_succeed/knapsack.rs
+++ b/creusot/tests/should_succeed/knapsack.rs
@@ -11,7 +11,7 @@ pub struct Item<Name> {
 }
 
 #[requires(true)]
-#[ensures(@result == a@.max(@b))]
+#[ensures(result@ == a@.max(b@))]
 fn max(a: usize, b: usize) -> usize {
     if a < b {
         b
@@ -43,7 +43,7 @@ fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
 }
 
 #[requires(items@.len() < 10000000)]
-#[requires(@max_weight < 10000000)]
+#[requires(max_weight@ < 10000000)]
 #[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
 pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&Item<Name>> {
     let mut best_value = vec![vec![0; max_weight + 1]; items.len() + 1];
@@ -51,10 +51,10 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
 
     #[invariant(items_len, items@.len() + 1 == best_value@.len())]
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                  @max_weight + 1 == (@best_value@[i]).len())]
-    #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                  @(@best_value@[ii])[ww] == m(@items, ii, ww))]
-    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  max_weight@ + 1 == (@best_value@[i]).len())]
+    #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
+                  @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
                   @(@best_value@[ii])[ww] <= 10000000 * ii)]
     while i < items.len() {
         let it = &items[i];
@@ -65,13 +65,13 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
 
         #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
         #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                      @max_weight + 1 == (@best_value@[i]).len())]
+                      max_weight@ + 1 == (@best_value@[i]).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
-                      0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                      @(@best_value@[ii])[ww] == m(@items, ii, ww))]
-        #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= @w-1 ==>
-                      @(@best_value@[@i+1])[ww] == m(@items, @i+1, ww))]
-        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                      0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
+                      @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+        #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= w@-1 ==>
+                      @(@best_value@[i@+1])[ww] == m(items@, i@+1, ww))]
+        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
                   @(@best_value@[ii])[ww] <= 10000000 * ii)]
         while w <= max_weight {
             best_value[i + 1][w] = if it.weight > w {
@@ -88,8 +88,8 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     let mut left_weight = max_weight;
 
     let mut j = items.len();
-    #[invariant(j_items_len, @j <= items@.len())]
-    #[invariant(left_weight_le_max, @left_weight <= @max_weight)]
+    #[invariant(j_items_len, j@ <= items@.len())]
+    #[invariant(left_weight_le_max, left_weight@ <= max_weight@)]
     while 0 < j {
         j -= 1;
         let it = &items[j];

--- a/creusot/tests/should_succeed/knapsack.rs
+++ b/creusot/tests/should_succeed/knapsack.rs
@@ -53,9 +53,9 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
                   max_weight@ + 1 == (best_value@[i]@).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
+                  (best_value@[ii]@)[ww]@ == m(items@, ii, ww))]
     #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
+                  (best_value@[ii]@)[ww]@ <= 10000000 * ii)]
     while i < items.len() {
         let it = &items[i];
 
@@ -68,11 +68,11 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
                       max_weight@ + 1 == (best_value@[i]@).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                      @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
+                      (best_value@[ii]@)[ww]@ == m(items@, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= w@-1 ==>
-                      @(best_value@[i@+1]@)[ww] == m(items@, i@+1, ww))]
+                      (best_value@[i@+1]@)[ww]@ == m(items@, i@+1, ww))]
         #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
+                  (best_value@[ii]@)[ww]@ <= 10000000 * ii)]
         while w <= max_weight {
             best_value[i + 1][w] = if it.weight > w {
                 best_value[i][w]

--- a/creusot/tests/should_succeed/knapsack.rs
+++ b/creusot/tests/should_succeed/knapsack.rs
@@ -34,28 +34,28 @@ fn max(a: usize, b: usize) -> usize {
 fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
     pearlite! {
         if i == 0 { 0 }
-        else if @items[i-1].weight > w {
+        else if items[i-1].weight@ > w {
             m(items, i-1, w)
         } else {
-            m(items, i-1, w).max(m(items, i-1, w - @items[i-1].weight) + @items[i-1].value)
+            m(items, i-1, w).max(m(items, i-1, w - items[i-1].weight@) + items[i-1].value@)
         }
     }
 }
 
 #[requires(items@.len() < 10000000)]
 #[requires(max_weight@ < 10000000)]
-#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
+#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> items@[i].value@ <= 10000000)]
 pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&Item<Name>> {
     let mut best_value = vec![vec![0; max_weight + 1]; items.len() + 1];
     let mut i = 0;
 
     #[invariant(items_len, items@.len() + 1 == best_value@.len())]
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                  max_weight@ + 1 == (@best_value@[i]).len())]
+                  max_weight@ + 1 == (best_value@[i]@).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+                  @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
     #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
+                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
     while i < items.len() {
         let it = &items[i];
 
@@ -65,14 +65,14 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
 
         #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
         #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                      max_weight@ + 1 == (@best_value@[i]).len())]
+                      max_weight@ + 1 == (best_value@[i]@).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                      @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+                      @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= w@-1 ==>
-                      @(@best_value@[i@+1])[ww] == m(items@, i@+1, ww))]
+                      @(best_value@[i@+1]@)[ww] == m(items@, i@+1, ww))]
         #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
+                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
         while w <= max_weight {
             best_value[i + 1][w] = if it.weight > w {
                 best_value[i][w]

--- a/creusot/tests/should_succeed/knapsack.rs
+++ b/creusot/tests/should_succeed/knapsack.rs
@@ -11,7 +11,7 @@ pub struct Item<Name> {
 }
 
 #[requires(true)]
-#[ensures(@result == (@a).max(@b))]
+#[ensures(@result == a@.max(@b))]
 fn max(a: usize, b: usize) -> usize {
     if a < b {
         b
@@ -42,20 +42,20 @@ fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
     }
 }
 
-#[requires((@items).len() < 10000000)]
+#[requires(items@.len() < 10000000)]
 #[requires(@max_weight < 10000000)]
-#[requires(forall<i: Int> 0 <= i && i < (@items).len() ==> @(@items)[i].value <= 10000000)]
+#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
 pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&Item<Name>> {
     let mut best_value = vec![vec![0; max_weight + 1]; items.len() + 1];
     let mut i = 0;
 
-    #[invariant(items_len, (@items).len() + 1 == (@best_value).len())]
-    #[invariant(weight_len, forall<i: Int> 0 <= i && i < (@best_value).len() ==>
-                  @max_weight + 1 == (@(@best_value)[i]).len())]
+    #[invariant(items_len, items@.len() + 1 == best_value@.len())]
+    #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
+                  @max_weight + 1 == (@best_value@[i]).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] == m(@items, ii, ww))]
-    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= (@items).len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] <= 10000000 * ii)]
+                  @(@best_value@[ii])[ww] == m(@items, ii, ww))]
+    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
     while i < items.len() {
         let it = &items[i];
 
@@ -63,16 +63,16 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
         // This makes it possible to allow 0-weight items, and makes the proof simpler.
         let mut w = 0;
 
-        #[invariant(items_len2, (@items).len() + 1 == (@best_value).len())]
-        #[invariant(weight_len2, forall<i: Int> 0 <= i && i < (@best_value).len() ==>
-                      @max_weight + 1 == (@(@best_value)[i]).len())]
+        #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
+        #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
+                      @max_weight + 1 == (@best_value@[i]).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                      @(@(@best_value)[ii])[ww] == m(@items, ii, ww))]
+                      @(@best_value@[ii])[ww] == m(@items, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= @w-1 ==>
-                      @(@(@best_value)[@i+1])[ww] == m(@items, @i+1, ww))]
-        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= (@items).len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] <= 10000000 * ii)]
+                      @(@best_value@[@i+1])[ww] == m(@items, @i+1, ww))]
+        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
         while w <= max_weight {
             best_value[i + 1][w] = if it.weight > w {
                 best_value[i][w]
@@ -88,7 +88,7 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     let mut left_weight = max_weight;
 
     let mut j = items.len();
-    #[invariant(j_items_len, @j <= (@items).len())]
+    #[invariant(j_items_len, @j <= items@.len())]
     #[invariant(left_weight_le_max, @left_weight <= @max_weight)]
     while 0 < j {
         j -= 1;

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -4,7 +4,7 @@ module KnapsackFull_Max_Interface
   use int.MinMax
   use prelude.Int
   val max [#"../knapsack_full.rs" 14 0 14 35] (a : usize) (b : usize) : usize
-    ensures { [#"../knapsack_full.rs" 13 10 13 33] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../knapsack_full.rs" 13 10 13 31] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module KnapsackFull_Max
@@ -12,7 +12,7 @@ module KnapsackFull_Max
   use prelude.UIntSize
   use int.MinMax
   let rec cfg max [#"../knapsack_full.rs" 14 0 14 35] [@cfg:stackify] [@cfg:subregion_analysis] (a : usize) (b : usize) : usize
-    ensures { [#"../knapsack_full.rs" 13 10 13 33] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../knapsack_full.rs" 13 10 13 31] UIntSize.to_int result = MinMax.max (UIntSize.to_int a) (UIntSize.to_int b) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -1747,11 +1747,11 @@ module KnapsackFull_Knapsack01Dyn_Interface
     type t = Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq (KnapsackFull_Item_Type.t_item name)
   val knapsack01_dyn [#"../knapsack_full.rs" 84 0 84 91] (items : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) (max_weight : usize) : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)
-    requires {[#"../knapsack_full.rs" 76 11 76 36] Seq.length (ShallowModel0.shallow_model items) < 10000000}
+    requires {[#"../knapsack_full.rs" 76 11 76 34] Seq.length (ShallowModel0.shallow_model items) < 10000000}
     requires {[#"../knapsack_full.rs" 77 11 77 33] UIntSize.to_int max_weight < 10000000}
-    requires {[#"../knapsack_full.rs" 78 0 78 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (KnapsackFull_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
-    ensures { [#"../knapsack_full.rs" 79 10 79 62] SumWeights0.sum_weights (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) <= UIntSize.to_int max_weight }
-    ensures { [#"../knapsack_full.rs" 80 10 80 56] SubseqRev0.subseq_rev (ShallowModel1.shallow_model result) 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) }
+    requires {[#"../knapsack_full.rs" 78 0 78 87] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (KnapsackFull_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
+    ensures { [#"../knapsack_full.rs" 79 10 79 60] SumWeights0.sum_weights (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) <= UIntSize.to_int max_weight }
+    ensures { [#"../knapsack_full.rs" 80 10 80 54] SubseqRev0.subseq_rev (ShallowModel1.shallow_model result) 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) }
     ensures { [#"../knapsack_full.rs" 81 0 83 2] forall s : Seq.seq (KnapsackFull_Item_Type.t_item name) . SubseqRev0.subseq_rev s 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UIntSize.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) }
     
 end
@@ -2056,11 +2056,11 @@ module KnapsackFull_Knapsack01Dyn
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
     val Max0.mAX' = Max1.mAX'
   let rec cfg knapsack01_dyn [#"../knapsack_full.rs" 84 0 84 91] [@cfg:stackify] [@cfg:subregion_analysis] (items : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)) (max_weight : usize) : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)
-    requires {[#"../knapsack_full.rs" 76 11 76 36] Seq.length (ShallowModel0.shallow_model items) < 10000000}
+    requires {[#"../knapsack_full.rs" 76 11 76 34] Seq.length (ShallowModel0.shallow_model items) < 10000000}
     requires {[#"../knapsack_full.rs" 77 11 77 33] UIntSize.to_int max_weight < 10000000}
-    requires {[#"../knapsack_full.rs" 78 0 78 91] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (KnapsackFull_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
-    ensures { [#"../knapsack_full.rs" 79 10 79 62] SumWeights0.sum_weights (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) <= UIntSize.to_int max_weight }
-    ensures { [#"../knapsack_full.rs" 80 10 80 56] SubseqRev0.subseq_rev (ShallowModel1.shallow_model result) 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) }
+    requires {[#"../knapsack_full.rs" 78 0 78 87] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model items) -> UIntSize.to_int (KnapsackFull_Item_Type.item_value (Seq.get (ShallowModel0.shallow_model items) i)) <= 10000000}
+    ensures { [#"../knapsack_full.rs" 79 10 79 60] SumWeights0.sum_weights (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) <= UIntSize.to_int max_weight }
+    ensures { [#"../knapsack_full.rs" 80 10 80 54] SubseqRev0.subseq_rev (ShallowModel1.shallow_model result) 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) }
     ensures { [#"../knapsack_full.rs" 81 0 83 2] forall s : Seq.seq (KnapsackFull_Item_Type.t_item name) . SubseqRev0.subseq_rev s 0 (ShallowModel0.shallow_model items) (Seq.length (ShallowModel0.shallow_model items)) /\ SumWeights0.sum_weights s (Seq.length s) <= UIntSize.to_int max_weight -> SumValues0.sum_values s (Seq.length s) <= SumValues0.sum_values (ShallowModel1.shallow_model result) (Seq.length (ShallowModel1.shallow_model result)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -2212,17 +2212,17 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB4 {
     _18 <- Core_Ops_Range_Range_Type.C_Range ([#"../knapsack_full.rs" 94 13 94 14] (0 : usize)) _19;
-    iter_17 <- ([#"../knapsack_full.rs" 87 4 87 70] IntoIter0.into_iter _18);
+    iter_17 <- ([#"../knapsack_full.rs" 87 4 87 66] IntoIter0.into_iter _18);
     goto BB5
   }
   BB5 {
     _23 <- ();
-    iter_old_21 <- ([#"../knapsack_full.rs" 87 4 87 70] Ghost.new iter_17);
+    iter_old_21 <- ([#"../knapsack_full.rs" 87 4 87 66] Ghost.new iter_17);
     goto BB6
   }
   BB6 {
     _27 <- ();
-    produced_24 <- ([#"../knapsack_full.rs" 87 4 87 70] Ghost.new (Seq.empty ));
+    produced_24 <- ([#"../knapsack_full.rs" 87 4 87 66] Ghost.new (Seq.empty ));
     goto BB7
   }
   BB7 {
@@ -2241,18 +2241,18 @@ module KnapsackFull_Knapsack01Dyn
     goto BB12
   }
   BB12 {
-    invariant type_invariant { [#"../knapsack_full.rs" 87 4 87 70] Invariant0.invariant' iter_17 };
-    invariant structural { [#"../knapsack_full.rs" 87 4 87 70] Produces0.produces (Ghost.inner iter_old_21) (Ghost.inner produced_24) iter_17 };
-    invariant items_len { [#"../knapsack_full.rs" 87 27 87 68] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel2.shallow_model best_value_9) };
-    invariant weight_len { [#"../knapsack_full.rs" 87 4 87 70] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model best_value_9) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) i)) };
-    invariant best_value { [#"../knapsack_full.rs" 87 4 87 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Ghost.inner produced_24) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
-    invariant best_value_bounds { [#"../knapsack_full.rs" 87 4 87 70] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) <= 10000000 * ii };
+    invariant type_invariant { [#"../knapsack_full.rs" 87 4 87 66] Invariant0.invariant' iter_17 };
+    invariant structural { [#"../knapsack_full.rs" 87 4 87 66] Produces0.produces (Ghost.inner iter_old_21) (Ghost.inner produced_24) iter_17 };
+    invariant items_len { [#"../knapsack_full.rs" 87 27 87 64] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel2.shallow_model best_value_9) };
+    invariant weight_len { [#"../knapsack_full.rs" 87 4 87 66] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model best_value_9) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) i)) };
+    invariant best_value { [#"../knapsack_full.rs" 87 4 87 66] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (Ghost.inner produced_24) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
+    invariant best_value_bounds { [#"../knapsack_full.rs" 87 4 87 66] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) <= 10000000 * ii };
     _37 <- borrow_mut iter_17;
     iter_17 <-  ^ _37;
     _36 <- borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     assume { Resolve0.resolve _37 };
-    _35 <- ([#"../knapsack_full.rs" 87 4 87 70] Next0.next _36);
+    _35 <- ([#"../knapsack_full.rs" 87 4 87 66] Next0.next _36);
     goto BB13
   }
   BB13 {
@@ -2275,7 +2275,7 @@ module KnapsackFull_Knapsack01Dyn
   BB16 {
     __creusot_proc_iter_elem_39 <- Core_Option_Option_Type.some_0 _35;
     _42 <- ();
-    _40 <- ([#"../knapsack_full.rs" 87 4 87 70] Ghost.new (Seq.(++) (Ghost.inner produced_24) (Seq.singleton __creusot_proc_iter_elem_39)));
+    _40 <- ([#"../knapsack_full.rs" 87 4 87 66] Ghost.new (Seq.(++) (Ghost.inner produced_24) (Seq.singleton __creusot_proc_iter_elem_39)));
     goto BB17
   }
   BB17 {
@@ -2295,17 +2295,17 @@ module KnapsackFull_Knapsack01Dyn
     goto BB19
   }
   BB19 {
-    iter_48 <- ([#"../knapsack_full.rs" 97 8 97 75] IntoIter1.into_iter _49);
+    iter_48 <- ([#"../knapsack_full.rs" 97 8 97 71] IntoIter1.into_iter _49);
     goto BB20
   }
   BB20 {
     _53 <- ();
-    iter_old_51 <- ([#"../knapsack_full.rs" 97 8 97 75] Ghost.new iter_48);
+    iter_old_51 <- ([#"../knapsack_full.rs" 97 8 97 71] Ghost.new iter_48);
     goto BB21
   }
   BB21 {
     _57 <- ();
-    produced_54 <- ([#"../knapsack_full.rs" 97 8 97 75] Ghost.new (Seq.empty ));
+    produced_54 <- ([#"../knapsack_full.rs" 97 8 97 71] Ghost.new (Seq.empty ));
     goto BB22
   }
   BB22 {
@@ -2327,19 +2327,19 @@ module KnapsackFull_Knapsack01Dyn
     goto BB28
   }
   BB28 {
-    invariant type_invariant { [#"../knapsack_full.rs" 97 8 97 75] Invariant1.invariant' iter_48 };
-    invariant structural { [#"../knapsack_full.rs" 97 8 97 75] Produces1.produces (Ghost.inner iter_old_51) (Ghost.inner produced_54) iter_48 };
-    invariant items_len2 { [#"../knapsack_full.rs" 97 32 97 73] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel2.shallow_model best_value_9) };
-    invariant weight_len2 { [#"../knapsack_full.rs" 97 8 97 75] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model best_value_9) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) i)) };
-    invariant best_value2 { [#"../knapsack_full.rs" 97 8 97 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_43 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
-    invariant best_value2 { [#"../knapsack_full.rs" 97 8 97 75] forall ww : int . 0 <= ww /\ ww <= Seq.length (Ghost.inner produced_54) - 1 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) (UIntSize.to_int i_43 + 1))) ww) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int i_43 + 1) ww };
-    invariant best_value_bounds { [#"../knapsack_full.rs" 97 8 97 75] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) <= 10000000 * ii };
+    invariant type_invariant { [#"../knapsack_full.rs" 97 8 97 71] Invariant1.invariant' iter_48 };
+    invariant structural { [#"../knapsack_full.rs" 97 8 97 71] Produces1.produces (Ghost.inner iter_old_51) (Ghost.inner produced_54) iter_48 };
+    invariant items_len2 { [#"../knapsack_full.rs" 97 32 97 69] Seq.length (ShallowModel0.shallow_model items_1) + 1 = Seq.length (ShallowModel2.shallow_model best_value_9) };
+    invariant weight_len2 { [#"../knapsack_full.rs" 97 8 97 71] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel2.shallow_model best_value_9) -> UIntSize.to_int max_weight_2 + 1 = Seq.length (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) i)) };
+    invariant best_value2 { [#"../knapsack_full.rs" 97 8 97 71] forall ww : int . forall ii : int . 0 <= ii /\ ii <= UIntSize.to_int i_43 /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) = M0.m (ShallowModel0.shallow_model items_1) ii ww };
+    invariant best_value2 { [#"../knapsack_full.rs" 97 8 97 71] forall ww : int . 0 <= ww /\ ww <= Seq.length (Ghost.inner produced_54) - 1 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) (UIntSize.to_int i_43 + 1))) ww) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int i_43 + 1) ww };
+    invariant best_value_bounds { [#"../knapsack_full.rs" 97 8 97 71] forall ww : int . forall ii : int . 0 <= ii /\ ii <= Seq.length (ShallowModel0.shallow_model items_1) /\ 0 <= ww /\ ww <= UIntSize.to_int max_weight_2 -> UIntSize.to_int (Seq.get (ShallowModel3.shallow_model (Seq.get (ShallowModel2.shallow_model best_value_9) ii)) ww) <= 10000000 * ii };
     _67 <- borrow_mut iter_48;
     iter_48 <-  ^ _67;
     _66 <- borrow_mut ( * _67);
     _67 <- { _67 with current = ( ^ _66) };
     assume { Resolve4.resolve _67 };
-    _65 <- ([#"../knapsack_full.rs" 97 8 97 75] Next1.next _66);
+    _65 <- ([#"../knapsack_full.rs" 97 8 97 71] Next1.next _66);
     goto BB29
   }
   BB29 {
@@ -2362,7 +2362,7 @@ module KnapsackFull_Knapsack01Dyn
   BB32 {
     __creusot_proc_iter_elem_69 <- Core_Option_Option_Type.some_0 _65;
     _72 <- ();
-    _70 <- ([#"../knapsack_full.rs" 97 8 97 75] Ghost.new (Seq.(++) (Ghost.inner produced_54) (Seq.singleton __creusot_proc_iter_elem_69)));
+    _70 <- ([#"../knapsack_full.rs" 97 8 97 71] Ghost.new (Seq.(++) (Ghost.inner produced_54) (Seq.singleton __creusot_proc_iter_elem_69)));
     goto BB33
   }
   BB33 {
@@ -2476,11 +2476,11 @@ module KnapsackFull_Knapsack01Dyn
     goto BB52
   }
   BB52 {
-    invariant j_items_len { [#"../knapsack_full.rs" 122 29 122 49] UIntSize.to_int j_115 <= Seq.length (ShallowModel0.shallow_model items_1) };
+    invariant j_items_len { [#"../knapsack_full.rs" 122 29 122 47] UIntSize.to_int j_115 <= Seq.length (ShallowModel0.shallow_model items_1) };
     invariant left_weight_le_max { [#"../knapsack_full.rs" 123 36 123 63] UIntSize.to_int left_weight_114 <= UIntSize.to_int max_weight_2 };
-    invariant result_weight { [#"../knapsack_full.rs" 122 4 122 51] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SumWeights0.sum_weights r (Seq.length (ShallowModel1.shallow_model result_111)) <= UIntSize.to_int left_weight_114 -> SumWeights0.sum_weights r 0 <= UIntSize.to_int max_weight_2 };
-    invariant result_value { [#"../knapsack_full.rs" 122 4 122 51] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SumValues0.sum_values r (Seq.length (ShallowModel1.shallow_model result_111)) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int j_115) (UIntSize.to_int left_weight_114) -> SumValues0.sum_values r 0 = M0.m (ShallowModel0.shallow_model items_1) (Seq.length (ShallowModel0.shallow_model items_1)) (UIntSize.to_int max_weight_2) };
-    invariant result_subseq { [#"../knapsack_full.rs" 122 4 122 51] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SubseqRev0.subseq_rev r (Seq.length (ShallowModel1.shallow_model result_111)) (ShallowModel0.shallow_model items_1) (UIntSize.to_int j_115) -> SubseqRev0.subseq_rev r 0 (ShallowModel0.shallow_model items_1) (Seq.length (ShallowModel0.shallow_model items_1)) };
+    invariant result_weight { [#"../knapsack_full.rs" 122 4 122 49] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SumWeights0.sum_weights r (Seq.length (ShallowModel1.shallow_model result_111)) <= UIntSize.to_int left_weight_114 -> SumWeights0.sum_weights r 0 <= UIntSize.to_int max_weight_2 };
+    invariant result_value { [#"../knapsack_full.rs" 122 4 122 49] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SumValues0.sum_values r (Seq.length (ShallowModel1.shallow_model result_111)) = M0.m (ShallowModel0.shallow_model items_1) (UIntSize.to_int j_115) (UIntSize.to_int left_weight_114) -> SumValues0.sum_values r 0 = M0.m (ShallowModel0.shallow_model items_1) (Seq.length (ShallowModel0.shallow_model items_1)) (UIntSize.to_int max_weight_2) };
+    invariant result_subseq { [#"../knapsack_full.rs" 122 4 122 49] forall r : Seq.seq (KnapsackFull_Item_Type.t_item name) . Seq.length (ShallowModel1.shallow_model result_111) <= Seq.length r /\ (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model result_111) -> Seq.get (ShallowModel1.shallow_model result_111) i = Seq.get r i) /\ SubseqRev0.subseq_rev r (Seq.length (ShallowModel1.shallow_model result_111)) (ShallowModel0.shallow_model items_1) (UIntSize.to_int j_115) -> SubseqRev0.subseq_rev r 0 (ShallowModel0.shallow_model items_1) (Seq.length (ShallowModel0.shallow_model items_1)) };
     _124 <- j_115;
     _123 <- ([#"../knapsack_full.rs" 139 10 139 15] ([#"../knapsack_full.rs" 139 10 139 11] (0 : usize)) < _124);
     switch (_123)

--- a/creusot/tests/should_succeed/knapsack_full.rs
+++ b/creusot/tests/should_succeed/knapsack_full.rs
@@ -26,7 +26,7 @@ fn max(a: usize, b: usize) -> usize {
 fn sum_weights<Name>(s: Seq<&Item<Name>>, i: Int) -> Int {
     pearlite! {
         if i == s.len() { 0 }
-        else { @s[i].weight + sum_weights(s, i+1) }
+        else { s[i].weight@ + sum_weights(s, i+1) }
     }
 }
 
@@ -36,7 +36,7 @@ fn sum_weights<Name>(s: Seq<&Item<Name>>, i: Int) -> Int {
 fn sum_values<Name>(s: Seq<&Item<Name>>, i: Int) -> Int {
     pearlite! {
         if i == s.len() { 0 }
-        else { @s[i].value + sum_values(s, i+1) }
+        else { s[i].value@ + sum_values(s, i+1) }
     }
 }
 
@@ -65,17 +65,17 @@ fn subseq_rev<T>(s1: Seq<&T>, i1: Int, s2: Seq<T>, i2: Int) -> bool {
 fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
     pearlite! {
         if i == 0 { 0 }
-        else if @items[i-1].weight > w {
+        else if items[i-1].weight@ > w {
             m(items, i-1, w)
         } else {
-            m(items, i-1, w).max(m(items, i-1, w - @items[i-1].weight) + @items[i-1].value)
+            m(items, i-1, w).max(m(items, i-1, w - items[i-1].weight@) + items[i-1].value@)
         }
     }
 }
 
 #[requires(items@.len() < 10000000)]
 #[requires(max_weight@ < 10000000)]
-#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
+#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> items@[i].value@ <= 10000000)]
 #[ensures(sum_weights(result@, result@.len()) <= max_weight@)]
 #[ensures(subseq_rev(result@, 0, items@, items@.len()))]
 #[ensures(forall<s: Seq<&Item<Name>>> subseq_rev(s, 0, items@, items@.len()) && sum_weights(s, s.len()) <= max_weight@ ==>
@@ -86,24 +86,24 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
 
     #[invariant(items_len, items@.len() + 1 == best_value@.len())]
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                  max_weight@ + 1 == (@best_value@[i]).len())]
+                  max_weight@ + 1 == (best_value@[i]@).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= produced.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+                  @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
     #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
+                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
     for i in 0..items.len() {
         let it = &items[i];
 
         #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
         #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                      max_weight@ + 1 == (@best_value@[i]).len())]
+                      max_weight@ + 1 == (best_value@[i]@).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                      @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+                      @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= produced.len() - 1 ==>
-                      @(@best_value@[i@+1])[ww] == m(items@, i@+1, ww))]
+                      @(best_value@[i@+1]@)[ww] == m(items@, i@+1, ww))]
         #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
+                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
         // Change compared to Rosetta Code: we start at w = 0.
         // This makes it possible to allow 0-weight items, and makes the proof simpler.
         for w in 0..=max_weight {

--- a/creusot/tests/should_succeed/knapsack_full.rs
+++ b/creusot/tests/should_succeed/knapsack_full.rs
@@ -10,7 +10,7 @@ pub struct Item<Name> {
     pub value: usize,
 }
 
-#[ensures(@result == a@.max(@b))]
+#[ensures(result@ == a@.max(b@))]
 fn max(a: usize, b: usize) -> usize {
     if a < b {
         b
@@ -74,35 +74,35 @@ fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
 }
 
 #[requires(items@.len() < 10000000)]
-#[requires(@max_weight < 10000000)]
+#[requires(max_weight@ < 10000000)]
 #[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
-#[ensures(sum_weights(@result, result@.len()) <= @max_weight)]
-#[ensures(subseq_rev(@result, 0, @items, items@.len()))]
-#[ensures(forall<s: Seq<&Item<Name>>> subseq_rev(s, 0, @items, items@.len()) && sum_weights(s, s.len()) <= @max_weight ==>
-    sum_values(s, s.len()) <= sum_values(@result, result@.len())
+#[ensures(sum_weights(result@, result@.len()) <= max_weight@)]
+#[ensures(subseq_rev(result@, 0, items@, items@.len()))]
+#[ensures(forall<s: Seq<&Item<Name>>> subseq_rev(s, 0, items@, items@.len()) && sum_weights(s, s.len()) <= max_weight@ ==>
+    sum_values(s, s.len()) <= sum_values(result@, result@.len())
 )]
 pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&Item<Name>> {
     let mut best_value = vec![vec![0; max_weight + 1]; items.len() + 1];
 
     #[invariant(items_len, items@.len() + 1 == best_value@.len())]
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                  @max_weight + 1 == (@best_value@[i]).len())]
-    #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= produced.len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@best_value@[ii])[ww] == m(@items, ii, ww))]
-    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  max_weight@ + 1 == (@best_value@[i]).len())]
+    #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= produced.len() && 0 <= ww && ww <= max_weight@ ==>
+                  @(@best_value@[ii])[ww] == m(items@, ii, ww))]
+    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
                   @(@best_value@[ii])[ww] <= 10000000 * ii)]
     for i in 0..items.len() {
         let it = &items[i];
 
         #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
         #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
-                      @max_weight + 1 == (@best_value@[i]).len())]
+                      max_weight@ + 1 == (@best_value@[i]).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
-                      0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                      @(@best_value@[ii])[ww] == m(@items, ii, ww))]
+                      0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
+                      @(@best_value@[ii])[ww] == m(items@, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= produced.len() - 1 ==>
-                      @(@best_value@[@i+1])[ww] == m(@items, @i+1, ww))]
-        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                      @(@best_value@[i@+1])[ww] == m(items@, i@+1, ww))]
+        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
                   @(@best_value@[ii])[ww] <= 10000000 * ii)]
         // Change compared to Rosetta Code: we start at w = 0.
         // This makes it possible to allow 0-weight items, and makes the proof simpler.
@@ -119,23 +119,23 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     let mut left_weight = max_weight;
 
     let mut j = items.len();
-    #[invariant(j_items_len, @j <= items@.len())]
-    #[invariant(left_weight_le_max, @left_weight <= @max_weight)]
+    #[invariant(j_items_len, j@ <= items@.len())]
+    #[invariant(left_weight_le_max, left_weight@ <= max_weight@)]
     #[invariant(result_weight, forall<r: Seq<&Item<Name>>>
                 result@.len() <= r.len() &&
                 (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
-                sum_weights(r, result@.len()) <= @left_weight ==>
-                sum_weights(r, 0) <= @max_weight)]
+                sum_weights(r, result@.len()) <= left_weight@ ==>
+                sum_weights(r, 0) <= max_weight@)]
     #[invariant(result_value, forall<r: Seq<&Item<Name>>>
                 result@.len() <= r.len() &&
                 (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
-                sum_values(r, result@.len()) == m(@items, @j, @left_weight) ==>
-                sum_values(r, 0) == m(@items, items@.len(), @max_weight))]
+                sum_values(r, result@.len()) == m(items@, j@, left_weight@) ==>
+                sum_values(r, 0) == m(items@, items@.len(), max_weight@))]
     #[invariant(result_subseq, forall<r: Seq<&Item<Name>>>
                 result@.len() <= r.len() &&
                 (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
-                subseq_rev(r, result@.len(), @items, @j) ==>
-                subseq_rev(r, 0, @items, items@.len()))]
+                subseq_rev(r, result@.len(), items@, j@) ==>
+                subseq_rev(r, 0, items@, items@.len()))]
     while 0 < j {
         j -= 1;
         let it = &items[j];

--- a/creusot/tests/should_succeed/knapsack_full.rs
+++ b/creusot/tests/should_succeed/knapsack_full.rs
@@ -88,9 +88,9 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
                   max_weight@ + 1 == (best_value@[i]@).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= produced.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
+                  (best_value@[ii]@)[ww]@ == m(items@, ii, ww))]
     #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
+                  (best_value@[ii]@)[ww]@ <= 10000000 * ii)]
     for i in 0..items.len() {
         let it = &items[i];
 
@@ -99,11 +99,11 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
                       max_weight@ + 1 == (best_value@[i]@).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= i@ && 0 <= ww && ww <= max_weight@ ==>
-                      @(best_value@[ii]@)[ww] == m(items@, ii, ww))]
+                      (best_value@[ii]@)[ww]@ == m(items@, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= produced.len() - 1 ==>
-                      @(best_value@[i@+1]@)[ww] == m(items@, i@+1, ww))]
+                      (best_value@[i@+1]@)[ww]@ == m(items@, i@+1, ww))]
         #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= max_weight@ ==>
-                  @(best_value@[ii]@)[ww] <= 10000000 * ii)]
+                  (best_value@[ii]@)[ww]@ <= 10000000 * ii)]
         // Change compared to Rosetta Code: we start at w = 0.
         // This makes it possible to allow 0-weight items, and makes the proof simpler.
         for w in 0..=max_weight {

--- a/creusot/tests/should_succeed/knapsack_full.rs
+++ b/creusot/tests/should_succeed/knapsack_full.rs
@@ -10,7 +10,7 @@ pub struct Item<Name> {
     pub value: usize,
 }
 
-#[ensures(@result == (@a).max(@b))]
+#[ensures(@result == a@.max(@b))]
 fn max(a: usize, b: usize) -> usize {
     if a < b {
         b
@@ -73,37 +73,37 @@ fn m<Name>(items: Seq<Item<Name>>, i: Int, w: Int) -> Int {
     }
 }
 
-#[requires((@items).len() < 10000000)]
+#[requires(items@.len() < 10000000)]
 #[requires(@max_weight < 10000000)]
-#[requires(forall<i: Int> 0 <= i && i < (@items).len() ==> @(@items)[i].value <= 10000000)]
-#[ensures(sum_weights(@result, (@result).len()) <= @max_weight)]
-#[ensures(subseq_rev(@result, 0, @items, (@items).len()))]
-#[ensures(forall<s: Seq<&Item<Name>>> subseq_rev(s, 0, @items, (@items).len()) && sum_weights(s, s.len()) <= @max_weight ==>
-    sum_values(s, s.len()) <= sum_values(@result, (@result).len())
+#[requires(forall<i: Int> 0 <= i && i < items@.len() ==> @items@[i].value <= 10000000)]
+#[ensures(sum_weights(@result, result@.len()) <= @max_weight)]
+#[ensures(subseq_rev(@result, 0, @items, items@.len()))]
+#[ensures(forall<s: Seq<&Item<Name>>> subseq_rev(s, 0, @items, items@.len()) && sum_weights(s, s.len()) <= @max_weight ==>
+    sum_values(s, s.len()) <= sum_values(@result, result@.len())
 )]
 pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&Item<Name>> {
     let mut best_value = vec![vec![0; max_weight + 1]; items.len() + 1];
 
-    #[invariant(items_len, (@items).len() + 1 == (@best_value).len())]
-    #[invariant(weight_len, forall<i: Int> 0 <= i && i < (@best_value).len() ==>
-                  @max_weight + 1 == (@(@best_value)[i]).len())]
+    #[invariant(items_len, items@.len() + 1 == best_value@.len())]
+    #[invariant(weight_len, forall<i: Int> 0 <= i && i < best_value@.len() ==>
+                  @max_weight + 1 == (@best_value@[i]).len())]
     #[invariant(best_value, forall<ii: Int, ww: Int> 0 <= ii && ii <= produced.len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] == m(@items, ii, ww))]
-    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= (@items).len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] <= 10000000 * ii)]
+                  @(@best_value@[ii])[ww] == m(@items, ii, ww))]
+    #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
     for i in 0..items.len() {
         let it = &items[i];
 
-        #[invariant(items_len2, (@items).len() + 1 == (@best_value).len())]
-        #[invariant(weight_len2, forall<i: Int> 0 <= i && i < (@best_value).len() ==>
-                      @max_weight + 1 == (@(@best_value)[i]).len())]
+        #[invariant(items_len2, items@.len() + 1 == best_value@.len())]
+        #[invariant(weight_len2, forall<i: Int> 0 <= i && i < best_value@.len() ==>
+                      @max_weight + 1 == (@best_value@[i]).len())]
         #[invariant(best_value2, forall<ii: Int, ww: Int>
                       0 <= ii && ii <= @i && 0 <= ww && ww <= @max_weight ==>
-                      @(@(@best_value)[ii])[ww] == m(@items, ii, ww))]
+                      @(@best_value@[ii])[ww] == m(@items, ii, ww))]
         #[invariant(best_value2, forall<ww: Int> 0 <= ww && ww <= produced.len() - 1 ==>
-                      @(@(@best_value)[@i+1])[ww] == m(@items, @i+1, ww))]
-        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= (@items).len() && 0 <= ww && ww <= @max_weight ==>
-                  @(@(@best_value)[ii])[ww] <= 10000000 * ii)]
+                      @(@best_value@[@i+1])[ww] == m(@items, @i+1, ww))]
+        #[invariant(best_value_bounds, forall<ii: Int, ww: Int> 0 <= ii && ii <= items@.len() && 0 <= ww && ww <= @max_weight ==>
+                  @(@best_value@[ii])[ww] <= 10000000 * ii)]
         // Change compared to Rosetta Code: we start at w = 0.
         // This makes it possible to allow 0-weight items, and makes the proof simpler.
         for w in 0..=max_weight {
@@ -119,23 +119,23 @@ pub fn knapsack01_dyn<Name>(items: &Vec<Item<Name>>, max_weight: usize) -> Vec<&
     let mut left_weight = max_weight;
 
     let mut j = items.len();
-    #[invariant(j_items_len, @j <= (@items).len())]
+    #[invariant(j_items_len, @j <= items@.len())]
     #[invariant(left_weight_le_max, @left_weight <= @max_weight)]
     #[invariant(result_weight, forall<r: Seq<&Item<Name>>>
-                (@result).len() <= r.len() &&
-                (forall<i: Int> 0 <= i && i < (@result).len() ==> (@result)[i] == r[i]) &&
-                sum_weights(r, (@result).len()) <= @left_weight ==>
+                result@.len() <= r.len() &&
+                (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
+                sum_weights(r, result@.len()) <= @left_weight ==>
                 sum_weights(r, 0) <= @max_weight)]
     #[invariant(result_value, forall<r: Seq<&Item<Name>>>
-                (@result).len() <= r.len() &&
-                (forall<i: Int> 0 <= i && i < (@result).len() ==> (@result)[i] == r[i]) &&
-                sum_values(r, (@result).len()) == m(@items, @j, @left_weight) ==>
-                sum_values(r, 0) == m(@items, (@items).len(), @max_weight))]
+                result@.len() <= r.len() &&
+                (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
+                sum_values(r, result@.len()) == m(@items, @j, @left_weight) ==>
+                sum_values(r, 0) == m(@items, items@.len(), @max_weight))]
     #[invariant(result_subseq, forall<r: Seq<&Item<Name>>>
-                (@result).len() <= r.len() &&
-                (forall<i: Int> 0 <= i && i < (@result).len() ==> (@result)[i] == r[i]) &&
-                subseq_rev(r, (@result).len(), @items, @j) ==>
-                subseq_rev(r, 0, @items, (@items).len()))]
+                result@.len() <= r.len() &&
+                (forall<i: Int> 0 <= i && i < result@.len() ==> result@[i] == r[i]) &&
+                subseq_rev(r, result@.len(), @items, @j) ==>
+                subseq_rev(r, 0, @items, items@.len()))]
     while 0 < j {
         j -= 1;
         let it = &items[j];

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -153,7 +153,7 @@ module ListIndexMut_IndexMut_Interface
     ensures { [#"../list_index_mut.rs" 39 10 39 51] ListIndexMut_Option_Type.C_Some ( * result) = Get0.get ( * param_l) (UIntSize.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 40 10 40 51] ListIndexMut_Option_Type.C_Some ( ^ result) = Get0.get ( ^ param_l) (UIntSize.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 41 10 41 40] Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { [#"../list_index_mut.rs" 42 0 42 114] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UIntSize.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    ensures { [#"../list_index_mut.rs" 42 0 42 112] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UIntSize.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     
 end
 module ListIndexMut_IndexMut
@@ -180,7 +180,7 @@ module ListIndexMut_IndexMut
     ensures { [#"../list_index_mut.rs" 39 10 39 51] ListIndexMut_Option_Type.C_Some ( * result) = Get0.get ( * param_l) (UIntSize.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 40 10 40 51] ListIndexMut_Option_Type.C_Some ( ^ result) = Get0.get ( ^ param_l) (UIntSize.to_int param_ix) }
     ensures { [#"../list_index_mut.rs" 41 10 41 40] Len0.len ( ^ param_l) = Len0.len ( * param_l) }
-    ensures { [#"../list_index_mut.rs" 42 0 42 114] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UIntSize.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
+    ensures { [#"../list_index_mut.rs" 42 0 42 112] forall i : int . 0 <= i /\ i < Len0.len ( * param_l) /\ i <> UIntSize.to_int param_ix -> Get0.get ( * param_l) i = Get0.get ( ^ param_l) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : borrowed uint32;

--- a/creusot/tests/should_succeed/list_index_mut.rs
+++ b/creusot/tests/should_succeed/list_index_mut.rs
@@ -39,7 +39,7 @@ fn get(l: List, ix: Int) -> Option<u32> {
 #[ensures(Some(*result) == get(*param_l, @param_ix))]
 #[ensures(Some(^result) == get(^param_l, @param_ix))]
 #[ensures(len(^param_l) == len(*param_l))]
-#[ensures(forall<i:Int> 0 <= i && i < len(*param_l) && i != (@param_ix) ==> get(*param_l, i) == get(^param_l, i))]
+#[ensures(forall<i:Int> 0 <= i && i < len(*param_l) && i != param_ix@ ==> get(*param_l, i) == get(^param_l, i))]
 pub fn index_mut(param_l: &mut List, param_ix: usize) -> &mut u32 {
     let old_l = ghost! { param_l };
     let mut l = param_l;

--- a/creusot/tests/should_succeed/list_index_mut.rs
+++ b/creusot/tests/should_succeed/list_index_mut.rs
@@ -35,22 +35,22 @@ fn get(l: List, ix: Int) -> Option<u32> {
     }
 }
 
-#[requires(@param_ix < len(*param_l))]
-#[ensures(Some(*result) == get(*param_l, @param_ix))]
-#[ensures(Some(^result) == get(^param_l, @param_ix))]
+#[requires(param_ix@ < len(*param_l))]
+#[ensures(Some(*result) == get(*param_l, param_ix@))]
+#[ensures(Some(^result) == get(^param_l, param_ix@))]
 #[ensures(len(^param_l) == len(*param_l))]
 #[ensures(forall<i:Int> 0 <= i && i < len(*param_l) && i != param_ix@ ==> get(*param_l, i) == get(^param_l, i))]
 pub fn index_mut(param_l: &mut List, param_ix: usize) -> &mut u32 {
     let old_l = ghost! { param_l };
     let mut l = param_l;
     let mut ix = param_ix;
-    #[invariant(valid_ix, 0usize <= ix && @ix < len (*l))]
-    #[invariant(get_target_now, get(*l, @ix) == get(**old_l, @param_ix))]
-    #[invariant(get_target_fin, get(^l, @ix) == get(^*old_l, @param_ix))]
+    #[invariant(valid_ix, 0usize <= ix && ix@ < len (*l))]
+    #[invariant(get_target_now, get(*l, ix@) == get(**old_l, param_ix@))]
+    #[invariant(get_target_fin, get(^l, ix@) == get(^*old_l, param_ix@))]
     #[invariant(len, len(^l) == len(*l) ==> len(^*old_l) == len(**old_l))]
     #[invariant(untouched,
-        (forall<i:Int> 0 <= i && i < len (*l) && i != @ix ==> get(^l, i) == get(*l, i)) ==>
-        forall<i:Int> 0 <= i && i < len (**old_l) && i != @param_ix ==>
+        (forall<i:Int> 0 <= i && i < len (*l) && i != ix@ ==> get(^l, i) == get(*l, i)) ==>
+        forall<i:Int> 0 <= i && i < len (**old_l) && i != param_ix@ ==>
             get (^*old_l, i) == get (**old_l, i)
     )]
     while ix > 0 {
@@ -67,10 +67,10 @@ pub fn index_mut(param_l: &mut List, param_ix: usize) -> &mut u32 {
 }
 
 // Ensure that this performs a set on the list
-#[requires(@ix < len(*l))]
-#[ensures(Some(v) == get(^l, @ix))]
+#[requires(ix@ < len(*l))]
+#[ensures(Some(v) == get(^l, ix@))]
 #[ensures(len(^l) == len(*l))]
-#[ensures(forall<i:Int> 0 <= i && i < len(*l) && i != @ix ==> get(*l, i) == get(^l, i))]
+#[ensures(forall<i:Int> 0 <= i && i < len(*l) && i != ix@ ==> get(*l, i) == get(^l, i))]
 pub fn write(l: &mut List, ix: usize, v: u32) {
     *index_mut(l, ix) = v;
 }

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -284,9 +284,9 @@ module MappingTest_F
   }
   BB0 {
     x_1 <- MappingTest_T_Type.C_T ([#"../mapping_test.rs" 38 23 38 25] (42 : int32));
-    assert { [#"../mapping_test.rs" 39 19 39 36] Map.get (ShallowModel0.shallow_model x_1) 13 = 1 };
+    assert { [#"../mapping_test.rs" 39 19 39 34] Map.get (ShallowModel0.shallow_model x_1) 13 = 1 };
     _2 <- ();
-    assert { [#"../mapping_test.rs" 40 19 40 36] Map.get (ShallowModel0.shallow_model x_1) 42 = 0 };
+    assert { [#"../mapping_test.rs" 40 19 40 34] Map.get (ShallowModel0.shallow_model x_1) 42 = 0 };
     _4 <- ();
     _8 <- borrow_mut x_1;
     x_1 <-  ^ _8;
@@ -297,9 +297,9 @@ module MappingTest_F
     goto BB1
   }
   BB1 {
-    assert { [#"../mapping_test.rs" 42 19 42 36] Map.get (ShallowModel0.shallow_model x_1) 13 = 1 };
+    assert { [#"../mapping_test.rs" 42 19 42 34] Map.get (ShallowModel0.shallow_model x_1) 13 = 1 };
     _9 <- ();
-    assert { [#"../mapping_test.rs" 43 19 43 36] Map.get (ShallowModel0.shallow_model x_1) 42 = 1 };
+    assert { [#"../mapping_test.rs" 43 19 43 34] Map.get (ShallowModel0.shallow_model x_1) 42 = 1 };
     _11 <- ();
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/mapping_test.rs
+++ b/creusot/tests/should_succeed/mapping_test.rs
@@ -23,9 +23,9 @@ impl ShallowModel for T {
     }
 }
 
-#[requires( 0 <= @(*t).a )] // otherwise its wrong !
-#[requires( @(*t).a < 1000 )] // to prevent overflow
-#[ensures( (^t)@ == t@.set(@(*t).a,1) )]
+#[requires( 0 <= (*t).a@ )] // otherwise its wrong !
+#[requires( (*t).a@ < 1000 )] // to prevent overflow
+#[ensures( (^t)@ == t@.set((*t).a@,1) )]
 fn incr(t: &mut T) {
     let old_t = ghost! { t };
     (*t).a += 1;

--- a/creusot/tests/should_succeed/mapping_test.rs
+++ b/creusot/tests/should_succeed/mapping_test.rs
@@ -25,13 +25,13 @@ impl ShallowModel for T {
 
 #[requires( 0 <= @(*t).a )] // otherwise its wrong !
 #[requires( @(*t).a < 1000 )] // to prevent overflow
-#[ensures( @^t == t@.set(@(*t).a,1) )]
+#[ensures( (^t)@ == t@.set(@(*t).a,1) )]
 fn incr(t: &mut T) {
     let old_t = ghost! { t };
     (*t).a += 1;
     // proving the post-consition via extensional equality of mappings
     // (notice `==` versus `==`)
-    proof_assert!( @^t == old_t@.set(@old_t.a,1) );
+    proof_assert!( (^t)@ == old_t@.set(@old_t.a,1) );
 }
 
 pub fn f() {

--- a/creusot/tests/should_succeed/mapping_test.rs
+++ b/creusot/tests/should_succeed/mapping_test.rs
@@ -25,20 +25,20 @@ impl ShallowModel for T {
 
 #[requires( 0 <= @(*t).a )] // otherwise its wrong !
 #[requires( @(*t).a < 1000 )] // to prevent overflow
-#[ensures( @^t == (@t).set(@(*t).a,1) )]
+#[ensures( @^t == t@.set(@(*t).a,1) )]
 fn incr(t: &mut T) {
     let old_t = ghost! { t };
     (*t).a += 1;
     // proving the post-consition via extensional equality of mappings
     // (notice `==` versus `==`)
-    proof_assert!( @^t == (@old_t).set(@old_t.a,1) );
+    proof_assert!( @^t == old_t@.set(@old_t.a,1) );
 }
 
 pub fn f() {
     let mut x = T { a: 42 };
-    proof_assert!( (@x).get(13) == 1 );
-    proof_assert!( (@x).get(42) == 0 );
+    proof_assert!( x@.get(13) == 1 );
+    proof_assert!( x@.get(42) == 0 );
     incr(&mut x);
-    proof_assert!( (@x).get(13) == 1 );
-    proof_assert!( (@x).get(42) == 1 );
+    proof_assert!( x@.get(13) == 1 );
+    proof_assert!( x@.get(42) == 1 );
 }

--- a/creusot/tests/should_succeed/mapping_test.rs
+++ b/creusot/tests/should_succeed/mapping_test.rs
@@ -17,7 +17,7 @@ impl ShallowModel for T {
     #[trusted]
     #[ensures(
         forall<i:Int>
-            result.get(i) == (if 0 <= i && i < @self.a { 1 } else { 0 }))]
+            result.get(i) == (if 0 <= i && i < self.a@ { 1 } else { 0 }))]
     fn shallow_model(self) -> Self::ShallowModelTy {
         absurd
     }
@@ -31,7 +31,7 @@ fn incr(t: &mut T) {
     (*t).a += 1;
     // proving the post-consition via extensional equality of mappings
     // (notice `==` versus `==`)
-    proof_assert!( (^t)@ == old_t@.set(@old_t.a,1) );
+    proof_assert!( (^t)@ == old_t@.set(old_t.a@,1) );
 }
 
 pub fn f() {

--- a/creusot/tests/should_succeed/model.rs
+++ b/creusot/tests/should_succeed/model.rs
@@ -14,7 +14,7 @@ impl ShallowModel for Seven {
 }
 
 #[trusted]
-#[ensures(@result == 7)]
+#[ensures(result@ == 7)]
 pub fn seven() -> Seven {
     Seven()
 }
@@ -32,7 +32,7 @@ impl<T, U> ShallowModel for Pair<T, U> {
 }
 
 #[trusted]
-#[ensures(@result == (a, b))]
+#[ensures(result@ == (a, b))]
 pub fn pair<T, U>(a: T, b: U) -> Pair<T, U> {
     Pair(a, b)
 }

--- a/creusot/tests/should_succeed/ord_trait.rs
+++ b/creusot/tests/should_succeed/ord_trait.rs
@@ -17,7 +17,7 @@ where
     x >= y
 }
 
-#[ensures(result == (@x <= @y))]
+#[ensures(result == (x@ <= y@))]
 pub fn gt_or_le_int(x: usize, y: usize) -> bool {
     x <= y
 }

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -420,7 +420,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 535 37 535 70] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 535 41 535 74] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -505,7 +505,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 532 39 532 75] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 532 43 532 79] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -527,7 +527,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 533 1 533 51] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 533 5 533 55] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -540,7 +540,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 533 1 533 51] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 533 5 533 55] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -559,7 +559,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 535 105 536 43] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 536 0 537 1] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -572,7 +572,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 535 105 536 43] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 536 0 537 1] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -588,7 +588,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 539 39 540 11] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 539 43 540 15] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -610,7 +610,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 540 46 541 31] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 540 50 542 3] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -623,7 +623,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 540 46 541 31] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 540 50 542 3] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -639,7 +639,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 546 0 548 29] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 546 4 548 33] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -661,7 +661,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 549 21 550 25] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 549 25 550 29] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -674,7 +674,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 549 21 550 25] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 549 25 550 29] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -689,7 +689,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 551 2 551 33] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 551 6 551 37] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -700,7 +700,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 551 2 551 33] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 551 6 551 37] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -715,7 +715,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 38 552 55] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 552 73 553 1] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 18 553 35] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 42 552 59] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 552 77 553 5] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 22 553 39] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -724,11 +724,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {[#"../red_black_tree.rs" 552 38 552 55] CmpLog0.cmp_log x y = o}
-    requires {[#"../red_black_tree.rs" 552 73 553 1] CmpLog0.cmp_log y z = o}
+    requires {[#"../red_black_tree.rs" 552 42 552 59] CmpLog0.cmp_log x y = o}
+    requires {[#"../red_black_tree.rs" 552 77 553 5] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 38 552 55] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 552 73 553 1] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 18 553 35] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 552 42 552 59] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 552 77 553 5] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 553 22 553 39] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -743,7 +743,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 8 554 38] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 555 6 555 39] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 12 554 42] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 555 10 555 43] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -752,10 +752,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 554 8 554 38] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../red_black_tree.rs" 554 12 554 42] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 8 554 38] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 555 6 555 39] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 554 12 554 42] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 555 10 555 43] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -770,7 +770,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 6 556 39] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 11 557 41] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 10 556 43] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 15 557 45] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -779,10 +779,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 556 6 556 39] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../red_black_tree.rs" 556 10 556 43] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 6 556 39] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 11 557 41] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 556 10 556 43] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 557 15 557 45] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -797,7 +797,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 557 105 558 44] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 558 3 558 48] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -808,7 +808,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 557 105 558 44] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 558 3 558 48] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Stub
   type k
@@ -1090,7 +1090,7 @@ module RedBlackTree_Impl0_HasMappingModel_Interface
     type v = v
   function has_mapping_model [#"../red_black_tree.rs" 110 4 112 33] (self : RedBlackTree_Tree_Type.t_tree k v) (k : DeepModelTy0.deepModelTy) : ()
     
-  axiom has_mapping_model_spec : forall self : RedBlackTree_Tree_Type.t_tree k v, k : DeepModelTy0.deepModelTy . ([#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 109 4 109 82] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v))
+  axiom has_mapping_model_spec : forall self : RedBlackTree_Tree_Type.t_tree k v, k : DeepModelTy0.deepModelTy . ([#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 109 4 109 80] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v))
 end
 module RedBlackTree_Impl0_HasMappingModel
   type k
@@ -1139,7 +1139,7 @@ module RedBlackTree_Impl0_HasMappingModel
     requires {[#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self}
     ensures { result = has_mapping_model self k }
     
-  axiom has_mapping_model_spec : forall self : RedBlackTree_Tree_Type.t_tree k v, k : DeepModelTy0.deepModelTy . ([#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 109 4 109 82] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v))
+  axiom has_mapping_model_spec : forall self : RedBlackTree_Tree_Type.t_tree k v, k : DeepModelTy0.deepModelTy . ([#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self) -> ([#"../red_black_tree.rs" 109 4 109 80] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v))
 end
 module RedBlackTree_Impl0_HasMappingModel_Impl
   type k
@@ -1253,7 +1253,7 @@ module RedBlackTree_Impl0_HasMappingModel_Impl
     function ModelAcc0.model_acc = ModelAcc0.model_acc
   let rec ghost function has_mapping_model [#"../red_black_tree.rs" 110 4 112 33] (self : RedBlackTree_Tree_Type.t_tree k v) (k : DeepModelTy0.deepModelTy) : ()
     requires {[#"../red_black_tree.rs" 108 15 108 35] BstInvariant0.bst_invariant self}
-    ensures { [#"../red_black_tree.rs" 109 4 109 82] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v) }
+    ensures { [#"../red_black_tree.rs" 109 4 109 80] forall v : v . HasMapping0.has_mapping self k v = (Map.get (ShallowModel0.shallow_model self) k = Core_Option_Option_Type.C_Some v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../red_black_tree.rs" 115 12 115 61] let _ = ModelAccHasMapping0.model_acc_has_mapping self (Const.const (Core_Option_Option_Type.C_None)) k in HasMappingModelAcc0.has_mapping_model_acc self (Const.const (Core_Option_Option_Type.C_None)) k
@@ -4713,7 +4713,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { [#"../red_black_tree.rs" 858 6 858 65] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../red_black_tree.rs" 858 24 858 83] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl15_InsertRec_Interface
@@ -5543,8 +5543,8 @@ module Alloc_Boxed_Impl55_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut (self : borrowed t) : borrowed t
-    ensures { [#"../red_black_tree.rs" 813 9 813 26]  * self =  * result }
-    ensures { [#"../red_black_tree.rs" 814 26 814 43]  ^ self =  ^ result }
+    ensures { [#"../red_black_tree.rs" 813 21 814 9]  * self =  * result }
+    ensures { [#"../red_black_tree.rs" 814 38 814 55]  ^ self =  ^ result }
     
 end
 module RedBlackTree_Impl15_DeleteMaxRec_Interface
@@ -6094,7 +6094,7 @@ module RedBlackTree_Impl15_DeleteMax_Interface
   val delete_max [#"../red_black_tree.rs" 662 4 662 50] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Core_Option_Option_Type.t_option (k, v)
     requires {[#"../red_black_tree.rs" 655 15 655 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 656 14 656 33] Invariant0.invariant' ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 657 14 661 63] match (result) with
+    ensures { [#"../red_black_tree.rs" 657 14 661 65] match (result) with
       | Core_Option_Option_Type.C_Some (k, v) -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model k) = Core_Option_Option_Type.C_Some v /\ (forall k2 : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model self) k2 = Core_Option_Option_Type.C_None \/ LeLog0.le_log k2 (DeepModel0.deep_model k)) /\ ShallowModel1.shallow_model ( ^ self) = Map.set (ShallowModel0.shallow_model self) (DeepModel0.deep_model k) (Core_Option_Option_Type.C_None)
       | Core_Option_Option_Type.C_None -> ShallowModel1.shallow_model ( ^ self) = ShallowModel0.shallow_model self /\ ShallowModel0.shallow_model self = Const.const (Core_Option_Option_Type.C_None)
       end }
@@ -6316,7 +6316,7 @@ module RedBlackTree_Impl15_DeleteMax
   let rec cfg delete_max [#"../red_black_tree.rs" 662 4 662 50] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : Core_Option_Option_Type.t_option (k, v)
     requires {[#"../red_black_tree.rs" 655 15 655 34] Invariant0.invariant' ( * self)}
     ensures { [#"../red_black_tree.rs" 656 14 656 33] Invariant0.invariant' ( ^ self) }
-    ensures { [#"../red_black_tree.rs" 657 14 661 63] match (result) with
+    ensures { [#"../red_black_tree.rs" 657 14 661 65] match (result) with
       | Core_Option_Option_Type.C_Some (k, v) -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model k) = Core_Option_Option_Type.C_Some v /\ (forall k2 : DeepModelTy0.deepModelTy . Map.get (ShallowModel0.shallow_model self) k2 = Core_Option_Option_Type.C_None \/ LeLog0.le_log k2 (DeepModel0.deep_model k)) /\ ShallowModel1.shallow_model ( ^ self) = Map.set (ShallowModel0.shallow_model self) (DeepModel0.deep_model k) (Core_Option_Option_Type.C_None)
       | Core_Option_Option_Type.C_None -> ShallowModel1.shallow_model ( ^ self) = ShallowModel0.shallow_model self /\ ShallowModel0.shallow_model self = Const.const (Core_Option_Option_Type.C_None)
       end }

--- a/creusot/tests/should_succeed/red_black_tree.rs
+++ b/creusot/tests/should_succeed/red_black_tree.rs
@@ -578,7 +578,7 @@ impl<K: DeepModel + Ord, V> Tree<K, V>
 where
     K::DeepModelTy: OrdLogic,
 {
-    #[ensures(@result == Mapping::cst(None))]
+    #[ensures(result@ == Mapping::cst(None))]
     #[ensures(result.invariant())]
     pub fn new() -> Tree<K, V> {
         Tree { node: None }
@@ -658,7 +658,7 @@ where
         Some((k, v)) => self@.get(k.deep_model()) == Some(v) &&
             (forall<k2: K::DeepModelTy> self@.get(k2) == None || k2 <= k.deep_model()) &&
             @^self == self@.set(k.deep_model(), None),
-        None => @^self == @self && @self == Mapping::cst(None)})]
+        None => @^self == self@ && self@ == Mapping::cst(None)})]
     pub fn delete_max(&mut self) -> Option<(K, V)> {
         let old_self = ghost! { self };
         if let Some(node) = &mut self.node {
@@ -709,7 +709,7 @@ where
             self@.get(k.deep_model()) == Some(v) &&
             (forall<k2: K::DeepModelTy> self@.get(k2) == None || k.deep_model() <= k2) &&
             @^self == self@.set(k.deep_model(), None),
-        None => @^self == @self && @self == Mapping::cst(None)
+        None => @^self == self@ && self@ == Mapping::cst(None)
     })]
     pub fn delete_min(&mut self) -> Option<(K, V)> {
         ghost! { Self::has_mapping_model };

--- a/creusot/tests/should_succeed/red_black_tree.rs
+++ b/creusot/tests/should_succeed/red_black_tree.rs
@@ -834,7 +834,7 @@ where
     #[ensures((^self).invariant())]
     #[ensures(match result {
         Some(v) => self@.get(key.deep_model()) == Some(*v) && (^self)@ == self@.set(key.deep_model(), Some(^v)),
-        None => self@.get(key.deep_model()) == None && (^self)@ == @self
+        None => self@.get(key.deep_model()) == None && (^self)@ == self@
     })]
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         ghost! { Self::has_mapping_model };

--- a/creusot/tests/should_succeed/red_black_tree.rs
+++ b/creusot/tests/should_succeed/red_black_tree.rs
@@ -106,7 +106,7 @@ impl<K: DeepModel, V> Tree<K, V> {
 
     #[logic]
     #[requires(self.bst_invariant())]
-    #[ensures(forall<v: V> self.has_mapping(k, v) == ((@self).get(k) == Some(v)))]
+    #[ensures(forall<v: V> self.has_mapping(k, v) == (self@.get(k) == Some(v)))]
     fn has_mapping_model(self, k: K::DeepModelTy)
     where
         K::DeepModelTy: OrdLogic,
@@ -128,7 +128,7 @@ impl<K: DeepModel, V> Tree<K, V> {
     {
         pearlite! { {
             self.has_mapping_model(k);
-            match (@self).get(k) { None => (), Some(_v) => () }
+            match self@.get(k) { None => (), Some(_v) => () }
         } }
     }
 }
@@ -617,7 +617,7 @@ where
 
     #[requires((*self).invariant())]
     #[ensures((^self).invariant())]
-    #[ensures(@^self == (@self).set(key.deep_model(), Some(val)))]
+    #[ensures(@^self == self@.set(key.deep_model(), Some(val)))]
     pub fn insert(&mut self, key: K, val: V) {
         self.insert_rec(key, val);
         self.node.as_mut().unwrap().color = Black;
@@ -655,9 +655,9 @@ where
     #[requires((*self).invariant())]
     #[ensures((^self).invariant())]
     #[ensures(match result {
-        Some((k, v)) => (@self).get(k.deep_model()) == Some(v) &&
-            (forall<k2: K::DeepModelTy> (@self).get(k2) == None || k2 <= k.deep_model()) &&
-            @^self == (@self).set(k.deep_model(), None),
+        Some((k, v)) => self@.get(k.deep_model()) == Some(v) &&
+            (forall<k2: K::DeepModelTy> self@.get(k2) == None || k2 <= k.deep_model()) &&
+            @^self == self@.set(k.deep_model(), None),
         None => @^self == @self && @self == Mapping::cst(None)})]
     pub fn delete_max(&mut self) -> Option<(K, V)> {
         let old_self = ghost! { self };
@@ -706,9 +706,9 @@ where
     #[ensures((^self).invariant())]
     #[ensures(match result {
         Some((k, v)) =>
-            (@self).get(k.deep_model()) == Some(v) &&
-            (forall<k2: K::DeepModelTy> (@self).get(k2) == None || k.deep_model() <= k2) &&
-            @^self == (@self).set(k.deep_model(), None),
+            self@.get(k.deep_model()) == Some(v) &&
+            (forall<k2: K::DeepModelTy> self@.get(k2) == None || k.deep_model() <= k2) &&
+            @^self == self@.set(k.deep_model(), None),
         None => @^self == @self && @self == Mapping::cst(None)
     })]
     pub fn delete_min(&mut self) -> Option<(K, V)> {
@@ -788,10 +788,10 @@ where
     #[ensures((^self).invariant())]
     #[ensures(match result {
         Some((k, v)) =>
-            k.deep_model() == key.deep_model() && (@self).get(key.deep_model()) == Some(v),
-        None => (@self).get(key.deep_model()) == None
+            k.deep_model() == key.deep_model() && self@.get(key.deep_model()) == Some(v),
+        None => self@.get(key.deep_model()) == None
     })]
-    #[ensures(@^self == (@self).set(key.deep_model(), None))]
+    #[ensures(@^self == self@.set(key.deep_model(), None))]
     pub fn delete(&mut self, key: &K) -> Option<(K, V)> {
         ghost! { Self::has_mapping_model };
 
@@ -811,8 +811,8 @@ where
 
     #[requires((*self).invariant())]
     #[ensures(match result {
-        Some(v) => (@self).get(key.deep_model()) == Some(*v),
-        None => (@self).get(key.deep_model()) == None
+        Some(v) => self@.get(key.deep_model()) == Some(*v),
+        None => self@.get(key.deep_model()) == None
     })]
     pub fn get(&self, key: &K) -> Option<&V> {
         ghost! { Self::has_mapping_model };
@@ -833,8 +833,8 @@ where
     #[requires((*self).invariant())]
     #[ensures((^self).invariant())]
     #[ensures(match result {
-        Some(v) => (@self).get(key.deep_model()) == Some(*v) && @^self == (@self).set(key.deep_model(), Some(^v)),
-        None => (@self).get(key.deep_model()) == None && @^self == @self
+        Some(v) => self@.get(key.deep_model()) == Some(*v) && @^self == self@.set(key.deep_model(), Some(^v)),
+        None => self@.get(key.deep_model()) == None && @^self == @self
     })]
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         ghost! { Self::has_mapping_model };

--- a/creusot/tests/should_succeed/red_black_tree.rs
+++ b/creusot/tests/should_succeed/red_black_tree.rs
@@ -617,7 +617,7 @@ where
 
     #[requires((*self).invariant())]
     #[ensures((^self).invariant())]
-    #[ensures(@^self == self@.set(key.deep_model(), Some(val)))]
+    #[ensures((^self)@ == self@.set(key.deep_model(), Some(val)))]
     pub fn insert(&mut self, key: K, val: V) {
         self.insert_rec(key, val);
         self.node.as_mut().unwrap().color = Black;
@@ -657,8 +657,8 @@ where
     #[ensures(match result {
         Some((k, v)) => self@.get(k.deep_model()) == Some(v) &&
             (forall<k2: K::DeepModelTy> self@.get(k2) == None || k2 <= k.deep_model()) &&
-            @^self == self@.set(k.deep_model(), None),
-        None => @^self == self@ && self@ == Mapping::cst(None)})]
+            (^self)@ == self@.set(k.deep_model(), None),
+        None => (^self)@ == self@ && self@ == Mapping::cst(None)})]
     pub fn delete_max(&mut self) -> Option<(K, V)> {
         let old_self = ghost! { self };
         if let Some(node) = &mut self.node {
@@ -708,8 +708,8 @@ where
         Some((k, v)) =>
             self@.get(k.deep_model()) == Some(v) &&
             (forall<k2: K::DeepModelTy> self@.get(k2) == None || k.deep_model() <= k2) &&
-            @^self == self@.set(k.deep_model(), None),
-        None => @^self == self@ && self@ == Mapping::cst(None)
+            (^self)@ == self@.set(k.deep_model(), None),
+        None => (^self)@ == self@ && self@ == Mapping::cst(None)
     })]
     pub fn delete_min(&mut self) -> Option<(K, V)> {
         ghost! { Self::has_mapping_model };
@@ -791,7 +791,7 @@ where
             k.deep_model() == key.deep_model() && self@.get(key.deep_model()) == Some(v),
         None => self@.get(key.deep_model()) == None
     })]
-    #[ensures(@^self == self@.set(key.deep_model(), None))]
+    #[ensures((^self)@ == self@.set(key.deep_model(), None))]
     pub fn delete(&mut self, key: &K) -> Option<(K, V)> {
         ghost! { Self::has_mapping_model };
 
@@ -833,8 +833,8 @@ where
     #[requires((*self).invariant())]
     #[ensures((^self).invariant())]
     #[ensures(match result {
-        Some(v) => self@.get(key.deep_model()) == Some(*v) && @^self == self@.set(key.deep_model(), Some(^v)),
-        None => self@.get(key.deep_model()) == None && @^self == @self
+        Some(v) => self@.get(key.deep_model()) == Some(*v) && (^self)@ == self@.set(key.deep_model(), Some(^v)),
+        None => self@.get(key.deep_model()) == None && (^self)@ == @self
     })]
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         ghost! { Self::has_mapping_model };

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -1488,7 +1488,7 @@ module SelectionSortGeneric_SelectionSort_Interface
     axiom .
   val selection_sort [#"../selection_sort_generic.rs" 30 0 32 29] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../selection_sort_generic.rs" 28 10 28 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../selection_sort_generic.rs" 29 10 29 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../selection_sort_generic.rs" 29 0 29 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
 end
 module SelectionSortGeneric_SelectionSort
@@ -1703,7 +1703,7 @@ module SelectionSortGeneric_SelectionSort
     predicate SortedRange0.sorted_range = SortedRange0.sorted_range
   let rec cfg selection_sort [#"../selection_sort_generic.rs" 30 0 32 29] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../selection_sort_generic.rs" 28 10 28 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../selection_sort_generic.rs" 29 10 29 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../selection_sort_generic.rs" 29 0 29 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1781,26 +1781,26 @@ module SelectionSortGeneric_SelectionSort
   }
   BB2 {
     _8 <- Core_Ops_Range_Range_Type.C_Range ([#"../selection_sort_generic.rs" 38 13 38 14] (0 : usize)) _9;
-    iter_7 <- ([#"../selection_sort_generic.rs" 35 4 35 58] IntoIter0.into_iter _8);
+    iter_7 <- ([#"../selection_sort_generic.rs" 35 4 35 56] IntoIter0.into_iter _8);
     goto BB3
   }
   BB3 {
     _13 <- ();
-    iter_old_11 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Ghost.new iter_7);
+    iter_old_11 <- ([#"../selection_sort_generic.rs" 35 4 35 56] Ghost.new iter_7);
     goto BB4
   }
   BB4 {
     _17 <- ();
-    produced_14 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Ghost.new (Seq.empty ));
+    produced_14 <- ([#"../selection_sort_generic.rs" 35 4 35 56] Ghost.new (Seq.empty ));
     goto BB5
   }
   BB5 {
     goto BB6
   }
   BB6 {
-    invariant type_invariant { [#"../selection_sort_generic.rs" 35 4 35 58] Invariant0.invariant' iter_7 };
-    invariant structural { [#"../selection_sort_generic.rs" 35 4 35 58] Produces0.produces (Ghost.inner iter_old_11) (Ghost.inner produced_14) iter_7 };
-    invariant permutation { [#"../selection_sort_generic.rs" 35 29 35 56] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_4) };
+    invariant type_invariant { [#"../selection_sort_generic.rs" 35 4 35 56] Invariant0.invariant' iter_7 };
+    invariant structural { [#"../selection_sort_generic.rs" 35 4 35 56] Produces0.produces (Ghost.inner iter_old_11) (Ghost.inner produced_14) iter_7 };
+    invariant permutation { [#"../selection_sort_generic.rs" 35 4 35 56] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_4) };
     invariant sorted { [#"../selection_sort_generic.rs" 36 24 36 71] SortedRange0.sorted_range (DeepModel1.deep_model v_1) 0 (Seq.length (Ghost.inner produced_14)) };
     invariant partition { [#"../selection_sort_generic.rs" 37 27 37 68] Partition0.partition (DeepModel1.deep_model v_1) (Seq.length (Ghost.inner produced_14)) };
     _26 <- borrow_mut iter_7;
@@ -1808,7 +1808,7 @@ module SelectionSortGeneric_SelectionSort
     _25 <- borrow_mut ( * _26);
     _26 <- { _26 with current = ( ^ _25) };
     assume { Resolve0.resolve _26 };
-    _24 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Next0.next _25);
+    _24 <- ([#"../selection_sort_generic.rs" 35 4 35 56] Next0.next _25);
     goto BB7
   }
   BB7 {
@@ -1829,7 +1829,7 @@ module SelectionSortGeneric_SelectionSort
   BB10 {
     __creusot_proc_iter_elem_28 <- Core_Option_Option_Type.some_0 _24;
     _31 <- ();
-    _29 <- ([#"../selection_sort_generic.rs" 35 4 35 58] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_28)));
+    _29 <- ([#"../selection_sort_generic.rs" 35 4 35 56] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_28)));
     goto BB11
   }
   BB11 {

--- a/creusot/tests/should_succeed/selection_sort_generic.rs
+++ b/creusot/tests/should_succeed/selection_sort_generic.rs
@@ -26,7 +26,7 @@ fn partition<T: OrdLogic>(v: Seq<T>, i: Int) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures(((^v)@).permutation_of(v@))]
+#[ensures((^v)@.permutation_of(v@))]
 pub fn selection_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/selection_sort_generic.rs
+++ b/creusot/tests/should_succeed/selection_sort_generic.rs
@@ -26,7 +26,7 @@ fn partition<T: OrdLogic>(v: Seq<T>, i: Int) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(v@))]
+#[ensures(((^v)@).permutation_of(v@))]
 pub fn selection_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/selection_sort_generic.rs
+++ b/creusot/tests/should_succeed/selection_sort_generic.rs
@@ -32,7 +32,7 @@ where
     T::DeepModelTy: OrdLogic,
 {
     let old_v = ghost! { v };
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
     #[invariant(sorted, sorted_range(v.deep_model(), 0, produced.len()))]
     #[invariant(partition, partition(v.deep_model(), produced.len()))]
     for i in 0..v.len() {

--- a/creusot/tests/should_succeed/selection_sort_generic.rs
+++ b/creusot/tests/should_succeed/selection_sort_generic.rs
@@ -26,19 +26,19 @@ fn partition<T: OrdLogic>(v: Seq<T>, i: Int) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(@v))]
+#[ensures((@^v).permutation_of(v@))]
 pub fn selection_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,
 {
     let old_v = ghost! { v };
-    #[invariant(permutation, v@.permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(old_v@))]
     #[invariant(sorted, sorted_range(v.deep_model(), 0, produced.len()))]
     #[invariant(partition, partition(v.deep_model(), produced.len()))]
     for i in 0..v.len() {
         let mut min = i;
-        #[invariant(min_is_min, forall<k: Int> @i <= k && k < produced.len() + @i + 1 ==> v.deep_model()[@min] <= v.deep_model()[k])]
-        #[invariant(min_bound, @i <= @min && @min < produced.len() + @i + 1)]
+        #[invariant(min_is_min, forall<k: Int> i@ <= k && k < produced.len() + i@ + 1 ==> v.deep_model()[min@] <= v.deep_model()[k])]
+        #[invariant(min_bound, i@ <= min@ && min@ < produced.len() + i@ + 1)]
         for j in (i + 1)..v.len() {
             if v[j] < v[min] {
                 min = j;

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -110,7 +110,7 @@ module C01_IndexSlice_Interface
     type t = seq uint32,
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32
   val index_slice [#"../01.rs" 6 0 6 36] (a : seq uint32) : uint32
-    requires {[#"../01.rs" 5 11 5 26] 10 < Seq.length (ShallowModel0.shallow_model a)}
+    requires {[#"../01.rs" 5 11 5 24] 10 < Seq.length (ShallowModel0.shallow_model a)}
     
 end
 module C01_IndexSlice
@@ -132,7 +132,7 @@ module C01_IndexSlice
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg index_slice [#"../01.rs" 6 0 6 36] [@cfg:stackify] [@cfg:subregion_analysis] (a : seq uint32) : uint32
-    requires {[#"../01.rs" 5 11 5 26] 10 < Seq.length (ShallowModel0.shallow_model a)}
+    requires {[#"../01.rs" 5 11 5 24] 10 < Seq.length (ShallowModel0.shallow_model a)}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : uint32;
@@ -221,7 +221,7 @@ module C01_IndexMutSlice_Interface
     type t = seq uint32,
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32
   val index_mut_slice [#"../01.rs" 12 0 12 37] (a : borrowed (seq uint32)) : ()
-    requires {[#"../01.rs" 10 11 10 26] Seq.length (ShallowModel0.shallow_model a) = 5}
+    requires {[#"../01.rs" 10 11 10 24] Seq.length (ShallowModel0.shallow_model a) = 5}
     ensures { [#"../01.rs" 11 10 11 24] UInt32.to_int (Seq.get (ShallowModel1.shallow_model ( ^ a)) 2) = 3 }
     
 end
@@ -246,7 +246,7 @@ module C01_IndexMutSlice
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg index_mut_slice [#"../01.rs" 12 0 12 37] [@cfg:stackify] [@cfg:subregion_analysis] (a : borrowed (seq uint32)) : ()
-    requires {[#"../01.rs" 10 11 10 26] Seq.length (ShallowModel0.shallow_model a) = 5}
+    requires {[#"../01.rs" 10 11 10 24] Seq.length (ShallowModel0.shallow_model a) = 5}
     ensures { [#"../01.rs" 11 10 11 24] UInt32.to_int (Seq.get (ShallowModel1.shallow_model ( ^ a)) 2) = 3 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]

--- a/creusot/tests/should_succeed/slices/01.rs
+++ b/creusot/tests/should_succeed/slices/01.rs
@@ -2,20 +2,20 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[requires(10 < (@a).len())]
+#[requires(10 < a@.len())]
 pub fn index_slice(a: &[u32]) -> u32 {
     a[10]
 }
 
-#[requires((@a).len() == 5)]
+#[requires(a@.len() == 5)]
 #[ensures(@(@^a)[2] == 3)]
 pub fn index_mut_slice(a: &mut [u32]) {
     a[2] = 3;
 }
 
 #[ensures(match result {
-    Some(v) => *v == (@a)[0],
-    None => (@a).len() == 0
+    Some(v) => *v == a@[0],
+    None => a@.len() == 0
 })]
 pub fn slice_first<T>(a: &[T]) -> Option<&T> {
     if a.len() > 0 {

--- a/creusot/tests/should_succeed/slices/01.rs
+++ b/creusot/tests/should_succeed/slices/01.rs
@@ -8,7 +8,7 @@ pub fn index_slice(a: &[u32]) -> u32 {
 }
 
 #[requires(a@.len() == 5)]
-#[ensures(@(^a)@[2] == 3)]
+#[ensures((^a)@[2]@ == 3)]
 pub fn index_mut_slice(a: &mut [u32]) {
     a[2] = 3;
 }

--- a/creusot/tests/should_succeed/slices/01.rs
+++ b/creusot/tests/should_succeed/slices/01.rs
@@ -8,7 +8,7 @@ pub fn index_slice(a: &[u32]) -> u32 {
 }
 
 #[requires(a@.len() == 5)]
-#[ensures(@(@^a)[2] == 3)]
+#[ensures(@((^a)@)[2] == 3)]
 pub fn index_mut_slice(a: &mut [u32]) {
     a[2] = 3;
 }

--- a/creusot/tests/should_succeed/slices/01.rs
+++ b/creusot/tests/should_succeed/slices/01.rs
@@ -8,7 +8,7 @@ pub fn index_slice(a: &[u32]) -> u32 {
 }
 
 #[requires(a@.len() == 5)]
-#[ensures(@((^a)@)[2] == 3)]
+#[ensures(@(^a)@[2] == 3)]
 pub fn index_mut_slice(a: &mut [u32]) {
     a[2] = 3;
 }

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -447,8 +447,8 @@ module C02Std_BinarySearch_Interface
     type t = seq uint32,
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32
   val binary_search [#"../02_std.rs" 8 0 8 40] (s : seq uint32) : usize
-    requires {[#"../02_std.rs" 6 0 6 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model s) i) = i}
-    requires {[#"../02_std.rs" 7 11 7 26] Seq.length (ShallowModel0.shallow_model s) = 5}
+    requires {[#"../02_std.rs" 6 0 6 65] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model s) i) = i}
+    requires {[#"../02_std.rs" 7 11 7 24] Seq.length (ShallowModel0.shallow_model s) = 5}
     
 end
 module C02Std_BinarySearch
@@ -513,8 +513,8 @@ module C02Std_BinarySearch
   let constant promoted0 [#"../02_std.rs" 8 0 8 40]  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
     let _1 = [#"../02_std.rs" 9 30 9 31] (2 : uint32) in let _0 = _1 in _0
   let rec cfg binary_search [#"../02_std.rs" 8 0 8 40] [@cfg:stackify] [@cfg:subregion_analysis] (s : seq uint32) : usize
-    requires {[#"../02_std.rs" 6 0 6 69] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model s) i) = i}
-    requires {[#"../02_std.rs" 7 11 7 26] Seq.length (ShallowModel0.shallow_model s) = 5}
+    requires {[#"../02_std.rs" 6 0 6 65] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model s) -> UInt32.to_int (Seq.get (ShallowModel0.shallow_model s) i) = i}
+    requires {[#"../02_std.rs" 7 11 7 24] Seq.length (ShallowModel0.shallow_model s) = 5}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;

--- a/creusot/tests/should_succeed/slices/02_std.rs
+++ b/creusot/tests/should_succeed/slices/02_std.rs
@@ -3,7 +3,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[requires(forall<i : _> 0 <= i && i < s@.len() ==> @s@[i] == i)]
+#[requires(forall<i : _> 0 <= i && i < s@.len() ==> s@[i]@ == i)]
 #[requires(s@.len() == 5)]
 pub fn binary_search(s: &[u32]) -> usize {
     let ix = s.binary_search(&2).unwrap();

--- a/creusot/tests/should_succeed/slices/02_std.rs
+++ b/creusot/tests/should_succeed/slices/02_std.rs
@@ -3,8 +3,8 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[requires(forall<i : _> 0 <= i && i < (@s).len() ==> @(@s)[i] == i)]
-#[requires((@s).len() == 5)]
+#[requires(forall<i : _> 0 <= i && i < s@.len() ==> @s@[i] == i)]
+#[requires(s@.len() == 5)]
 pub fn binary_search(s: &[u32]) -> usize {
     let ix = s.binary_search(&2).unwrap();
 

--- a/creusot/tests/should_succeed/slices/02_std.rs
+++ b/creusot/tests/should_succeed/slices/02_std.rs
@@ -8,6 +8,6 @@ use creusot_contracts::*;
 pub fn binary_search(s: &[u32]) -> usize {
     let ix = s.binary_search(&2).unwrap();
 
-    proof_assert! { @ix < 5 };
+    proof_assert! { ix@ < 5 };
     ix
 }

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -146,7 +146,7 @@ module SparseArray_Impl1_IsElt
     axiom .
   use SparseArray_Sparse_Type as SparseArray_Sparse_Type
   predicate is_elt [#"../sparse_array.rs" 55 4 55 36] (self : SparseArray_Sparse_Type.t_sparse t) (i : int) =
-    [#"../sparse_array.rs" 56 20 58 58] 0 <= i /\ i < UIntSize.to_int (SparseArray_Sparse_Type.sparse_size self) /\ UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_idx self)) i) < UIntSize.to_int (SparseArray_Sparse_Type.sparse_n self) /\ UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_back self)) (UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_idx self)) i))) = i
+    [#"../sparse_array.rs" 56 20 58 54] 0 <= i /\ i < UIntSize.to_int (SparseArray_Sparse_Type.sparse_size self) /\ UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_idx self)) i) < UIntSize.to_int (SparseArray_Sparse_Type.sparse_n self) /\ UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_back self)) (UIntSize.to_int (Seq.get (ShallowModel0.shallow_model (SparseArray_Sparse_Type.sparse_idx self)) i))) = i
   val is_elt [#"../sparse_array.rs" 55 4 55 36] (self : SparseArray_Sparse_Type.t_sparse t) (i : int) : bool
     ensures { result = is_elt self i }
     
@@ -501,7 +501,7 @@ module SparseArray_Impl1_Get_Interface
     type t = t
   val get [#"../sparse_array.rs" 92 4 92 45] (self : SparseArray_Sparse_Type.t_sparse t) (i : usize) : Core_Option_Option_Type.t_option t
     requires {[#"../sparse_array.rs" 82 15 82 32] SparseInv0.sparse_inv self}
-    requires {[#"../sparse_array.rs" 83 15 83 33] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../sparse_array.rs" 83 15 83 31] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
     ensures { [#"../sparse_array.rs" 84 14 87 5] match (result) with
       | Core_Option_Option_Type.C_None -> Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int i) = Core_Option_Option_Type.C_None
       | Core_Option_Option_Type.C_Some x -> Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some x
@@ -592,7 +592,7 @@ module SparseArray_Impl1_Get
     val Max0.mAX' = Max0.mAX'
   let rec cfg get [#"../sparse_array.rs" 92 4 92 45] [@cfg:stackify] [@cfg:subregion_analysis] (self : SparseArray_Sparse_Type.t_sparse t) (i : usize) : Core_Option_Option_Type.t_option t
     requires {[#"../sparse_array.rs" 82 15 82 32] SparseInv0.sparse_inv self}
-    requires {[#"../sparse_array.rs" 83 15 83 33] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../sparse_array.rs" 83 15 83 31] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
     ensures { [#"../sparse_array.rs" 84 14 87 5] match (result) with
       | Core_Option_Option_Type.C_None -> Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int i) = Core_Option_Option_Type.C_None
       | Core_Option_Option_Type.C_Some x -> Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some x
@@ -965,10 +965,10 @@ module SparseArray_Impl1_Set_Interface
     type t = t
   val set [#"../sparse_array.rs" 118 4 118 41] (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) (i : usize) (v : t) : ()
     requires {[#"../sparse_array.rs" 112 15 112 35] SparseInv0.sparse_inv ( * self)}
-    requires {[#"../sparse_array.rs" 113 15 113 33] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../sparse_array.rs" 113 15 113 31] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
     ensures { [#"../sparse_array.rs" 114 14 114 34] SparseInv0.sparse_inv ( ^ self) }
-    ensures { [#"../sparse_array.rs" 115 14 115 45] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
-    ensures { [#"../sparse_array.rs" 116 4 116 68] forall j : int . j <> UIntSize.to_int i -> Seq.get (ShallowModel1.shallow_model ( ^ self)) j = Seq.get (ShallowModel0.shallow_model self) j }
+    ensures { [#"../sparse_array.rs" 115 14 115 43] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../sparse_array.rs" 116 4 116 66] forall j : int . j <> UIntSize.to_int i -> Seq.get (ShallowModel1.shallow_model ( ^ self)) j = Seq.get (ShallowModel0.shallow_model self) j }
     ensures { [#"../sparse_array.rs" 117 14 117 37] Seq.get (ShallowModel1.shallow_model ( ^ self)) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v }
     
 end
@@ -1088,10 +1088,10 @@ module SparseArray_Impl1_Set
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg set [#"../sparse_array.rs" 118 4 118 41] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (SparseArray_Sparse_Type.t_sparse t)) (i : usize) (v : t) : ()
     requires {[#"../sparse_array.rs" 112 15 112 35] SparseInv0.sparse_inv ( * self)}
-    requires {[#"../sparse_array.rs" 113 15 113 33] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../sparse_array.rs" 113 15 113 31] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self)}
     ensures { [#"../sparse_array.rs" 114 14 114 34] SparseInv0.sparse_inv ( ^ self) }
-    ensures { [#"../sparse_array.rs" 115 14 115 45] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
-    ensures { [#"../sparse_array.rs" 116 4 116 68] forall j : int . j <> UIntSize.to_int i -> Seq.get (ShallowModel1.shallow_model ( ^ self)) j = Seq.get (ShallowModel0.shallow_model self) j }
+    ensures { [#"../sparse_array.rs" 115 14 115 43] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../sparse_array.rs" 116 4 116 66] forall j : int . j <> UIntSize.to_int i -> Seq.get (ShallowModel1.shallow_model ( ^ self)) j = Seq.get (ShallowModel0.shallow_model self) j }
     ensures { [#"../sparse_array.rs" 117 14 117 37] Seq.get (ShallowModel1.shallow_model ( ^ self)) (UIntSize.to_int i) = Core_Option_Option_Type.C_Some v }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -1293,7 +1293,7 @@ module SparseArray_Create_Interface
   val create [#"../sparse_array.rs" 141 0 141 64] (sz : usize) (dummy : t) : SparseArray_Sparse_Type.t_sparse t
     ensures { [#"../sparse_array.rs" 138 10 138 29] SparseInv0.sparse_inv result }
     ensures { [#"../sparse_array.rs" 139 10 139 27] SparseArray_Sparse_Type.sparse_size result = sz }
-    ensures { [#"../sparse_array.rs" 140 0 140 47] forall i : int . Seq.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
+    ensures { [#"../sparse_array.rs" 140 0 140 45] forall i : int . Seq.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
     
 end
 module SparseArray_Create
@@ -1350,7 +1350,7 @@ module SparseArray_Create
   let rec cfg create [#"../sparse_array.rs" 141 0 141 64] [@cfg:stackify] [@cfg:subregion_analysis] (sz : usize) (dummy : t) : SparseArray_Sparse_Type.t_sparse t
     ensures { [#"../sparse_array.rs" 138 10 138 29] SparseInv0.sparse_inv result }
     ensures { [#"../sparse_array.rs" 139 10 139 27] SparseArray_Sparse_Type.sparse_size result = sz }
-    ensures { [#"../sparse_array.rs" 140 0 140 47] forall i : int . Seq.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
+    ensures { [#"../sparse_array.rs" 140 0 140 45] forall i : int . Seq.get (ShallowModel0.shallow_model result) i = Core_Option_Option_Type.C_None }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : SparseArray_Sparse_Type.t_sparse t;

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -34,9 +34,9 @@ impl<T> ShallowModel for Sparse<T> {
 
     #[logic]
     #[trusted]
-    #[ensures(result.len() == @self.size)]
+    #[ensures(result.len() == self.size@)]
     #[ensures(forall<i:Int>
-              result[i] == (if self.is_elt(i) { Some((@self.values)[i]) } else { None })
+              result[i] == (if self.is_elt(i) { Some((self.values@)[i]) } else { None })
     )]
     fn shallow_model(self) -> Self::ShallowModelTy {
         // we miss a way to define the sequence, we need
@@ -54,8 +54,8 @@ impl<T> Sparse<T> {
     #[predicate]
     fn is_elt(&self, i: Int) -> bool {
         pearlite! { 0 <= i && i < @self.size
-                    && @(@self.idx)[i] < @self.n
-                    && @(@self.back)[@(@self.idx)[i]] == i
+                    && @(self.idx@)[i] < @self.n
+                    && @(self.back@)[@(self.idx@)[i]] == i
         }
     }
 
@@ -64,15 +64,15 @@ impl<T> Sparse<T> {
     #[predicate]
     fn sparse_inv(&self) -> bool {
         pearlite! {
-            @self.n <= @self.size
+            self.n@ <= @self.size
                 && self@.len() == @self.size
-                && (@self.values).len() == @self.size
-                && (@self.idx).len() == @self.size
-                && (@self.back).len() == @self.size
-                && forall<i: Int> 0 <= i && i < @self.n ==>
-                match (@self.back)[i] {
+                && (self.values@).len() == @self.size
+                && (self.idx@).len() == @self.size
+                && (self.back@).len() == @self.size
+                && forall<i: Int> 0 <= i && i < self.n@ ==>
+                match (self.back@)[i] {
                     j => 0 <= j@ && j@ < @self.size
-                        && @(@self.idx)[j@] == i
+                        && @(self.idx@)[j@] == i
                 }
         }
     }
@@ -103,7 +103,7 @@ impl<T> Sparse<T> {
     #[logic]
     #[requires(self.sparse_inv())]
     #[requires(self.n == self.size)]
-    #[requires(0 <= i && i < @self.size)]
+    #[requires(0 <= i && i < self.size@)]
     #[ensures(self.is_elt(i))]
     fn lemma_permutation(self, i: Int) {}
 
@@ -121,7 +121,7 @@ impl<T> Sparse<T> {
         if !(index < self.n && self.back[index] == i) {
             // the hard assertion!
             ghost!(Self::lemma_permutation);
-            proof_assert!(@self.n < @self.size);
+            proof_assert!(self.n@ < self.size@);
             // assert!(self.n < self.size);
             self.idx[i] = self.n;
             self.back[self.n] = i;

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -112,9 +112,9 @@ impl<T> Sparse<T> {
     #[requires((*self).sparse_inv())]
     #[requires(i@ < self@.len())]
     #[ensures((^self).sparse_inv())]
-    #[ensures(((^self)@).len() == self@.len())]
-    #[ensures(forall<j: Int> j != i@ ==> ((^self)@)[j] == self@[j])]
-    #[ensures(((^self)@)[i@] == Some(v))]
+    #[ensures((^self)@.len() == self@.len())]
+    #[ensures(forall<j: Int> j != i@ ==> (^self)@[j] == self@[j])]
+    #[ensures((^self)@[i@] == Some(v))]
     pub fn set(&mut self, i: usize, v: T) {
         self.values[i] = v;
         let index = self.idx[i];

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -36,7 +36,7 @@ impl<T> ShallowModel for Sparse<T> {
     #[trusted]
     #[ensures(result.len() == self.size@)]
     #[ensures(forall<i:Int>
-              result[i] == (if self.is_elt(i) { Some((self.values@)[i]) } else { None })
+              result[i] == (if self.is_elt(i) { Some(self.values@[i]) } else { None })
     )]
     fn shallow_model(self) -> Self::ShallowModelTy {
         // we miss a way to define the sequence, we need
@@ -54,8 +54,8 @@ impl<T> Sparse<T> {
     #[predicate]
     fn is_elt(&self, i: Int) -> bool {
         pearlite! { 0 <= i && i < self.size@
-                    && (self.idx@)[i]@ < self.n@
-                    && (self.back@)[(self.idx@)[i]@]@ == i
+                    && self.idx@[i]@ < self.n@
+                    && self.back@[self.idx@[i]@]@ == i
         }
     }
 
@@ -66,13 +66,13 @@ impl<T> Sparse<T> {
         pearlite! {
             self.n@ <= self.size@
                 && self@.len() == self.size@
-                && (self.values@).len() == self.size@
-                && (self.idx@).len() == self.size@
-                && (self.back@).len() == self.size@
+                && self.values@.len() == self.size@
+                && self.idx@.len() == self.size@
+                && self.back@.len() == self.size@
                 && forall<i: Int> 0 <= i && i < self.n@ ==>
-                match (self.back@)[i] {
+                match self.back@[i] {
                     j => 0 <= j@ && j@ < self.size@
-                        && (self.idx@)[j@]@ == i
+                        && self.idx@[j@]@ == i
                 }
         }
     }

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -53,9 +53,9 @@ impl<T> Sparse<T> {
      */
     #[predicate]
     fn is_elt(&self, i: Int) -> bool {
-        pearlite! { 0 <= i && i < @self.size
-                    && @(self.idx@)[i] < @self.n
-                    && @(self.back@)[@(self.idx@)[i]] == i
+        pearlite! { 0 <= i && i < self.size@
+                    && (self.idx@)[i]@ < self.n@
+                    && (self.back@)[(self.idx@)[i]@]@ == i
         }
     }
 
@@ -64,15 +64,15 @@ impl<T> Sparse<T> {
     #[predicate]
     fn sparse_inv(&self) -> bool {
         pearlite! {
-            self.n@ <= @self.size
-                && self@.len() == @self.size
-                && (self.values@).len() == @self.size
-                && (self.idx@).len() == @self.size
-                && (self.back@).len() == @self.size
+            self.n@ <= self.size@
+                && self@.len() == self.size@
+                && (self.values@).len() == self.size@
+                && (self.idx@).len() == self.size@
+                && (self.back@).len() == self.size@
                 && forall<i: Int> 0 <= i && i < self.n@ ==>
                 match (self.back@)[i] {
-                    j => 0 <= j@ && j@ < @self.size
-                        && @(self.idx@)[j@] == i
+                    j => 0 <= j@ && j@ < self.size@
+                        && (self.idx@)[j@]@ == i
                 }
         }
     }

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -71,8 +71,8 @@ impl<T> Sparse<T> {
                 && (@self.back).len() == @self.size
                 && forall<i: Int> 0 <= i && i < @self.n ==>
                 match (@self.back)[i] {
-                    j => 0 <= @j && @j < @self.size
-                        && @(@self.idx)[@j] == i
+                    j => 0 <= j@ && j@ < @self.size
+                        && @(@self.idx)[j@] == i
                 }
         }
     }
@@ -80,12 +80,12 @@ impl<T> Sparse<T> {
     /* The method for accessing
      */
     #[requires(self.sparse_inv())]
-    #[requires(@i < self@.len())]
+    #[requires(i@ < self@.len())]
     #[ensures(match result {
-        None => self@[@i] == None,
-        Some(x) => self@[@i] == Some(*x)
+        None => self@[i@] == None,
+        Some(x) => self@[i@] == Some(*x)
     })]
-    #[ensures(match self@[@i] {
+    #[ensures(match self@[i@] {
         None => result == None,
         Some(_) => true // result == Some(x) need 'asref'
     })]
@@ -110,11 +110,11 @@ impl<T> Sparse<T> {
     /* The method for modifying
      */
     #[requires((*self).sparse_inv())]
-    #[requires(@i < self@.len())]
+    #[requires(i@ < self@.len())]
     #[ensures((^self).sparse_inv())]
     #[ensures((@^self).len() == self@.len())]
-    #[ensures(forall<j: Int> j != @i ==> (@^self)[j] == self@[j])]
-    #[ensures((@^self)[@i] == Some(v))]
+    #[ensures(forall<j: Int> j != i@ ==> (@^self)[j] == self@[j])]
+    #[ensures((@^self)[i@] == Some(v))]
     pub fn set(&mut self, i: usize, v: T) {
         self.values[i] = v;
         let index = self.idx[i];
@@ -158,11 +158,11 @@ pub fn f() {
     y = b.get(7);
     proof_assert!(match x {
         None => false,
-        Some(z) => @z == 1
+        Some(z) => z@ == 1
     });
     proof_assert!(match y {
         None => false,
-        Some(z) => @z == 2
+        Some(z) => z@ == 2
     });
     // assert!(x == Some(1) && y == Some(2));
     x = a.get(7);

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -65,7 +65,7 @@ impl<T> Sparse<T> {
     fn sparse_inv(&self) -> bool {
         pearlite! {
             @self.n <= @self.size
-                && (@self).len() == @self.size
+                && self@.len() == @self.size
                 && (@self.values).len() == @self.size
                 && (@self.idx).len() == @self.size
                 && (@self.back).len() == @self.size
@@ -80,12 +80,12 @@ impl<T> Sparse<T> {
     /* The method for accessing
      */
     #[requires(self.sparse_inv())]
-    #[requires(@i < (@self).len())]
+    #[requires(@i < self@.len())]
     #[ensures(match result {
-        None => (@self)[@i] == None,
-        Some(x) => (@self)[@i] == Some(*x)
+        None => self@[@i] == None,
+        Some(x) => self@[@i] == Some(*x)
     })]
-    #[ensures(match (@self)[@i] {
+    #[ensures(match self@[@i] {
         None => result == None,
         Some(_) => true // result == Some(x) need 'asref'
     })]
@@ -110,10 +110,10 @@ impl<T> Sparse<T> {
     /* The method for modifying
      */
     #[requires((*self).sparse_inv())]
-    #[requires(@i < (@self).len())]
+    #[requires(@i < self@.len())]
     #[ensures((^self).sparse_inv())]
-    #[ensures((@^self).len() == (@self).len())]
-    #[ensures(forall<j: Int> j != @i ==> (@^self)[j] == (@self)[j])]
+    #[ensures((@^self).len() == self@.len())]
+    #[ensures(forall<j: Int> j != @i ==> (@^self)[j] == self@[j])]
     #[ensures((@^self)[@i] == Some(v))]
     pub fn set(&mut self, i: usize, v: T) {
         self.values[i] = v;
@@ -137,7 +137,7 @@ impl<T> Sparse<T> {
  */
 #[ensures(result.sparse_inv())]
 #[ensures(result.size == sz)]
-#[ensures(forall<i: Int> (@result)[i] == None)]
+#[ensures(forall<i: Int> result@[i] == None)]
 pub fn create<T: Clone + Copy>(sz: usize, dummy: T) -> Sparse<T> {
     Sparse { size: sz, n: 0, values: vec![dummy; sz], idx: vec![0; sz], back: vec![0; sz] }
 }

--- a/creusot/tests/should_succeed/sparse_array.rs
+++ b/creusot/tests/should_succeed/sparse_array.rs
@@ -112,9 +112,9 @@ impl<T> Sparse<T> {
     #[requires((*self).sparse_inv())]
     #[requires(i@ < self@.len())]
     #[ensures((^self).sparse_inv())]
-    #[ensures((@^self).len() == self@.len())]
-    #[ensures(forall<j: Int> j != i@ ==> (@^self)[j] == self@[j])]
-    #[ensures((@^self)[i@] == Some(v))]
+    #[ensures(((^self)@).len() == self@.len())]
+    #[ensures(forall<j: Int> j != i@ ==> ((^self)@)[j] == self@[j])]
+    #[ensures(((^self)@)[i@] == Some(v))]
     pub fn set(&mut self, i: usize, v: T) {
         self.values[i] = v;
         let index = self.idx[i];

--- a/creusot/tests/should_succeed/sum.rs
+++ b/creusot/tests/should_succeed/sum.rs
@@ -1,11 +1,11 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[requires(@n < 1000)]
-#[ensures(@result == @n * (@n + 1) / 2)]
+#[requires(n@ < 1000)]
+#[ensures(result@ == n@ * (n@ + 1) / 2)]
 pub fn sum_first_n(n: u32) -> u32 {
     let mut sum = 0;
-    #[invariant(sum_value, @sum == produced.len() * (produced.len() - 1) / 2)]
+    #[invariant(sum_value, sum@ == produced.len() * (produced.len() - 1) / 2)]
     for i in 0..=n {
         sum += i;
     }

--- a/creusot/tests/should_succeed/sum_of_odds.rs
+++ b/creusot/tests/should_succeed/sum_of_odds.rs
@@ -31,14 +31,14 @@ fn sum_of_odd_is_sqr(x: Int) {
     pearlite! { if x > 0 { sum_of_odd_is_sqr(x-1) } else { () } }
 }
 
-#[requires(@x < 0x10000)]
-#[ensures(@result == sum_of_odd(@x))]
+#[requires(x@ < 0x10000)]
+#[ensures(result@ == sum_of_odd(x@))]
 fn compute_sum_of_odd(x: u32) -> u32 {
     let mut s: u32 = 0;
-    #[invariant(s_is_sum, @s == sum_of_odd(produced.len()))]
+    #[invariant(s_is_sum, s@ == sum_of_odd(produced.len()))]
     for i in 0..x {
         proof_assert! {
-            sum_of_odd_is_sqr(@i);
+            sum_of_odd_is_sqr(i@);
             true
         };
         s += 2 * i + 1;
@@ -46,11 +46,11 @@ fn compute_sum_of_odd(x: u32) -> u32 {
     return s;
 }
 
-#[requires(@x < 0x10000)]
+#[requires(x@ < 0x10000)]
 pub fn test(x: u32) {
     let y = compute_sum_of_odd(x);
     proof_assert! {
-        sum_of_odd_is_sqr(@x);
-        is_square(@y)
+        sum_of_odd_is_sqr(x@);
+        is_square(y@)
     }
 }

--- a/creusot/tests/should_succeed/syntax/02_operators.rs
+++ b/creusot/tests/should_succeed/syntax/02_operators.rs
@@ -34,7 +34,7 @@ fn modulus_int(x: Int, y: Int) -> Int {
     x % y
 }
 
-#[requires(x@ * y@ <= @usize::MAX)]
+#[requires(x@ * y@ <= usize::MAX@)]
 fn multiply(x: usize, y: usize) -> usize {
     x * y
 }
@@ -44,7 +44,7 @@ fn multiply_int(x: Int, y: Int) -> Int {
     x * y
 }
 
-#[requires(x@ + y@ <= @usize::MAX)]
+#[requires(x@ + y@ <= usize::MAX@)]
 fn add(x: usize, y: usize) -> usize {
     x + y
 }
@@ -72,7 +72,7 @@ fn sub_int(x: Int, y: Int) -> Int {
 // Precedence
 
 #[requires(y@ > 0)]
-#[requires(x@ / y@ * z@ <= @usize::MAX)]
+#[requires(x@ / y@ * z@ <= usize::MAX@)]
 #[ensures(result)]
 fn expression(x: usize, y: usize, z: usize) -> bool {
     x / y * z == (x / y) * z

--- a/creusot/tests/should_succeed/syntax/02_operators.rs
+++ b/creusot/tests/should_succeed/syntax/02_operators.rs
@@ -4,7 +4,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::{logic::Int, *};
 
-#[requires(@y > 0)]
+#[requires(y@ > 0)]
 fn division(x: usize, y: usize) -> usize {
     x / y
 }
@@ -19,7 +19,7 @@ fn division_int(x: Int, y: Int) -> Int {
     x / y
 }
 
-#[requires(@y > 0)]
+#[requires(y@ > 0)]
 fn modulus(x: usize, y: usize) -> usize {
     x % y
 }
@@ -34,7 +34,7 @@ fn modulus_int(x: Int, y: Int) -> Int {
     x % y
 }
 
-#[requires(@x * @y <= @usize::MAX)]
+#[requires(x@ * y@ <= @usize::MAX)]
 fn multiply(x: usize, y: usize) -> usize {
     x * y
 }
@@ -44,7 +44,7 @@ fn multiply_int(x: Int, y: Int) -> Int {
     x * y
 }
 
-#[requires(@x + @y <= @usize::MAX)]
+#[requires(x@ + y@ <= @usize::MAX)]
 fn add(x: usize, y: usize) -> usize {
     x + y
 }
@@ -59,7 +59,7 @@ fn add_int(x: Int, y: Int) -> Int {
 //     x + y
 // }
 
-#[requires(@x - @y >= 0)]
+#[requires(x@ - y@ >= 0)]
 fn sub(x: usize, y: usize) -> usize {
     x - y
 }
@@ -71,8 +71,8 @@ fn sub_int(x: Int, y: Int) -> Int {
 
 // Precedence
 
-#[requires(@y > 0)]
-#[requires(@x / @y * @z <= @usize::MAX)]
+#[requires(y@ > 0)]
+#[requires(x@ / y@ * z@ <= @usize::MAX)]
 #[ensures(result)]
 fn expression(x: usize, y: usize, z: usize) -> bool {
     x / y * z == (x / y) * z

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.rs
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.rs
@@ -9,5 +9,5 @@ use creusot_contracts::*;
 #[ensures(x.0 == x.1)]
 pub fn respect_prec(x: (u32, u32)) {}
 
-#[ensures(@0u32 + @1u32 == 0)]
+#[ensures(0u32@ + 1u32@ == 0)]
 pub fn respect_assoc() {}

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -1,4 +1,170 @@
 
+module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
+  type self
+  type shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Stub
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel_Interface
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_ShallowModel_ShallowModel
+  type self
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = self
+  function shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+  val shallow_model (self : self) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Stub
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Interface
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+end
+module CreusotContracts_Model_Impl1_ShallowModel
+  type t
+  use prelude.Borrow
+  clone CreusotContracts_Model_ShallowModel_ShallowModelTy_Type as ShallowModelTy0 with
+    type self = t
+  clone CreusotContracts_Model_ShallowModel_ShallowModel_Stub as ShallowModel0 with
+    type self = t,
+    type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
+  function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
+    ShallowModel0.shallow_model self
+  val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
+    ensures { result = shallow_model self }
+    
+end
+module Core_Num_Impl11_Max_Stub
+  use prelude.Int
+  use prelude.UIntSize
+  val constant mAX'  : usize
+end
+module Core_Num_Impl11_Max
+  use prelude.Int
+  use prelude.UIntSize
+  let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
+    (18446744073709551615 : usize)
+end
+module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
+  type t
+  use seq.Seq
+  use prelude.UIntSize
+  use prelude.Int
+  use prelude.Slice
+  use prelude.Seq
+  clone Core_Num_Impl11_Max_Stub as Max0
+  function shallow_model (self : seq t) : Seq.seq t
+end
+module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
+  type t
+  use seq.Seq
+  use prelude.UIntSize
+  use prelude.Int
+  use prelude.Slice
+  use prelude.Seq
+  clone Core_Num_Impl11_Max_Stub as Max0
+  function shallow_model (self : seq t) : Seq.seq t
+  axiom shallow_model_spec : forall self : seq t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+end
+module CreusotContracts_Std1_Slice_Impl0_ShallowModel
+  type t
+  use seq.Seq
+  use prelude.UIntSize
+  use prelude.Int
+  use prelude.Slice
+  use prelude.Seq
+  clone Core_Num_Impl11_Max_Stub as Max0
+  function shallow_model (self : seq t) : Seq.seq t
+  val shallow_model (self : seq t) : Seq.seq t
+    ensures { result = shallow_model self }
+    
+  axiom shallow_model_spec : forall self : seq t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+end
+module C05Pearlite_HasLen3_Stub
+  use seq.Seq
+  use prelude.Borrow
+  use prelude.Slice
+  use prelude.Seq
+  use prelude.Int
+  use prelude.UInt32
+  use seq.Seq
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = seq uint32,
+    type ShallowModelTy0.shallowModelTy = Seq.seq uint32
+  predicate has_len_3 [#"../05_pearlite.rs" 8 0 8 35] (v : seq uint32)
+end
+module C05Pearlite_HasLen3_Interface
+  use seq.Seq
+  use prelude.Borrow
+  use prelude.Slice
+  use prelude.Seq
+  use prelude.Int
+  use prelude.UInt32
+  use seq.Seq
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = seq uint32,
+    type ShallowModelTy0.shallowModelTy = Seq.seq uint32
+  predicate has_len_3 [#"../05_pearlite.rs" 8 0 8 35] (v : seq uint32)
+end
+module C05Pearlite_HasLen3
+  use seq.Seq
+  use prelude.Borrow
+  use prelude.Slice
+  use prelude.Seq
+  use prelude.Int
+  use prelude.UInt32
+  use seq.Seq
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = seq uint32,
+    type ShallowModelTy0.shallowModelTy = Seq.seq uint32
+  predicate has_len_3 [#"../05_pearlite.rs" 8 0 8 35] (v : seq uint32) =
+    [#"../05_pearlite.rs" 9 16 9 29] Seq.length (ShallowModel0.shallow_model v) = 3
+  val has_len_3 [#"../05_pearlite.rs" 8 0 8 35] (v : seq uint32) : bool
+    requires {[#"../05_pearlite.rs" 7 11 7 24] Seq.length (ShallowModel0.shallow_model v) = 3}
+    ensures { result = has_len_3 v }
+    
+end
+module C05Pearlite_HasLen3_Impl
+  use seq.Seq
+  use prelude.Borrow
+  use prelude.Slice
+  use prelude.Seq
+  use prelude.Int
+  use prelude.UInt32
+  clone Core_Num_Impl11_Max as Max0
+  clone CreusotContracts_Std1_Slice_Impl0_ShallowModel as ShallowModel1 with
+    type t = uint32,
+    val Max0.mAX' = Max0.mAX',
+    axiom .
+  use seq.Seq
+  clone CreusotContracts_Model_Impl1_ShallowModel as ShallowModel0 with
+    type t = seq uint32,
+    type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
+    function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  let rec ghost predicate has_len_3 [#"../05_pearlite.rs" 8 0 8 35] (v : seq uint32)
+    requires {[#"../05_pearlite.rs" 7 11 7 24] Seq.length (ShallowModel0.shallow_model v) = 3}
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+    [#"../05_pearlite.rs" 9 16 9 29] let a = let a' = ShallowModel0.shallow_model v in Seq.length a' in pure {a = 3}
+end
 module C05Pearlite_A_Type
   type t_a  =
     | C_A bool
@@ -10,20 +176,20 @@ module C05Pearlite_A_Type
 end
 module C05Pearlite_Solver_Interface
   use C05Pearlite_A_Type as C05Pearlite_A_Type
-  val solver [#"../05_pearlite.rs" 12 0 12 19] (x : C05Pearlite_A_Type.t_a) : ()
-    ensures { [#"../05_pearlite.rs" 11 10 11 20] C05Pearlite_A_Type.a_a x = C05Pearlite_A_Type.a_a x }
+  val solver [#"../05_pearlite.rs" 20 0 20 19] (x : C05Pearlite_A_Type.t_a) : ()
+    ensures { [#"../05_pearlite.rs" 19 10 19 20] C05Pearlite_A_Type.a_a x = C05Pearlite_A_Type.a_a x }
     
 end
 module C05Pearlite_StructInPearlite_Interface
   use C05Pearlite_A_Type as C05Pearlite_A_Type
-  val struct_in_pearlite [#"../05_pearlite.rs" 15 0 15 31] (x : C05Pearlite_A_Type.t_a) : ()
-    ensures { [#"../05_pearlite.rs" 14 10 14 30] x = C05Pearlite_A_Type.C_A false }
+  val struct_in_pearlite [#"../05_pearlite.rs" 23 0 23 31] (x : C05Pearlite_A_Type.t_a) : ()
+    ensures { [#"../05_pearlite.rs" 22 10 22 30] x = C05Pearlite_A_Type.C_A false }
     
 end
 module C05Pearlite_StructInPearlite
   use C05Pearlite_A_Type as C05Pearlite_A_Type
-  let rec cfg struct_in_pearlite [#"../05_pearlite.rs" 15 0 15 31] [@cfg:stackify] [@cfg:subregion_analysis] (x : C05Pearlite_A_Type.t_a) : ()
-    ensures { [#"../05_pearlite.rs" 14 10 14 30] x = C05Pearlite_A_Type.C_A false }
+  let rec cfg struct_in_pearlite [#"../05_pearlite.rs" 23 0 23 31] [@cfg:stackify] [@cfg:subregion_analysis] (x : C05Pearlite_A_Type.t_a) : ()
+    ensures { [#"../05_pearlite.rs" 22 10 22 30] x = C05Pearlite_A_Type.C_A false }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -49,16 +215,16 @@ module C05Pearlite_StructOrder_Interface
   use prelude.Int
   use prelude.UInt32
   use C05Pearlite_B_Type as C05Pearlite_B_Type
-  val struct_order [#"../05_pearlite.rs" 23 0 23 25] (x : C05Pearlite_B_Type.t_b) : ()
-    ensures { [#"../05_pearlite.rs" 22 10 22 48] x = C05Pearlite_B_Type.C_B false (0 : uint32) }
+  val struct_order [#"../05_pearlite.rs" 31 0 31 25] (x : C05Pearlite_B_Type.t_b) : ()
+    ensures { [#"../05_pearlite.rs" 30 10 30 48] x = C05Pearlite_B_Type.C_B false (0 : uint32) }
     
 end
 module C05Pearlite_StructOrder
   use prelude.Int
   use prelude.UInt32
   use C05Pearlite_B_Type as C05Pearlite_B_Type
-  let rec cfg struct_order [#"../05_pearlite.rs" 23 0 23 25] [@cfg:stackify] [@cfg:subregion_analysis] (x : C05Pearlite_B_Type.t_b) : ()
-    ensures { [#"../05_pearlite.rs" 22 10 22 48] x = C05Pearlite_B_Type.C_B false (0 : uint32) }
+  let rec cfg struct_order [#"../05_pearlite.rs" 31 0 31 25] [@cfg:stackify] [@cfg:subregion_analysis] (x : C05Pearlite_B_Type.t_b) : ()
+    ensures { [#"../05_pearlite.rs" 30 10 30 48] x = C05Pearlite_B_Type.C_B false (0 : uint32) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -75,27 +241,27 @@ module C05Pearlite_StructOrder
 end
 module C05Pearlite_Field1IsTrue_Stub
   use C05Pearlite_B_Type as C05Pearlite_B_Type
-  predicate field1_is_true [#"../05_pearlite.rs" 27 0 27 35] (x : C05Pearlite_B_Type.t_b)
+  predicate field1_is_true [#"../05_pearlite.rs" 35 0 35 35] (x : C05Pearlite_B_Type.t_b)
 end
 module C05Pearlite_Field1IsTrue_Interface
   use C05Pearlite_B_Type as C05Pearlite_B_Type
-  predicate field1_is_true [#"../05_pearlite.rs" 27 0 27 35] (x : C05Pearlite_B_Type.t_b)
+  predicate field1_is_true [#"../05_pearlite.rs" 35 0 35 35] (x : C05Pearlite_B_Type.t_b)
 end
 module C05Pearlite_Field1IsTrue
   use prelude.UInt32
   use C05Pearlite_B_Type as C05Pearlite_B_Type
-  predicate field1_is_true [#"../05_pearlite.rs" 27 0 27 35] (x : C05Pearlite_B_Type.t_b) =
-    [#"../05_pearlite.rs" 30 8 34 9] match (x) with
+  predicate field1_is_true [#"../05_pearlite.rs" 35 0 35 35] (x : C05Pearlite_B_Type.t_b) =
+    [#"../05_pearlite.rs" 38 8 42 9] match (x) with
       | C05Pearlite_B_Type.C_B (True) _ -> true
       | C05Pearlite_B_Type.C_B _f field2 -> UInt32.to_int field2 = 0
       | _ -> false
       end
-  val field1_is_true [#"../05_pearlite.rs" 27 0 27 35] (x : C05Pearlite_B_Type.t_b) : bool
+  val field1_is_true [#"../05_pearlite.rs" 35 0 35 35] (x : C05Pearlite_B_Type.t_b) : bool
     ensures { result = field1_is_true x }
     
 end
 module C05Pearlite_GhostClosure_Interface
-  val ghost_closure [#"../05_pearlite.rs" 38 0 38 22] (_1' : ()) : ()
+  val ghost_closure [#"../05_pearlite.rs" 46 0 46 22] (_1' : ()) : ()
 end
 module C05Pearlite_GhostClosure
   use prelude.Ghost
@@ -103,7 +269,7 @@ module C05Pearlite_GhostClosure
   use prelude.Int
   use prelude.UInt32
   use prelude.Mapping
-  let rec cfg ghost_closure [#"../05_pearlite.rs" 38 0 38 22] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : ()
+  let rec cfg ghost_closure [#"../05_pearlite.rs" 46 0 46 22] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : ()
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var _x_1 : Ghost.ghost_ty (Map.map uint32 uint32);
@@ -113,7 +279,7 @@ module C05Pearlite_GhostClosure
   }
   BB0 {
     _4 <- ();
-    _x_1 <- ([#"../05_pearlite.rs" 39 13 39 50] Ghost.new (Mapping.from_fn (fun (a : uint32) -> a)));
+    _x_1 <- ([#"../05_pearlite.rs" 47 13 47 50] Ghost.new (Mapping.from_fn (fun (a : uint32) -> a)));
     goto BB1
   }
   BB1 {
@@ -127,14 +293,14 @@ module C05Pearlite_PearliteClosure_Interface
   use map.Map
   use prelude.Int
   use prelude.UInt32
-  val pearlite_closure [#"../05_pearlite.rs" 42 0 42 54] (_x : Ghost.ghost_ty (Map.map uint32 bool)) : ()
+  val pearlite_closure [#"../05_pearlite.rs" 50 0 50 54] (_x : Ghost.ghost_ty (Map.map uint32 bool)) : ()
 end
 module C05Pearlite_PearliteClosure
   use prelude.Ghost
   use map.Map
   use prelude.Int
   use prelude.UInt32
-  let rec cfg pearlite_closure [#"../05_pearlite.rs" 42 0 42 54] [@cfg:stackify] [@cfg:subregion_analysis] (_x : Ghost.ghost_ty (Map.map uint32 bool)) : ()
+  let rec cfg pearlite_closure [#"../05_pearlite.rs" 50 0 50 54] [@cfg:stackify] [@cfg:subregion_analysis] (_x : Ghost.ghost_ty (Map.map uint32 bool)) : ()
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -150,7 +316,7 @@ module C05Pearlite_PearliteClosure
   
 end
 module C05Pearlite_Caller_Interface
-  val caller [#"../05_pearlite.rs" 44 0 44 15] (_1' : ()) : ()
+  val caller [#"../05_pearlite.rs" 52 0 52 15] (_1' : ()) : ()
 end
 module C05Pearlite_Caller
   use prelude.Ghost
@@ -159,7 +325,7 @@ module C05Pearlite_Caller
   use prelude.UInt32
   use prelude.Mapping
   clone C05Pearlite_PearliteClosure_Interface as PearliteClosure0
-  let rec cfg caller [#"../05_pearlite.rs" 44 0 44 15] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : ()
+  let rec cfg caller [#"../05_pearlite.rs" 52 0 52 15] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : ()) : ()
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var _1 : ();
@@ -170,11 +336,11 @@ module C05Pearlite_Caller
   }
   BB0 {
     _5 <- ();
-    _2 <- ([#"../05_pearlite.rs" 45 21 45 54] Ghost.new (Mapping.from_fn (fun (_a : uint32) -> true)));
+    _2 <- ([#"../05_pearlite.rs" 53 21 53 54] Ghost.new (Mapping.from_fn (fun (_a : uint32) -> true)));
     goto BB1
   }
   BB1 {
-    _1 <- ([#"../05_pearlite.rs" 45 4 45 55] PearliteClosure0.pearlite_closure _2);
+    _1 <- ([#"../05_pearlite.rs" 53 4 53 55] PearliteClosure0.pearlite_closure _2);
     goto BB2
   }
   BB2 {
@@ -191,64 +357,64 @@ end
 module C05Pearlite_Impl0_X_Stub
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function x [#"../05_pearlite.rs" 54 4 54 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+  function x [#"../05_pearlite.rs" 62 4 62 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
 end
 module C05Pearlite_Impl0_X_Interface
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function x [#"../05_pearlite.rs" 54 4 54 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+  function x [#"../05_pearlite.rs" 62 4 62 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
 end
 module C05Pearlite_Impl0_X
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function x [#"../05_pearlite.rs" 54 4 54 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool =
-    [#"../05_pearlite.rs" 55 8 55 12] true
-  val x [#"../05_pearlite.rs" 54 4 54 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
+  function x [#"../05_pearlite.rs" 62 4 62 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool =
+    [#"../05_pearlite.rs" 63 8 63 12] true
+  val x [#"../05_pearlite.rs" 62 4 62 31] (self : borrowed (C05Pearlite_S_Type.t_s)) : bool
     ensures { result = x self }
     
 end
 module C05Pearlite_Proj_Stub
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function proj [#"../05_pearlite.rs" 60 0 60 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+  function proj [#"../05_pearlite.rs" 68 0 68 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
 end
 module C05Pearlite_Proj_Interface
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function proj [#"../05_pearlite.rs" 60 0 60 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+  function proj [#"../05_pearlite.rs" 68 0 68 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
 end
 module C05Pearlite_Proj
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
   clone C05Pearlite_Impl0_X_Stub as X0
-  function proj [#"../05_pearlite.rs" 60 0 60 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+  function proj [#"../05_pearlite.rs" 68 0 68 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
    =
-    [#"../05_pearlite.rs" 59 0 59 8] X0.x {current = let (a, _) =  * x in a; final = let (a, _) =  ^ x in a}
-  val proj [#"../05_pearlite.rs" 60 0 60 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
+    [#"../05_pearlite.rs" 67 0 67 8] X0.x {current = let (a, _) =  * x in a; final = let (a, _) =  ^ x in a}
+  val proj [#"../05_pearlite.rs" 68 0 68 35] (x : borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s)) : bool
     ensures { result = proj x }
     
 end
 module C05Pearlite_Proj2_Stub
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function proj2 [#"../05_pearlite.rs" 65 0 65 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+  function proj2 [#"../05_pearlite.rs" 73 0 73 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
     
 end
 module C05Pearlite_Proj2_Interface
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
-  function proj2 [#"../05_pearlite.rs" 65 0 65 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+  function proj2 [#"../05_pearlite.rs" 73 0 73 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
     
 end
 module C05Pearlite_Proj2
   use prelude.Borrow
   use C05Pearlite_S_Type as C05Pearlite_S_Type
   clone C05Pearlite_Impl0_X_Stub as X0
-  function proj2 [#"../05_pearlite.rs" 65 0 65 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+  function proj2 [#"../05_pearlite.rs" 73 0 73 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
     
    =
-    [#"../05_pearlite.rs" 64 0 64 8] X0.x {current = let (a, _) =  *  * x in a; final = let (a, _) =  ^  * x in a}
-  val proj2 [#"../05_pearlite.rs" 65 0 65 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
+    [#"../05_pearlite.rs" 72 0 72 8] X0.x {current = let (a, _) =  *  * x in a; final = let (a, _) =  ^  * x in a}
+  val proj2 [#"../05_pearlite.rs" 73 0 73 41] (x : borrowed (borrowed (C05Pearlite_S_Type.t_s, C05Pearlite_S_Type.t_s))) : bool
     ensures { result = proj2 x }
     
 end

--- a/creusot/tests/should_succeed/syntax/05_pearlite.rs
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.rs
@@ -37,7 +37,7 @@ pub fn field1_is_true(x: B) -> bool {
         use crate::B; // verify that imports work properly
         match x {
             B { field1: true, .. } => true,
-            B { field2, field1: _f } => @field2 == 0,
+            B { field2, field1: _f } => field2@ == 0,
             _ => false
         }
     }

--- a/creusot/tests/should_succeed/syntax/05_pearlite.rs
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.rs
@@ -1,6 +1,14 @@
 extern crate creusot_contracts;
 use creusot_contracts::{logic::Mapping, *};
 
+// Test postfix model operator
+
+#[predicate]
+#[requires(v@.len() == 3)]
+pub fn has_len_3(v: &[u32]) -> bool {
+    pearlite! { v@.len() == 3 }
+}
+
 // Tests that we can use field access syntax in pearlite.
 
 pub struct A {

--- a/creusot/tests/should_succeed/syntax/09_maintains.rs
+++ b/creusot/tests/should_succeed/syntax/09_maintains.rs
@@ -33,7 +33,7 @@ pub fn test_2(a: &mut A, b: bool, c: u64) {}
 #[maintains((mut a).invariant(mut b, c))]
 pub fn test_3(a: &mut A, b: &mut bool, c: u64) {}
 
-#[maintains(a.inv2(@b + 0))]
+#[maintains(a.inv2(b@ + 0))]
 pub fn test_5(a: A, b: usize) {}
 
 #[maintains(other_inv(a, b))]

--- a/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
@@ -31,7 +31,7 @@ module C11ArrayTypes_Omg_Interface
   clone Core_Num_Impl11_Max_Stub as Max0
   use C11ArrayTypes_UsesArray_Type as C11ArrayTypes_UsesArray_Type
   val omg [#"../11_array_types.rs" 8 0 8 28] (x : C11ArrayTypes_UsesArray_Type.t_usesarray) : ()
-    requires {[#"../11_array_types.rs" 7 11 7 57] Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) > 0 /\ Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) < UIntSize.to_int Max0.mAX'}
+    requires {[#"../11_array_types.rs" 7 11 7 53] Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) > 0 /\ Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) < UIntSize.to_int Max0.mAX'}
     
 end
 module C11ArrayTypes_Omg
@@ -43,7 +43,7 @@ module C11ArrayTypes_Omg
   clone Core_Num_Impl11_Max as Max0
   use C11ArrayTypes_UsesArray_Type as C11ArrayTypes_UsesArray_Type
   let rec cfg omg [#"../11_array_types.rs" 8 0 8 28] [@cfg:stackify] [@cfg:subregion_analysis] (x : C11ArrayTypes_UsesArray_Type.t_usesarray) : ()
-    requires {[#"../11_array_types.rs" 7 11 7 57] Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) > 0 /\ Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) < UIntSize.to_int Max0.mAX'}
+    requires {[#"../11_array_types.rs" 7 11 7 53] Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) > 0 /\ Seq.length (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x)) < UIntSize.to_int Max0.mAX'}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -65,7 +65,7 @@ module C11ArrayTypes_Omg
   }
   BB1 {
     x_1 <- (let C11ArrayTypes_UsesArray_Type.C_UsesArray a = x_1 in C11ArrayTypes_UsesArray_Type.C_UsesArray (Seq.set (C11ArrayTypes_UsesArray_Type.usesarray_0 x_1) (UIntSize.to_int _3) ([#"../11_array_types.rs" 9 13 9 14] (5 : int64))));
-    assert { [#"../11_array_types.rs" 11 20 11 35] Int64.to_int (Seq.get (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x_1)) 0) = 5 };
+    assert { [#"../11_array_types.rs" 11 20 11 33] Int64.to_int (Seq.get (Slice.id (C11ArrayTypes_UsesArray_Type.usesarray_0 x_1)) 0) = 5 };
     _6 <- ();
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/syntax/11_array_types.rs
+++ b/creusot/tests/should_succeed/syntax/11_array_types.rs
@@ -8,7 +8,7 @@ pub struct UsesArray([i64; 5]);
 pub fn omg(mut x: UsesArray) {
     x.0[0] = 5;
 
-    proof_assert! { @(x.0@)[0] == 5};
+    proof_assert! { (x.0@)[0]@ == 5};
 }
 
 pub fn call_omg() {

--- a/creusot/tests/should_succeed/syntax/11_array_types.rs
+++ b/creusot/tests/should_succeed/syntax/11_array_types.rs
@@ -4,7 +4,7 @@ use creusot_contracts::*;
 
 pub struct UsesArray([i64; 5]);
 
-#[requires((x.0@).len() > 0 && (x.0@).len() < @usize::MAX)]
+#[requires((x.0@).len() > 0 && (x.0@).len() < usize::MAX@)]
 pub fn omg(mut x: UsesArray) {
     x.0[0] = 5;
 

--- a/creusot/tests/should_succeed/syntax/11_array_types.rs
+++ b/creusot/tests/should_succeed/syntax/11_array_types.rs
@@ -4,11 +4,11 @@ use creusot_contracts::*;
 
 pub struct UsesArray([i64; 5]);
 
-#[requires((@x.0).len() > 0 && (@x.0).len() < @usize::MAX)]
+#[requires((x.0@).len() > 0 && (x.0@).len() < @usize::MAX)]
 pub fn omg(mut x: UsesArray) {
     x.0[0] = 5;
 
-    proof_assert! { @(@x.0)[0] == 5};
+    proof_assert! { @(x.0@)[0] == 5};
 }
 
 pub fn call_omg() {

--- a/creusot/tests/should_succeed/syntax/11_array_types.rs
+++ b/creusot/tests/should_succeed/syntax/11_array_types.rs
@@ -4,11 +4,11 @@ use creusot_contracts::*;
 
 pub struct UsesArray([i64; 5]);
 
-#[requires((x.0@).len() > 0 && (x.0@).len() < usize::MAX@)]
+#[requires(x.0@.len() > 0 && x.0@.len() < usize::MAX@)]
 pub fn omg(mut x: UsesArray) {
     x.0[0] = 5;
 
-    proof_assert! { (x.0@)[0]@ == 5};
+    proof_assert! { x.0@[0]@ == 5};
 }
 
 pub fn call_omg() {

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.rs
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.rs
@@ -38,7 +38,7 @@ pub struct MyStruct {
     g: Ghost<u32>,
 }
 
-#[requires(@x.g == 0)]
+#[requires(x.g@ == 0)]
 pub fn takes_struct(mut x: MyStruct) {
     x.g = ghost! { x.f };
 }

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -295,7 +295,7 @@ module C13VecMacro_X
     goto BB1
   }
   BB1 {
-    assert { [#"../13_vec_macro.rs" 7 20 7 36] Seq.length (ShallowModel0.shallow_model v0_1) = 0 };
+    assert { [#"../13_vec_macro.rs" 7 20 7 34] Seq.length (ShallowModel0.shallow_model v0_1) = 0 };
     goto BB2
   }
   BB2 {
@@ -304,7 +304,7 @@ module C13VecMacro_X
     goto BB3
   }
   BB3 {
-    assert { [#"../13_vec_macro.rs" 10 20 10 36] Seq.length (ShallowModel1.shallow_model v1_4) = 2 };
+    assert { [#"../13_vec_macro.rs" 10 20 10 34] Seq.length (ShallowModel1.shallow_model v1_4) = 2 };
     goto BB4
   }
   BB4 {
@@ -322,7 +322,7 @@ module C13VecMacro_X
     goto BB7
   }
   BB7 {
-    assert { [#"../13_vec_macro.rs" 13 20 13 36] Seq.length (ShallowModel1.shallow_model v2_7) = 3 };
+    assert { [#"../13_vec_macro.rs" 13 20 13 34] Seq.length (ShallowModel1.shallow_model v2_7) = 3 };
     goto BB8
   }
   BB8 {

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.rs
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.rs
@@ -4,11 +4,11 @@ use creusot_contracts::{vec, *};
 
 pub fn x() {
     let v0: Vec<u32> = vec![];
-    proof_assert! { (@v0).len() == 0 };
+    proof_assert! { v0@.len() == 0 };
 
     let v1 = vec![0; 2];
-    proof_assert! { (@v1).len() == 2 };
+    proof_assert! { v1@.len() == 2 };
 
     let v2 = vec![1, 2, 3];
-    proof_assert! { (@v2).len() == 3 };
+    proof_assert! { v2@.len() == 3 };
 }

--- a/creusot/tests/should_succeed/take_first_mut.rs
+++ b/creusot/tests/should_succeed/take_first_mut.rs
@@ -5,13 +5,13 @@ use std::mem;
 
 #[ensures(match result {
     Some(r) => {
-        * r == (@**self_)[0] &&
-        ^ r == (@^*self_)[0] &&
-        (@**self_).len() > 0 && // ^*s.len == **s.len ? (i dont think so)
-        (@^*self_).len() > 0 &&
-        @*^self_ == (@**self_).tail() && @^^self_ == (@^*self_).tail()
+        * r == ((**self_)@)[0] &&
+        ^ r == (^*self_)@[0] &&
+        ((**self_)@).len() > 0 && // ^*s.len == **s.len ? (i dont think so)
+        (^*self_)@.len() > 0 &&
+        (*^self_)@ == (**self_)@.tail() && (^^self_)@ == (^*self_)@.tail()
     }
-    None => ^self_ == * self_ && (@**self_).len() == 0
+    None => ^self_ == * self_ && (**self_)@.len() == 0
 })]
 pub fn take_first_mut<'a, T>(self_: &mut &'a mut [T]) -> Option<&'a mut T> {
     match mem::take(self_).split_first_mut() {

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
@@ -150,7 +150,7 @@ module C16ImplCloning_Test_Interface
     type t = C16ImplCloning_Vec_Type.t_vec t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val test [#"../16_impl_cloning.rs" 16 0 16 30] (x : borrowed (C16ImplCloning_Vec_Type.t_vec t)) : ()
-    ensures { [#"../16_impl_cloning.rs" 15 10 15 19] ShallowModel0.shallow_model x = ShallowModel1.shallow_model ( * x) }
+    ensures { [#"../16_impl_cloning.rs" 15 10 15 21] ShallowModel0.shallow_model x = ShallowModel1.shallow_model ( * x) }
     
 end
 module C16ImplCloning_Test
@@ -168,7 +168,7 @@ module C16ImplCloning_Test
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   let rec cfg test [#"../16_impl_cloning.rs" 16 0 16 30] [@cfg:stackify] [@cfg:subregion_analysis] (x : borrowed (C16ImplCloning_Vec_Type.t_vec t)) : ()
-    ensures { [#"../16_impl_cloning.rs" 15 10 15 19] ShallowModel0.shallow_model x = ShallowModel1.shallow_model ( * x) }
+    ensures { [#"../16_impl_cloning.rs" 15 10 15 21] ShallowModel0.shallow_model x = ShallowModel1.shallow_model ( * x) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.rs
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.rs
@@ -12,5 +12,5 @@ impl<T> ShallowModel for Vec<T> {
     }
 }
 
-#[ensures(x@ == @*x)]
+#[ensures(x@ == (*x)@)]
 pub fn test<T>(x: &mut Vec<T>) {}

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.rs
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.rs
@@ -12,5 +12,5 @@ impl<T> ShallowModel for Vec<T> {
     }
 }
 
-#[ensures(@x == @*x)]
+#[ensures(x@ == @*x)]
 pub fn test<T>(x: &mut Vec<T>) {}

--- a/creusot/tests/should_succeed/type_invariants/borrows.rs
+++ b/creusot/tests/should_succeed/type_invariants/borrows.rs
@@ -18,7 +18,7 @@ impl NonZeroU32 {
     }
 
     #[requires(self.0@ > rhs.0@)]
-    #[ensures(@(^self).0 == @(*self).0 - rhs.0@)]
+    #[ensures((^self).0@ == (*self).0@ - rhs.0@)]
     pub fn sub_mut(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }

--- a/creusot/tests/should_succeed/type_invariants/borrows.rs
+++ b/creusot/tests/should_succeed/type_invariants/borrows.rs
@@ -6,7 +6,7 @@ pub struct NonZeroU32(u32);
 impl Invariant for NonZeroU32 {
     #[predicate]
     fn invariant(self) -> bool {
-        pearlite! { @self.0 > 0 }
+        pearlite! { self.0@ > 0 }
     }
 }
 
@@ -17,14 +17,14 @@ impl NonZeroU32 {
         Self(n)
     }
 
-    #[requires(@self.0 > @rhs.0)]
-    #[ensures(@(^self).0 == @(*self).0 - @rhs.0)]
+    #[requires(self.0@ > rhs.0@)]
+    #[ensures(@(^self).0 == @(*self).0 - rhs.0@)]
     pub fn sub_mut(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }
 }
 
-#[requires(@n.0 > 1)]
+#[requires(n.0@ > 1)]
 pub fn dec(mut n: NonZeroU32) -> NonZeroU32 {
     let borrowed = &mut n;
     borrowed.sub_mut(NonZeroU32::new(1));

--- a/creusot/tests/should_succeed/type_invariants/borrows.rs
+++ b/creusot/tests/should_succeed/type_invariants/borrows.rs
@@ -11,7 +11,7 @@ impl Invariant for NonZeroU32 {
 }
 
 impl NonZeroU32 {
-    #[requires(@n > 0)]
+    #[requires(n@ > 0)]
     #[ensures(result.0 == n)]
     pub fn new(n: u32) -> Self {
         Self(n)

--- a/creusot/tests/should_succeed/type_invariants/non_zero.rs
+++ b/creusot/tests/should_succeed/type_invariants/non_zero.rs
@@ -26,7 +26,7 @@ impl NonZeroU32 {
         Self(n)
     }
 
-    #[requires(self.0@ + rhs.0@ <= @u32::MAX)]
+    #[requires(self.0@ + rhs.0@ <= u32::MAX@)]
     pub fn add(self, rhs: Self) -> Self {
         Self(self.0 + rhs.0)
     }

--- a/creusot/tests/should_succeed/type_invariants/non_zero.rs
+++ b/creusot/tests/should_succeed/type_invariants/non_zero.rs
@@ -21,7 +21,7 @@ impl Invariant for NonZeroU32 {
 }
 
 impl NonZeroU32 {
-    #[requires(@n > 0)]
+    #[requires(n@ > 0)]
     pub fn new(n: u32) -> Self {
         Self(n)
     }

--- a/creusot/tests/should_succeed/type_invariants/non_zero.rs
+++ b/creusot/tests/should_succeed/type_invariants/non_zero.rs
@@ -6,7 +6,7 @@ pub struct NonZeroU32(u32);
 impl Invariant for NonZeroU32 {
     #[predicate]
     fn invariant(self) -> bool {
-        pearlite! { @self.0 > 0 }
+        pearlite! { self.0@ > 0 }
     }
 
     #[law]
@@ -26,14 +26,14 @@ impl NonZeroU32 {
         Self(n)
     }
 
-    #[requires(@self.0 + @rhs.0 <= @u32::MAX)]
+    #[requires(self.0@ + rhs.0@ <= @u32::MAX)]
     pub fn add(self, rhs: Self) -> Self {
         Self(self.0 + rhs.0)
     }
 
     #[predicate]
     pub fn sub_pre(self, rhs: Self) -> bool {
-        pearlite! { @self.0 > @rhs.0 }
+        pearlite! { self.0@ > rhs.0@ }
     }
 
     #[law]

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -845,7 +845,7 @@ module C01_AllZero_Interface
     axiom .
   val all_zero [#"../01.rs" 7 0 7 33] (v : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../01.rs" 5 0 5 74] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ v)) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = (0 : uint32) }
-    ensures { [#"../01.rs" 6 10 6 35] Seq.length (ShallowModel1.shallow_model v) = Seq.length (ShallowModel0.shallow_model ( ^ v)) }
+    ensures { [#"../01.rs" 6 10 6 33] Seq.length (ShallowModel1.shallow_model v) = Seq.length (ShallowModel0.shallow_model ( ^ v)) }
     
 end
 module C01_AllZero
@@ -950,7 +950,7 @@ module C01_AllZero
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   let rec cfg all_zero [#"../01.rs" 7 0 7 33] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../01.rs" 5 0 5 74] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ v)) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = (0 : uint32) }
-    ensures { [#"../01.rs" 6 10 6 35] Seq.length (ShallowModel1.shallow_model v) = Seq.length (ShallowModel0.shallow_model ( ^ v)) }
+    ensures { [#"../01.rs" 6 10 6 33] Seq.length (ShallowModel1.shallow_model v) = Seq.length (ShallowModel0.shallow_model ( ^ v)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -994,33 +994,33 @@ module C01_AllZero
   }
   BB2 {
     _8 <- Core_Ops_Range_Range_Type.C_Range ([#"../01.rs" 13 13 13 14] (0 : usize)) _9;
-    iter_7 <- ([#"../01.rs" 11 4 11 57] IntoIter0.into_iter _8);
+    iter_7 <- ([#"../01.rs" 11 4 11 53] IntoIter0.into_iter _8);
     goto BB3
   }
   BB3 {
     _13 <- ();
-    iter_old_11 <- ([#"../01.rs" 11 4 11 57] Ghost.new iter_7);
+    iter_old_11 <- ([#"../01.rs" 11 4 11 53] Ghost.new iter_7);
     goto BB4
   }
   BB4 {
     _17 <- ();
-    produced_14 <- ([#"../01.rs" 11 4 11 57] Ghost.new (Seq.empty ));
+    produced_14 <- ([#"../01.rs" 11 4 11 53] Ghost.new (Seq.empty ));
     goto BB5
   }
   BB5 {
     goto BB6
   }
   BB6 {
-    invariant type_invariant { [#"../01.rs" 11 4 11 57] Invariant0.invariant' iter_7 };
-    invariant structural { [#"../01.rs" 11 4 11 57] Produces0.produces (Ghost.inner iter_old_11) (Ghost.inner produced_14) iter_7 };
-    invariant in_bounds { [#"../01.rs" 11 27 11 55] Seq.length (ShallowModel1.shallow_model v_1) = Seq.length (ShallowModel2.shallow_model old_v_4) };
-    invariant all_zero { [#"../01.rs" 11 4 11 57] forall j : int . 0 <= j /\ j < Seq.length (Ghost.inner produced_14) -> Seq.get (ShallowModel1.shallow_model v_1) j = (0 : uint32) };
+    invariant type_invariant { [#"../01.rs" 11 4 11 53] Invariant0.invariant' iter_7 };
+    invariant structural { [#"../01.rs" 11 4 11 53] Produces0.produces (Ghost.inner iter_old_11) (Ghost.inner produced_14) iter_7 };
+    invariant in_bounds { [#"../01.rs" 11 27 11 51] Seq.length (ShallowModel1.shallow_model v_1) = Seq.length (ShallowModel2.shallow_model old_v_4) };
+    invariant all_zero { [#"../01.rs" 11 4 11 53] forall j : int . 0 <= j /\ j < Seq.length (Ghost.inner produced_14) -> Seq.get (ShallowModel1.shallow_model v_1) j = (0 : uint32) };
     _25 <- borrow_mut iter_7;
     iter_7 <-  ^ _25;
     _24 <- borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
     assume { Resolve0.resolve _25 };
-    _23 <- ([#"../01.rs" 11 4 11 57] Next0.next _24);
+    _23 <- ([#"../01.rs" 11 4 11 53] Next0.next _24);
     goto BB7
   }
   BB7 {
@@ -1041,7 +1041,7 @@ module C01_AllZero
   BB10 {
     __creusot_proc_iter_elem_27 <- Core_Option_Option_Type.some_0 _23;
     _30 <- ();
-    _28 <- ([#"../01.rs" 11 4 11 57] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_27)));
+    _28 <- ([#"../01.rs" 11 4 11 53] Ghost.new (Seq.(++) (Ghost.inner produced_14) (Seq.singleton __creusot_proc_iter_elem_27)));
     goto BB11
   }
   BB11 {

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -2,8 +2,8 @@ extern crate creusot_contracts;
 
 use creusot_contracts::{logic::Int, *};
 
-#[ensures(forall<i : Int> 0 <= i && i < ((^v)@).len() ==> ((^v)@)[i] == 0u32)]
-#[ensures(v@.len() == ((^v)@).len())]
+#[ensures(forall<i : Int> 0 <= i && i < (^v)@.len() ==> (^v)@[i] == 0u32)]
+#[ensures(v@.len() == (^v)@.len())]
 pub fn all_zero(v: &mut Vec<u32>) {
     let old_v = ghost! { v };
     // This invariant is because why3 can't determine that the prophecy isn't modified by the loop

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -3,13 +3,13 @@ extern crate creusot_contracts;
 use creusot_contracts::{logic::Int, *};
 
 #[ensures(forall<i : Int> 0 <= i && i < (@^v).len() ==> (@^v)[i] == 0u32)]
-#[ensures((@v).len() == (@^v).len())]
+#[ensures(v@.len() == (@^v).len())]
 pub fn all_zero(v: &mut Vec<u32>) {
     let old_v = ghost! { v };
     // This invariant is because why3 can't determine that the prophecy isn't modified by the loop
     // Either Why3 or Creusot should be improved to do this automaticallly (probably why3)
-    #[invariant(in_bounds, (@v).len() == (@old_v).len())]
-    #[invariant(all_zero, forall<j : Int> 0 <= j && j < produced.len() ==> (@v)[j] == 0u32)]
+    #[invariant(in_bounds, v@.len() == old_v@.len())]
+    #[invariant(all_zero, forall<j : Int> 0 <= j && j < produced.len() ==> v@[j] == 0u32)]
     for i in 0..v.len() {
         v[i] = 0;
     }

--- a/creusot/tests/should_succeed/vector/01.rs
+++ b/creusot/tests/should_succeed/vector/01.rs
@@ -2,8 +2,8 @@ extern crate creusot_contracts;
 
 use creusot_contracts::{logic::Int, *};
 
-#[ensures(forall<i : Int> 0 <= i && i < (@^v).len() ==> (@^v)[i] == 0u32)]
-#[ensures(v@.len() == (@^v).len())]
+#[ensures(forall<i : Int> 0 <= i && i < ((^v)@).len() ==> ((^v)@)[i] == 0u32)]
+#[ensures(v@.len() == ((^v)@).len())]
 pub fn all_zero(v: &mut Vec<u32>) {
     let old_v = ghost! { v };
     // This invariant is because why3 can't determine that the prophecy isn't modified by the loop

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -1098,7 +1098,7 @@ module C02Gnome_GnomeSort_Interface
     axiom .
   val gnome_sort [#"../02_gnome.rs" 22 0 24 29] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../02_gnome.rs" 20 10 20 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../02_gnome.rs" 21 10 21 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_gnome.rs" 21 0 21 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
 end
 module C02Gnome_GnomeSort
@@ -1267,7 +1267,7 @@ module C02Gnome_GnomeSort
     predicate SortedRange0.sorted_range = SortedRange0.sorted_range
   let rec cfg gnome_sort [#"../02_gnome.rs" 22 0 24 29] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
     ensures { [#"../02_gnome.rs" 20 10 20 35] Sorted0.sorted (DeepModel0.deep_model ( ^ v)) }
-    ensures { [#"../02_gnome.rs" 21 10 21 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../02_gnome.rs" 21 0 21 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -1319,7 +1319,7 @@ module C02Gnome_GnomeSort
   }
   BB2 {
     invariant sorted { [#"../02_gnome.rs" 28 24 28 59] SortedRange0.sorted_range (DeepModel1.deep_model v_1) 0 (UIntSize.to_int i_7) };
-    invariant permutation { [#"../02_gnome.rs" 29 29 29 56] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_4) };
+    invariant permutation { [#"../02_gnome.rs" 28 4 28 61] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_4) };
     _12 <- i_7;
     _14 <-  * v_1;
     _13 <- ([#"../02_gnome.rs" 30 14 30 21] Len0.len _14);

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -18,7 +18,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures(((^v)@).permutation_of(v@))]
+#[ensures((^v)@.permutation_of(v@))]
 pub fn gnome_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -26,7 +26,7 @@ where
     let old_v = ghost! { v };
     let mut i = 0;
     #[invariant(sorted, sorted_range(v.deep_model(), 0, @i))]
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
     while i < v.len() {
         if i == 0 || v[i - 1].le(&v[i]) {
             i += 1;

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -18,15 +18,15 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(@v))]
+#[ensures((@^v).permutation_of(v@))]
 pub fn gnome_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,
 {
     let old_v = ghost! { v };
     let mut i = 0;
-    #[invariant(sorted, sorted_range(v.deep_model(), 0, @i))]
-    #[invariant(permutation, v@.permutation_of(@old_v))]
+    #[invariant(sorted, sorted_range(v.deep_model(), 0, i@))]
+    #[invariant(permutation, v@.permutation_of(old_v@))]
     while i < v.len() {
         if i == 0 || v[i - 1].le(&v[i]) {
             i += 1;

--- a/creusot/tests/should_succeed/vector/02_gnome.rs
+++ b/creusot/tests/should_succeed/vector/02_gnome.rs
@@ -18,7 +18,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 }
 
 #[ensures(sorted((^v).deep_model()))]
-#[ensures((@^v).permutation_of(v@))]
+#[ensures(((^v)@).permutation_of(v@))]
 pub fn gnome_sort<T: Ord + DeepModel>(v: &mut Vec<T>)
 where
     T::DeepModelTy: OrdLogic,

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -755,7 +755,7 @@ module C03KnuthShuffle_KnuthShuffle_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val knuth_shuffle [#"../03_knuth_shuffle.rs" 13 0 13 39] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../03_knuth_shuffle.rs" 12 10 12 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../03_knuth_shuffle.rs" 12 0 12 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
 end
 module C03KnuthShuffle_KnuthShuffle
@@ -868,7 +868,7 @@ module C03KnuthShuffle_KnuthShuffle
   clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with
     type t = t
   let rec cfg knuth_shuffle [#"../03_knuth_shuffle.rs" 13 0 13 39] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../03_knuth_shuffle.rs" 12 10 12 34] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
+    ensures { [#"../03_knuth_shuffle.rs" 12 0 12 36] PermutationOf0.permutation_of (ShallowModel0.shallow_model ( ^ v)) (ShallowModel1.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -922,32 +922,32 @@ module C03KnuthShuffle_KnuthShuffle
   }
   BB2 {
     _7 <- Core_Ops_Range_Range_Type.C_Range ([#"../03_knuth_shuffle.rs" 17 13 17 14] (0 : usize)) _8;
-    iter_6 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] IntoIter0.into_iter _7);
+    iter_6 <- ([#"../03_knuth_shuffle.rs" 16 4 16 56] IntoIter0.into_iter _7);
     goto BB3
   }
   BB3 {
     _12 <- ();
-    iter_old_10 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Ghost.new iter_6);
+    iter_old_10 <- ([#"../03_knuth_shuffle.rs" 16 4 16 56] Ghost.new iter_6);
     goto BB4
   }
   BB4 {
     _16 <- ();
-    produced_13 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Ghost.new (Seq.empty ));
+    produced_13 <- ([#"../03_knuth_shuffle.rs" 16 4 16 56] Ghost.new (Seq.empty ));
     goto BB5
   }
   BB5 {
     goto BB6
   }
   BB6 {
-    invariant type_invariant { [#"../03_knuth_shuffle.rs" 16 4 16 58] Invariant0.invariant' iter_6 };
-    invariant structural { [#"../03_knuth_shuffle.rs" 16 4 16 58] Produces0.produces (Ghost.inner iter_old_10) (Ghost.inner produced_13) iter_6 };
-    invariant permutation { [#"../03_knuth_shuffle.rs" 16 29 16 56] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_3) };
+    invariant type_invariant { [#"../03_knuth_shuffle.rs" 16 4 16 56] Invariant0.invariant' iter_6 };
+    invariant structural { [#"../03_knuth_shuffle.rs" 16 4 16 56] Produces0.produces (Ghost.inner iter_old_10) (Ghost.inner produced_13) iter_6 };
+    invariant permutation { [#"../03_knuth_shuffle.rs" 16 4 16 56] PermutationOf0.permutation_of (ShallowModel1.shallow_model v_1) (ShallowModel2.shallow_model old_v_3) };
     _23 <- borrow_mut iter_6;
     iter_6 <-  ^ _23;
     _22 <- borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _22) };
     assume { Resolve0.resolve _23 };
-    _21 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Next0.next _22);
+    _21 <- ([#"../03_knuth_shuffle.rs" 16 4 16 56] Next0.next _22);
     goto BB7
   }
   BB7 {
@@ -968,7 +968,7 @@ module C03KnuthShuffle_KnuthShuffle
   BB10 {
     __creusot_proc_iter_elem_25 <- Core_Option_Option_Type.some_0 _21;
     _28 <- ();
-    _26 <- ([#"../03_knuth_shuffle.rs" 16 4 16 58] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_25)));
+    _26 <- ([#"../03_knuth_shuffle.rs" 16 4 16 56] Ghost.new (Seq.(++) (Ghost.inner produced_13) (Seq.singleton __creusot_proc_iter_elem_25)));
     goto BB11
   }
   BB11 {

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -9,7 +9,7 @@ fn rand_in_range(l: usize, u: usize) -> usize {
     panic!()
 }
 
-#[ensures((@^v).permutation_of(v@))]
+#[ensures(((^v)@).permutation_of(v@))]
 pub fn knuth_shuffle<T>(v: &mut Vec<T>) {
     let old_v = ghost! { v };
 

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -13,7 +13,7 @@ fn rand_in_range(l: usize, u: usize) -> usize {
 pub fn knuth_shuffle<T>(v: &mut Vec<T>) {
     let old_v = ghost! { v };
 
-    #[invariant(permutation, (@v).permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(@old_v))]
     for n in 0..v.len() {
         // We assign the length to a variable to work around a limitation with two-phase borrows
         // where we forget the value stored in the reference.

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -3,17 +3,17 @@ extern crate creusot_contracts;
 use creusot_contracts::*;
 
 #[trusted]
-#[requires(@l <= @u)]
-#[ensures(@l <= @result && @result  < @u)]
+#[requires(l@ <= u@)]
+#[ensures(l@ <= result@ && result@  < u@)]
 fn rand_in_range(l: usize, u: usize) -> usize {
     panic!()
 }
 
-#[ensures((@^v).permutation_of(@v))]
+#[ensures((@^v).permutation_of(v@))]
 pub fn knuth_shuffle<T>(v: &mut Vec<T>) {
     let old_v = ghost! { v };
 
-    #[invariant(permutation, v@.permutation_of(@old_v))]
+    #[invariant(permutation, v@.permutation_of(old_v@))]
     for n in 0..v.len() {
         // We assign the length to a variable to work around a limitation with two-phase borrows
         // where we forget the value stored in the reference.

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.rs
@@ -9,7 +9,7 @@ fn rand_in_range(l: usize, u: usize) -> usize {
     panic!()
 }
 
-#[ensures(((^v)@).permutation_of(v@))]
+#[ensures((^v)@.permutation_of(v@))]
 pub fn knuth_shuffle<T>(v: &mut Vec<T>) {
     let old_v = ghost! { v };
 

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -362,11 +362,11 @@ module C04BinarySearch_BinarySearch_Interface
     type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32
   val binary_search [#"../04_binary_search.rs" 26 0 26 71] (arr : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) (elem : uint32) : Core_Result_Result_Type.t_result usize usize
-    requires {[#"../04_binary_search.rs" 19 11 19 38] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
+    requires {[#"../04_binary_search.rs" 19 11 19 36] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
     requires {[#"../04_binary_search.rs" 20 11 20 23] Sorted0.sorted (ShallowModel0.shallow_model arr)}
-    ensures { [#"../04_binary_search.rs" 21 0 21 66] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int x) = elem }
-    ensures { [#"../04_binary_search.rs" 22 0 23 51] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i) <= elem) }
-    ensures { [#"../04_binary_search.rs" 24 0 25 70] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x < i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> elem < Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i)) }
+    ensures { [#"../04_binary_search.rs" 21 0 21 64] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int x) = elem }
+    ensures { [#"../04_binary_search.rs" 22 0 23 49] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i) <= elem) }
+    ensures { [#"../04_binary_search.rs" 24 0 25 66] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x < i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> elem < Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i)) }
     
 end
 module C04BinarySearch_BinarySearch
@@ -409,11 +409,11 @@ module C04BinarySearch_BinarySearch
     predicate SortedRange0.sorted_range = SortedRange0.sorted_range
   use Core_Result_Result_Type as Core_Result_Result_Type
   let rec cfg binary_search [#"../04_binary_search.rs" 26 0 26 71] [@cfg:stackify] [@cfg:subregion_analysis] (arr : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) (elem : uint32) : Core_Result_Result_Type.t_result usize usize
-    requires {[#"../04_binary_search.rs" 19 11 19 38] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
+    requires {[#"../04_binary_search.rs" 19 11 19 36] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
     requires {[#"../04_binary_search.rs" 20 11 20 23] Sorted0.sorted (ShallowModel0.shallow_model arr)}
-    ensures { [#"../04_binary_search.rs" 21 0 21 66] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int x) = elem }
-    ensures { [#"../04_binary_search.rs" 22 0 23 51] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i) <= elem) }
-    ensures { [#"../04_binary_search.rs" 24 0 25 70] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x < i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> elem < Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i)) }
+    ensures { [#"../04_binary_search.rs" 21 0 21 64] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int x) = elem }
+    ensures { [#"../04_binary_search.rs" 22 0 23 49] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i) <= elem) }
+    ensures { [#"../04_binary_search.rs" 24 0 25 66] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x < i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> elem < Seq.get (ShallowModel0.shallow_model arr) (UIntSize.to_int i)) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Result_Result_Type.t_result usize usize;
@@ -494,9 +494,9 @@ module C04BinarySearch_BinarySearch
     goto BB5
   }
   BB5 {
-    invariant size_valid { [#"../04_binary_search.rs" 33 28 33 70] 0 < UIntSize.to_int size_13 /\ UIntSize.to_int size_13 + UIntSize.to_int base_15 <= Seq.length (ShallowModel0.shallow_model arr_1) };
-    invariant lower_b { [#"../04_binary_search.rs" 33 4 33 72] forall i : usize . i < base_15 -> Seq.get (ShallowModel0.shallow_model arr_1) (UIntSize.to_int i) <= elem_2 };
-    invariant lower_b { [#"../04_binary_search.rs" 33 4 33 72] forall i : usize . UIntSize.to_int base_15 + UIntSize.to_int size_13 < UIntSize.to_int i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr_1) -> elem_2 < Seq.get (ShallowModel0.shallow_model arr_1) (UIntSize.to_int i) };
+    invariant size_valid { [#"../04_binary_search.rs" 33 28 33 68] 0 < UIntSize.to_int size_13 /\ UIntSize.to_int size_13 + UIntSize.to_int base_15 <= Seq.length (ShallowModel0.shallow_model arr_1) };
+    invariant lower_b { [#"../04_binary_search.rs" 33 4 33 70] forall i : usize . i < base_15 -> Seq.get (ShallowModel0.shallow_model arr_1) (UIntSize.to_int i) <= elem_2 };
+    invariant lower_b { [#"../04_binary_search.rs" 33 4 33 70] forall i : usize . UIntSize.to_int base_15 + UIntSize.to_int size_13 < UIntSize.to_int i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr_1) -> elem_2 < Seq.get (ShallowModel0.shallow_model arr_1) (UIntSize.to_int i) };
     _22 <- size_13;
     _21 <- ([#"../04_binary_search.rs" 36 10 36 18] _22 > ([#"../04_binary_search.rs" 36 17 36 18] (1 : usize)));
     switch (_21)

--- a/creusot/tests/should_succeed/vector/04_binary_search.rs
+++ b/creusot/tests/should_succeed/vector/04_binary_search.rs
@@ -16,13 +16,13 @@ fn sorted(s: Seq<u32>) -> bool {
     sorted_range(s, 0, s.len())
 }
 
-#[requires((@arr).len() <= @usize::MAX)]
+#[requires(arr@.len() <= @usize::MAX)]
 #[requires(sorted(@arr))]
-#[ensures(forall<x:usize> result == Ok(x) ==> (@arr)[@x] == elem)]
+#[ensures(forall<x:usize> result == Ok(x) ==> arr@[@x] == elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize>  i < x ==> (@arr)[@i] <= elem)]
+    forall<i:usize>  i < x ==> arr@[@i] <= elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> x < i && @i < (@arr).len() ==> elem < (@arr)[@i])]
+    forall<i:usize> x < i && @i < arr@.len() ==> elem < arr@[@i])]
 pub fn binary_search(arr: &Vec<u32>, elem: u32) -> Result<usize, usize> {
     if arr.len() == 0 {
         return Err(0);
@@ -30,9 +30,9 @@ pub fn binary_search(arr: &Vec<u32>, elem: u32) -> Result<usize, usize> {
     let mut size = arr.len();
     let mut base = 0;
 
-    #[invariant(size_valid, 0 < @size && @size + @base <= (@arr).len())]
-    #[invariant(lower_b, forall<i : usize> i < base ==> (@arr)[@i] <= elem)]
-    #[invariant(lower_b, forall<i : usize> @base + @size < @i && @i < (@arr).len() ==> elem < (@arr)[@i])]
+    #[invariant(size_valid, 0 < @size && @size + @base <= arr@.len())]
+    #[invariant(lower_b, forall<i : usize> i < base ==> arr@[@i] <= elem)]
+    #[invariant(lower_b, forall<i : usize> @base + @size < @i && @i < arr@.len() ==> elem < arr@[@i])]
     while size > 1 {
         let half = size / 2;
         let mid = base + half;

--- a/creusot/tests/should_succeed/vector/04_binary_search.rs
+++ b/creusot/tests/should_succeed/vector/04_binary_search.rs
@@ -17,12 +17,12 @@ fn sorted(s: Seq<u32>) -> bool {
 }
 
 #[requires(arr@.len() <= @usize::MAX)]
-#[requires(sorted(@arr))]
-#[ensures(forall<x:usize> result == Ok(x) ==> arr@[@x] == elem)]
+#[requires(sorted(arr@))]
+#[ensures(forall<x:usize> result == Ok(x) ==> arr@[x@] == elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize>  i < x ==> arr@[@i] <= elem)]
+    forall<i:usize>  i < x ==> arr@[i@] <= elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> x < i && @i < arr@.len() ==> elem < arr@[@i])]
+    forall<i:usize> x < i && i@ < arr@.len() ==> elem < arr@[i@])]
 pub fn binary_search(arr: &Vec<u32>, elem: u32) -> Result<usize, usize> {
     if arr.len() == 0 {
         return Err(0);
@@ -30,9 +30,9 @@ pub fn binary_search(arr: &Vec<u32>, elem: u32) -> Result<usize, usize> {
     let mut size = arr.len();
     let mut base = 0;
 
-    #[invariant(size_valid, 0 < @size && @size + @base <= arr@.len())]
-    #[invariant(lower_b, forall<i : usize> i < base ==> arr@[@i] <= elem)]
-    #[invariant(lower_b, forall<i : usize> @base + @size < @i && @i < arr@.len() ==> elem < arr@[@i])]
+    #[invariant(size_valid, 0 < size@ && size@ + base@ <= arr@.len())]
+    #[invariant(lower_b, forall<i : usize> i < base ==> arr@[i@] <= elem)]
+    #[invariant(lower_b, forall<i : usize> base@ + size@ < i@ && i@ < arr@.len() ==> elem < arr@[i@])]
     while size > 1 {
         let half = size / 2;
         let mid = base + half;

--- a/creusot/tests/should_succeed/vector/04_binary_search.rs
+++ b/creusot/tests/should_succeed/vector/04_binary_search.rs
@@ -16,7 +16,7 @@ fn sorted(s: Seq<u32>) -> bool {
     sorted_range(s, 0, s.len())
 }
 
-#[requires(arr@.len() <= @usize::MAX)]
+#[requires(arr@.len() <= usize::MAX@)]
 #[requires(sorted(arr@))]
 #[ensures(forall<x:usize> result == Ok(x) ==> arr@[x@] == elem)]
 #[ensures(forall<x:usize> result == Err(x) ==>

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -901,11 +901,11 @@ module C05BinarySearchGeneric_BinarySearch_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val binary_search [#"../05_binary_search_generic.rs" 27 0 29 29] (arr : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) (elem : t) : Core_Result_Result_Type.t_result usize usize
-    requires {[#"../05_binary_search_generic.rs" 20 11 20 38] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
+    requires {[#"../05_binary_search_generic.rs" 20 11 20 36] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
     requires {[#"../05_binary_search_generic.rs" 21 11 21 35] Sorted0.sorted (DeepModel0.deep_model arr)}
     ensures { [#"../05_binary_search_generic.rs" 22 0 22 89] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int x) = DeepModel1.deep_model elem }
     ensures { [#"../05_binary_search_generic.rs" 23 0 24 74] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> LeLog0.le_log (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i)) (DeepModel1.deep_model elem)) }
-    ensures { [#"../05_binary_search_generic.rs" 25 0 26 94] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x <= i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> LtLog0.lt_log (DeepModel1.deep_model elem) (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i))) }
+    ensures { [#"../05_binary_search_generic.rs" 25 0 26 92] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x <= i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> LtLog0.lt_log (DeepModel1.deep_model elem) (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i))) }
     
 end
 module C05BinarySearchGeneric_BinarySearch
@@ -1042,11 +1042,11 @@ module C05BinarySearchGeneric_BinarySearch
     function DeepModel0.deep_model = DeepModel2.deep_model
   use Core_Result_Result_Type as Core_Result_Result_Type
   let rec cfg binary_search [#"../05_binary_search_generic.rs" 27 0 29 29] [@cfg:stackify] [@cfg:subregion_analysis] (arr : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) (elem : t) : Core_Result_Result_Type.t_result usize usize
-    requires {[#"../05_binary_search_generic.rs" 20 11 20 38] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
+    requires {[#"../05_binary_search_generic.rs" 20 11 20 36] Seq.length (ShallowModel0.shallow_model arr) <= UIntSize.to_int Max0.mAX'}
     requires {[#"../05_binary_search_generic.rs" 21 11 21 35] Sorted0.sorted (DeepModel0.deep_model arr)}
     ensures { [#"../05_binary_search_generic.rs" 22 0 22 89] forall x : usize . result = Core_Result_Result_Type.C_Ok x -> Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int x) = DeepModel1.deep_model elem }
     ensures { [#"../05_binary_search_generic.rs" 23 0 24 74] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . i < x -> LeLog0.le_log (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i)) (DeepModel1.deep_model elem)) }
-    ensures { [#"../05_binary_search_generic.rs" 25 0 26 94] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x <= i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> LtLog0.lt_log (DeepModel1.deep_model elem) (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i))) }
+    ensures { [#"../05_binary_search_generic.rs" 25 0 26 92] forall x : usize . result = Core_Result_Result_Type.C_Err x -> (forall i : usize . x <= i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr) -> LtLog0.lt_log (DeepModel1.deep_model elem) (Seq.get (DeepModel0.deep_model arr) (UIntSize.to_int i))) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Result_Result_Type.t_result usize usize;
@@ -1143,9 +1143,9 @@ module C05BinarySearchGeneric_BinarySearch
     goto BB10
   }
   BB10 {
-    invariant size_valid { [#"../05_binary_search_generic.rs" 37 28 37 70] 0 < UIntSize.to_int size_13 /\ UIntSize.to_int size_13 + UIntSize.to_int base_15 <= Seq.length (ShallowModel0.shallow_model arr_1) };
-    invariant lower_b { [#"../05_binary_search_generic.rs" 37 4 37 72] forall i : usize . i < base_15 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model arr_1) (UIntSize.to_int i)) (DeepModel1.deep_model elem_2) };
-    invariant lower_b { [#"../05_binary_search_generic.rs" 37 4 37 72] forall i : usize . UIntSize.to_int base_15 + UIntSize.to_int size_13 <= UIntSize.to_int i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr_1) -> LtLog0.lt_log (DeepModel1.deep_model elem_2) (Seq.get (DeepModel0.deep_model arr_1) (UIntSize.to_int i)) };
+    invariant size_valid { [#"../05_binary_search_generic.rs" 37 28 37 68] 0 < UIntSize.to_int size_13 /\ UIntSize.to_int size_13 + UIntSize.to_int base_15 <= Seq.length (ShallowModel0.shallow_model arr_1) };
+    invariant lower_b { [#"../05_binary_search_generic.rs" 37 4 37 70] forall i : usize . i < base_15 -> LeLog0.le_log (Seq.get (DeepModel0.deep_model arr_1) (UIntSize.to_int i)) (DeepModel1.deep_model elem_2) };
+    invariant lower_b { [#"../05_binary_search_generic.rs" 37 4 37 70] forall i : usize . UIntSize.to_int base_15 + UIntSize.to_int size_13 <= UIntSize.to_int i /\ UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model arr_1) -> LtLog0.lt_log (DeepModel1.deep_model elem_2) (Seq.get (DeepModel0.deep_model arr_1) (UIntSize.to_int i)) };
     _22 <- size_13;
     _21 <- ([#"../05_binary_search_generic.rs" 40 10 40 18] _22 > ([#"../05_binary_search_generic.rs" 40 17 40 18] (1 : usize)));
     switch (_21)

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
@@ -17,7 +17,7 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
     sorted_range(s, 0, s.len())
 }
 
-#[requires(arr@.len() <= @usize::MAX)]
+#[requires(arr@.len() <= usize::MAX@)]
 #[requires(sorted(arr.deep_model()))]
 #[ensures(forall<x:usize> result == Ok(x) ==> arr.deep_model()[x@] == elem.deep_model())]
 #[ensures(forall<x:usize> result == Err(x) ==>

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
@@ -19,11 +19,11 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
 
 #[requires(arr@.len() <= @usize::MAX)]
 #[requires(sorted(arr.deep_model()))]
-#[ensures(forall<x:usize> result == Ok(x) ==> arr.deep_model()[@x] == elem.deep_model())]
+#[ensures(forall<x:usize> result == Ok(x) ==> arr.deep_model()[x@] == elem.deep_model())]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize>  i < x ==> arr.deep_model()[@i] <= elem.deep_model())]
+    forall<i:usize>  i < x ==> arr.deep_model()[i@] <= elem.deep_model())]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> x <= i && @i < arr@.len() ==> elem.deep_model() < arr.deep_model()[@i])]
+    forall<i:usize> x <= i && i@ < arr@.len() ==> elem.deep_model() < arr.deep_model()[i@])]
 pub fn binary_search<T: Ord + DeepModel>(arr: &Vec<T>, elem: T) -> Result<usize, usize>
 where
     T::DeepModelTy: OrdLogic,
@@ -34,9 +34,9 @@ where
     let mut size: usize = arr.len();
     let mut base: usize = 0;
 
-    #[invariant(size_valid, 0 < @size && @size + @base <= arr@.len())]
-    #[invariant(lower_b, forall<i : usize> i < base ==> arr.deep_model()[@i] <= elem.deep_model())]
-    #[invariant(lower_b, forall<i : usize> @base + @size <= @i && @i < arr@.len() ==> elem.deep_model() < arr.deep_model()[@i])]
+    #[invariant(size_valid, 0 < size@ && size@ + base@ <= arr@.len())]
+    #[invariant(lower_b, forall<i : usize> i < base ==> arr.deep_model()[i@] <= elem.deep_model())]
+    #[invariant(lower_b, forall<i : usize> base@ + size@ <= i@ && i@ < arr@.len() ==> elem.deep_model() < arr.deep_model()[i@])]
     while size > 1 {
         let half = size / 2;
         let mid = base + half;

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.rs
@@ -17,13 +17,13 @@ fn sorted<T: OrdLogic>(s: Seq<T>) -> bool {
     sorted_range(s, 0, s.len())
 }
 
-#[requires((@arr).len() <= @usize::MAX)]
+#[requires(arr@.len() <= @usize::MAX)]
 #[requires(sorted(arr.deep_model()))]
 #[ensures(forall<x:usize> result == Ok(x) ==> arr.deep_model()[@x] == elem.deep_model())]
 #[ensures(forall<x:usize> result == Err(x) ==>
     forall<i:usize>  i < x ==> arr.deep_model()[@i] <= elem.deep_model())]
 #[ensures(forall<x:usize> result == Err(x) ==>
-    forall<i:usize> x <= i && @i < (@arr).len() ==> elem.deep_model() < arr.deep_model()[@i])]
+    forall<i:usize> x <= i && @i < arr@.len() ==> elem.deep_model() < arr.deep_model()[@i])]
 pub fn binary_search<T: Ord + DeepModel>(arr: &Vec<T>, elem: T) -> Result<usize, usize>
 where
     T::DeepModelTy: OrdLogic,
@@ -34,9 +34,9 @@ where
     let mut size: usize = arr.len();
     let mut base: usize = 0;
 
-    #[invariant(size_valid, 0 < @size && @size + @base <= (@arr).len())]
+    #[invariant(size_valid, 0 < @size && @size + @base <= arr@.len())]
     #[invariant(lower_b, forall<i : usize> i < base ==> arr.deep_model()[@i] <= elem.deep_model())]
-    #[invariant(lower_b, forall<i : usize> @base + @size <= @i && @i < (@arr).len() ==> elem.deep_model() < arr.deep_model()[@i])]
+    #[invariant(lower_b, forall<i : usize> @base + @size <= @i && @i < arr@.len() ==> elem.deep_model() < arr.deep_model()[@i])]
     while size > 1 {
         let half = size / 2;
         let mid = base + half;

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -429,29 +429,29 @@ module C06KnightsTour_Impl1_New_Closure3_Interface
     type a = Alloc_Alloc_Global_Type.t_global,
     val Max0.mAX' = Max0.mAX',
     axiom .
-  let function field_0 [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) : usize
+  let function field_0 [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) : usize
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../06_knights_tour.rs" 1 0 1 0] let C06KnightsTour_Impl1_New_Closure3 a = self in a
-  predicate resolve [#"../06_knights_tour.rs" 43 16 43 52] (_1' : c06knightstour_impl1_new_closure3) =
+  predicate resolve [#"../06_knights_tour.rs" 43 16 43 50] (_1' : c06knightstour_impl1_new_closure3) =
     [#"../06_knights_tour.rs" 1 0 1 0] true
-  predicate unnest [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (_2' : c06knightstour_impl1_new_closure3)
+  predicate unnest [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (_2' : c06knightstour_impl1_new_closure3)
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] field_0 _2' = field_0 self /\ true
-  predicate precondition [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize)))
+  predicate precondition [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize)))
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] let (_2', _3') = args in true
-  predicate postcondition_once [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
+  predicate postcondition_once [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../06_knights_tour.rs" 43 26 43 50] let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 self)
-  predicate postcondition_mut [#"../06_knights_tour.rs" 43 16 43 52] (self : borrowed c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
+    [#"../06_knights_tour.rs" 43 26 43 48] let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 self)
+  predicate postcondition_mut [#"../06_knights_tour.rs" 43 16 43 50] (self : borrowed c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] (let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ self))) /\ unnest ( * self) ( ^ self)
-  val c06KnightsTour_Impl1_New_Closure3 [#"../06_knights_tour.rs" 43 16 43 52] (_1' : borrowed c06knightstour_impl1_new_closure3) (_2' : usize) (_3' : Ghost.ghost_ty (Seq.seq usize)) : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../06_knights_tour.rs" 43 26 43 50] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ _1')) }
+  val c06KnightsTour_Impl1_New_Closure3 [#"../06_knights_tour.rs" 43 16 43 50] (_1' : borrowed c06knightstour_impl1_new_closure3) (_2' : usize) (_3' : Ghost.ghost_ty (Seq.seq usize)) : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
+    ensures { [#"../06_knights_tour.rs" 43 26 43 48] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ _1')) }
     ensures { unnest ( * _1') ( ^ _1') }
     
 end
@@ -485,29 +485,29 @@ module C06KnightsTour_Impl1_New_Closure3
     val Max0.mAX' = Max0.mAX'
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = c06knightstour_impl1_new_closure3
-  let function field_0 [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) : usize
+  let function field_0 [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) : usize
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../06_knights_tour.rs" 1 0 1 0] let C06KnightsTour_Impl1_New_Closure3 a = self in a
-  predicate resolve [#"../06_knights_tour.rs" 43 16 43 52] (_1' : c06knightstour_impl1_new_closure3) =
+  predicate resolve [#"../06_knights_tour.rs" 43 16 43 50] (_1' : c06knightstour_impl1_new_closure3) =
     [#"../06_knights_tour.rs" 1 0 1 0] true
-  predicate unnest [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (_2' : c06knightstour_impl1_new_closure3)
+  predicate unnest [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (_2' : c06knightstour_impl1_new_closure3)
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] field_0 _2' = field_0 self /\ true
-  predicate precondition [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize)))
+  predicate precondition [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize)))
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] let (_2', _3') = args in true
-  predicate postcondition_once [#"../06_knights_tour.rs" 43 16 43 52] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
+  predicate postcondition_once [#"../06_knights_tour.rs" 43 16 43 50] (self : c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
-    [#"../06_knights_tour.rs" 43 26 43 50] let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 self)
-  predicate postcondition_mut [#"../06_knights_tour.rs" 43 16 43 52] (self : borrowed c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
+    [#"../06_knights_tour.rs" 43 26 43 48] let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 self)
+  predicate postcondition_mut [#"../06_knights_tour.rs" 43 16 43 50] (self : borrowed c06knightstour_impl1_new_closure3) (args : (usize, Ghost.ghost_ty (Seq.seq usize))) (result : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global))
     
    =
     [#"../06_knights_tour.rs" 1 0 1 0] (let (_2', _3') = args in Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ self))) /\ unnest ( * self) ( ^ self)
-  let rec cfg c06KnightsTour_Impl1_New_Closure3 [#"../06_knights_tour.rs" 43 16 43 52] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : borrowed c06knightstour_impl1_new_closure3) (_2' : usize) (_3' : Ghost.ghost_ty (Seq.seq usize)) : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../06_knights_tour.rs" 43 26 43 50] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ _1')) }
+  let rec cfg c06KnightsTour_Impl1_New_Closure3 [#"../06_knights_tour.rs" 43 16 43 50] [@cfg:stackify] [@cfg:subregion_analysis] (_1' : borrowed c06knightstour_impl1_new_closure3) (_2' : usize) (_3' : Ghost.ghost_ty (Seq.seq usize)) : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
+    ensures { [#"../06_knights_tour.rs" 43 26 43 48] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int (field_0 ( ^ _1')) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global);
@@ -2380,8 +2380,8 @@ module C06KnightsTour_Moves_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val moves [#"../06_knights_tour.rs" 95 0 95 33] (_1' : ()) : Alloc_Vec_Vec_Type.t_vec (isize, isize) (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../06_knights_tour.rs" 93 10 93 30] Seq.length (ShallowModel0.shallow_model result) = 8 }
-    ensures { [#"../06_knights_tour.rs" 94 0 94 142] forall i : int . 0 <= i /\ i < 8 -> - 2 <= IntSize.to_int (let (a, _) = Seq.get (ShallowModel0.shallow_model result) i in a) /\ IntSize.to_int (let (a, _) = Seq.get (ShallowModel0.shallow_model result) i in a) <= 2 /\ - 2 <= IntSize.to_int (let (_, a) = Seq.get (ShallowModel0.shallow_model result) i in a) /\ IntSize.to_int (let (_, a) = Seq.get (ShallowModel0.shallow_model result) i in a) <= 2 }
+    ensures { [#"../06_knights_tour.rs" 93 10 93 28] Seq.length (ShallowModel0.shallow_model result) = 8 }
+    ensures { [#"../06_knights_tour.rs" 94 0 94 134] forall i : int . 0 <= i /\ i < 8 -> - 2 <= IntSize.to_int (let (a, _) = Seq.get (ShallowModel0.shallow_model result) i in a) /\ IntSize.to_int (let (a, _) = Seq.get (ShallowModel0.shallow_model result) i in a) <= 2 /\ - 2 <= IntSize.to_int (let (_, a) = Seq.get (ShallowModel0.shallow_model result) i in a) /\ IntSize.to_int (let (_, a) = Seq.get (ShallowModel0.shallow_model result) i in a) <= 2 }
     
 end
 module CreusotContracts_Std1_Vec_Impl3_IntoIterPre_Stub
@@ -3502,7 +3502,7 @@ module C06KnightsTour_Min_Interface
     type ShallowModelTy0.shallowModelTy = Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
   use Core_Option_Option_Type as Core_Option_Option_Type
   val min [#"../06_knights_tour.rs" 111 0 111 58] (v : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Core_Option_Option_Type.t_option (usize, C06KnightsTour_Point_Type.t_point)
-    ensures { [#"../06_knights_tour.rs" 109 0 110 67] forall r : (usize, C06KnightsTour_Point_Type.t_point) . result = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v) /\ Seq.get (ShallowModel0.shallow_model v) i = r) }
+    ensures { [#"../06_knights_tour.rs" 109 0 110 63] forall r : (usize, C06KnightsTour_Point_Type.t_point) . result = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v) /\ Seq.get (ShallowModel0.shallow_model v) i = r) }
     
 end
 module C06KnightsTour_Min
@@ -3596,7 +3596,7 @@ module C06KnightsTour_Min
     predicate IntoIterPost0.into_iter_post = IntoIterPost0.into_iter_post,
     predicate Invariant0.invariant' = Invariant0.invariant'
   let rec cfg min [#"../06_knights_tour.rs" 111 0 111 58] [@cfg:stackify] [@cfg:subregion_analysis] (v : Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global)) : Core_Option_Option_Type.t_option (usize, C06KnightsTour_Point_Type.t_point)
-    ensures { [#"../06_knights_tour.rs" 109 0 110 67] forall r : (usize, C06KnightsTour_Point_Type.t_point) . result = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v) /\ Seq.get (ShallowModel0.shallow_model v) i = r) }
+    ensures { [#"../06_knights_tour.rs" 109 0 110 63] forall r : (usize, C06KnightsTour_Point_Type.t_point) . result = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v) /\ Seq.get (ShallowModel0.shallow_model v) i = r) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.t_option (usize, C06KnightsTour_Point_Type.t_point);
@@ -3636,32 +3636,32 @@ module C06KnightsTour_Min
   BB0 {
     min_3 <- Core_Option_Option_Type.C_None;
     _6 <- v_1;
-    iter_5 <- ([#"../06_knights_tour.rs" 113 4 114 79] IntoIter0.into_iter _6);
+    iter_5 <- ([#"../06_knights_tour.rs" 113 4 114 75] IntoIter0.into_iter _6);
     goto BB1
   }
   BB1 {
     _9 <- ();
-    iter_old_7 <- ([#"../06_knights_tour.rs" 113 4 114 79] Ghost.new iter_5);
+    iter_old_7 <- ([#"../06_knights_tour.rs" 113 4 114 75] Ghost.new iter_5);
     goto BB2
   }
   BB2 {
     _13 <- ();
-    produced_10 <- ([#"../06_knights_tour.rs" 113 4 114 79] Ghost.new (Seq.empty ));
+    produced_10 <- ([#"../06_knights_tour.rs" 113 4 114 75] Ghost.new (Seq.empty ));
     goto BB3
   }
   BB3 {
     goto BB4
   }
   BB4 {
-    invariant type_invariant { [#"../06_knights_tour.rs" 113 4 114 79] Invariant0.invariant' iter_5 };
-    invariant structural { [#"../06_knights_tour.rs" 113 4 114 79] Produces0.produces (Ghost.inner iter_old_7) (Ghost.inner produced_10) iter_5 };
-    invariant post { [#"../06_knights_tour.rs" 113 4 114 79] forall r : (usize, C06KnightsTour_Point_Type.t_point) . min_3 = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v_1) /\ Seq.get (ShallowModel0.shallow_model v_1) i = r) };
+    invariant type_invariant { [#"../06_knights_tour.rs" 113 4 114 75] Invariant0.invariant' iter_5 };
+    invariant structural { [#"../06_knights_tour.rs" 113 4 114 75] Produces0.produces (Ghost.inner iter_old_7) (Ghost.inner produced_10) iter_5 };
+    invariant post { [#"../06_knights_tour.rs" 113 4 114 75] forall r : (usize, C06KnightsTour_Point_Type.t_point) . min_3 = Core_Option_Option_Type.C_Some r -> (exists i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model v_1) /\ Seq.get (ShallowModel0.shallow_model v_1) i = r) };
     _20 <- borrow_mut iter_5;
     iter_5 <-  ^ _20;
     _19 <- borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
     assume { Resolve0.resolve _20 };
-    _18 <- ([#"../06_knights_tour.rs" 113 4 114 79] Next0.next _19);
+    _18 <- ([#"../06_knights_tour.rs" 113 4 114 75] Next0.next _19);
     goto BB5
   }
   BB5 {
@@ -3681,7 +3681,7 @@ module C06KnightsTour_Min
   BB8 {
     __creusot_proc_iter_elem_22 <- Core_Option_Option_Type.some_0 _18;
     _25 <- ();
-    _23 <- ([#"../06_knights_tour.rs" 113 4 114 79] Ghost.new (Seq.(++) (Ghost.inner produced_10) (Seq.singleton __creusot_proc_iter_elem_22)));
+    _23 <- ([#"../06_knights_tour.rs" 113 4 114 75] Ghost.new (Seq.(++) (Ghost.inner produced_10) (Seq.singleton __creusot_proc_iter_elem_22)));
     goto BB9
   }
   BB9 {
@@ -4313,17 +4313,17 @@ module C06KnightsTour_KnightsTour
     goto BB16
   }
   BB16 {
-    iter_51 <- ([#"../06_knights_tour.rs" 148 8 149 57] IntoIter2.into_iter _52);
+    iter_51 <- ([#"../06_knights_tour.rs" 148 8 149 55] IntoIter2.into_iter _52);
     goto BB17
   }
   BB17 {
     _55 <- ();
-    iter_old_53 <- ([#"../06_knights_tour.rs" 148 8 149 57] Ghost.new iter_51);
+    iter_old_53 <- ([#"../06_knights_tour.rs" 148 8 149 55] Ghost.new iter_51);
     goto BB18
   }
   BB18 {
     _59 <- ();
-    produced_56 <- ([#"../06_knights_tour.rs" 148 8 149 57] Ghost.new (Seq.empty ));
+    produced_56 <- ([#"../06_knights_tour.rs" 148 8 149 55] Ghost.new (Seq.empty ));
     goto BB19
   }
   BB19 {
@@ -4339,15 +4339,15 @@ module C06KnightsTour_KnightsTour
     goto BB23
   }
   BB23 {
-    invariant type_invariant { [#"../06_knights_tour.rs" 148 8 149 57] Invariant1.invariant' iter_51 };
-    invariant structural { [#"../06_knights_tour.rs" 148 8 149 57] Produces1.produces (Ghost.inner iter_old_53) (Ghost.inner produced_56) iter_51 };
-    invariant c { [#"../06_knights_tour.rs" 148 8 149 57] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model candidates_49) -> InBounds0.in_bounds board_7 (let (_, a) = Seq.get (ShallowModel0.shallow_model candidates_49) i in a) };
+    invariant type_invariant { [#"../06_knights_tour.rs" 148 8 149 55] Invariant1.invariant' iter_51 };
+    invariant structural { [#"../06_knights_tour.rs" 148 8 149 55] Produces1.produces (Ghost.inner iter_old_53) (Ghost.inner produced_56) iter_51 };
+    invariant c { [#"../06_knights_tour.rs" 148 8 149 55] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model candidates_49) -> InBounds0.in_bounds board_7 (let (_, a) = Seq.get (ShallowModel0.shallow_model candidates_49) i in a) };
     _65 <- borrow_mut iter_51;
     iter_51 <-  ^ _65;
     _64 <- borrow_mut ( * _65);
     _65 <- { _65 with current = ( ^ _64) };
     assume { Resolve1.resolve _65 };
-    _63 <- ([#"../06_knights_tour.rs" 148 8 149 57] Next1.next _64);
+    _63 <- ([#"../06_knights_tour.rs" 148 8 149 55] Next1.next _64);
     goto BB24
   }
   BB24 {
@@ -4370,7 +4370,7 @@ module C06KnightsTour_KnightsTour
     assume { Resolve4.resolve __creusot_proc_iter_elem_67 };
     __creusot_proc_iter_elem_67 <- Core_Option_Option_Type.some_0 _63;
     _70 <- ();
-    _68 <- ([#"../06_knights_tour.rs" 148 8 149 57] Ghost.new (Seq.(++) (Ghost.inner produced_56) (Seq.singleton __creusot_proc_iter_elem_67)));
+    _68 <- ([#"../06_knights_tour.rs" 148 8 149 55] Ghost.new (Seq.(++) (Ghost.inner produced_56) (Seq.singleton __creusot_proc_iter_elem_67)));
     goto BB28
   }
   BB28 {

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -40,7 +40,7 @@ impl Board {
     fn new(size: usize) -> Self {
         let rows = (0..size)
             .map_inv(
-                #[ensures((@result).len() == @size)]
+                #[ensures(result@.len() == @size)]
                 |_, _| vec![0; size],
             )
             .collect();
@@ -90,8 +90,8 @@ impl Board {
 }
 
 #[trusted]
-#[ensures((@result).len() == 8)]
-#[ensures(forall<i : Int> 0 <= i && i < 8 ==> -2 <= @(@result)[i].0 && @(@result)[i].0 <= 2 && -2 <= @(@result)[i].1 && @(@result)[i].1 <= 2)]
+#[ensures(result@.len() == 8)]
+#[ensures(forall<i : Int> 0 <= i && i < 8 ==> -2 <= @result@[i].0 && @result@[i].0 <= 2 && -2 <= @result@[i].1 && @result@[i].1 <= 2)]
 fn moves() -> Vec<(isize, isize)> {
     let mut v = Vec::new();
     v.push((2, 1));
@@ -107,11 +107,11 @@ fn moves() -> Vec<(isize, isize)> {
 }
 
 #[ensures(forall<r: &(usize, Point)> result == Some(r) ==>
-          exists<i:Int> 0 <= i && i < (@v).len() && (@v)[i] == *r)]
+          exists<i:Int> 0 <= i && i < v@.len() && v@[i] == *r)]
 fn min(v: &Vec<(usize, Point)>) -> Option<&(usize, Point)> {
     let mut min = None;
     #[invariant(post, forall<r: &(usize, Point)> min == Some(r) ==>
-                      exists<i:Int> 0 <= i && i < (@v).len() && (@v)[i] == *r)]
+                      exists<i:Int> 0 <= i && i < v@.len() && v@[i] == *r)]
     for x in v {
         match min {
             None => min = Some(x),
@@ -145,8 +145,8 @@ pub fn knights_tour(size: usize, x: usize, y: usize) -> Option<Board> {
     for step in 2..(size * size) {
         // choose next square by Warnsdorf's rule
         let mut candidates: Vec<(usize, Point)> = Vec::new();
-        #[invariant(c, forall<i: Int> 0 <= i && i < (@candidates).len() ==>
-                    board.in_bounds((@candidates)[i].1))]
+        #[invariant(c, forall<i: Int> 0 <= i && i < candidates@.len() ==>
+                    board.in_bounds(candidates@[i].1))]
         for m in moves() {
             let adj = p.mov(&m);
             if board.available(adj) {

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -9,12 +9,12 @@ struct Point {
 
 // ISSUE: patterns in function binders are unsupported!
 impl Point {
-    #[requires(-10000 <= @self.x && @self.x <= 10000)]
-    #[requires(-10000 <= @self.y && @self.y <= 10000)]
-    #[requires(-10000 <= @p.0 && @p.0 <= 10000)]
-    #[requires(-10000 <= @p.1 && @p.1 <= 10000)]
-    #[ensures(@result.x == @self.x + @p.0)]
-    #[ensures(@result.y == @self.y + @p.1)]
+    #[requires(-10000 <= self.x@ && self.x@ <= 10000)]
+    #[requires(-10000 <= self.y@ && self.y@ <= 10000)]
+    #[requires(-10000 <= p.0@ && p.0@ <= 10000)]
+    #[requires(-10000 <= p.1@ && p.1@ <= 10000)]
+    #[ensures(result.x@ == self.x@ + p.0@)]
+    #[ensures(result.y@ == self.y@ + p.1@)]
     fn mov(&self, p: &(isize, isize)) -> Self {
         Self { x: (self.x + p.0), y: (self.y + p.1) }
     }
@@ -29,9 +29,9 @@ impl Board {
     #[predicate]
     fn wf(self) -> bool {
         pearlite! {
-            @self.size <= 1_000 &&
-            (@self.field).len() == @self.size &&
-            forall<i : Int> 0 <= i && i < @self.size ==> (@(@self.field)[i]).len() == @self.size
+            self.size@ <= 1_000 &&
+            (self.field@).len() == self.size@ &&
+            forall<i : Int> 0 <= i && i < self.size@ ==> (@(self.field@)[i]).len() == @self.size
         }
     }
     #[requires(size@ <= 1000)]
@@ -60,7 +60,7 @@ impl Board {
     #[predicate]
     fn in_bounds(self, p: Point) -> bool {
         pearlite! {
-            0 <= @p.x && @p.x< @self.size && 0 <= @p.y && @p.y < @self.size
+            0 <= p.x@ && p.x@< self.size@ && 0 <= p.y@ && p.y@ < @self.size
         }
     }
 
@@ -91,7 +91,7 @@ impl Board {
 
 #[trusted]
 #[ensures(result@.len() == 8)]
-#[ensures(forall<i : Int> 0 <= i && i < 8 ==> -2 <= @result@[i].0 && @result@[i].0 <= 2 && -2 <= @result@[i].1 && @result@[i].1 <= 2)]
+#[ensures(forall<i : Int> 0 <= i && i < 8 ==> -2 <= result@[i].0@ && result@[i].0@ <= 2 && -2 <= result@[i].1@ && result@[i].1@ <= 2)]
 fn moves() -> Vec<(isize, isize)> {
     let mut v = Vec::new();
     v.push((2, 1));

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -34,13 +34,13 @@ impl Board {
             forall<i : Int> 0 <= i && i < @self.size ==> (@(@self.field)[i]).len() == @self.size
         }
     }
-    #[requires(@size <= 1000)]
+    #[requires(size@ <= 1000)]
     #[ensures(result.size == size)]
     #[ensures(result.wf())]
     fn new(size: usize) -> Self {
         let rows = (0..size)
             .map_inv(
-                #[ensures(result@.len() == @size)]
+                #[ensures(result@.len() == size@)]
                 |_, _| vec![0; size],
             )
             .collect();
@@ -70,7 +70,7 @@ impl Board {
     fn count_degree(&self, p: Point) -> usize {
         let mut count = 0;
 
-        #[invariant(count, @count <= produced.len())]
+        #[invariant(count, count@ <= produced.len())]
         for m in moves() {
             let next = p.mov(&m);
             if self.available(next) {
@@ -126,11 +126,11 @@ fn min(v: &Vec<(usize, Point)>) -> Option<&(usize, Point)> {
 }
 
 #[logic]
-#[requires(@a <= 1_000)]
-#[ensures(@a * @a <= 1_000_000)]
+#[requires(a@ <= 1_000)]
+#[ensures(a@ * a@ <= 1_000_000)]
 fn dumb_nonlinear_arith(a: usize) {}
 
-#[requires(0 < @size && @size <= 1000)]
+#[requires(0 < size@ && size@ <= 1000)]
 #[requires(x < size)]
 #[requires(y < size)]
 pub fn knights_tour(size: usize, x: usize, y: usize) -> Option<Board> {

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -30,8 +30,8 @@ impl Board {
     fn wf(self) -> bool {
         pearlite! {
             self.size@ <= 1_000 &&
-            (self.field@).len() == self.size@ &&
-            forall<i : Int> 0 <= i && i < self.size@ ==> ((self.field@)[i]@).len() == self.size@
+            self.field@.len() == self.size@ &&
+            forall<i : Int> 0 <= i && i < self.size@ ==> (self.field@[i]@).len() == self.size@
         }
     }
     #[requires(size@ <= 1000)]

--- a/creusot/tests/should_succeed/vector/06_knights_tour.rs
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.rs
@@ -31,7 +31,7 @@ impl Board {
         pearlite! {
             self.size@ <= 1_000 &&
             (self.field@).len() == self.size@ &&
-            forall<i : Int> 0 <= i && i < self.size@ ==> (@(self.field@)[i]).len() == @self.size
+            forall<i : Int> 0 <= i && i < self.size@ ==> ((self.field@)[i]@).len() == self.size@
         }
     }
     #[requires(size@ <= 1000)]
@@ -60,7 +60,7 @@ impl Board {
     #[predicate]
     fn in_bounds(self, p: Point) -> bool {
         pearlite! {
-            0 <= p.x@ && p.x@< self.size@ && 0 <= p.y@ && p.y@ < @self.size
+            0 <= p.x@ && p.x@< self.size@ && 0 <= p.y@ && p.y@ < self.size@
         }
     }
 

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -518,7 +518,7 @@ module C07ReadWrite_ReadWrite_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val read_write [#"../07_read_write.rs" 6 0 6 75] (a : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (i : usize) (x : t) : ()
-    requires {[#"../07_read_write.rs" 5 11 5 26] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model a)}
+    requires {[#"../07_read_write.rs" 5 11 5 24] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model a)}
     
 end
 module C07ReadWrite_ReadWrite
@@ -593,7 +593,7 @@ module C07ReadWrite_ReadWrite
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = t
   let rec cfg read_write [#"../07_read_write.rs" 6 0 6 75] [@cfg:stackify] [@cfg:subregion_analysis] (a : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (i : usize) (x : t) : ()
-    requires {[#"../07_read_write.rs" 5 11 5 26] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model a)}
+    requires {[#"../07_read_write.rs" 5 11 5 24] UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model a)}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/vector/07_read_write.rs
+++ b/creusot/tests/should_succeed/vector/07_read_write.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[requires(@i < (@a).len())]
+#[requires(@i < a@.len())]
 pub fn read_write<T: Eq + Copy + DeepModel>(a: &mut Vec<T>, i: usize, x: T) {
     a[i] = x; // a is slice
     assert!(a[i] == x);

--- a/creusot/tests/should_succeed/vector/07_read_write.rs
+++ b/creusot/tests/should_succeed/vector/07_read_write.rs
@@ -2,7 +2,7 @@ extern crate creusot_contracts;
 
 use creusot_contracts::*;
 
-#[requires(@i < a@.len())]
+#[requires(i@ < a@.len())]
 pub fn read_write<T: Eq + Copy + DeepModel>(a: &mut Vec<T>, i: usize, x: T) {
     a[i] = x; // a is slice
     assert!(a[i] == x);

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -1196,10 +1196,10 @@ module C08Haystack_Search_Interface
     type t = Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq uint8
   val search [#"../08_haystack.rs" 21 0 21 60] (needle : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) (haystack : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) : usize
-    requires {[#"../08_haystack.rs" 15 11 15 71] Seq.length (ShallowModel0.shallow_model needle) >= 1 /\ Seq.length (ShallowModel0.shallow_model needle) <= Seq.length (ShallowModel0.shallow_model haystack)}
-    ensures { [#"../08_haystack.rs" 16 10 16 91] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) \/ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) - Seq.length (ShallowModel0.shallow_model needle) + 1 }
-    ensures { [#"../08_haystack.rs" 17 0 19 110] UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) -> MatchAt0.match_at needle haystack (UIntSize.to_int result) (Seq.length (ShallowModel0.shallow_model needle)) /\ (forall i : int . 0 <= i /\ i < UIntSize.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
-    ensures { [#"../08_haystack.rs" 20 0 20 145] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
+    requires {[#"../08_haystack.rs" 15 11 15 65] Seq.length (ShallowModel0.shallow_model needle) >= 1 /\ Seq.length (ShallowModel0.shallow_model needle) <= Seq.length (ShallowModel0.shallow_model haystack)}
+    ensures { [#"../08_haystack.rs" 16 10 16 85] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) \/ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) - Seq.length (ShallowModel0.shallow_model needle) + 1 }
+    ensures { [#"../08_haystack.rs" 17 0 19 108] UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) -> MatchAt0.match_at needle haystack (UIntSize.to_int result) (Seq.length (ShallowModel0.shallow_model needle)) /\ (forall i : int . 0 <= i /\ i < UIntSize.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
+    ensures { [#"../08_haystack.rs" 20 0 20 139] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
     
 end
 module C08Haystack_Search
@@ -1360,10 +1360,10 @@ module C08Haystack_Search
   clone C08Haystack_MatchAt as MatchAt0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
   let rec cfg search [#"../08_haystack.rs" 21 0 21 60] [@cfg:stackify] [@cfg:subregion_analysis] (needle : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) (haystack : Alloc_Vec_Vec_Type.t_vec uint8 (Alloc_Alloc_Global_Type.t_global)) : usize
-    requires {[#"../08_haystack.rs" 15 11 15 71] Seq.length (ShallowModel0.shallow_model needle) >= 1 /\ Seq.length (ShallowModel0.shallow_model needle) <= Seq.length (ShallowModel0.shallow_model haystack)}
-    ensures { [#"../08_haystack.rs" 16 10 16 91] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) \/ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) - Seq.length (ShallowModel0.shallow_model needle) + 1 }
-    ensures { [#"../08_haystack.rs" 17 0 19 110] UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) -> MatchAt0.match_at needle haystack (UIntSize.to_int result) (Seq.length (ShallowModel0.shallow_model needle)) /\ (forall i : int . 0 <= i /\ i < UIntSize.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
-    ensures { [#"../08_haystack.rs" 20 0 20 145] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
+    requires {[#"../08_haystack.rs" 15 11 15 65] Seq.length (ShallowModel0.shallow_model needle) >= 1 /\ Seq.length (ShallowModel0.shallow_model needle) <= Seq.length (ShallowModel0.shallow_model haystack)}
+    ensures { [#"../08_haystack.rs" 16 10 16 85] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) \/ UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) - Seq.length (ShallowModel0.shallow_model needle) + 1 }
+    ensures { [#"../08_haystack.rs" 17 0 19 108] UIntSize.to_int result < Seq.length (ShallowModel0.shallow_model haystack) -> MatchAt0.match_at needle haystack (UIntSize.to_int result) (Seq.length (ShallowModel0.shallow_model needle)) /\ (forall i : int . 0 <= i /\ i < UIntSize.to_int result -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
+    ensures { [#"../08_haystack.rs" 20 0 20 139] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model haystack) -> (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model haystack) -> not MatchAt0.match_at needle haystack i (Seq.length (ShallowModel0.shallow_model needle))) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : usize;
@@ -1445,32 +1445,32 @@ module C08Haystack_Search
     goto BB3
   }
   BB3 {
-    iter_9 <- ([#"../08_haystack.rs" 22 4 22 123] IntoIter0.into_iter _10);
+    iter_9 <- ([#"../08_haystack.rs" 22 4 22 121] IntoIter0.into_iter _10);
     goto BB4
   }
   BB4 {
     _18 <- ();
-    iter_old_16 <- ([#"../08_haystack.rs" 22 4 22 123] Ghost.new iter_9);
+    iter_old_16 <- ([#"../08_haystack.rs" 22 4 22 121] Ghost.new iter_9);
     goto BB5
   }
   BB5 {
     _22 <- ();
-    produced_19 <- ([#"../08_haystack.rs" 22 4 22 123] Ghost.new (Seq.empty ));
+    produced_19 <- ([#"../08_haystack.rs" 22 4 22 121] Ghost.new (Seq.empty ));
     goto BB6
   }
   BB6 {
     goto BB7
   }
   BB7 {
-    invariant type_invariant { [#"../08_haystack.rs" 22 4 22 123] Invariant0.invariant' iter_9 };
-    invariant structural { [#"../08_haystack.rs" 22 4 22 123] Produces0.produces (Ghost.inner iter_old_16) (Ghost.inner produced_19) iter_9 };
-    invariant no_match { [#"../08_haystack.rs" 22 4 22 123] forall k : int . 0 <= k /\ k < Seq.length (Ghost.inner produced_19) -> not MatchAt0.match_at needle_1 haystack_2 k (Seq.length (ShallowModel0.shallow_model needle_1)) };
+    invariant type_invariant { [#"../08_haystack.rs" 22 4 22 121] Invariant0.invariant' iter_9 };
+    invariant structural { [#"../08_haystack.rs" 22 4 22 121] Produces0.produces (Ghost.inner iter_old_16) (Ghost.inner produced_19) iter_9 };
+    invariant no_match { [#"../08_haystack.rs" 22 4 22 121] forall k : int . 0 <= k /\ k < Seq.length (Ghost.inner produced_19) -> not MatchAt0.match_at needle_1 haystack_2 k (Seq.length (ShallowModel0.shallow_model needle_1)) };
     _29 <- borrow_mut iter_9;
     iter_9 <-  ^ _29;
     _28 <- borrow_mut ( * _29);
     _29 <- { _29 with current = ( ^ _28) };
     assume { Resolve0.resolve _29 };
-    _27 <- ([#"../08_haystack.rs" 22 4 22 123] Next0.next _28);
+    _27 <- ([#"../08_haystack.rs" 22 4 22 121] Next0.next _28);
     goto BB8
   }
   BB8 {
@@ -1491,7 +1491,7 @@ module C08Haystack_Search
   BB11 {
     __creusot_proc_iter_elem_31 <- Core_Option_Option_Type.some_0 _27;
     _34 <- ();
-    _32 <- ([#"../08_haystack.rs" 22 4 22 123] Ghost.new (Seq.(++) (Ghost.inner produced_19) (Seq.singleton __creusot_proc_iter_elem_31)));
+    _32 <- ([#"../08_haystack.rs" 22 4 22 121] Ghost.new (Seq.(++) (Ghost.inner produced_19) (Seq.singleton __creusot_proc_iter_elem_31)));
     goto BB12
   }
   BB12 {

--- a/creusot/tests/should_succeed/vector/08_haystack.rs
+++ b/creusot/tests/should_succeed/vector/08_haystack.rs
@@ -1,4 +1,4 @@
-// This example was tken from an issue of @yannickmoy (#309).
+// This example was tken from an issue of yannickmoy@ (#309).
 // It performs a 'substring' match between two vectors of u8.
 extern crate creusot_contracts;
 use creusot_contracts::{logic::Int, *};
@@ -13,15 +13,15 @@ fn match_at(needle: &Vec<u8>, haystack: &Vec<u8>, pos: Int, len: Int) -> bool {
 }
 
 #[requires(needle@.len() >= 1 && needle@.len() <= haystack@.len())]
-#[ensures(@result == haystack@.len() || @result < haystack@.len() - needle@.len() + 1)]
-#[ensures(@result < haystack@.len() ==>
-            match_at(needle, haystack, @result, needle@.len())
-             && (forall <i: Int> 0 <= i && i < @result ==> ! match_at(needle, haystack, i, needle@.len())))]
-#[ensures(@result == haystack@.len() ==> forall <i: Int> 0 <= i && i < haystack@.len() ==> ! match_at(needle, haystack, i, needle@.len()))]
+#[ensures(result@ == haystack@.len() || result@ < haystack@.len() - needle@.len() + 1)]
+#[ensures(result@ < haystack@.len() ==>
+            match_at(needle, haystack, result@, needle@.len())
+             && (forall <i: Int> 0 <= i && i < result@ ==> ! match_at(needle, haystack, i, needle@.len())))]
+#[ensures(result@ == haystack@.len() ==> forall <i: Int> 0 <= i && i < haystack@.len() ==> ! match_at(needle, haystack, i, needle@.len()))]
 pub fn search(needle: &Vec<u8>, haystack: &Vec<u8>) -> usize {
     #[invariant(no_match,forall<k: Int> 0 <= k && k < produced.len() ==> ! match_at(needle, haystack, k, needle@.len()))]
     'a: for i in 0..=haystack.len() - needle.len() {
-        #[invariant(partial_match,match_at(needle, haystack, @i, produced.len()))]
+        #[invariant(partial_match,match_at(needle, haystack, i@, produced.len()))]
         for j in 0..needle.len() {
             if needle[j] != haystack[i + j] {
                 continue 'a;

--- a/creusot/tests/should_succeed/vector/08_haystack.rs
+++ b/creusot/tests/should_succeed/vector/08_haystack.rs
@@ -5,21 +5,21 @@ use creusot_contracts::{logic::Int, *};
 
 #[predicate]
 fn match_at(needle: &Vec<u8>, haystack: &Vec<u8>, pos: Int, len: Int) -> bool {
-    pearlite! { len <= (@needle).len()
-      && pos <= (@haystack).len() - len
+    pearlite! { len <= needle@.len()
+      && pos <= haystack@.len() - len
       && forall<i: Int>
-          0 <= i && i < len ==> (@needle)[i] == (@haystack)[pos + i]
+          0 <= i && i < len ==> needle@[i] == haystack@[pos + i]
     }
 }
 
-#[requires((@needle).len() >= 1 && (@needle).len() <= (@haystack).len())]
-#[ensures(@result == (@haystack).len() || @result < (@haystack).len() - (@needle).len() + 1)]
-#[ensures(@result < (@haystack).len() ==>
-            match_at(needle, haystack, @result, (@needle).len())
-             && (forall <i: Int> 0 <= i && i < @result ==> ! match_at(needle, haystack, i, (@needle).len())))]
-#[ensures(@result == (@haystack).len() ==> forall <i: Int> 0 <= i && i < (@haystack).len() ==> ! match_at(needle, haystack, i, (@needle).len()))]
+#[requires(needle@.len() >= 1 && needle@.len() <= haystack@.len())]
+#[ensures(@result == haystack@.len() || @result < haystack@.len() - needle@.len() + 1)]
+#[ensures(@result < haystack@.len() ==>
+            match_at(needle, haystack, @result, needle@.len())
+             && (forall <i: Int> 0 <= i && i < @result ==> ! match_at(needle, haystack, i, needle@.len())))]
+#[ensures(@result == haystack@.len() ==> forall <i: Int> 0 <= i && i < haystack@.len() ==> ! match_at(needle, haystack, i, needle@.len()))]
 pub fn search(needle: &Vec<u8>, haystack: &Vec<u8>) -> usize {
-    #[invariant(no_match,forall<k: Int> 0 <= k && k < produced.len() ==> ! match_at(needle, haystack, k, (@needle).len()))]
+    #[invariant(no_match,forall<k: Int> 0 <= k && k < produced.len() ==> ! match_at(needle, haystack, k, needle@.len()))]
     'a: for i in 0..=haystack.len() - needle.len() {
         #[invariant(partial_match,match_at(needle, haystack, @i, produced.len()))]
         for j in 0..needle.len() {

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -260,8 +260,8 @@ module C09Capacity_ChangeCapacity_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val change_capacity [#"../09_capacity.rs" 6 0 6 41] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../09_capacity.rs" 4 10 4 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../09_capacity.rs" 5 0 5 75] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = Seq.get (ShallowModel1.shallow_model v) i }
+    ensures { [#"../09_capacity.rs" 4 10 4 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../09_capacity.rs" 5 0 5 71] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = Seq.get (ShallowModel1.shallow_model v) i }
     
 end
 module C09Capacity_ChangeCapacity
@@ -310,8 +310,8 @@ module C09Capacity_ChangeCapacity
     function ShallowModel1.shallow_model = ShallowModel1.shallow_model,
     val Max0.mAX' = Max0.mAX'
   let rec cfg change_capacity [#"../09_capacity.rs" 6 0 6 41] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    ensures { [#"../09_capacity.rs" 4 10 4 35] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../09_capacity.rs" 5 0 5 75] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = Seq.get (ShallowModel1.shallow_model v) i }
+    ensures { [#"../09_capacity.rs" 4 10 4 33] Seq.length (ShallowModel0.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
+    ensures { [#"../09_capacity.rs" 5 0 5 71] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel1.shallow_model v) -> Seq.get (ShallowModel0.shallow_model ( ^ v)) i = Seq.get (ShallowModel1.shallow_model v) i }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();

--- a/creusot/tests/should_succeed/vector/09_capacity.rs
+++ b/creusot/tests/should_succeed/vector/09_capacity.rs
@@ -1,8 +1,8 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[ensures(((^v)@).len() == v@.len())]
-#[ensures(forall<i: Int> 0 <= i && i < v@.len() ==> ((^v)@)[i] == v@[i])]
+#[ensures((^v)@.len() == v@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < v@.len() ==> (^v)@[i] == v@[i])]
 pub fn change_capacity<T>(v: &mut Vec<T>) {
     v.reserve(100);
     v.reserve_exact(200);
@@ -10,7 +10,7 @@ pub fn change_capacity<T>(v: &mut Vec<T>) {
     v.shrink_to(1);
 }
 
-#[ensures(((^v)@).len() == 0)]
+#[ensures((^v)@.len() == 0)]
 pub fn clear_vec<T>(v: &mut Vec<T>) {
     v.clear();
 }

--- a/creusot/tests/should_succeed/vector/09_capacity.rs
+++ b/creusot/tests/should_succeed/vector/09_capacity.rs
@@ -1,8 +1,8 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[ensures((@^v).len() == (@v).len())]
-#[ensures(forall<i: Int> 0 <= i && i < (@v).len() ==> (@^v)[i] == (@v)[i])]
+#[ensures((@^v).len() == v@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < v@.len() ==> (@^v)[i] == v@[i])]
 pub fn change_capacity<T>(v: &mut Vec<T>) {
     v.reserve(100);
     v.reserve_exact(200);

--- a/creusot/tests/should_succeed/vector/09_capacity.rs
+++ b/creusot/tests/should_succeed/vector/09_capacity.rs
@@ -1,8 +1,8 @@
 extern crate creusot_contracts;
 use creusot_contracts::*;
 
-#[ensures((@^v).len() == v@.len())]
-#[ensures(forall<i: Int> 0 <= i && i < v@.len() ==> (@^v)[i] == v@[i])]
+#[ensures(((^v)@).len() == v@.len())]
+#[ensures(forall<i: Int> 0 <= i && i < v@.len() ==> ((^v)@)[i] == v@[i])]
 pub fn change_capacity<T>(v: &mut Vec<T>) {
     v.reserve(100);
     v.reserve_exact(200);
@@ -10,7 +10,7 @@ pub fn change_capacity<T>(v: &mut Vec<T>) {
     v.shrink_to(1);
 }
 
-#[ensures((@^v).len() == 0)]
+#[ensures(((^v)@).len() == 0)]
 pub fn clear_vec<T>(v: &mut Vec<T>) {
     v.clear();
 }

--- a/pearlite-syn/src/term.rs
+++ b/pearlite-syn/src/term.rs
@@ -109,7 +109,7 @@ ast_enum_of_structs! {
         /// The model of a term: `@x`
         Model(TermModel),
 
-        /// The model of a term: `x.@`
+        /// The model of a term: `x@`
         ModelPost(TermModelPost),
 
         /// Tokens in term position not interpreted by Syn.
@@ -433,7 +433,6 @@ ast_struct! {
 ast_struct! {
     pub struct TermModelPost {
         pub term: Box<Term>,
-        pub dot_token: Token![.],
         pub at_token: Token![@],
     }
 }
@@ -1029,11 +1028,6 @@ pub(crate) mod parsing {
                     }
                 }
 
-                if let Some(at_token) = input.parse::<Option<Token![@]>>()? {
-                    e = Term::ModelPost(TermModelPost { term: Box::new(e), dot_token, at_token });
-                    continue;
-                }
-
                 let member: Member = input.parse()?;
                 let turbofish = if matches!(member, Member::Named(_)) && input.peek(Token![::]) {
                     Some(TermMethodTurbofish {
@@ -1084,6 +1078,8 @@ pub(crate) mod parsing {
                     bracket_token: bracketed!(content in input),
                     index: content.parse()?,
                 });
+            } else if input.peek(Token![@]) {
+                e = Term::ModelPost(TermModelPost { term: Box::new(e), at_token: input.parse()? });
             } else {
                 break;
             }
@@ -1867,7 +1863,6 @@ pub(crate) mod printing {
     impl ToTokens for TermModelPost {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.term.to_tokens(tokens);
-            self.dot_token.to_tokens(tokens);
             self.at_token.to_tokens(tokens);
         }
     }

--- a/pearlite-syn/src/term.rs
+++ b/pearlite-syn/src/term.rs
@@ -106,11 +106,8 @@ ast_enum_of_structs! {
         /// The final value of a borrow: `^x`
         Final(TermFinal),
 
-        /// The model of a term: `@x`
-        Model(TermModel),
-
         /// The model of a term: `x@`
-        ModelPost(TermModelPost),
+        Model(TermModel),
 
         /// Tokens in term position not interpreted by Syn.
         Verbatim(TokenStream),
@@ -425,13 +422,6 @@ ast_struct! {
 
 ast_struct! {
     pub struct TermModel {
-        pub at_token: Token![@],
-        pub term: Box<Term>
-    }
-}
-
-ast_struct! {
-    pub struct TermModelPost {
         pub term: Box<Term>,
         pub at_token: Token![@],
     }
@@ -986,12 +976,6 @@ pub(crate) mod parsing {
                 final_token: input.parse()?,
                 term: Box::new(unary_term(input, allow_struct)?),
             }))
-        } else if input.peek(Token![@]) {
-            // @ <trailer>
-            Ok(Term::Model(TermModel {
-                at_token: input.parse()?,
-                term: Box::new(unary_term(input, allow_struct)?),
-            }))
         } else {
             trailer_term(input, allow_struct)
         }
@@ -1079,7 +1063,7 @@ pub(crate) mod parsing {
                     index: content.parse()?,
                 });
             } else if input.peek(Token![@]) {
-                e = Term::ModelPost(TermModelPost { term: Box::new(e), at_token: input.parse()? });
+                e = Term::Model(TermModel { term: Box::new(e), at_token: input.parse()? });
             } else {
                 break;
             }
@@ -1854,13 +1838,6 @@ pub(crate) mod printing {
     }
 
     impl ToTokens for TermModel {
-        fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.at_token.to_tokens(tokens);
-            self.term.to_tokens(tokens);
-        }
-    }
-
-    impl ToTokens for TermModelPost {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.term.to_tokens(tokens);
             self.at_token.to_tokens(tokens);

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -81,7 +81,7 @@ fn test_model() {
 
 #[test]
 fn test_model_post() {
-    snapshot!(quote!(a.@) as Term, @r###"
+    snapshot!(quote!(a@) as Term, @r###"
     TermModelPost {
         term: TermPath {
             inner: ExprPath {
@@ -100,7 +100,6 @@ fn test_model_post() {
                 },
             },
         },
-        dot_token: Dot,
         at_token: At,
     }"###);
 }

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -80,6 +80,32 @@ fn test_model() {
 }
 
 #[test]
+fn test_model_post() {
+    snapshot!(quote!(a.@) as Term, @r###"
+    TermModelPost {
+        term: TermPath {
+            inner: ExprPath {
+                attrs: [],
+                qself: None,
+                path: Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                a,
+                            ),
+                            arguments: None,
+                        },
+                    ],
+                },
+            },
+        },
+        dot_token: Dot,
+        at_token: At,
+    }"###);
+}
+
+#[test]
 fn test_forall() {
     snapshot!(quote!(forall<x : u32> true) as Term, @r###"
     TermForall {

--- a/pearlite-syn/tests/test_term.rs
+++ b/pearlite-syn/tests/test_term.rs
@@ -56,33 +56,8 @@ fn test_final() {
 
 #[test]
 fn test_model() {
-    snapshot!(quote!(@a) as Term, @r###"
-    TermModel {
-        at_token: At,
-        term: TermPath {
-            inner: ExprPath {
-                attrs: [],
-                qself: None,
-                path: Path {
-                    leading_colon: None,
-                    segments: [
-                        PathSegment {
-                            ident: Ident(
-                                a,
-                            ),
-                            arguments: None,
-                        },
-                    ],
-                },
-            },
-        },
-    }"###);
-}
-
-#[test]
-fn test_model_post() {
     snapshot!(quote!(a@) as Term, @r###"
-    TermModelPost {
+    TermModel {
         term: TermPath {
             inner: ExprPath {
                 attrs: [],


### PR DESCRIPTION
Allows referring to the model of a value using the syntax `foo.@`.
For now, this still accepts the old prefix syntax to permit a gradual migration.
