### PR TITLE
Add FSet::is_subset and FSet::is_superset

### DIFF
--- a/creusot-contracts/src/logic/fset.rs
+++ b/creusot-contracts/src/logic/fset.rs
@@ -57,6 +57,18 @@ impl<T: ?Sized> FSet<T> {
         pearlite! { absurd }
     }
 
+    #[predicate]
+    #[creusot::builtins = "set.Fset.subset"]
+    pub fn is_subset(self, _: Self) -> bool {
+        pearlite! { absurd }
+    }
+
+    #[predicate]
+    #[why3::attr = "inline:trivial"]
+    pub fn is_superset(self, other: Self) -> bool {
+        Self::is_subset(other, self)
+    }
+
     #[logic]
     #[creusot::builtins = "set.Fset.cardinal"]
     pub fn len(self) -> Int {

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -420,7 +420,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 600 5 601 2] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 609 10 610 15] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -505,7 +505,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 594 109 595 17] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 601 25 603 15] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -527,7 +527,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 596 5 597 10] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 603 50 605 26] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -540,7 +540,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 596 5 597 10] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 603 50 605 26] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -559,7 +559,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 602 9 603 38] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 612 8 613 11] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -572,7 +572,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 602 9 603 38] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 612 8 613 11] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -588,7 +588,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 607 36 608 24] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../red_black_tree.rs" 618 3 618 36] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -610,7 +610,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 609 16 611 14] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 619 34 620 45] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -623,7 +623,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 609 16 611 14] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 619 34 620 45] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -639,7 +639,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 614 49 614 85] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../red_black_tree.rs" 623 13 623 49] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -661,7 +661,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 618 12 619 25] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 624 33 627 32] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -674,7 +674,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 618 12 619 25] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 624 33 627 32] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -689,7 +689,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 620 55 621 19] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 629 10 629 41] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -700,7 +700,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 620 55 621 19] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 629 10 629 41] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -715,7 +715,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 622 24 623 6] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 623 24 623 41] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 624 7 624 24] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 630 28 631 0] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 631 18 631 35] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 631 52 632 16] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -724,11 +724,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {[#"../red_black_tree.rs" 622 24 623 6] CmpLog0.cmp_log x y = o}
-    requires {[#"../red_black_tree.rs" 623 24 623 41] CmpLog0.cmp_log y z = o}
+    requires {[#"../red_black_tree.rs" 630 28 631 0] CmpLog0.cmp_log x y = o}
+    requires {[#"../red_black_tree.rs" 631 18 631 35] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 622 24 623 6] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 623 24 623 41] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 624 7 624 24] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 630 28 631 0] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 631 18 631 35] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 631 52 632 16] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -743,7 +743,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 628 11 628 41] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 629 16 629 49] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 633 31 633 61] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 633 78 634 6] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -752,10 +752,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 628 11 628 41] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../red_black_tree.rs" 633 31 633 61] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 628 11 628 41] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 629 16 629 49] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 633 31 633 61] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 633 78 634 6] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -770,7 +770,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 631 4 631 37] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 632 1 632 31] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 634 71 635 29] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 635 46 636 2] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -779,10 +779,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 631 4 631 37] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../red_black_tree.rs" 634 71 635 29] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 631 4 631 37] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 632 1 632 31] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 634 71 635 29] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 635 46 636 2] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -797,7 +797,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 633 26 633 71] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 637 24 637 69] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -808,7 +808,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 633 26 633 71] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 637 24 637 69] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Stub
   type k


### PR DESCRIPTION
The names are chosen to be coherent with Rust's stdlib.

FSet::is_subset is mapped to fset.Fset.subset as a builtin, and FSet::is_superset flips its arguments.