### PR TITLE
Fix `Span` encoding

### DIFF
--- a/creusot-metadata/src/decoder.rs
+++ b/creusot-metadata/src/decoder.rs
@@ -11,7 +11,7 @@ use rustc_middle::{
 };
 use rustc_serialize::opaque;
 pub use rustc_serialize::{Decodable, Decoder};
-use rustc_span::{BytePos, FileName, Span, SyntaxContext};
+use rustc_span::{BytePos, Span, SyntaxContext};
 use std::{fs::File, io::Read, path::Path};
 
 // copied from rustc
@@ -81,8 +81,9 @@ impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for CrateNum {
 }
 
 impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for Span {
+    // KNOWN ISSUE: Currently we make no attempt to encode the `SyntaxContext`
+    // this may lead to issues?
     fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Span {
-        // let ctxt = SyntaxContext::decode(d);
         let lo = BytePos::decode(d);
         let len = BytePos::decode(d);
         let hi = lo + len;

--- a/creusot-metadata/src/encoder.rs
+++ b/creusot-metadata/src/encoder.rs
@@ -8,7 +8,7 @@ pub use rustc_serialize::{Encodable, Encoder};
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
 use rustc_middle::ty::TyCtxt;
-use rustc_span::{Span, SyntaxContext};
+use rustc_span::Span;
 
 pub struct MetadataEncoder<'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -84,13 +84,9 @@ impl<'tcx> Encodable<MetadataEncoder<'tcx>> for CrateNum {
     }
 }
 
-// impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for SyntaxContext {
-//     fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
-//         rustc_span::hygiene::raw_encode_syntax_context(*self, &s.hygiene_ctxt, s);
-//     }
-// }
-
 impl<'tcx> Encodable<MetadataEncoder<'tcx>> for Span {
+    // KNOWN ISSUE: Currently we make no attempt to encode the `SyntaxContext`
+    // this may lead to issues?
     fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
         let span = self.data();
         // span.ctxt.encode(s);
@@ -116,7 +112,7 @@ impl<'tcx> Encodable<MetadataEncoder<'tcx>> for Span {
             }
             _ => None,
         };
-        // source_map.path_mapping().to_embeddable_absolute_path();
+
         path.encode(s);
     }
 }

--- a/creusot-metadata/src/encoder.rs
+++ b/creusot-metadata/src/encoder.rs
@@ -8,6 +8,7 @@ pub use rustc_serialize::{Encodable, Encoder};
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
 use rustc_middle::ty::TyCtxt;
+use rustc_span::{Span, SyntaxContext};
 
 pub struct MetadataEncoder<'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -80,6 +81,43 @@ impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for DefIndex {
 impl<'tcx> Encodable<MetadataEncoder<'tcx>> for CrateNum {
     fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
         s.tcx.stable_crate_id(*self).encode(s)
+    }
+}
+
+// impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for SyntaxContext {
+//     fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
+//         rustc_span::hygiene::raw_encode_syntax_context(*self, &s.hygiene_ctxt, s);
+//     }
+// }
+
+impl<'tcx> Encodable<MetadataEncoder<'tcx>> for Span {
+    fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
+        let span = self.data();
+        // span.ctxt.encode(s);
+
+        let source_map = s.tcx.sess.source_map();
+
+        let source_file = source_map.lookup_source_file(span.lo);
+
+        let lo = span.lo - source_file.start_pos;
+        let len = span.hi - span.lo;
+
+        lo.encode(s);
+        len.encode(s);
+
+        let working_directory = &s.tcx.sess.opts.working_dir;
+        use rustc_span::FileName;
+
+        let path = match source_map.span_to_filename(*self) {
+            FileName::Real(r) => {
+                let fname =
+                    source_map.path_mapping().to_embeddable_absolute_path(r, working_directory);
+                Some(fname)
+            }
+            _ => None,
+        };
+        // source_map.path_mapping().to_embeddable_absolute_path();
+        path.encode(s);
     }
 }
 

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -63,7 +63,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -77,7 +77,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Alloc_Global_Type
   type t_global  =
@@ -131,7 +131,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -181,7 +181,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -198,7 +198,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -224,7 +224,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -246,7 +246,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -260,7 +260,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_fail/bug/222.mlcfg
+++ b/creusot/tests/should_fail/bug/222.mlcfg
@@ -118,7 +118,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -128,7 +128,7 @@ module Core_Option_Impl0_Take_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val take (self : borrowed (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option t
-    ensures { result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
     
 end
 module C222_UsesInvariant_Interface

--- a/creusot/tests/should_fail/bug/492.mlcfg
+++ b/creusot/tests/should_fail/bug/492.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -87,7 +87,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -103,7 +103,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_fail/bug/692.mlcfg
+++ b/creusot/tests/should_fail/bug/692.mlcfg
@@ -111,7 +111,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -153,7 +153,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -176,7 +176,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -240,7 +240,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -262,7 +262,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl1_Unnest_Stub
   type args
@@ -313,7 +313,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -330,12 +330,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -352,7 +352,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -361,11 +361,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -382,7 +382,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -391,13 +391,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -436,7 +436,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -459,7 +459,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C692_Incorrect_Interface
   type c
@@ -768,7 +768,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_fail/bug/695.mlcfg
+++ b/creusot/tests/should_fail/bug/695.mlcfg
@@ -139,8 +139,8 @@ module Core_Ops_Function_Fn_Call_Interface
     type args = args,
     type f = self
   val call (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { Postcondition0.postcondition self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 155 27 155 52] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Postcondition0.postcondition self args result }
     
 end
 module CreusotContracts_Std1_Ops_FnOnceExt_Precondition_Stub
@@ -202,8 +202,8 @@ module Core_Ops_Function_FnOnce_CallOnce_Interface
     type self = self,
     type args = args
   val call_once (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { PostconditionOnce0.postcondition_once self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] PostconditionOnce0.postcondition_once self args result }
     
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMut_Stub
@@ -250,7 +250,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -292,7 +292,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -315,7 +315,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce_Stub
   type args
@@ -352,7 +352,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -374,7 +374,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl1_Unnest_Stub
   type args
@@ -425,7 +425,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -442,12 +442,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -464,7 +464,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -473,11 +473,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -494,7 +494,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -503,13 +503,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -548,7 +548,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -571,7 +571,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C695_InversedIf_Interface
   type c
@@ -941,7 +941,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_fail/bug/specialize.mlcfg
+++ b/creusot/tests/should_fail/bug/specialize.mlcfg
@@ -85,7 +85,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -99,7 +99,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -148,7 +148,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -198,7 +198,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -214,7 +214,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -73,7 +73,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -129,7 +129,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -164,7 +164,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -178,7 +178,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
@@ -194,7 +194,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -246,7 +246,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -296,7 +296,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -318,8 +318,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -333,7 +333,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -373,9 +373,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -439,7 +439,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -468,7 +468,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -560,8 +560,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -587,7 +587,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -654,11 +654,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -674,7 +674,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -690,7 +690,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -706,18 +706,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -734,7 +734,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -743,11 +743,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -766,7 +766,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -777,13 +777,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -799,7 +799,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -828,7 +828,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -844,7 +844,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -869,7 +869,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -894,7 +894,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -919,7 +919,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     

--- a/creusot/tests/should_succeed/all_zero.mlcfg
+++ b/creusot/tests/should_succeed/all_zero.mlcfg
@@ -91,7 +91,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -133,7 +133,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -189,7 +189,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -217,7 +217,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -402,10 +402,10 @@ module Core_Num_Impl9_WrappingMul_Interface
   clone Core_Num_Impl9_Min_Stub as Min0
   clone Core_Num_Impl9_Bits_Stub as Bits0
   val wrapping_mul (self : uint64) (rhs : uint64) : uint64
-    ensures { UInt64.to_int result = EuclideanDivision.mod (UInt64.to_int self * UInt64.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt64.to_int Min0.mIN' }
-    ensures { UInt64.to_int self * UInt64.to_int rhs >= UInt64.to_int Min0.mIN' /\ UInt64.to_int self * UInt64.to_int rhs <= UInt64.to_int Max0.mAX' -> UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs }
-    ensures { UInt64.to_int self * UInt64.to_int rhs < UInt64.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs + k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
-    ensures { UInt64.to_int self * UInt64.to_int rhs > UInt64.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs - k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] UInt64.to_int result = EuclideanDivision.mod (UInt64.to_int self * UInt64.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt64.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] UInt64.to_int self * UInt64.to_int rhs >= UInt64.to_int Min0.mIN' /\ UInt64.to_int self * UInt64.to_int rhs <= UInt64.to_int Max0.mAX' -> UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] UInt64.to_int self * UInt64.to_int rhs < UInt64.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs + k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] UInt64.to_int self * UInt64.to_int rhs > UInt64.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self * UInt64.to_int rhs - k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl9_WrappingAdd_Interface
@@ -418,10 +418,10 @@ module Core_Num_Impl9_WrappingAdd_Interface
   clone Core_Num_Impl9_Min_Stub as Min0
   clone Core_Num_Impl9_Bits_Stub as Bits0
   val wrapping_add (self : uint64) (rhs : uint64) : uint64
-    ensures { UInt64.to_int result = EuclideanDivision.mod (UInt64.to_int self + UInt64.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt64.to_int Min0.mIN' }
-    ensures { UInt64.to_int self + UInt64.to_int rhs >= UInt64.to_int Min0.mIN' /\ UInt64.to_int self + UInt64.to_int rhs <= UInt64.to_int Max0.mAX' -> UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs }
-    ensures { UInt64.to_int self + UInt64.to_int rhs < UInt64.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs + k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
-    ensures { UInt64.to_int self + UInt64.to_int rhs > UInt64.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs - k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] UInt64.to_int result = EuclideanDivision.mod (UInt64.to_int self + UInt64.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt64.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] UInt64.to_int self + UInt64.to_int rhs >= UInt64.to_int Min0.mIN' /\ UInt64.to_int self + UInt64.to_int rhs <= UInt64.to_int Max0.mAX' -> UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] UInt64.to_int self + UInt64.to_int rhs < UInt64.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs + k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] UInt64.to_int self + UInt64.to_int rhs > UInt64.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt64.to_int result = UInt64.to_int self + UInt64.to_int rhs - k * (UInt64.to_int Max0.mAX' - UInt64.to_int Min0.mIN' + 1)) }
     
 end
 module CreusotContracts_Std1_Tuples_Impl4_DeepModel_Stub
@@ -456,7 +456,7 @@ module CreusotContracts_Std1_Tuples_Impl4_DeepModel
     type self = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : (a, b)) : (DeepModelTy0.deepModelTy, DeepModelTy1.deepModelTy) =
-    (DeepModel0.deep_model (let (a, _) = self in a), DeepModel1.deep_model (let (_, a) = self in a))
+    [#"../../../../creusot-contracts/src/std/tuples.rs" 26 28 26 57] (DeepModel0.deep_model (let (a, _) = self in a), DeepModel1.deep_model (let (_, a) = self in a))
   val deep_model (self : (a, b)) : (DeepModelTy0.deepModelTy, DeepModelTy1.deepModelTy)
     ensures { result = deep_model self }
     
@@ -685,7 +685,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -790,7 +790,7 @@ module Core_Cmp_Impls_Impl25_Eq_Interface
     type t = uint64,
     type DeepModelTy0.deepModelTy = int
   val eq (self : uint64) (other : uint64) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
     
 end
 module Bdd_Impl3_DeepModel_Stub
@@ -828,7 +828,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -847,7 +847,7 @@ module CreusotContracts_Std1_Num_Impl10_DeepModel
   use prelude.Int
   use prelude.UInt64
   function deep_model (self : uint64) : int =
-    UInt64.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt64.to_int self
   val deep_model (self : uint64) : int
     ensures { result = deep_model self }
     
@@ -1068,7 +1068,7 @@ module Core_Clone_Impls_Impl9_Clone_Interface
   use prelude.Int
   use prelude.UInt64
   val clone' (self : uint64) : uint64
-    ensures { result = self }
+    ensures { [#"../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module Bdd_Impl0_Clone_Interface
@@ -2411,7 +2411,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -3507,7 +3507,7 @@ module CreusotContracts_Logic_Ord_Impl2_CmpLog
   use prelude.Int
   use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
   function cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering =
-    if self < o then
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 72 12 80 17] if self < o then
       Core_Cmp_Ordering_Type.C_Less
     else
       if self = o then Core_Cmp_Ordering_Type.C_Equal else Core_Cmp_Ordering_Type.C_Greater
@@ -3524,7 +3524,7 @@ module Core_Cmp_Impls_Impl63_Cmp_Interface
   clone CreusotContracts_Logic_Ord_Impl2_CmpLog_Stub as CmpLog0
   clone CreusotContracts_Std1_Num_Impl10_DeepModel_Stub as DeepModel0
   val cmp (self : uint64) (other : uint64) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 44 26 44 85] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module Bdd_Impl10_And_Interface

--- a/creusot/tests/should_succeed/bug/206.mlcfg
+++ b/creusot/tests/should_succeed/bug/206.mlcfg
@@ -82,7 +82,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -96,7 +96,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module C206_U2_Stub
   use prelude.Int

--- a/creusot/tests/should_succeed/bug/217.mlcfg
+++ b/creusot/tests/should_succeed/bug/217.mlcfg
@@ -14,7 +14,7 @@ module CreusotContracts_Logic_Seq_Impl0_Tail
   use seq.Seq
   use seq_ext.SeqExt
   function tail (self : Seq.seq t) : Seq.seq t =
-    SeqExt.subsequence self 1 (Seq.length self)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 42 8 42 39] SeqExt.subsequence self 1 (Seq.length self)
   val tail (self : Seq.seq t) : Seq.seq t
     ensures { result = tail self }
     

--- a/creusot/tests/should_succeed/bug/387.mlcfg
+++ b/creusot/tests/should_succeed/bug/387.mlcfg
@@ -153,7 +153,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -172,7 +172,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -191,7 +191,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -210,11 +210,11 @@ module Core_Cmp_Ord_Max_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val max (self : self) (other : self) : self
-    ensures { GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model self) }
-    ensures { GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model other) }
-    ensures { result = self \/ result = other }
-    ensures { LeLog0.le_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) -> result = other }
-    ensures { LtLog0.lt_log (DeepModel0.deep_model other) (DeepModel0.deep_model self) -> result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 47 26 47 66] GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 48 26 48 63] GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 7 0 56 1] result = self \/ result = other }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 50 16 50 79] LeLog0.le_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) -> result = other }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 51 16 51 81] LtLog0.lt_log (DeepModel0.deep_model other) (DeepModel0.deep_model self) -> result = self }
     
 end
 module CreusotContracts_Std1_Num_Impl10_DeepModel_Stub
@@ -231,7 +231,7 @@ module CreusotContracts_Std1_Num_Impl10_DeepModel
   use prelude.Int
   use prelude.UInt64
   function deep_model (self : uint64) : int =
-    UInt64.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt64.to_int self
   val deep_model (self : uint64) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/463.mlcfg
+++ b/creusot/tests/should_succeed/bug/463.mlcfg
@@ -101,7 +101,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bug/552.mlcfg
+++ b/creusot/tests/should_succeed/bug/552.mlcfg
@@ -39,7 +39,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bug/594.mlcfg
+++ b/creusot/tests/should_succeed/bug/594.mlcfg
@@ -51,7 +51,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -67,7 +67,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -24,7 +24,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bug/691.mlcfg
+++ b/creusot/tests/should_succeed/bug/691.mlcfg
@@ -112,7 +112,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -66,7 +66,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/eq_panic.mlcfg
+++ b/creusot/tests/should_succeed/bug/eq_panic.mlcfg
@@ -62,7 +62,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -80,7 +80,7 @@ module Core_Cmp_Impls_Impl9_Eq_Interface
     type t = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : a) (other : b) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
     
 end
 module EqPanic_Omg_Interface

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -74,7 +74,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -132,7 +132,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -160,7 +160,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -178,7 +178,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Core_Num_Impl11_Max_Stub
@@ -211,7 +211,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -225,7 +225,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Vec_Impl1_Push_Interface
   type t
@@ -244,7 +244,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module TwoPhase_Test_Interface

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -306,7 +306,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -375,7 +375,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -467,8 +467,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Core_Num_Impl11_Max_Stub
@@ -501,7 +501,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -515,7 +515,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
   type t
@@ -537,7 +537,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -562,7 +562,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     

--- a/creusot/tests/should_succeed/checked_ops.mlcfg
+++ b/creusot/tests/should_succeed/checked_ops.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -72,16 +72,16 @@ module Core_Num_Impl6_CheckedAdd_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_add (self : uint8) (rhs : uint8) : Core_Option_Option_Type.t_option uint8
-    ensures { (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
-    ensures { forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self + UInt8.to_int rhs }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap (self : Core_Option_Option_Type.t_option t) : t
-    requires {self <> Core_Option_Option_Type.C_None}
-    ensures { Core_Option_Option_Type.C_Some result = self }
+    requires {[#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self <> Core_Option_Option_Type.C_None}
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] Core_Option_Option_Type.C_Some result = self }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -89,7 +89,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module Core_Num_Impl6_Bits_Stub
@@ -113,10 +113,10 @@ module Core_Num_Impl6_WrappingAdd_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val wrapping_add (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl6_SaturatingAdd_Interface
@@ -125,9 +125,9 @@ module Core_Num_Impl6_SaturatingAdd_Interface
   clone Core_Num_Impl6_Max_Stub as Max0
   clone Core_Num_Impl6_Min_Stub as Min0
   val saturating_add (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl6_OverflowingAdd_Interface
@@ -140,11 +140,11 @@ module Core_Num_Impl6_OverflowingAdd_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val overflowing_add (self : uint8) (rhs : uint8) : (uint8, bool)
-    ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs }
-    ensures { UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self + UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] UInt8.to_int self + UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self + UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self + UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (UInt8.to_int self + UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self + UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -158,7 +158,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -810,8 +810,8 @@ module Core_Num_Impl6_CheckedSub_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_sub (self : uint8) (rhs : uint8) : Core_Option_Option_Type.t_option uint8
-    ensures { (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
-    ensures { forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self - UInt8.to_int rhs }
     
 end
 module Core_Num_Impl6_WrappingSub_Interface
@@ -824,10 +824,10 @@ module Core_Num_Impl6_WrappingSub_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val wrapping_sub (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl6_SaturatingSub_Interface
@@ -836,9 +836,9 @@ module Core_Num_Impl6_SaturatingSub_Interface
   clone Core_Num_Impl6_Max_Stub as Max0
   clone Core_Num_Impl6_Min_Stub as Min0
   val saturating_sub (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl6_OverflowingSub_Interface
@@ -851,11 +851,11 @@ module Core_Num_Impl6_OverflowingSub_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val overflowing_sub (self : uint8) (rhs : uint8) : (uint8, bool)
-    ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs }
-    ensures { UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self - UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] UInt8.to_int self - UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self - UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self - UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (UInt8.to_int self - UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self - UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
     
 end
 module CheckedOps_TestU8SubExample_Interface
@@ -1509,8 +1509,8 @@ module Core_Num_Impl6_CheckedMul_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_mul (self : uint8) (rhs : uint8) : Core_Option_Option_Type.t_option uint8
-    ensures { (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
-    ensures { forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = UInt8.to_int self * UInt8.to_int rhs }
     
 end
 module Core_Num_Impl6_WrappingMul_Interface
@@ -1523,10 +1523,10 @@ module Core_Num_Impl6_WrappingMul_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val wrapping_mul (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] UInt8.to_int result = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl6_SaturatingMul_Interface
@@ -1535,9 +1535,9 @@ module Core_Num_Impl6_SaturatingMul_Interface
   clone Core_Num_Impl6_Max_Stub as Max0
   clone Core_Num_Impl6_Min_Stub as Min0
   val saturating_mul (self : uint8) (rhs : uint8) : uint8
-    ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> UInt8.to_int result = UInt8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl6_OverflowingMul_Interface
@@ -1550,11 +1550,11 @@ module Core_Num_Impl6_OverflowingMul_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   clone Core_Num_Impl6_Bits_Stub as Bits0
   val overflowing_mul (self : uint8) (rhs : uint8) : (uint8, bool)
-    ensures { UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs }
-    ensures { UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] UInt8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (UInt8.to_int self * UInt8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] UInt8.to_int self * UInt8.to_int rhs >= UInt8.to_int Min0.mIN' /\ UInt8.to_int self * UInt8.to_int rhs <= UInt8.to_int Max0.mAX' -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs + k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self * UInt8.to_int rhs - k * (UInt8.to_int Max0.mAX' - UInt8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (UInt8.to_int self * UInt8.to_int rhs < UInt8.to_int Min0.mIN' \/ UInt8.to_int self * UInt8.to_int rhs > UInt8.to_int Max0.mAX') }
     
 end
 module CheckedOps_TestU8MulExample_Interface
@@ -2149,8 +2149,8 @@ module Core_Num_Impl6_CheckedDiv_Interface
   clone Core_Num_Impl6_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_div (self : uint8) (rhs : uint8) : Core_Option_Option_Type.t_option uint8
-    ensures { (result = Core_Option_Option_Type.C_None) = (UInt8.to_int rhs = 0 \/ UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1) }
-    ensures { forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 63 26 63 97] (result = Core_Option_Option_Type.C_None) = (UInt8.to_int rhs = 0 \/ UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 65 16 65 85] forall r : uint8 . result = Core_Option_Option_Type.C_Some r -> UInt8.to_int r = div (UInt8.to_int self) (UInt8.to_int rhs) }
     
 end
 module Core_Num_Impl6_WrappingDiv_Interface
@@ -2158,9 +2158,9 @@ module Core_Num_Impl6_WrappingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl6_Min_Stub as Min0
   val wrapping_div (self : uint8) (rhs : uint8) : uint8
-    requires {UInt8.to_int rhs <> 0}
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int result = UInt8.to_int self }
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int result = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 70 27 70 36] UInt8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 72 16 72 85] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int result = UInt8.to_int self }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 74 26 74 89] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int result = div (UInt8.to_int self) (UInt8.to_int rhs) }
     
 end
 module Core_Num_Impl6_SaturatingDiv_Interface
@@ -2168,9 +2168,9 @@ module Core_Num_Impl6_SaturatingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl6_Min_Stub as Min0
   val saturating_div (self : uint8) (rhs : uint8) : uint8
-    requires {UInt8.to_int rhs <> 0}
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int result = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 79 27 79 36] UInt8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 81 16 81 91] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int result = UInt8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 83 26 83 89] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int result = div (UInt8.to_int self) (UInt8.to_int rhs) }
     
 end
 module Core_Num_Impl6_OverflowingDiv_Interface
@@ -2178,10 +2178,10 @@ module Core_Num_Impl6_OverflowingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl6_Min_Stub as Min0
   val overflowing_div (self : uint8) (rhs : uint8) : (uint8, bool)
-    requires {UInt8.to_int rhs <> 0}
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self }
-    ensures { UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int (let (a, _) = result in a) = div (UInt8.to_int self) (UInt8.to_int rhs) }
-    ensures { (let (_, a) = result in a) = (UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 88 27 88 36] UInt8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 90 16 90 87] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 -> UInt8.to_int (let (a, _) = result in a) = UInt8.to_int self }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 92 26 92 91] UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1 \/ UInt8.to_int (let (a, _) = result in a) = div (UInt8.to_int self) (UInt8.to_int rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 94 26 94 74] (let (_, a) = result in a) = (UInt8.to_int self = UInt8.to_int Min0.mIN' /\ UInt8.to_int rhs = - 1) }
     
 end
 module CheckedOps_TestU8DivExample_Interface
@@ -2681,8 +2681,8 @@ module Core_Num_Impl0_CheckedAdd_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_add (self : int8) (rhs : int8) : Core_Option_Option_Type.t_option int8
-    ensures { (result = Core_Option_Option_Type.C_None) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX') }
-    ensures { forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self + Int8.to_int rhs }
     
 end
 module Core_Num_Impl0_Bits_Stub
@@ -2706,10 +2706,10 @@ module Core_Num_Impl0_WrappingAdd_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val wrapping_add (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] Int8.to_int result = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl0_SaturatingAdd_Interface
@@ -2718,9 +2718,9 @@ module Core_Num_Impl0_SaturatingAdd_Interface
   clone Core_Num_Impl0_Max_Stub as Max0
   clone Core_Num_Impl0_Min_Stub as Min0
   val saturating_add (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self + Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl0_OverflowingAdd_Interface
@@ -2733,11 +2733,11 @@ module Core_Num_Impl0_OverflowingAdd_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val overflowing_add (self : int8) (rhs : int8) : (int8, bool)
-    ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs }
-    ensures { Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self + Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] Int8.to_int self + Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self + Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self + Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (Int8.to_int self + Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self + Int8.to_int rhs > Int8.to_int Max0.mAX') }
     
 end
 module CheckedOps_TestI8AddExample_Interface
@@ -3694,8 +3694,8 @@ module Core_Num_Impl0_CheckedSub_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_sub (self : int8) (rhs : int8) : Core_Option_Option_Type.t_option int8
-    ensures { (result = Core_Option_Option_Type.C_None) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX') }
-    ensures { forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self - Int8.to_int rhs }
     
 end
 module Core_Num_Impl0_WrappingSub_Interface
@@ -3708,10 +3708,10 @@ module Core_Num_Impl0_WrappingSub_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val wrapping_sub (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] Int8.to_int result = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl0_SaturatingSub_Interface
@@ -3720,9 +3720,9 @@ module Core_Num_Impl0_SaturatingSub_Interface
   clone Core_Num_Impl0_Max_Stub as Max0
   clone Core_Num_Impl0_Min_Stub as Min0
   val saturating_sub (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self - Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl0_OverflowingSub_Interface
@@ -3735,11 +3735,11 @@ module Core_Num_Impl0_OverflowingSub_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val overflowing_sub (self : int8) (rhs : int8) : (int8, bool)
-    ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs }
-    ensures { Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self - Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] Int8.to_int self - Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self - Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self - Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (Int8.to_int self - Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self - Int8.to_int rhs > Int8.to_int Max0.mAX') }
     
 end
 module CheckedOps_TestI8SubExample_Interface
@@ -4700,8 +4700,8 @@ module Core_Num_Impl0_CheckedMul_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_mul (self : int8) (rhs : int8) : Core_Option_Option_Type.t_option int8
-    ensures { (result = Core_Option_Option_Type.C_None) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX') }
-    ensures { forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 121 20 122 89] (result = Core_Option_Option_Type.C_None) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 125 16 125 89] forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = Int8.to_int self * Int8.to_int rhs }
     
 end
 module Core_Num_Impl0_WrappingMul_Interface
@@ -4714,10 +4714,10 @@ module Core_Num_Impl0_WrappingMul_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val wrapping_mul (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int result = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 132 20 132 93] Int8.to_int result = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 135 16 138 18] Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 142 16 146 18] Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 147 16 151 18] Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int result = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
     
 end
 module Core_Num_Impl0_SaturatingMul_Interface
@@ -4726,9 +4726,9 @@ module Core_Num_Impl0_SaturatingMul_Interface
   clone Core_Num_Impl0_Max_Stub as Max0
   clone Core_Num_Impl0_Min_Stub as Min0
   val saturating_mul (self : int8) (rhs : int8) : int8
-    ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 158 16 161 18] Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int self * Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 163 16 163 85] Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> Int8.to_int result = Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 164 16 164 85] Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> Int8.to_int result = Int8.to_int Max0.mAX' }
     
 end
 module Core_Num_Impl0_OverflowingMul_Interface
@@ -4741,11 +4741,11 @@ module Core_Num_Impl0_OverflowingMul_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   clone Core_Num_Impl0_Bits_Stub as Bits0
   val overflowing_mul (self : int8) (rhs : int8) : (int8, bool)
-    ensures { Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs }
-    ensures { Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
-    ensures { (let (_, a) = result in a) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX') }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 172 20 172 95] Int8.to_int (let (a, _) = result in a) = EuclideanDivision.mod (Int8.to_int self * Int8.to_int rhs) (Power.power 2 (UInt32.to_int Bits0.bITS')) + Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 175 16 178 18] Int8.to_int self * Int8.to_int rhs >= Int8.to_int Min0.mIN' /\ Int8.to_int self * Int8.to_int rhs <= Int8.to_int Max0.mAX' -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 182 16 186 18] Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs + k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 187 16 191 18] Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX' -> (exists k : int . k > 0 /\ Int8.to_int (let (a, _) = result in a) = Int8.to_int self * Int8.to_int rhs - k * (Int8.to_int Max0.mAX' - Int8.to_int Min0.mIN' + 1)) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 194 20 194 98] (let (_, a) = result in a) = (Int8.to_int self * Int8.to_int rhs < Int8.to_int Min0.mIN' \/ Int8.to_int self * Int8.to_int rhs > Int8.to_int Max0.mAX') }
     
 end
 module CheckedOps_TestI8MulExample_Interface
@@ -5453,8 +5453,8 @@ module Core_Num_Impl0_CheckedDiv_Interface
   clone Core_Num_Impl0_Min_Stub as Min0
   use Core_Option_Option_Type as Core_Option_Option_Type
   val checked_div (self : int8) (rhs : int8) : Core_Option_Option_Type.t_option int8
-    ensures { (result = Core_Option_Option_Type.C_None) = (Int8.to_int rhs = 0 \/ Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1) }
-    ensures { forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 63 26 63 97] (result = Core_Option_Option_Type.C_None) = (Int8.to_int rhs = 0 \/ Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 65 16 65 85] forall r : int8 . result = Core_Option_Option_Type.C_Some r -> Int8.to_int r = div (Int8.to_int self) (Int8.to_int rhs) }
     
 end
 module Core_Num_Impl0_WrappingDiv_Interface
@@ -5462,9 +5462,9 @@ module Core_Num_Impl0_WrappingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl0_Min_Stub as Min0
   val wrapping_div (self : int8) (rhs : int8) : int8
-    requires {Int8.to_int rhs <> 0}
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int result = Int8.to_int self }
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int result = div (Int8.to_int self) (Int8.to_int rhs) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 70 27 70 36] Int8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 72 16 72 85] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int result = Int8.to_int self }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 74 26 74 89] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int result = div (Int8.to_int self) (Int8.to_int rhs) }
     
 end
 module Core_Num_Impl0_SaturatingDiv_Interface
@@ -5472,9 +5472,9 @@ module Core_Num_Impl0_SaturatingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl0_Min_Stub as Min0
   val saturating_div (self : int8) (rhs : int8) : int8
-    requires {Int8.to_int rhs <> 0}
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int result = Int8.to_int Min0.mIN' }
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int result = div (Int8.to_int self) (Int8.to_int rhs) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 79 27 79 36] Int8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 81 16 81 91] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int result = Int8.to_int Min0.mIN' }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 83 26 83 89] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int result = div (Int8.to_int self) (Int8.to_int rhs) }
     
 end
 module Core_Num_Impl0_OverflowingDiv_Interface
@@ -5482,10 +5482,10 @@ module Core_Num_Impl0_OverflowingDiv_Interface
   use prelude.Int
   clone Core_Num_Impl0_Min_Stub as Min0
   val overflowing_div (self : int8) (rhs : int8) : (int8, bool)
-    requires {Int8.to_int rhs <> 0}
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self }
-    ensures { Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int (let (a, _) = result in a) = div (Int8.to_int self) (Int8.to_int rhs) }
-    ensures { (let (_, a) = result in a) = (Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1) }
+    requires {[#"../../../../creusot-contracts/src/std/num.rs" 88 27 88 36] Int8.to_int rhs <> 0}
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 90 16 90 87] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 -> Int8.to_int (let (a, _) = result in a) = Int8.to_int self }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 92 26 92 91] Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1 \/ Int8.to_int (let (a, _) = result in a) = div (Int8.to_int self) (Int8.to_int rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 94 26 94 74] (let (_, a) = result in a) = (Int8.to_int self = Int8.to_int Min0.mIN' /\ Int8.to_int rhs = - 1) }
     
 end
 module CheckedOps_TestI8DivExample_Interface

--- a/creusot/tests/should_succeed/closures/01_basic.mlcfg
+++ b/creusot/tests/should_succeed/closures/01_basic.mlcfg
@@ -101,7 +101,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -267,7 +267,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/closures/02_nested.mlcfg
+++ b/creusot/tests/should_succeed/closures/02_nested.mlcfg
@@ -104,7 +104,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
+++ b/creusot/tests/should_succeed/closures/03_generic_bound.mlcfg
@@ -82,8 +82,8 @@ module Core_Ops_Function_Fn_Call_Interface
     type args = args,
     type f = self
   val call (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { Postcondition0.postcondition self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 155 27 155 52] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Postcondition0.postcondition self args result }
     
 end
 module CreusotContracts_Std1_Ops_Impl2_Postcondition_Stub
@@ -160,7 +160,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -202,7 +202,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -225,7 +225,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -289,7 +289,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -311,7 +311,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl1_Unnest_Stub
   type args
@@ -362,7 +362,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -379,12 +379,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -401,7 +401,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -410,11 +410,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -431,7 +431,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -440,13 +440,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -485,7 +485,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -508,7 +508,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C03GenericBound_ClosureParam_Interface
   type f

--- a/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
+++ b/creusot/tests/should_succeed/closures/04_generic_closure.mlcfg
@@ -82,8 +82,8 @@ module Core_Ops_Function_Fn_Call_Interface
     type args = args,
     type f = self
   val call (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { Postcondition0.postcondition self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 155 27 155 52] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Postcondition0.postcondition self args result }
     
 end
 module CreusotContracts_Std1_Ops_Impl2_Postcondition_Stub
@@ -160,7 +160,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -202,7 +202,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -225,7 +225,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -289,7 +289,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -311,7 +311,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl1_Unnest_Stub
   type args
@@ -362,7 +362,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -379,12 +379,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -401,7 +401,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -410,11 +410,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -431,7 +431,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -440,13 +440,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -485,7 +485,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -508,7 +508,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C04GenericClosure_GenericClosure_Interface
   type a

--- a/creusot/tests/should_succeed/closures/05_map.mlcfg
+++ b/creusot/tests/should_succeed/closures/05_map.mlcfg
@@ -37,7 +37,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -137,8 +137,8 @@ module Core_Ops_Function_Fn_Call_Interface
     type args = args,
     type f = self
   val call (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { Postcondition0.postcondition self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 155 27 155 52] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Postcondition0.postcondition self args result }
     
 end
 module CreusotContracts_Std1_Ops_Impl2_Postcondition_Stub
@@ -238,7 +238,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -261,7 +261,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -325,7 +325,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -347,7 +347,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl1_Unnest_Stub
   type args
@@ -398,7 +398,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -415,12 +415,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -437,7 +437,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -446,11 +446,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -467,7 +467,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -476,13 +476,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -521,7 +521,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -544,7 +544,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C05Map_Impl0_Next_Interface
   type a

--- a/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
+++ b/creusot/tests/should_succeed/closures/06_fn_specs.mlcfg
@@ -138,8 +138,8 @@ module Core_Ops_Function_FnOnce_CallOnce_Interface
     type self = self,
     type args = args
   val call_once (self : self) (args : args) : Output0.output
-    requires {Precondition0.precondition self args}
-    ensures { PostconditionOnce0.postcondition_once self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] Precondition0.precondition self args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] PostconditionOnce0.postcondition_once self args result }
     
 end
 module C06FnSpecs_Weaken3_Interface
@@ -274,7 +274,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_PostconditionMutUnnest_Interface
     type args = args,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed self) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed self, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed self, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 27 15 27 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 28 14 28 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_FnMutExt_PostconditionMutUnnest
   type self
@@ -292,10 +292,10 @@ module CreusotContracts_Std1_Ops_FnMutExt_PostconditionMutUnnest
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed self) (args : args) (res : Output0.output) : ()
   val postcondition_mut_unnest (self : borrowed self) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 27 15 27 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed self, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed self, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 27 15 27 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 28 14 28 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_FnMutExt_UnnestRefl_Stub
   type self
@@ -312,7 +312,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_UnnestRefl_Interface
     type self = self,
     type args = args
   function unnest_refl (self : self) : ()
-  axiom unnest_refl_spec : forall self : self . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : self . [#"../../../../../creusot-contracts/src/std/ops.rs" 32 14 32 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_FnMutExt_UnnestRefl
   type self
@@ -324,7 +324,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_UnnestRefl
   val unnest_refl (self : self) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : self . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : self . [#"../../../../../creusot-contracts/src/std/ops.rs" 32 14 32 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_FnMutExt_UnnestTrans_Stub
   type self
@@ -341,7 +341,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_UnnestTrans_Interface
     type self = self,
     type args = args
   function unnest_trans (self : self) (b : self) (c : self) : ()
-  axiom unnest_trans_spec : forall self : self, b : self, c : self . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : self, b : self, c : self . ([#"../../../../../creusot-contracts/src/std/ops.rs" 36 15 36 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 37 15 37 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 38 14 38 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_FnMutExt_UnnestTrans
   type self
@@ -351,11 +351,11 @@ module CreusotContracts_Std1_Ops_FnMutExt_UnnestTrans
     type args = args
   function unnest_trans (self : self) (b : self) (c : self) : ()
   val unnest_trans (self : self) (b : self) (c : self) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 36 15 36 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 37 15 37 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : self, b : self, c : self . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : self, b : self, c : self . ([#"../../../../../creusot-contracts/src/std/ops.rs" 36 15 36 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 37 15 37 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 38 14 38 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_FnMutExt_FnMutOnce_Stub
   type self
@@ -394,7 +394,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_FnMutOnce_Interface
     type args = args,
     type Output0.output = Output0.output
   function fn_mut_once (self : self) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed self .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 42 14 42 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed self .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_FnMutExt_FnMutOnce
   type self
@@ -417,7 +417,7 @@ module CreusotContracts_Std1_Ops_FnMutExt_FnMutOnce
   val fn_mut_once (self : self) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed self .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 42 14 42 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed self .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C06FnSpecs_Weaken2_Interface
   type a
@@ -552,7 +552,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -594,7 +594,7 @@ module CreusotContracts_Std1_Ops_FnExt_FnMut_Interface
     type args = args,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed self) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed self, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 56 14 56 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_FnExt_FnMut
   type self
@@ -617,7 +617,7 @@ module CreusotContracts_Std1_Ops_FnExt_FnMut
   val fn_mut (self : borrowed self) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed self, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 56 14 56 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_FnExt_FnOnce_Stub
   type self
@@ -654,7 +654,7 @@ module CreusotContracts_Std1_Ops_FnExt_FnOnce_Interface
     type args = args,
     type Output0.output = Output0.output
   function fn_once (self : self) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 60 14 60 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_FnExt_FnOnce
   type self
@@ -676,7 +676,7 @@ module CreusotContracts_Std1_Ops_FnExt_FnOnce
   val fn_once (self : self) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : self, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : self, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 60 14 60 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module C06FnSpecs_Weaken_Interface
   type a
@@ -1053,7 +1053,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -1070,12 +1070,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -1092,7 +1092,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -1101,11 +1101,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -1122,7 +1122,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -1131,13 +1131,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Stub
   type args
@@ -1176,7 +1176,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -1199,7 +1199,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C06FnSpecs_Weaken2Std_Interface
   type a
@@ -1357,7 +1357,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnMut
   type args
@@ -1380,7 +1380,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnMut
   val fn_mut (self : borrowed f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut self args res }
     
-  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
+  axiom fn_mut_spec : forall self : borrowed f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 128 14 128 100] PostconditionMut0.postcondition_mut self args res = (Resolve0.resolve self /\ Postcondition0.postcondition ( * self) args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce_Stub
   type args
@@ -1417,7 +1417,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module CreusotContracts_Std1_Ops_Impl2_FnOnce
   type args
@@ -1439,7 +1439,7 @@ module CreusotContracts_Std1_Ops_Impl2_FnOnce
   val fn_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_once self args res }
     
-  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
+  axiom fn_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 133 14 133 101] PostconditionOnce0.postcondition_once self args res = (Resolve0.resolve self /\ Postcondition0.postcondition self args res)
 end
 module C06FnSpecs_WeakenStd_Interface
   type a
@@ -1651,7 +1651,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -142,7 +142,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/constrained_types.mlcfg
+++ b/creusot/tests/should_succeed/constrained_types.mlcfg
@@ -32,7 +32,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -85,7 +85,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -129,7 +129,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -152,7 +152,7 @@ module CreusotContracts_Logic_Ord_Impl0_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = b
   predicate lt_log (self : (a, b)) (o : (a, b)) =
-    (let (a, _) = self in a) = (let (a, _) = o in a) /\ LtLog0.lt_log (let (_, a) = self in a) (let (_, a) = o in a) \/ LtLog1.lt_log (let (a, _) = self in a) (let (a, _) = o in a)
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 198 20 198 67] (let (a, _) = self in a) = (let (a, _) = o in a) /\ LtLog0.lt_log (let (_, a) = self in a) (let (_, a) = o in a) \/ LtLog1.lt_log (let (a, _) = self in a) (let (a, _) = o in a)
   val lt_log (self : (a, b)) (o : (a, b)) : bool
     ensures { result = lt_log self o }
     
@@ -186,7 +186,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -223,7 +223,7 @@ module CreusotContracts_Std1_Tuples_Impl4_DeepModel
     type self = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : (a, b)) : (DeepModelTy0.deepModelTy, DeepModelTy1.deepModelTy) =
-    (DeepModel0.deep_model (let (a, _) = self in a), DeepModel1.deep_model (let (_, a) = self in a))
+    [#"../../../../creusot-contracts/src/std/tuples.rs" 26 28 26 57] (DeepModel0.deep_model (let (a, _) = self in a), DeepModel1.deep_model (let (_, a) = self in a))
   val deep_model (self : (a, b)) : (DeepModelTy0.deepModelTy, DeepModelTy1.deepModelTy)
     ensures { result = deep_model self }
     
@@ -259,7 +259,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/drop_pair.mlcfg
+++ b/creusot/tests/should_succeed/drop_pair.mlcfg
@@ -32,7 +32,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -51,7 +51,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -31,7 +31,7 @@ end
 module CreusotContracts_Std1_Time_SecsToNanos
   use prelude.Int
   function secs_to_nanos (secs : int) : int =
-    secs * 1000000000
+    [#"../../../../creusot-contracts/src/std/time.rs" 46 4 46 24] secs * 1000000000
   val secs_to_nanos (secs : int) : int
     ensures { result = secs_to_nanos secs }
     
@@ -62,7 +62,7 @@ module CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface
   clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
   clone Core_Num_Impl9_Max_Stub as Max0
   function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . [#"../../../../creusot-contracts/src/std/time.rs" 12 14 12 77] shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel
   use prelude.Int
@@ -74,7 +74,7 @@ module CreusotContracts_Std1_Time_Impl0_ShallowModel
   val shallow_model (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . [#"../../../../creusot-contracts/src/std/time.rs" 12 14 12 77] shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module CreusotContracts_Std1_Time_NanosToSecs_Stub
   use prelude.Int
@@ -87,7 +87,7 @@ end
 module CreusotContracts_Std1_Time_NanosToSecs
   use prelude.Int
   function nanos_to_secs (nanos : int) : int =
-    div nanos 1000000000
+    [#"../../../../creusot-contracts/src/std/time.rs" 41 4 41 25] div nanos 1000000000
   val nanos_to_secs (nanos : int) : int
     ensures { result = nanos_to_secs nanos }
     
@@ -105,8 +105,8 @@ module Core_Time_Impl1_New_Interface
     axiom .
   clone CreusotContracts_Std1_Time_NanosToSecs_Stub as NanosToSecs0
   val new (secs : uint64) (nanos : uint32) : Core_Time_Duration_Type.t_duration
-    requires {UInt64.to_int secs + NanosToSecs0.nanos_to_secs (UInt32.to_int nanos) <= UInt64.to_int Max0.mAX'}
-    ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) + UInt32.to_int nanos }
+    requires {[#"../../../../creusot-contracts/src/std/time.rs" 76 27 76 69] UInt64.to_int secs + NanosToSecs0.nanos_to_secs (UInt32.to_int nanos) <= UInt64.to_int Max0.mAX'}
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 77 26 77 66] ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) + UInt32.to_int nanos }
     
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
@@ -157,7 +157,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -175,8 +175,8 @@ module Core_Time_Impl1_AsNanos_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val as_nanos (self : Core_Time_Duration_Type.t_duration) : uint128
-    ensures { UInt128.to_int result = ShallowModel0.shallow_model self }
-    ensures { UInt128.to_int result <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 117 26 117 42] UInt128.to_int result = ShallowModel0.shallow_model self }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 118 26 118 75] UInt128.to_int result <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999 }
     
 end
 module Core_Time_Impl1_FromSecs_Interface
@@ -190,7 +190,7 @@ module Core_Time_Impl1_FromSecs_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_secs (secs : uint64) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 80 26 80 57] ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
     
 end
 module Core_Time_Impl1_FromMillis_Interface
@@ -204,7 +204,7 @@ module Core_Time_Impl1_FromMillis_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_millis (millis : uint64) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result = UInt64.to_int millis * 1000000 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 83 26 83 58] ShallowModel0.shallow_model result = UInt64.to_int millis * 1000000 }
     
 end
 module Core_Time_Impl1_FromMicros_Interface
@@ -218,7 +218,7 @@ module Core_Time_Impl1_FromMicros_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_micros (micros : uint64) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result = UInt64.to_int micros * 1000 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 86 26 86 54] ShallowModel0.shallow_model result = UInt64.to_int micros * 1000 }
     
 end
 module Core_Time_Impl1_FromNanos_Interface
@@ -232,7 +232,7 @@ module Core_Time_Impl1_FromNanos_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_nanos (nanos : uint64) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result = UInt64.to_int nanos }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 89 26 89 43] ShallowModel0.shallow_model result = UInt64.to_int nanos }
     
 end
 module Core_Time_Impl1_IsZero_Interface
@@ -244,8 +244,8 @@ module Core_Time_Impl1_IsZero_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val is_zero (self : Core_Time_Duration_Type.t_duration) : bool
-    ensures { ShallowModel0.shallow_model self = 0 -> result = true }
-    ensures { ShallowModel0.shallow_model self <> 0 -> result = false }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 92 16 92 57] ShallowModel0.shallow_model self = 0 -> result = true }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 93 16 93 58] ShallowModel0.shallow_model self <> 0 -> result = false }
     
 end
 module Core_Time_Impl1_AsSecs_Interface
@@ -259,7 +259,7 @@ module Core_Time_Impl1_AsSecs_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val as_secs (self : Core_Time_Duration_Type.t_duration) : uint64
-    ensures { UInt64.to_int result = NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 96 26 96 57] UInt64.to_int result = NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Time_NanosToMillis_Stub
@@ -273,7 +273,7 @@ end
 module CreusotContracts_Std1_Time_NanosToMillis
   use prelude.Int
   function nanos_to_millis (nanos : int) : int =
-    div nanos 1000000
+    [#"../../../../creusot-contracts/src/std/time.rs" 36 4 36 21] div nanos 1000000
   val nanos_to_millis (nanos : int) : int
     ensures { result = nanos_to_millis nanos }
     
@@ -289,8 +289,8 @@ module Core_Time_Impl1_SubsecMillis_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val subsec_millis (self : Core_Time_Duration_Type.t_duration) : uint32
-    ensures { UInt32.to_int result = mod (NanosToMillis0.nanos_to_millis (ShallowModel0.shallow_model self)) 1000 }
-    ensures { result < (1000 : uint32) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 99 26 99 67] UInt32.to_int result = mod (NanosToMillis0.nanos_to_millis (ShallowModel0.shallow_model self)) 1000 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 100 26 100 44] result < (1000 : uint32) }
     
 end
 module CreusotContracts_Std1_Time_NanosToMicros_Stub
@@ -304,7 +304,7 @@ end
 module CreusotContracts_Std1_Time_NanosToMicros
   use prelude.Int
   function nanos_to_micros (nanos : int) : int =
-    div nanos 1000
+    [#"../../../../creusot-contracts/src/std/time.rs" 32 4 32 17] div nanos 1000
   val nanos_to_micros (nanos : int) : int
     ensures { result = nanos_to_micros nanos }
     
@@ -320,8 +320,8 @@ module Core_Time_Impl1_SubsecMicros_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val subsec_micros (self : Core_Time_Duration_Type.t_duration) : uint32
-    ensures { UInt32.to_int result = mod (NanosToMicros0.nanos_to_micros (ShallowModel0.shallow_model self)) 1000000 }
-    ensures { result < (1000000 : uint32) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 103 26 103 71] UInt32.to_int result = mod (NanosToMicros0.nanos_to_micros (ShallowModel0.shallow_model self)) 1000000 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 104 26 104 48] result < (1000000 : uint32) }
     
 end
 module Core_Time_Impl1_SubsecNanos_Interface
@@ -334,8 +334,8 @@ module Core_Time_Impl1_SubsecNanos_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val subsec_nanos (self : Core_Time_Duration_Type.t_duration) : uint32
-    ensures { UInt32.to_int result = mod (ShallowModel0.shallow_model self) 1000000000 }
-    ensures { result < (1000000000 : uint32) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 107 26 107 60] UInt32.to_int result = mod (ShallowModel0.shallow_model self) 1000000000 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 108 26 108 52] result < (1000000000 : uint32) }
     
 end
 module Core_Time_Impl1_AsMillis_Interface
@@ -349,7 +349,7 @@ module Core_Time_Impl1_AsMillis_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val as_millis (self : Core_Time_Duration_Type.t_duration) : uint128
-    ensures { UInt128.to_int result = NanosToMillis0.nanos_to_millis (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 111 26 111 59] UInt128.to_int result = NanosToMillis0.nanos_to_millis (ShallowModel0.shallow_model self) }
     
 end
 module Core_Time_Impl1_AsMicros_Interface
@@ -363,7 +363,7 @@ module Core_Time_Impl1_AsMicros_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type ShallowModelTy0.shallowModelTy = int
   val as_micros (self : Core_Time_Duration_Type.t_duration) : uint128
-    ensures { UInt128.to_int result = NanosToMicros0.nanos_to_micros (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 114 26 114 59] UInt128.to_int result = NanosToMicros0.nanos_to_micros (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
@@ -418,7 +418,7 @@ module CreusotContracts_Std1_Option_Impl0_DeepModel
   function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
     
    =
-    match (self) with
+    [#"../../../../creusot-contracts/src/std/option.rs" 9 8 12 9] match (self) with
       | Core_Option_Option_Type.C_Some t -> Core_Option_Option_Type.C_Some (DeepModel0.deep_model t)
       | Core_Option_Option_Type.C_None -> Core_Option_Option_Type.C_None
       end
@@ -443,8 +443,8 @@ module Core_Time_Impl1_CheckedAdd_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_add (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
-    ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
-    ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) <= UInt64.to_int Max0.mAX' -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 121 16 121 86] NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 122 16 122 114] NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) <= UInt64.to_int Max0.mAX' -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs) }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -452,7 +452,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module Core_Option_Impl0_IsSome_Interface
@@ -460,7 +460,7 @@ module Core_Option_Impl0_IsSome_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_some (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self <> Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 20 26 20 51] result = (self <> Core_Option_Option_Type.C_None) }
     
 end
 module Core_Time_Impl1_CheckedSub_Interface
@@ -478,8 +478,8 @@ module Core_Time_Impl1_CheckedSub_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_sub (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
-    ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs < 0 -> result = Core_Option_Option_Type.C_None }
-    ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 125 16 125 63] ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs < 0 -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 126 16 126 91] ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs) }
     
 end
 module Core_Time_Impl1_CheckedMul_Interface
@@ -500,8 +500,8 @@ module Core_Time_Impl1_CheckedMul_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_mul (self : Core_Time_Duration_Type.t_duration) (rhs : uint32) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
-    ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
-    ensures { NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) <= UInt64.to_int Max0.mAX' -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self * UInt32.to_int rhs) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 129 16 129 86] NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) > UInt64.to_int Max0.mAX' -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 130 16 130 114] NanosToSecs0.nanos_to_secs (ShallowModel0.shallow_model self * UInt32.to_int rhs) <= UInt64.to_int Max0.mAX' -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel0.shallow_model self * UInt32.to_int rhs) }
     
 end
 module Core_Time_Impl1_CheckedDiv_Interface
@@ -520,8 +520,8 @@ module Core_Time_Impl1_CheckedDiv_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type DeepModelTy0.deepModelTy = int
   val checked_div (self : Core_Time_Duration_Type.t_duration) (rhs : uint32) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
-    ensures { rhs = (0 : uint32) -> result = Core_Option_Option_Type.C_None }
-    ensures { rhs <> (0 : uint32) -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (div (ShallowModel0.shallow_model self) (UInt32.to_int rhs)) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 133 16 133 58] rhs = (0 : uint32) -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 134 16 134 85] rhs <> (0 : uint32) -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (div (ShallowModel0.shallow_model self) (UInt32.to_int rhs)) }
     
 end
 module Core_Time_Impl2_Add_Interface
@@ -535,8 +535,8 @@ module Core_Time_Impl2_Add_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val add (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
-    requires {ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999}
-    ensures { ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    requires {[#"../../../../creusot-contracts/src/std/time.rs" 169 0 199 1] ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999}
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 169 0 199 1] ShallowModel0.shallow_model self + ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
     
 end
 module Core_Time_Impl4_Sub_Interface
@@ -549,8 +549,8 @@ module Core_Time_Impl4_Sub_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val sub (self : Core_Time_Duration_Type.t_duration) (rhs : Core_Time_Duration_Type.t_duration) : Core_Time_Duration_Type.t_duration
-    requires {ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0}
-    ensures { ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
+    requires {[#"../../../../creusot-contracts/src/std/time.rs" 169 0 199 1] ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs >= 0}
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 169 0 199 1] ShallowModel0.shallow_model self - ShallowModel0.shallow_model rhs = ShallowModel0.shallow_model result }
     
 end
 module CreusotContracts_Std1_Time_Impl1_DeepModel_Stub
@@ -576,7 +576,7 @@ module CreusotContracts_Std1_Time_Impl1_DeepModel_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   function deep_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . ([#"../../../../creusot-contracts/src/std/time.rs" 24 14 24 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 23 14 23 77] deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999)
 end
 module CreusotContracts_Std1_Time_Impl1_DeepModel
   use prelude.Int
@@ -592,7 +592,7 @@ module CreusotContracts_Std1_Time_Impl1_DeepModel
   val deep_model (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . ([#"../../../../creusot-contracts/src/std/time.rs" 24 14 24 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 23 14 23 77] deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999)
 end
 module Duration_TestDuration_Interface
   val test_duration [#"../duration.rs" 7 0 7 22] (_1' : ()) : ()

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -207,7 +207,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -221,7 +221,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
@@ -237,7 +237,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -289,7 +289,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -339,7 +339,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -367,7 +367,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -385,7 +385,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_InBounds_Stub
@@ -475,8 +475,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Alloc_Vec_FromElem_Interface
@@ -496,8 +496,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -523,7 +523,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -590,11 +590,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -617,7 +617,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -642,7 +642,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -667,7 +667,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -683,7 +683,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -157,7 +157,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -192,7 +192,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -348,7 +348,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -362,7 +362,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Hashmap_Impl4_BucketIx_Stub
   type k
@@ -460,7 +460,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -677,8 +677,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module Hashmap_Impl5_New_Interface
@@ -845,7 +845,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -864,7 +864,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -892,7 +892,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -910,7 +910,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Hashmap_Hash_Hash_Interface
@@ -1054,11 +1054,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Core_Cmp_PartialEq_Eq_Interface
@@ -1074,7 +1074,7 @@ module Core_Cmp_PartialEq_Eq_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : self) (other : rhs) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -1097,7 +1097,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1122,7 +1122,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -1147,7 +1147,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -1573,8 +1573,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Hashmap_Impl5_Get_Interface
@@ -1889,7 +1889,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1898,8 +1898,8 @@ module Core_Mem_Replace_Interface
   type t
   use prelude.Borrow
   val replace (dest : borrowed t) (src : t) : t
-    ensures {  ^ dest = src }
-    ensures { result =  * dest }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 7 22 7 34]  ^ dest = src }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 8 22 8 37] result =  * dest }
     
 end
 module Hashmap_Impl5_Resize_Interface

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -54,7 +54,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -101,7 +101,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -114,7 +114,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub
   type self
@@ -130,7 +130,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -152,7 +152,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -165,7 +165,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -181,7 +181,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -203,7 +203,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -216,7 +216,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -232,7 +232,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -254,7 +254,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -267,7 +267,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -282,7 +282,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -293,7 +293,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -308,7 +308,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -317,11 +317,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -336,7 +336,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -345,10 +345,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -363,7 +363,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -372,10 +372,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -390,7 +390,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -401,7 +401,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module HeapsortGeneric_HeapFragMax_Stub
   type t
@@ -567,7 +567,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -620,7 +620,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -689,7 +689,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -703,7 +703,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Logic_Ops_Impl0_IndexLogic_Stub
   type t
@@ -727,7 +727,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -775,7 +775,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Vec_Impl1_DeepModel
   type t
@@ -801,7 +801,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel
   val deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Logic_Seq_Impl0_PermutationOf_Stub
   type t
@@ -818,7 +818,7 @@ module CreusotContracts_Logic_Seq_Impl0_PermutationOf
   use seq.Seq
   use seq.Permut
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) =
-    Permut.permut self o 0 (Seq.length self)
+    [#"../../../../creusot-contracts/src/logic/seq.rs" 89 8 89 37] Permut.permut self o 0 (Seq.length self)
   val permutation_of (self : Seq.seq t) (o : Seq.seq t) : bool
     ensures { result = permutation_of self o }
     
@@ -851,7 +851,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -879,7 +879,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -898,7 +898,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -1005,8 +1005,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_Impl0_DeepModel_Stub
@@ -1032,7 +1032,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -1052,7 +1052,7 @@ module Core_Cmp_PartialOrd_Lt_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val lt (self : self) (other : rhs) : bool
-    ensures { result = LtLog0.lt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 27 26 27 76] result = LtLog0.lt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module Core_Cmp_PartialOrd_Le_Interface
@@ -1070,7 +1070,7 @@ module Core_Cmp_PartialOrd_Le_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val le (self : self) (other : rhs) : bool
-    ensures { result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 30 26 30 77] result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -1090,7 +1090,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -1103,7 +1103,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module Alloc_Vec_Impl10_DerefMut_Interface
   type t
@@ -1130,8 +1130,8 @@ module Alloc_Vec_Impl10_DerefMut_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : borrowed (slice t)
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
-    ensures { ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 138 26 138 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 139 26 139 48] ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
     
 end
 module Core_Slice_Impl0_Swap_Interface
@@ -1152,9 +1152,9 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
-    ensures { Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 213 19 213 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 214 19 214 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 215 8 215 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -1177,7 +1177,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1202,7 +1202,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -1735,7 +1735,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module HeapsortGeneric_HeapSort_Interface

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -63,7 +63,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -77,7 +77,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -127,7 +127,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -154,7 +154,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -187,7 +187,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -215,7 +215,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -249,7 +249,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -267,7 +267,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -287,7 +287,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module Hillel_RightPad_Interface
@@ -485,10 +485,10 @@ module Alloc_Vec_Impl1_Insert_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val insert (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : usize) (element : t) : ()
-    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int index -> IndexLogic0.index_logic ( ^ self) i = IndexLogic1.index_logic self i }
-    ensures { IndexLogic0.index_logic ( ^ self) (UIntSize.to_int index) = element }
-    ensures { forall i : int . UIntSize.to_int index < i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ self)) -> IndexLogic0.index_logic ( ^ self) i = IndexLogic1.index_logic self (i - 1) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 82 26 82 59] Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 83 16 83 89] forall i : int . 0 <= i /\ i < UIntSize.to_int index -> IndexLogic0.index_logic ( ^ self) i = IndexLogic1.index_logic self i }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 84 26 84 52] IndexLogic0.index_logic ( ^ self) (UIntSize.to_int index) = element }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 85 16 85 105] forall i : int . UIntSize.to_int index < i /\ i < Seq.length (ShallowModel0.shallow_model ( ^ self)) -> IndexLogic0.index_logic ( ^ self) i = IndexLogic1.index_logic self (i - 1) }
     
 end
 module CreusotContracts_Std1_Num_Impl15_ShallowModel_Stub
@@ -856,7 +856,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -904,7 +904,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Vec_Impl1_DeepModel
   type t
@@ -930,7 +930,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel
   val deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module Core_Slice_Iter_Iter_Type
   use prelude.Opaque
@@ -963,7 +963,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -1021,7 +1021,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function to_ref_seq (self : slice t) : Seq.seq t
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   type t
@@ -1040,7 +1040,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   val to_ref_seq (self : slice t) : Seq.seq t
     ensures { result = to_ref_seq self }
     
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl15_Produces_Stub
   type t
@@ -1081,7 +1081,7 @@ module CreusotContracts_Std1_Slice_Impl15_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../creusot-contracts/src/std/slice.rs" 348 12 348 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -1109,7 +1109,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -1129,7 +1129,7 @@ module Alloc_Vec_Impl9_Deref_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref (self : Alloc_Vec_Vec_Type.t_vec t a) : slice t
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 133 26 133 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     
 end
 module Core_Slice_Impl0_Iter_Interface
@@ -1140,7 +1140,7 @@ module Core_Slice_Impl0_Iter_Interface
   clone CreusotContracts_Std1_Slice_Impl13_ShallowModel_Stub as ShallowModel0 with
     type t = t
   val iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
-    ensures { ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] ShallowModel0.shallow_model result = self }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -1154,7 +1154,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -1194,9 +1194,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -1217,7 +1217,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -1230,7 +1230,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl15_Completed_Stub
   type t
@@ -1261,7 +1261,7 @@ module CreusotContracts_Std1_Slice_Impl15_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../creusot-contracts/src/std/slice.rs" 342 20 342 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -1283,7 +1283,7 @@ module Core_Slice_Iter_Impl181_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Slice_Iter_Iter_Type.t_iter t
   val next (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -1302,7 +1302,7 @@ module Core_Cmp_Impls_Impl9_Eq_Interface
     type t = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : a) (other : b) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -1318,7 +1318,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -1334,7 +1334,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -1350,18 +1350,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesRefl_Stub
   type t
@@ -1378,7 +1378,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl_Interface
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   type t
@@ -1387,11 +1387,11 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/slice.rs" 352 4 352 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Stub
   type t
@@ -1412,7 +1412,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Interface
     type t = t
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   type t
@@ -1424,13 +1424,13 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/slice.rs" 356 4 356 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module Hillel_InsertUnique_Interface
   type t
@@ -1871,7 +1871,7 @@ module CreusotContracts_Logic_Seq_Impl0_New
   type t
   use seq.Seq
   function new (_1' : ()) : Seq.seq t =
-    Seq.empty 
+    [#"../../../../creusot-contracts/src/logic/seq.rs" 14 8 14 19] Seq.empty 
   val new (_1' : ()) : Seq.seq t
     ensures { result = new _1' }
     
@@ -1902,7 +1902,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -1937,7 +1937,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -1954,7 +1954,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module Core_Slice_Impl0_Len_Interface
@@ -1969,7 +1969,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : slice t) : usize
-    ensures { Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub
@@ -2028,7 +2028,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -2073,7 +2073,7 @@ module CreusotContracts_Std1_Slice_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : slice t) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 30 4 30 95] forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 29 14 29 41] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Slice_Impl1_DeepModel
   type t
@@ -2097,7 +2097,7 @@ module CreusotContracts_Std1_Slice_Impl1_DeepModel
   val deep_model (self : slice t) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 30 4 30 95] forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/slice.rs" 29 14 29 41] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -2114,7 +2114,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -2123,11 +2123,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -2146,7 +2146,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -2157,13 +2157,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -2179,7 +2179,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -2208,7 +2208,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -2686,7 +2686,7 @@ end
 module CreusotContracts_Logic_Int_Impl0_AbsDiff
   use prelude.Int
   function abs_diff (self : int) (other : int) : int =
-    if self < other then other - self else self - other
+    [#"../../../../creusot-contracts/src/logic/int.rs" 45 4 45 12] if self < other then other - self else self - other
   val abs_diff (self : int) (other : int) : int
     ensures { result = abs_diff self other }
     
@@ -2761,7 +2761,7 @@ module CreusotContracts_Std1_Slice_Impl11_IntoIterPre
   use prelude.Borrow
   use prelude.Slice
   predicate into_iter_pre (self : slice t) =
-    true
+    [#"../../../../creusot-contracts/src/std/slice.rs" 306 20 306 24] true
   val into_iter_pre (self : slice t) : bool
     ensures { result = into_iter_pre self }
     
@@ -2788,7 +2788,7 @@ module CreusotContracts_Std1_Slice_Impl11_IntoIterPost
   clone CreusotContracts_Std1_Slice_Impl13_ShallowModel_Stub as ShallowModel0 with
     type t = t
   predicate into_iter_post (self : slice t) (res : Core_Slice_Iter_Iter_Type.t_iter t) =
-    self = ShallowModel0.shallow_model res
+    [#"../../../../creusot-contracts/src/std/slice.rs" 311 20 311 32] self = ShallowModel0.shallow_model res
   val into_iter_post (self : slice t) (res : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = into_iter_post self res }
     
@@ -2805,8 +2805,8 @@ module Core_Slice_Iter_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Slice_Impl11_IntoIterPre_Stub as IntoIterPre0 with
     type t = t
   val into_iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
-    requires {IntoIterPre0.into_iter_pre self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -2815,7 +2815,7 @@ module Core_Num_Impl8_AbsDiff_Interface
   use prelude.Int
   clone CreusotContracts_Logic_Int_Impl0_AbsDiff_Stub as AbsDiff0
   val abs_diff (self : uint32) (other : uint32) : uint32
-    ensures { UInt32.to_int result = AbsDiff0.abs_diff (UInt32.to_int self) (UInt32.to_int other) }
+    ensures { [#"../../../../creusot-contracts/src/std/num.rs" 209 26 209 59] UInt32.to_int result = AbsDiff0.abs_diff (UInt32.to_int self) (UInt32.to_int other) }
     
 end
 module Hillel_Fulcrum_Interface

--- a/creusot/tests/should_succeed/immut.mlcfg
+++ b/creusot/tests/should_succeed/immut.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -63,7 +63,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -77,7 +77,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -126,7 +126,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -181,7 +181,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -198,7 +198,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -224,7 +224,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -246,7 +246,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -260,7 +260,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -421,7 +421,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -449,7 +449,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -541,8 +541,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Core_Slice_Impl0_Len_Interface
@@ -557,7 +557,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : slice t) : usize
-    ensures { Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module Alloc_Vec_Impl9_Deref_Interface
@@ -575,7 +575,7 @@ module Alloc_Vec_Impl9_Deref_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref (self : Alloc_Vec_Vec_Type.t_vec t a) : slice t
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 133 26 133 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     
 end
 module Core_Slice_Impl0_Get_Interface
@@ -602,8 +602,8 @@ module Core_Slice_Impl0_Get_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val get (self : slice t) (index : i) : Core_Option_Option_Type.t_option Output0.output
-    ensures { InBounds0.in_bounds index (ShallowModel0.shallow_model self) -> (exists r : Output0.output . result = Core_Option_Option_Type.C_Some r /\ HasValue0.has_value index (ShallowModel0.shallow_model self) r) }
-    ensures { InBounds0.in_bounds index (ShallowModel0.shallow_model self) \/ result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 218 8 218 102] InBounds0.in_bounds index (ShallowModel0.shallow_model self) -> (exists r : Output0.output . result = Core_Option_Option_Type.C_Some r /\ HasValue0.has_value index (ShallowModel0.shallow_model self) r) }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 219 18 219 55] InBounds0.in_bounds index (ShallowModel0.shallow_model self) \/ result = Core_Option_Option_Type.C_None }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -611,7 +611,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_ResolveElswhere_Stub
@@ -676,11 +676,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -696,7 +696,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl6_InBounds_Stub
@@ -722,7 +722,7 @@ module CreusotContracts_Std1_Slice_Impl6_InBounds
   use seq.Seq
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
   predicate in_bounds (self : Core_Ops_Range_Range_Type.t_range usize) (seq : Seq.seq t) =
-    UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self) <= UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) /\ UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) <= Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 121 20 121 70] UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self) <= UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) /\ UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) <= Seq.length seq
   val in_bounds (self : Core_Ops_Range_Range_Type.t_range usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -744,7 +744,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -757,7 +757,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl6_HasValue_Stub
   type t
@@ -791,7 +791,7 @@ module CreusotContracts_Std1_Slice_Impl6_HasValue
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
   predicate has_value (self : Core_Ops_Range_Range_Type.t_range usize) (seq : Seq.seq t) (out : slice t) =
-    SeqExt.subsequence seq (UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self)) (UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self)) = ShallowModel0.shallow_model out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 126 20 126 67] SeqExt.subsequence seq (UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self)) (UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self)) = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_Range_Type.t_range usize) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -819,7 +819,7 @@ module CreusotContracts_Std1_Slice_Impl6_ResolveElswhere
   use seq.Seq
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
   predicate resolve_elswhere (self : Core_Ops_Range_Range_Type.t_range usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ (i < UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self) \/ UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) <= i) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 131 8 134 9] forall i : int . 0 <= i /\ (i < UIntSize.to_int (Core_Ops_Range_Range_Type.range_start self) \/ UIntSize.to_int (Core_Ops_Range_Range_Type.range_end self) <= i) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere (self : Core_Ops_Range_Range_Type.t_range usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -844,7 +844,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -869,7 +869,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -1694,7 +1694,7 @@ module CreusotContracts_Std1_Slice_Impl7_InBounds
   use seq.Seq
   use Core_Ops_Range_RangeTo_Type as Core_Ops_Range_RangeTo_Type
   predicate in_bounds (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (seq : Seq.seq t) =
-    UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self) <= Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 141 20 141 42] UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self) <= Seq.length seq
   val in_bounds (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1731,7 +1731,7 @@ module CreusotContracts_Std1_Slice_Impl7_HasValue
     axiom .
   use Core_Ops_Range_RangeTo_Type as Core_Ops_Range_RangeTo_Type
   predicate has_value (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (seq : Seq.seq t) (out : slice t) =
-    SeqExt.subsequence seq 0 (UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self)) = ShallowModel0.shallow_model out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 146 20 146 57] SeqExt.subsequence seq 0 (UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self)) = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -1759,7 +1759,7 @@ module CreusotContracts_Std1_Slice_Impl7_ResolveElswhere
   use seq.Seq
   use Core_Ops_Range_RangeTo_Type as Core_Ops_Range_RangeTo_Type
   predicate resolve_elswhere (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self) <= i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 151 8 151 90] forall i : int . UIntSize.to_int (Core_Ops_Range_RangeTo_Type.rangeto_end self) <= i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere (self : Core_Ops_Range_RangeTo_Type.t_rangeto usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -2342,7 +2342,7 @@ module CreusotContracts_Std1_Slice_Impl8_InBounds
   use seq.Seq
   use Core_Ops_Range_RangeFrom_Type as Core_Ops_Range_RangeFrom_Type
   predicate in_bounds (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (seq : Seq.seq t) =
-    UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self) <= Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 158 20 158 44] UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self) <= Seq.length seq
   val in_bounds (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -2379,7 +2379,7 @@ module CreusotContracts_Std1_Slice_Impl8_HasValue
     axiom .
   use Core_Ops_Range_RangeFrom_Type as Core_Ops_Range_RangeFrom_Type
   predicate has_value (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (seq : Seq.seq t) (out : slice t) =
-    SeqExt.subsequence seq (UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self)) (Seq.length seq) = ShallowModel0.shallow_model out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 163 20 163 67] SeqExt.subsequence seq (UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self)) (Seq.length seq) = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -2411,7 +2411,7 @@ module CreusotContracts_Std1_Slice_Impl8_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : int . 0 <= i /\ i < UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 168 8 170 9] forall i : int . 0 <= i /\ i < UIntSize.to_int (Core_Ops_Range_RangeFrom_Type.rangefrom_start self) /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere (self : Core_Ops_Range_RangeFrom_Type.t_rangefrom usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -3023,7 +3023,7 @@ module CreusotContracts_Std1_Slice_Impl9_InBounds
   use seq.Seq
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate in_bounds (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_seq : Seq.seq t) =
-    true
+    [#"../../../../creusot-contracts/src/std/slice.rs" 177 20 177 24] true
   val in_bounds (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_seq : Seq.seq t) : bool
     ensures { result = in_bounds self _seq }
     
@@ -3053,7 +3053,7 @@ module CreusotContracts_Std1_Slice_Impl9_HasValue
     axiom .
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate has_value (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (seq : Seq.seq t) (out : slice t) =
-    seq = ShallowModel0.shallow_model out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 182 20 182 31] seq = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -3075,7 +3075,7 @@ module CreusotContracts_Std1_Slice_Impl9_ResolveElswhere
   use seq.Seq
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate resolve_elswhere (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_old : Seq.seq t) (_fin : Seq.seq t) =
-    true
+    [#"../../../../creusot-contracts/src/std/slice.rs" 187 20 187 24] true
   val resolve_elswhere (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_old : Seq.seq t) (_fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self _old _fin }
     
@@ -3634,7 +3634,7 @@ module CreusotContracts_Std1_Slice_Impl10_InBounds
   use seq.Seq
   use Core_Ops_Range_RangeToInclusive_Type as Core_Ops_Range_RangeToInclusive_Type
   predicate in_bounds (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (seq : Seq.seq t) =
-    UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 194 20 194 41] UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) < Seq.length seq
   val in_bounds (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -3675,7 +3675,7 @@ module CreusotContracts_Std1_Slice_Impl10_HasValue
   predicate has_value (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (seq : Seq.seq t) (out : slice t)
     
    =
-    SeqExt.subsequence seq 0 (UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) + 1) = ShallowModel0.shallow_model out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 199 20 199 61] SeqExt.subsequence seq 0 (UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) + 1) = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -3707,7 +3707,7 @@ module CreusotContracts_Std1_Slice_Impl10_ResolveElswhere
   predicate resolve_elswhere (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (old' : Seq.seq t) (fin : Seq.seq t)
     
    =
-    forall i : int . UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) < i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 204 8 204 89] forall i : int . UIntSize.to_int (Core_Ops_Range_RangeToInclusive_Type.rangetoinclusive_end self) < i /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere (self : Core_Ops_Range_RangeToInclusive_Type.t_rangetoinclusive usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     

--- a/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
+++ b/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
@@ -65,7 +65,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -74,8 +74,8 @@ module Core_Mem_Replace_Interface
   type t
   use prelude.Borrow
   val replace (dest : borrowed t) (src : t) : t
-    ensures {  ^ dest = src }
-    ensures { result =  * dest }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 7 22 7 34]  ^ dest = src }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 8 22 8 37] result =  * dest }
     
 end
 module Core_Ptr_NonNull_NonNull_Type

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -56,7 +56,7 @@ module CreusotContracts_Std1_Time_Impl2_ShallowModel_Interface
   use prelude.Int
   use Std_Time_Instant_Type as Std_Time_Instant_Type
   function shallow_model (self : Std_Time_Instant_Type.t_instant) : int
-  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . shallow_model self >= 0
+  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . [#"../../../../creusot-contracts/src/std/time.rs" 54 14 54 25] shallow_model self >= 0
 end
 module CreusotContracts_Std1_Time_Impl2_ShallowModel
   use prelude.Int
@@ -65,7 +65,7 @@ module CreusotContracts_Std1_Time_Impl2_ShallowModel
   val shallow_model (self : Std_Time_Instant_Type.t_instant) : int
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . shallow_model self >= 0
+  axiom shallow_model_spec : forall self : Std_Time_Instant_Type.t_instant . [#"../../../../creusot-contracts/src/std/time.rs" 54 14 54 25] shallow_model self >= 0
 end
 module Std_Time_Impl0_Now_Interface
   use prelude.Int
@@ -73,7 +73,7 @@ module Std_Time_Impl0_Now_Interface
   clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
     axiom .
   val now (_1' : ()) : Std_Time_Instant_Type.t_instant
-    ensures { ShallowModel0.shallow_model result >= 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 139 26 139 38] ShallowModel0.shallow_model result >= 0 }
     
 end
 module CreusotContracts_Std1_Time_SecsToNanos_Stub
@@ -87,7 +87,7 @@ end
 module CreusotContracts_Std1_Time_SecsToNanos
   use prelude.Int
   function secs_to_nanos (secs : int) : int =
-    secs * 1000000000
+    [#"../../../../creusot-contracts/src/std/time.rs" 46 4 46 24] secs * 1000000000
   val secs_to_nanos (secs : int) : int
     ensures { result = secs_to_nanos secs }
     
@@ -118,7 +118,7 @@ module CreusotContracts_Std1_Time_Impl0_ShallowModel_Interface
   clone CreusotContracts_Std1_Time_SecsToNanos_Stub as SecsToNanos0
   clone Core_Num_Impl9_Max_Stub as Max0
   function shallow_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . [#"../../../../creusot-contracts/src/std/time.rs" 12 14 12 77] shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel
   use prelude.Int
@@ -130,7 +130,7 @@ module CreusotContracts_Std1_Time_Impl0_ShallowModel
   val shallow_model (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom shallow_model_spec : forall self : Core_Time_Duration_Type.t_duration . [#"../../../../creusot-contracts/src/std/time.rs" 12 14 12 77] shallow_model self >= 0 /\ shallow_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
 end
 module Core_Time_Impl1_FromSecs_Interface
   use prelude.UInt64
@@ -143,7 +143,7 @@ module Core_Time_Impl1_FromSecs_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val from_secs (secs : uint64) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 80 26 80 57] ShallowModel0.shallow_model result = SecsToNanos0.secs_to_nanos (UInt64.to_int secs) }
     
 end
 module Std_Time_Impl0_Elapsed_Interface
@@ -158,7 +158,7 @@ module Std_Time_Impl0_Elapsed_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val elapsed (self : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model result >= 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 142 26 142 38] ShallowModel0.shallow_model result >= 0 }
     
 end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
@@ -209,7 +209,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -253,7 +253,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -273,7 +273,7 @@ module Core_Cmp_PartialOrd_Ge_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val ge (self : self) (other : rhs) : bool
-    ensures { result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 36 26 36 77] result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Option_Impl0_DeepModel_Stub
@@ -303,7 +303,7 @@ module CreusotContracts_Std1_Option_Impl0_DeepModel
   function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
     
    =
-    match (self) with
+    [#"../../../../creusot-contracts/src/std/option.rs" 9 8 12 9] match (self) with
       | Core_Option_Option_Type.C_Some t -> Core_Option_Option_Type.C_Some (DeepModel0.deep_model t)
       | Core_Option_Option_Type.C_None -> Core_Option_Option_Type.C_None
       end
@@ -359,7 +359,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -378,7 +378,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -405,16 +405,16 @@ module Std_Time_Impl0_CheckedAdd_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_add (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
-    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
-    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> LtLog0.lt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 157 16 157 81] ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 158 16 158 97] ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> LtLog0.lt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap (self : Core_Option_Option_Type.t_option t) : t
-    requires {self <> Core_Option_Option_Type.C_None}
-    ensures { Core_Option_Option_Type.C_Some result = self }
+    requires {[#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self <> Core_Option_Option_Type.C_None}
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] Core_Option_Option_Type.C_Some result = self }
     
 end
 module Std_Time_Impl21_Eq_Interface
@@ -426,7 +426,7 @@ module Std_Time_Impl21_Eq_Interface
     type t = Std_Time_Instant_Type.t_instant,
     type DeepModelTy0.deepModelTy = int
   val eq (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
     
 end
 module Std_Time_Impl1_Add_Interface
@@ -442,8 +442,8 @@ module Std_Time_Impl1_Add_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val add (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
-    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
-    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self < ShallowModel1.shallow_model result }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 183 8 183 50] ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 184 8 184 48] ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self < ShallowModel1.shallow_model result }
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
@@ -460,7 +460,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -487,8 +487,8 @@ module Std_Time_Impl0_CheckedSub_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val checked_sub (self : Std_Time_Instant_Type.t_instant) (duration : Core_Time_Duration_Type.t_duration) : Core_Option_Option_Type.t_option (Std_Time_Instant_Type.t_instant)
-    ensures { ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
-    ensures { ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> GtLog0.gt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 161 16 161 81] ShallowModel0.shallow_model duration = 0 -> DeepModel0.deep_model result = Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 162 16 162 97] ShallowModel0.shallow_model duration > 0 /\ result <> Core_Option_Option_Type.C_None -> GtLog0.gt_log (Core_Option_Option_Type.C_Some (ShallowModel1.shallow_model self)) (DeepModel0.deep_model result) }
     
 end
 module Std_Time_Impl3_Sub_Interface
@@ -504,8 +504,8 @@ module Std_Time_Impl3_Sub_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   val sub (self : Std_Time_Instant_Type.t_instant) (other : Core_Time_Duration_Type.t_duration) : Std_Time_Instant_Type.t_instant
-    ensures { ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
-    ensures { ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self > ShallowModel1.shallow_model result }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 189 8 189 50] ShallowModel0.shallow_model other = 0 -> ShallowModel1.shallow_model self = ShallowModel1.shallow_model result }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 190 8 190 48] ShallowModel0.shallow_model other > 0 -> ShallowModel1.shallow_model self > ShallowModel1.shallow_model result }
     
 end
 module Std_Time_Impl5_Sub_Interface
@@ -521,8 +521,8 @@ module Std_Time_Impl5_Sub_Interface
   clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
     axiom .
   val sub (self : Std_Time_Instant_Type.t_instant) (other : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model self > ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result > 0 }
-    ensures { ShallowModel0.shallow_model self <= ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 195 8 195 50] ShallowModel0.shallow_model self > ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result > 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 196 8 196 52] ShallowModel0.shallow_model self <= ShallowModel0.shallow_model other -> ShallowModel1.shallow_model result = 0 }
     
 end
 module Core_Time_Impl29_Eq_Interface
@@ -534,7 +534,7 @@ module Core_Time_Impl29_Eq_Interface
     type t = Core_Time_Duration_Type.t_duration,
     type DeepModelTy0.deepModelTy = int
   val eq (self : Core_Time_Duration_Type.t_duration) (other : Core_Time_Duration_Type.t_duration) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
     
 end
 module Core_Cmp_PartialOrd_Gt_Interface
@@ -552,7 +552,7 @@ module Core_Cmp_PartialOrd_Gt_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val gt (self : self) (other : rhs) : bool
-    ensures { result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 33 26 33 76] result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module Std_Time_Impl0_DurationSince_Interface
@@ -573,8 +573,8 @@ module Std_Time_Impl0_DurationSince_Interface
     type t = Std_Time_Instant_Type.t_instant,
     type ShallowModelTy0.shallowModelTy = int
   val duration_since (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
-    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 145 16 145 60] ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 146 16 146 62] ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
     
 end
 module Std_Time_Impl0_CheckedDurationSince_Interface
@@ -590,8 +590,8 @@ module Std_Time_Impl0_CheckedDurationSince_Interface
     type t = Std_Time_Instant_Type.t_instant,
     type ShallowModelTy0.shallowModelTy = int
   val checked_duration_since (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Option_Option_Type.t_option (Core_Time_Duration_Type.t_duration)
-    ensures { ShallowModel0.shallow_model self >= ShallowModel1.shallow_model earlier -> result <> Core_Option_Option_Type.C_None }
-    ensures { ShallowModel0.shallow_model self < ShallowModel1.shallow_model earlier -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 149 16 149 64] ShallowModel0.shallow_model self >= ShallowModel1.shallow_model earlier -> result <> Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 150 16 150 63] ShallowModel0.shallow_model self < ShallowModel1.shallow_model earlier -> result = Core_Option_Option_Type.C_None }
     
 end
 module Core_Option_Impl0_IsSome_Interface
@@ -599,7 +599,7 @@ module Core_Option_Impl0_IsSome_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_some (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self <> Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 20 26 20 51] result = (self <> Core_Option_Option_Type.C_None) }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -607,7 +607,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module Std_Time_Impl0_SaturatingDurationSince_Interface
@@ -628,8 +628,8 @@ module Std_Time_Impl0_SaturatingDurationSince_Interface
     type t = Std_Time_Instant_Type.t_instant,
     type ShallowModelTy0.shallowModelTy = int
   val saturating_duration_since (self : Std_Time_Instant_Type.t_instant) (earlier : Std_Time_Instant_Type.t_instant) : Core_Time_Duration_Type.t_duration
-    ensures { ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
-    ensures { ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 153 16 153 60] ShallowModel0.shallow_model self > ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result > 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/time.rs" 154 16 154 62] ShallowModel0.shallow_model self <= ShallowModel1.shallow_model earlier -> ShallowModel2.shallow_model result = 0 }
     
 end
 module CreusotContracts_Logic_Ord_Impl2_GeLog_Stub
@@ -689,7 +689,7 @@ module CreusotContracts_Std1_Time_Impl1_DeepModel_Interface
     function SecsToNanos0.secs_to_nanos = SecsToNanos0.secs_to_nanos,
     axiom .
   function deep_model (self : Core_Time_Duration_Type.t_duration) : int
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . ([#"../../../../creusot-contracts/src/std/time.rs" 24 14 24 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 23 14 23 77] deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999)
 end
 module CreusotContracts_Std1_Time_Impl1_DeepModel
   use prelude.Int
@@ -705,7 +705,7 @@ module CreusotContracts_Std1_Time_Impl1_DeepModel
   val deep_model (self : Core_Time_Duration_Type.t_duration) : int
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999
+  axiom deep_model_spec : forall self : Core_Time_Duration_Type.t_duration . ([#"../../../../creusot-contracts/src/std/time.rs" 24 14 24 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 23 14 23 77] deep_model self >= 0 /\ deep_model self <= SecsToNanos0.secs_to_nanos (UInt64.to_int Max0.mAX') + 999999999)
 end
 module CreusotContracts_Std1_Time_Impl3_DeepModel_Stub
   use prelude.Int
@@ -720,7 +720,7 @@ module CreusotContracts_Std1_Time_Impl3_DeepModel_Interface
   clone CreusotContracts_Std1_Time_Impl2_ShallowModel_Stub as ShallowModel0 with
     axiom .
   function deep_model (self : Std_Time_Instant_Type.t_instant) : int
-  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0
+  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . ([#"../../../../creusot-contracts/src/std/time.rs" 66 14 66 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 65 14 65 25] deep_model self >= 0)
 end
 module CreusotContracts_Std1_Time_Impl3_DeepModel
   use prelude.Int
@@ -731,7 +731,7 @@ module CreusotContracts_Std1_Time_Impl3_DeepModel
   val deep_model (self : Std_Time_Instant_Type.t_instant) : int
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . deep_model self = ShallowModel0.shallow_model self && deep_model self >= 0
+  axiom deep_model_spec : forall self : Std_Time_Instant_Type.t_instant . ([#"../../../../creusot-contracts/src/std/time.rs" 66 14 66 44] deep_model self = ShallowModel0.shallow_model self) && ([#"../../../../creusot-contracts/src/std/time.rs" 65 14 65 25] deep_model self >= 0)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub
   type self
@@ -747,7 +747,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -769,7 +769,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -782,7 +782,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -801,7 +801,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -814,7 +814,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Stub
   type self
@@ -833,7 +833,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -846,7 +846,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Stub
   type self
@@ -865,7 +865,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -878,7 +878,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -893,7 +893,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -904,7 +904,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -919,7 +919,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -928,11 +928,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -947,7 +947,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -956,10 +956,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -974,7 +974,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -983,10 +983,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -1001,7 +1001,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -1012,7 +1012,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub
   type t
@@ -1037,7 +1037,7 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLog
   function cmp_log (self : Core_Option_Option_Type.t_option t) (o : Core_Option_Option_Type.t_option t) : Core_Cmp_Ordering_Type.t_ordering
     
    =
-    match ((self, o)) with
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 239 8 244 9] match ((self, o)) with
       | (Core_Option_Option_Type.C_None, Core_Option_Option_Type.C_None) -> Core_Cmp_Ordering_Type.C_Equal
       | (Core_Option_Option_Type.C_None, Core_Option_Option_Type.C_Some _) -> Core_Cmp_Ordering_Type.C_Less
       | (Core_Option_Option_Type.C_Some _, Core_Option_Option_Type.C_None) -> Core_Cmp_Ordering_Type.C_Greater
@@ -1066,7 +1066,7 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 248 14 248 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpLeLog
   type t
@@ -1077,11 +1077,11 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 247 4 247 10] ()
   val cmp_le_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 248 14 248 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpLtLog_Stub
   type t
@@ -1102,7 +1102,7 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 252 14 252 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpLtLog
   type t
@@ -1113,11 +1113,11 @@ module CreusotContracts_Logic_Ord_Impl1_CmpLtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 251 4 251 10] ()
   val cmp_lt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 252 14 252 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpGeLog_Stub
   type t
@@ -1138,7 +1138,7 @@ module CreusotContracts_Logic_Ord_Impl1_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 256 14 256 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpGeLog
   type t
@@ -1149,11 +1149,11 @@ module CreusotContracts_Logic_Ord_Impl1_CmpGeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 255 4 255 10] ()
   val cmp_ge_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 256 14 256 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpGtLog_Stub
   type t
@@ -1174,7 +1174,7 @@ module CreusotContracts_Logic_Ord_Impl1_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 260 14 260 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_CmpGtLog
   type t
@@ -1185,11 +1185,11 @@ module CreusotContracts_Logic_Ord_Impl1_CmpGtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = Core_Option_Option_Type.t_option t
   function cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 259 4 259 10] ()
   val cmp_gt_log (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 260 14 260 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_Refl_Stub
   type t
@@ -1206,7 +1206,7 @@ module CreusotContracts_Logic_Ord_Impl1_Refl_Interface
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function refl (x : Core_Option_Option_Type.t_option t) : ()
-  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 264 14 264 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_Impl1_Refl
   type t
@@ -1215,11 +1215,11 @@ module CreusotContracts_Logic_Ord_Impl1_Refl
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function refl (x : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 263 4 263 10] ()
   val refl (x : Core_Option_Option_Type.t_option t) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 264 14 264 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_Impl1_Trans_Stub
   type t
@@ -1238,7 +1238,7 @@ module CreusotContracts_Logic_Ord_Impl1_Trans_Interface
     type t = t
   function trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
     
-  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 268 15 268 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 269 15 269 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 270 14 270 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_Impl1_Trans
   type t
@@ -1249,13 +1249,13 @@ module CreusotContracts_Logic_Ord_Impl1_Trans
   function trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 267 4 267 10] ()
   val trans (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) (z : Core_Option_Option_Type.t_option t) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 268 15 268 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 269 15 269 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t, z : Core_Option_Option_Type.t_option t, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 268 15 268 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 269 15 269 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 270 14 270 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_Impl1_Antisym1_Stub
   type t
@@ -1272,7 +1272,7 @@ module CreusotContracts_Logic_Ord_Impl1_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . ([#"../../../../creusot-contracts/src/logic/ord.rs" 274 15 274 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 275 14 275 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_Antisym1
   type t
@@ -1281,12 +1281,12 @@ module CreusotContracts_Logic_Ord_Impl1_Antisym1
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 273 4 273 10] ()
   val antisym1 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 274 15 274 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . ([#"../../../../creusot-contracts/src/logic/ord.rs" 274 15 274 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 275 14 275 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_Impl1_Antisym2_Stub
   type t
@@ -1303,7 +1303,7 @@ module CreusotContracts_Logic_Ord_Impl1_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . ([#"../../../../creusot-contracts/src/logic/ord.rs" 279 15 279 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 280 14 280 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_Antisym2
   type t
@@ -1312,12 +1312,12 @@ module CreusotContracts_Logic_Ord_Impl1_Antisym2
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 278 4 278 10] ()
   val antisym2 (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 279 15 279 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . ([#"../../../../creusot-contracts/src/logic/ord.rs" 279 15 279 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 280 14 280 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_Impl1_EqCmp_Stub
   type t
@@ -1334,7 +1334,7 @@ module CreusotContracts_Logic_Ord_Impl1_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
-  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 284 14 284 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_Impl1_EqCmp
   type t
@@ -1343,11 +1343,11 @@ module CreusotContracts_Logic_Ord_Impl1_EqCmp
   clone CreusotContracts_Logic_Ord_Impl1_CmpLog_Stub as CmpLog0 with
     type t = t
   function eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : () =
-    ()
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 283 4 283 10] ()
   val eq_cmp (x : Core_Option_Option_Type.t_option t) (y : Core_Option_Option_Type.t_option t) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : Core_Option_Option_Type.t_option t, y : Core_Option_Option_Type.t_option t . [#"../../../../creusot-contracts/src/logic/ord.rs" 284 14 284 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_Impl2_CmpLog_Stub
   use prelude.Int
@@ -1363,7 +1363,7 @@ module CreusotContracts_Logic_Ord_Impl2_CmpLog
   use prelude.Int
   use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
   function cmp_log (self : int) (o : int) : Core_Cmp_Ordering_Type.t_ordering =
-    if self < o then
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 72 12 80 17] if self < o then
       Core_Cmp_Ordering_Type.C_Less
     else
       if self = o then Core_Cmp_Ordering_Type.C_Equal else Core_Cmp_Ordering_Type.C_Greater

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -58,7 +58,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -93,7 +93,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -107,7 +107,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -156,7 +156,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -206,7 +206,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -234,7 +234,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -259,7 +259,7 @@ module Alloc_Vec_Impl1_Pop_Interface
     axiom .
   use Core_Option_Option_Type as Core_Option_Option_Type
   val pop (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 68 26 73 17] match (result) with
       | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 0 (Seq.length (ShallowModel1.shallow_model self) - 1) /\ ShallowModel1.shallow_model self = Seq.snoc (ShallowModel0.shallow_model ( ^ self)) t
       | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
       end }
@@ -276,7 +276,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -67,7 +67,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -120,7 +120,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -205,7 +205,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -290,7 +290,7 @@ module Core_Clone_Impls_Impl5_Clone_Interface
   use prelude.Int
   use prelude.UIntSize
   val clone' (self : usize) : usize
-    ensures { result = self }
+    ensures { [#"../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module Alloc_Boxed_Impl12_Clone_Interface
@@ -969,7 +969,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/iterators/01_range.mlcfg
+++ b/creusot/tests/should_succeed/iterators/01_range.mlcfg
@@ -28,7 +28,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -288,7 +288,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -304,18 +304,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C01Range_SumRange_Interface
   use prelude.IntSize
@@ -459,7 +459,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -51,7 +51,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module C02IterMut_Impl0_Invariant_Stub
   type t
@@ -93,7 +93,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -146,7 +146,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -203,7 +203,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -243,7 +243,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToMutSeq_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function to_mut_seq (self : borrowed (slice t)) : Seq.seq (borrowed t)
-  axiom to_mut_seq_spec : forall self : borrowed (slice t) . (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_mut_seq_spec : forall self : borrowed (slice t) . ([#"../../../../../creusot-contracts/src/std/slice.rs" 70 4 70 85] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 69 4 69 82] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 68 14 68 41] Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToMutSeq
   type t
@@ -265,7 +265,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToMutSeq
   val to_mut_seq (self : borrowed (slice t)) : Seq.seq (borrowed t)
     ensures { result = to_mut_seq self }
     
-  axiom to_mut_seq_spec : forall self : borrowed (slice t) . (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_mut_seq_spec : forall self : borrowed (slice t) . ([#"../../../../../creusot-contracts/src/std/slice.rs" 70 4 70 85] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 69 4 69 82] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 68 14 68 41] Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module C02IterMut_Impl1_Produces_Stub
   type t
@@ -507,7 +507,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -528,7 +528,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -559,7 +559,7 @@ module CreusotContracts_Logic_Seq_Impl0_Tail
   use seq.Seq
   use seq_ext.SeqExt
   function tail (self : Seq.seq t) : Seq.seq t =
-    SeqExt.subsequence self 1 (Seq.length self)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 42 8 42 39] SeqExt.subsequence self 1 (Seq.length self)
   val tail (self : Seq.seq t) : Seq.seq t
     ensures { result = tail self }
     
@@ -582,7 +582,7 @@ module Core_Slice_Impl0_TakeFirstMut_Interface
     type s = slice t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val take_first_mut (self : borrowed (borrowed (slice t))) : Core_Option_Option_Type.t_option (borrowed t)
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 242 18 251 9] match (result) with
       | Core_Option_Option_Type.C_Some r ->  * r = IndexLogic0.index_logic ( *  * self) 0 /\  ^ r = IndexLogic0.index_logic ( ^  * self) 0 /\ Seq.length (ShallowModel0.shallow_model ( *  * self)) > 0 /\ Seq.length (ShallowModel0.shallow_model ( ^  * self)) > 0 /\ Seq.(==) (ShallowModel0.shallow_model ( *  ^ self)) (Tail0.tail (ShallowModel0.shallow_model ( *  * self))) /\ Seq.(==) (ShallowModel0.shallow_model ( ^  ^ self)) (Tail0.tail (ShallowModel0.shallow_model ( ^  * self)))
       | Core_Option_Option_Type.C_None ->  ^ self =  * self /\ Seq.length (ShallowModel0.shallow_model ( *  * self)) = 0
       end }
@@ -810,7 +810,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -824,7 +824,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Alloc_Global_Type
   type t_global  =
@@ -960,11 +960,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl9_InBounds_Stub
@@ -984,7 +984,7 @@ module CreusotContracts_Std1_Slice_Impl9_InBounds
   use seq.Seq
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate in_bounds (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_seq : Seq.seq t) =
-    true
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 177 20 177 24] true
   val in_bounds (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_seq : Seq.seq t) : bool
     ensures { result = in_bounds self _seq }
     
@@ -1014,7 +1014,7 @@ module CreusotContracts_Std1_Slice_Impl9_HasValue
     axiom .
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate has_value (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (seq : Seq.seq t) (out : slice t) =
-    seq = ShallowModel0.shallow_model out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 182 20 182 31] seq = ShallowModel0.shallow_model out
   val has_value (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (seq : Seq.seq t) (out : slice t) : bool
     ensures { result = has_value self seq out }
     
@@ -1036,7 +1036,7 @@ module CreusotContracts_Std1_Slice_Impl9_ResolveElswhere
   use seq.Seq
   use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
   predicate resolve_elswhere (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_old : Seq.seq t) (_fin : Seq.seq t) =
-    true
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 187 20 187 24] true
   val resolve_elswhere (self : Core_Ops_Range_RangeFull_Type.t_rangefull) (_old : Seq.seq t) (_fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self _old _fin }
     

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -109,7 +109,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -160,7 +160,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -194,7 +194,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function to_ref_seq (self : slice t) : Seq.seq t
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   type t
@@ -213,7 +213,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   val to_ref_seq (self : slice t) : Seq.seq t
     ensures { result = to_ref_seq self }
     
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl15_Produces_Stub
   type t
@@ -254,7 +254,7 @@ module CreusotContracts_Std1_Slice_Impl15_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 348 12 348 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -273,7 +273,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -286,7 +286,7 @@ module Core_Slice_Impl0_Iter_Interface
   clone CreusotContracts_Std1_Slice_Impl13_ShallowModel_Stub as ShallowModel0 with
     type t = t
   val iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
-    ensures { ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] ShallowModel0.shallow_model result = self }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -300,7 +300,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -340,9 +340,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -369,7 +369,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -402,7 +402,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -415,7 +415,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl15_Completed_Stub
   type t
@@ -446,7 +446,7 @@ module CreusotContracts_Std1_Slice_Impl15_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 342 20 342 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -468,7 +468,7 @@ module Core_Slice_Iter_Impl181_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Slice_Iter_Iter_Type.t_iter t
   val next (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -487,7 +487,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -503,7 +503,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -519,18 +519,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesRefl_Stub
   type t
@@ -547,7 +547,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl_Interface
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   type t
@@ -556,11 +556,11 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 352 4 352 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Stub
   type t
@@ -581,7 +581,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Interface
     type t = t
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   type t
@@ -593,13 +593,13 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 356 4 356 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_SliceIter_Interface
   type t
@@ -860,7 +860,7 @@ module CreusotContracts_Std1_Vec_Impl4_IntoIterPre
   use prelude.Borrow
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   predicate into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) =
-    true
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 165 20 165 24] true
   val into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) : bool
     ensures { result = into_iter_pre self }
     
@@ -899,7 +899,7 @@ module CreusotContracts_Std1_Vec_Impl4_IntoIterPost
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   predicate into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Core_Slice_Iter_Iter_Type.t_iter t) =
-    ShallowModel0.shallow_model self = ShallowModel2.shallow_model (ShallowModel1.shallow_model res)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 170 20 170 34] ShallowModel0.shallow_model self = ShallowModel2.shallow_model (ShallowModel1.shallow_model res)
   val into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = into_iter_post self res }
     
@@ -919,8 +919,8 @@ module Alloc_Vec_Impl17_IntoIter_Interface
     type t = t,
     type a = a
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
-    requires {IntoIterPre0.into_iter_pre self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -943,7 +943,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -957,7 +957,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module C03StdIterators_VecIter_Interface
   type t
@@ -1214,7 +1214,7 @@ module CreusotContracts_Std1_Slice_Impl16_ShallowModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
-  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self))
+  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 368 14 368 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl16_ShallowModel
   type t
@@ -1231,7 +1231,7 @@ module CreusotContracts_Std1_Slice_Impl16_ShallowModel
   val shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self))
+  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 368 14 368 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl17_Invariant_Stub
   type t
@@ -1259,7 +1259,7 @@ module CreusotContracts_Std1_Slice_Impl17_Invariant
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate invariant' (self : Core_Slice_Iter_IterMut_Type.t_itermut t) =
-    Seq.length (ShallowModel1.shallow_model ( ^ ShallowModel0.shallow_model self)) = Seq.length (ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 387 20 387 54] Seq.length (ShallowModel1.shallow_model ( ^ ShallowModel0.shallow_model self)) = Seq.length (ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self))
   val invariant' (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : bool
     ensures { result = invariant' self }
     
@@ -1299,7 +1299,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToMutSeq_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function to_mut_seq (self : borrowed (slice t)) : Seq.seq (borrowed t)
-  axiom to_mut_seq_spec : forall self : borrowed (slice t) . (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_mut_seq_spec : forall self : borrowed (slice t) . ([#"../../../../../creusot-contracts/src/std/slice.rs" 70 4 70 85] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 69 4 69 82] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 68 14 68 41] Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToMutSeq
   type t
@@ -1321,7 +1321,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToMutSeq
   val to_mut_seq (self : borrowed (slice t)) : Seq.seq (borrowed t)
     ensures { result = to_mut_seq self }
     
-  axiom to_mut_seq_spec : forall self : borrowed (slice t) . (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && (forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_mut_seq_spec : forall self : borrowed (slice t) . ([#"../../../../../creusot-contracts/src/std/slice.rs" 70 4 70 85] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  ^ Seq.get (to_mut_seq self) i = IndexLogic1.index_logic ( ^ self) i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 69 4 69 82] forall i : int . 0 <= i /\ i < Seq.length (to_mut_seq self) ->  * Seq.get (to_mut_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 68 14 68 41] Seq.length (to_mut_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl18_Produces_Stub
   type t
@@ -1374,7 +1374,7 @@ module CreusotContracts_Std1_Slice_Impl18_Produces
   predicate produces (self : Core_Slice_Iter_IterMut_Type.t_itermut t) (visited : Seq.seq (borrowed t)) (tl : Core_Slice_Iter_IterMut_Type.t_itermut t)
     
    =
-    ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 400 12 400 66] ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_IterMut_Type.t_itermut t) (visited : Seq.seq (borrowed t)) (tl : Core_Slice_Iter_IterMut_Type.t_itermut t) : bool
     ensures { result = produces self visited tl }
     
@@ -1404,7 +1404,7 @@ module CreusotContracts_Std1_Slice_Impl19_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Core_Slice_Iter_IterMut_Type.t_itermut t) =
-     * ShallowModel0.shallow_model self =  ^ ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 378 20 378 36]  * ShallowModel0.shallow_model self =  ^ ShallowModel0.shallow_model self
   val resolve (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : bool
     ensures { result = resolve self }
     
@@ -1434,8 +1434,8 @@ module Alloc_Vec_Impl10_DerefMut_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : borrowed (slice t)
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
-    ensures { ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 138 26 138 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 139 26 139 48] ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
     
 end
 module Core_Slice_Impl0_IterMut_Interface
@@ -1456,8 +1456,8 @@ module Core_Slice_Impl0_IterMut_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val iter_mut (self : borrowed (slice t)) : Core_Slice_Iter_IterMut_Type.t_itermut t
-    ensures { ShallowModel0.shallow_model result = self }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 258 18 258 36] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Slice_Impl18_Completed_Stub
@@ -1489,7 +1489,7 @@ module CreusotContracts_Std1_Slice_Impl18_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_IterMut_Type.t_itermut t
   predicate completed (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut t)) =
-    Resolve0.resolve self /\ ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 394 20 394 61] Resolve0.resolve self /\ ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut t)) : bool
     ensures { result = completed self }
     
@@ -1507,7 +1507,7 @@ module Core_Slice_Iter_Impl188_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Slice_Iter_IterMut_Type.t_itermut t
   val next (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut t)) : Core_Option_Option_Type.t_option (borrowed t)
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -1528,7 +1528,7 @@ module CreusotContracts_Std1_Slice_Impl18_ProducesRefl_Interface
   clone CreusotContracts_Std1_Slice_Impl18_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 405 14 405 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl18_ProducesRefl
   type t
@@ -1537,11 +1537,11 @@ module CreusotContracts_Std1_Slice_Impl18_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl18_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 404 4 404 10] ()
   val produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 405 14 405 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl18_ProducesTrans_Stub
   type t
@@ -1562,7 +1562,7 @@ module CreusotContracts_Std1_Slice_Impl18_ProducesTrans_Interface
     type t = t
   function produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 409 15 409 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 410 15 410 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 411 14 411 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl18_ProducesTrans
   type t
@@ -1574,13 +1574,13 @@ module CreusotContracts_Std1_Slice_Impl18_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 408 4 408 10] ()
   val produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 409 15 409 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 410 15 410 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 409 15 409 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 410 15 410 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 411 14 411 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_AllZero_Interface
   use prelude.Borrow
@@ -1894,7 +1894,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl3_Resolve
   clone CreusotContracts_Std1_Iter_Skip_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate resolve (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) =
-    Resolve0.resolve (Iter0.iter self)
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 31 12 31 33] Resolve0.resolve (Iter0.iter self)
   val resolve (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : bool
     ensures { result = resolve self }
     
@@ -1932,7 +1932,7 @@ module CreusotContracts_Std1_Iter_Take_Impl0_N_Interface
   use Core_Iter_Adapters_Take_Take_Type as Core_Iter_Adapters_Take_Take_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function n (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : int
-  axiom n_spec : forall self : Core_Iter_Adapters_Take_Take_Type.t_take i . n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
+  axiom n_spec : forall self : Core_Iter_Adapters_Take_Take_Type.t_take i . [#"../../../../../creusot-contracts/src/std/iter/take.rs" 30 14 30 50] n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Iter_Take_Impl0_N
   type i
@@ -1944,7 +1944,7 @@ module CreusotContracts_Std1_Iter_Take_Impl0_N
   val n (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : int
     ensures { result = n self }
     
-  axiom n_spec : forall self : Core_Iter_Adapters_Take_Take_Type.t_take i . n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
+  axiom n_spec : forall self : Core_Iter_Adapters_Take_Take_Type.t_take i . [#"../../../../../creusot-contracts/src/std/iter/take.rs" 30 14 30 50] n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Iter_Take_Impl1_Invariant_Stub
   type i
@@ -1964,7 +1964,7 @@ module CreusotContracts_Std1_Iter_Take_Impl1_Invariant
   clone CreusotContracts_Std1_Iter_Take_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate invariant' (self : Core_Iter_Adapters_Take_Take_Type.t_take i) =
-    Invariant0.invariant' (Iter0.iter self)
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 49 8 49 31] Invariant0.invariant' (Iter0.iter self)
   val invariant' (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : bool
     ensures { result = invariant' self }
     
@@ -1987,7 +1987,7 @@ module Core_Iter_Traits_Iterator_Iterator_Take_Interface
     type self = self
   val take (self : self) (n : usize) : Core_Iter_Adapters_Take_Take_Type.t_take self
     requires {Invariant0.invariant' self}
-    ensures { Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
     ensures { Invariant1.invariant' result }
     
 end
@@ -2006,7 +2006,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl0_N_Interface
   use Core_Iter_Adapters_Skip_Skip_Type as Core_Iter_Adapters_Skip_Skip_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function n (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : int
-  axiom n_spec : forall self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
+  axiom n_spec : forall self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 20 14 20 50] n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Iter_Skip_Impl0_N
   type i
@@ -2018,7 +2018,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl0_N
   val n (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : int
     ensures { result = n self }
     
-  axiom n_spec : forall self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
+  axiom n_spec : forall self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 20 14 20 50] n self >= 0 /\ n self <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Iter_Skip_Impl1_Invariant_Stub
   type i
@@ -2038,7 +2038,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl1_Invariant
   clone CreusotContracts_Std1_Iter_Skip_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate invariant' (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) =
-    Invariant0.invariant' (Iter0.iter self)
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 39 8 39 31] Invariant0.invariant' (Iter0.iter self)
   val invariant' (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : bool
     ensures { result = invariant' self }
     
@@ -2061,7 +2061,7 @@ module Core_Iter_Traits_Iterator_Iterator_Skip_Interface
     type self = self
   val skip (self : self) (n : usize) : Core_Iter_Adapters_Skip_Skip_Type.t_skip self
     requires {Invariant0.invariant' self}
-    ensures { Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
     ensures { Invariant1.invariant' result }
     
 end
@@ -2081,7 +2081,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -2149,7 +2149,7 @@ module Core_Iter_Adapters_Skip_Impl1_Next_Interface
     type t = Core_Iter_Adapters_Skip_Skip_Type.t_skip i
   val next (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip i)) : Core_Option_Option_Type.t_option Item1.item
     requires {Invariant0.invariant' self}
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -2174,7 +2174,7 @@ module CreusotContracts_Std1_Iter_Take_Impl3_Resolve
   clone CreusotContracts_Std1_Iter_Take_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate resolve (self : Core_Iter_Adapters_Take_Take_Type.t_take i) =
-    Resolve0.resolve (Iter0.iter self)
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 41 12 41 33] Resolve0.resolve (Iter0.iter self)
   val resolve (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : bool
     ensures { result = resolve self }
     
@@ -2216,7 +2216,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_Completed
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate completed (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip i)) =
-    N0.n ( ^ self) = 0 /\ (exists i : borrowed i . Invariant0.invariant' i /\ (exists s : Seq.seq Item0.item . Seq.length s <= N0.n ( * self) /\ Produces0.produces (Iter0.iter ( * self)) s ( * i) /\ (forall i : int . 0 <= i /\ i < Seq.length s -> Resolve0.resolve (Seq.get s i)) /\ Completed0.completed i /\  ^ i = Iter0.iter ( ^ self)))
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 46 8 54 9] N0.n ( ^ self) = 0 /\ (exists i : borrowed i . Invariant0.invariant' i /\ (exists s : Seq.seq Item0.item . Seq.length s <= N0.n ( * self) /\ Produces0.produces (Iter0.iter ( * self)) s ( * i) /\ (forall i : int . 0 <= i /\ i < Seq.length s -> Resolve0.resolve (Seq.get s i)) /\ Completed0.completed i /\  ^ i = Iter0.iter ( ^ self)))
   val completed (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip i)) : bool
     ensures { result = completed self }
     
@@ -2261,7 +2261,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_Produces
   predicate produces (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (visited : Seq.seq Item0.item) (o : Core_Iter_Adapters_Skip_Skip_Type.t_skip i)
     
    =
-    visited = Seq.empty  /\ self = o \/ N0.n o = 0 /\ Seq.length visited > 0 /\ (exists s : Seq.seq Item0.item . Seq.length s = N0.n self /\ Produces0.produces (Iter0.iter self) (Seq.(++) s visited) (Iter0.iter o) /\ (forall i : int . 0 <= i /\ i < Seq.length s -> Resolve0.resolve (Seq.get s i)))
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 59 8 66 9] visited = Seq.empty  /\ self = o \/ N0.n o = 0 /\ Seq.length visited > 0 /\ (exists s : Seq.seq Item0.item . Seq.length s = N0.n self /\ Produces0.produces (Iter0.iter self) (Seq.(++) s visited) (Iter0.iter o) /\ (forall i : int . 0 <= i /\ i < Seq.length s -> Resolve0.resolve (Seq.get s i)))
   val produces (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (visited : Seq.seq Item0.item) (o : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : bool
     ensures { result = produces self visited o }
     
@@ -2291,7 +2291,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Skip_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl
   type i
@@ -2305,12 +2305,12 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl
   clone CreusotContracts_Std1_Iter_Skip_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 69 4 69 10] ()
   val produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans_Stub
   type i
@@ -2339,7 +2339,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans
   type i
@@ -2355,16 +2355,16 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans
   function produces_trans (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 73 4 73 10] ()
   val produces_trans (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_Produces_Stub
   type i
@@ -2404,7 +2404,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_Produces
   predicate produces (self : Core_Iter_Adapters_Take_Take_Type.t_take i) (visited : Seq.seq Item0.item) (o : Core_Iter_Adapters_Take_Take_Type.t_take i)
     
    =
-    N0.n self = N0.n o + Seq.length visited /\ Produces0.produces (Iter0.iter self) visited (Iter0.iter o)
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 65 12 65 88] N0.n self = N0.n o + Seq.length visited /\ Produces0.produces (Iter0.iter self) visited (Iter0.iter o)
   val produces (self : Core_Iter_Adapters_Take_Take_Type.t_take i) (visited : Seq.seq Item0.item) (o : Core_Iter_Adapters_Take_Take_Type.t_take i) : bool
     ensures { result = produces self visited o }
     
@@ -2424,7 +2424,7 @@ module CreusotContracts_Std1_Iter_Take_Impl0_IterMut_Interface
   clone CreusotContracts_Std1_Iter_Take_Impl0_Iter_Stub as Iter0 with
     type i = i
   function iter_mut (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) : borrowed i
-  axiom iter_mut_spec : forall self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i) . Iter0.iter ( * self) =  * iter_mut self /\ Iter0.iter ( ^ self) =  ^ iter_mut self
+  axiom iter_mut_spec : forall self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i) . [#"../../../../../creusot-contracts/src/std/iter/take.rs" 23 14 23 68] Iter0.iter ( * self) =  * iter_mut self /\ Iter0.iter ( ^ self) =  ^ iter_mut self
 end
 module CreusotContracts_Std1_Iter_Take_Impl0_IterMut
   type i
@@ -2436,7 +2436,7 @@ module CreusotContracts_Std1_Iter_Take_Impl0_IterMut
   val iter_mut (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) : borrowed i
     ensures { result = iter_mut self }
     
-  axiom iter_mut_spec : forall self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i) . Iter0.iter ( * self) =  * iter_mut self /\ Iter0.iter ( ^ self) =  ^ iter_mut self
+  axiom iter_mut_spec : forall self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i) . [#"../../../../../creusot-contracts/src/std/iter/take.rs" 23 14 23 68] Iter0.iter ( * self) =  * iter_mut self /\ Iter0.iter ( ^ self) =  ^ iter_mut self
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_Completed_Stub
   type i
@@ -2471,7 +2471,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_Completed
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate completed (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) =
-    N0.n ( * self) = 0 /\ Resolve0.resolve self \/ N0.n ( * self) > 0 /\ N0.n ( * self) = N0.n ( ^ self) + 1 /\ Completed0.completed (IterMut0.iter_mut self)
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 57 12 58 92] N0.n ( * self) = 0 /\ Resolve0.resolve self \/ N0.n ( * self) > 0 /\ N0.n ( * self) = N0.n ( ^ self) + 1 /\ Completed0.completed (IterMut0.iter_mut self)
   val completed (self : borrowed (Core_Iter_Adapters_Take_Take_Type.t_take i)) : bool
     ensures { result = completed self }
     
@@ -2501,7 +2501,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Take_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl
   type i
@@ -2515,12 +2515,12 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl
   clone CreusotContracts_Std1_Iter_Take_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 69 4 69 10] ()
   val produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans_Stub
   type i
@@ -2549,7 +2549,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Take_Take_Type.t_take i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Take_Take_Type.t_take i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans
   type i
@@ -2565,16 +2565,16 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans
   function produces_trans (a : Core_Iter_Adapters_Take_Take_Type.t_take i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Take_Take_Type.t_take i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/take.rs" 73 4 73 10] ()
   val produces_trans (a : Core_Iter_Adapters_Take_Take_Type.t_take i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Take_Take_Type.t_take i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Stub
   type self
@@ -2599,7 +2599,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -2616,7 +2616,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -2641,7 +2641,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -2655,14 +2655,14 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_SkipTake_Interface
   type i
@@ -3070,7 +3070,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -3090,7 +3090,7 @@ module Alloc_Vec_Impl9_Deref_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref (self : Alloc_Vec_Vec_Type.t_vec t a) : slice t
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 133 26 133 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     
 end
 module CreusotContracts_Std1_Ops_Impl0_Precondition_Stub
@@ -3144,7 +3144,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_Completed
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate completed (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)) =
-    Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced ( ^ self)) = Seq.empty  /\ Completed0.completed {current = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( * self); final = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ self)} /\ CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( * self) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ self)
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 14 8 17 9] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced ( ^ self)) = Seq.empty  /\ Completed0.completed {current = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( * self); final = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ self)} /\ CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( * self) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ self)
   val completed (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)) : bool
     ensures { result = completed self }
     
@@ -3187,7 +3187,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_NextPrecondition
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate next_precondition (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    forall i : i . Invariant0.invariant' i -> (forall e : Item0.item . Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.singleton e) i -> Precondition0.precondition (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (e, CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 105 8 109 9] forall i : i . Invariant0.invariant' i -> (forall e : Item0.item . Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.singleton e) i -> Precondition0.precondition (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (e, CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self))
   val next_precondition (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = next_precondition self }
     
@@ -3266,7 +3266,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_Preservation
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate preservation (iter : i) (func : f) =
-    forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest func ( * f) -> Produces0.produces iter (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new s) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new s) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc s e1)))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 138 8 145 9] forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest func ( * f) -> Produces0.produces iter (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new s) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new s) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc s e1)))
   val preservation (iter : i) (func : f) : bool
     ensures { result = preservation iter func }
     
@@ -3308,7 +3308,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_Reinitialize
     type f = f,
     type Item0.item = Item0.item
   predicate reinitialize (_1' : ()) =
-    forall reset : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) . Completed0.completed reset -> Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) -> NextPrecondition0.next_precondition ( ^ reset) /\ Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ reset))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 114 8 120 9] forall reset : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) . Completed0.completed reset -> Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) -> NextPrecondition0.next_precondition ( ^ reset) /\ Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ reset))
   val reinitialize (_1' : ()) : bool
     ensures { result = reinitialize _1' }
     
@@ -3341,11 +3341,11 @@ module CreusotContracts_Std1_Iter_Iterator_MapInv_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val map_inv (self : self) (func : f) : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv self Item0.item f
-    requires {forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
-    requires {Reinitialize0.reinitialize ()}
-    requires {Preservation0.preservation self func}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 39 4 39 138] forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 40 15 40 51] Reinitialize0.reinitialize ()}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 41 15 41 70] Preservation0.preservation self func}
     requires {Invariant0.invariant' self}
-    ensures { result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 42 14 42 85] result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
     
 end
 module CreusotContracts_Std1_Iter_FromIterator_FromIterPost_Stub
@@ -3392,7 +3392,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
     type self = self
   val collect (self : self) : b
     requires {Invariant0.invariant' self}
-    ensures { exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -3406,7 +3406,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -3440,7 +3440,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv_Interface
     type f = f
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)
-  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 124 4 124 106] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv
   type i
@@ -3474,11 +3474,11 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv
     type f = f
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) ( * f) -> Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s) e1)))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 126 8 133 9] forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) ( * f) -> Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s) e1)))
   val preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = preservation_inv self }
     
-  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 124 4 124 106] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl1_Invariant_Stub
   type i
@@ -3528,7 +3528,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl1_Invariant
     type b = b,
     type f = f
   predicate invariant' (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    Reinitialize0.reinitialize () /\ PreservationInv0.preservation_inv self /\ Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ NextPrecondition0.next_precondition self
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 64 8 69 9] Reinitialize0.reinitialize () /\ PreservationInv0.preservation_inv self /\ Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ NextPrecondition0.next_precondition self
   val invariant' (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = invariant' self }
     
@@ -3557,7 +3557,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl4_Resolve
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate resolve (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i b f) =
-    Resolve0.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ Resolve1.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 51 4 51 16] Resolve0.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ Resolve1.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
   val resolve (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i b f) : bool
     ensures { result = resolve self }
     
@@ -3614,7 +3614,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_Produces
   predicate produces [@inline:trivial] (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (visited : Seq.seq b) (succ : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)
     
    =
-    Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ) /\ (exists s : Seq.seq Item0.item . Seq.length s = Seq.length visited /\ Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) s (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter succ) /\ Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced succ) = Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s /\ (exists fs : Seq.seq (borrowed f) . Seq.length fs = Seq.length visited /\ (forall i : int . 1 <= i /\ i < Seq.length fs ->  ^ Seq.get fs (i - 1) =  * Seq.get fs i) /\ (if Seq.length visited = 0 then
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 33 8 45 9] Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ) /\ (exists s : Seq.seq Item0.item . Seq.length s = Seq.length visited /\ Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) s (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter succ) /\ Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced succ) = Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s /\ (exists fs : Seq.seq (borrowed f) . Seq.length fs = Seq.length visited /\ (forall i : int . 1 <= i /\ i < Seq.length fs ->  ^ Seq.get fs (i - 1) =  * Seq.get fs i) /\ (if Seq.length visited = 0 then
       CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ
     else
        * Seq.get fs 0 = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self /\  ^ Seq.get fs (Seq.length visited - 1) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ
@@ -3649,7 +3649,7 @@ module CreusotContracts_Std1_Vec_Impl9_FromIterPost
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate from_iter_post (prod : Seq.seq t) (res : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    prod = ShallowModel0.shallow_model res
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 233 20 233 32] prod = ShallowModel0.shallow_model res
   val from_iter_post (prod : Seq.seq t) (res : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = from_iter_post prod res }
     
@@ -3683,7 +3683,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl_Interface
     type f = f,
     type Item0.item = Item0.item
   function produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
-  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 21 14 21 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl
   type i
@@ -3699,11 +3699,11 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl
     type f = f,
     type Item0.item = Item0.item
   function produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 20 4 20 10] ()
   val produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 21 14 21 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans_Stub
   type i
@@ -3736,7 +3736,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     
-  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 27 14 27 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans
   type i
@@ -3754,13 +3754,13 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans
   function produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 4 24 10] ()
   val produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 27 14 27 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_Counter_Interface
   use prelude.Int
@@ -4129,7 +4129,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -4148,7 +4148,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -4169,7 +4169,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -4178,11 +4178,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -4201,7 +4201,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -4212,13 +4212,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl34_DeepModel_Stub
   use prelude.Int
@@ -4234,7 +4234,7 @@ module CreusotContracts_Std1_Num_Impl34_DeepModel
   use prelude.Int
   use prelude.IntSize
   function deep_model (self : isize) : int =
-    IntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] IntSize.to_int self
   val deep_model (self : isize) : int
     ensures { result = deep_model self }
     
@@ -4263,7 +4263,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -4505,7 +4505,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant
   clone CreusotContracts_Std1_Iter_Enumerate_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate invariant' (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) =
-    Invariant0.invariant' (Iter0.iter self) /\ (forall i : i . Invariant0.invariant' i -> (forall s : Seq.seq Item0.item . Produces0.produces (Iter0.iter self) s i -> N0.n self + Seq.length s < UIntSize.to_int Max0.mAX')) /\ (forall i : borrowed i . Invariant1.invariant' i -> Completed0.completed i -> Produces0.produces ( * i) (Seq.empty ) ( ^ i))
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 39 12 41 79] Invariant0.invariant' (Iter0.iter self) /\ (forall i : i . Invariant0.invariant' i -> (forall s : Seq.seq Item0.item . Produces0.produces (Iter0.iter self) s i -> N0.n self + Seq.length s < UIntSize.to_int Max0.mAX')) /\ (forall i : borrowed i . Invariant1.invariant' i -> Completed0.completed i -> Produces0.produces ( * i) (Seq.empty ) ( ^ i))
   val invariant' (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : bool
     ensures { result = invariant' self }
     
@@ -4550,7 +4550,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_Produces
   predicate produces (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (visited : Seq.seq (usize, Item0.item)) (o : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)
     
    =
-    Seq.length visited = N0.n o - N0.n self /\ (exists s : Seq.seq Item0.item . Produces0.produces (Iter0.iter self) s (Iter0.iter o) /\ Seq.length visited = Seq.length s /\ (forall i : int . 0 <= i /\ i < Seq.length s -> UIntSize.to_int (let (a, _) = Seq.get visited i in a) = N0.n self + i /\ (let (_, a) = Seq.get visited i in a) = Seq.get s i))
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 57 8 62 9] Seq.length visited = N0.n o - N0.n self /\ (exists s : Seq.seq Item0.item . Produces0.produces (Iter0.iter self) s (Iter0.iter o) /\ Seq.length visited = Seq.length s /\ (forall i : int . 0 <= i /\ i < Seq.length s -> UIntSize.to_int (let (a, _) = Seq.get visited i in a) = N0.n self + i /\ (let (_, a) = Seq.get visited i in a) = Seq.get s i))
   val produces (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (visited : Seq.seq (usize, Item0.item)) (o : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : bool
     ensures { result = produces self visited o }
     
@@ -4573,7 +4573,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl3_Resolve
   clone CreusotContracts_Std1_Iter_Enumerate_Impl0_Iter_Stub as Iter0 with
     type i = i
   predicate resolve (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) =
-    Resolve0.resolve (Iter0.iter self)
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 30 12 30 33] Resolve0.resolve (Iter0.iter self)
   val resolve (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : bool
     ensures { result = resolve self }
     
@@ -4596,7 +4596,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -4614,7 +4614,7 @@ module Core_Iter_Traits_Iterator_Iterator_Enumerate_Interface
     type self = self
   val enumerate (self : self) : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate self
     requires {Invariant0.invariant' self}
-    ensures { Iter0.iter result = self /\ N0.n result = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = 0 }
     ensures { Invariant1.invariant' result }
     
 end
@@ -4641,7 +4641,7 @@ module Core_Iter_Adapters_Enumerate_Impl1_Next_Interface
     type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i
   val next (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)) : Core_Option_Option_Type.t_option (usize, Item1.item)
     requires {Invariant0.invariant' self}
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -4673,7 +4673,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl
   type i
@@ -4687,12 +4687,12 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl
   clone CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 65 4 65 10] ()
   val produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans_Stub
   type i
@@ -4725,7 +4725,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (ab : Seq.seq (usize, Item0.item)) (b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (bc : Seq.seq (usize, Item0.item)) (c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans
   type i
@@ -4743,16 +4743,16 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans
   function produces_trans (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (ab : Seq.seq (usize, Item0.item)) (b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (bc : Seq.seq (usize, Item0.item)) (c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 69 4 69 10] ()
   val produces_trans (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (ab : Seq.seq (usize, Item0.item)) (b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (bc : Seq.seq (usize, Item0.item)) (c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_Completed_Stub
   type i
@@ -4777,7 +4777,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_Completed
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = i
   predicate completed (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)) =
-    exists inner : borrowed i . Invariant0.invariant' inner /\  * inner = Iter0.iter ( * self) /\  ^ inner = Iter0.iter ( ^ self) /\ Completed0.completed inner
+    [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 52 8 52 115] exists inner : borrowed i . Invariant0.invariant' inner /\  * inner = Iter0.iter ( * self) /\  ^ inner = Iter0.iter ( ^ self) /\ Completed0.completed inner
   val completed (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)) : bool
     ensures { result = completed self }
     
@@ -4796,7 +4796,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/iterators/04_skip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/04_skip.mlcfg
@@ -25,7 +25,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -67,7 +67,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -271,18 +271,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C04Skip_Impl1_Produces_Stub
   type i
@@ -540,7 +540,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -566,8 +566,8 @@ module Core_Mem_Take_Interface
   clone CreusotContracts_Std1_Default_Default_IsDefault_Stub as IsDefault0 with
     type self = t
   val take (dest : borrowed t) : t
-    ensures { result =  * dest }
-    ensures { IsDefault0.is_default ( ^ dest) }
+    ensures { [#"../../../../../creusot-contracts/src/std/mem.rs" 15 22 15 37] result =  * dest }
+    ensures { [#"../../../../../creusot-contracts/src/std/mem.rs" 16 22 16 42] IsDefault0.is_default ( ^ dest) }
     
 end
 module C04Skip_Common_Iterator_Next_Interface
@@ -609,7 +609,7 @@ module CreusotContracts_Std1_Num_Impl17_IsDefault
   use prelude.Int
   use prelude.UIntSize
   predicate is_default (self : usize) =
-    self = (0 : usize)
+    [#"../../../../../creusot-contracts/src/std/num.rs" 27 28 27 41] self = (0 : usize)
   val is_default (self : usize) : bool
     ensures { result = is_default self }
     

--- a/creusot/tests/should_succeed/iterators/05_map.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_map.mlcfg
@@ -71,7 +71,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -301,18 +301,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C05Map_Common_Iterator_ProducesRefl_Stub
   type self
@@ -436,7 +436,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -453,12 +453,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -475,7 +475,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -484,11 +484,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -505,7 +505,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -514,13 +514,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -601,7 +601,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -624,7 +624,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C05Map_Impl1_PreservationInv_Stub
   type i
@@ -1509,7 +1509,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -1530,7 +1530,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -1852,8 +1852,8 @@ module Core_Ops_Function_FnMut_CallMut_Interface
     type args = args,
     type f = self
   val call_mut (self : borrowed self) (args : args) : Output0.output
-    requires {Precondition0.precondition ( * self) args}
-    ensures { PostconditionMut0.postcondition_mut self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 149 27 149 52] Precondition0.precondition ( * self) args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] PostconditionMut0.postcondition_mut self args result }
     
 end
 module C05Map_Impl0_Next_Interface

--- a/creusot/tests/should_succeed/iterators/05_take.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_take.mlcfg
@@ -28,7 +28,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -118,7 +118,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -225,18 +225,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C05Take_Impl0_Produces_Stub
   type i
@@ -498,7 +498,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -51,7 +51,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -182,18 +182,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C06MapPrecond_Impl0_Completed_Stub
   type i
@@ -469,7 +469,7 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest_Interface
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
   type args
@@ -486,12 +486,12 @@ module CreusotContracts_Std1_Ops_Impl1_PostconditionMutUnnest
     type f = f,
     type Output0.output = Output0.output
   function postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 97 4 97 10] ()
   val postcondition_mut_unnest (self : borrowed f) (args : args) (res : Output0.output) : ()
-    requires {PostconditionMut0.postcondition_mut self args res}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res}
     ensures { result = postcondition_mut_unnest self args res }
     
-  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . PostconditionMut0.postcondition_mut self args res -> Unnest0.unnest ( * self) ( ^ self)
+  axiom postcondition_mut_unnest_spec : forall self : borrowed f, args : args, res : Output0.output . ([#"../../../../../creusot-contracts/src/std/ops.rs" 98 15 98 48] PostconditionMut0.postcondition_mut self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 99 14 99 35] Unnest0.unnest ( * self) ( ^ self))
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Stub
   type args
@@ -508,7 +508,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl_Interface
     type args = args,
     type f = f
   function unnest_refl (self : f) : ()
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
   type args
@@ -517,11 +517,11 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestRefl
     type args = args,
     type f = f
   function unnest_refl (self : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 102 4 102 10] ()
   val unnest_refl (self : f) : ()
     ensures { result = unnest_refl self }
     
-  axiom unnest_refl_spec : forall self : f . Unnest0.unnest self self
+  axiom unnest_refl_spec : forall self : f . [#"../../../../../creusot-contracts/src/std/ops.rs" 103 14 103 31] Unnest0.unnest self self
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Stub
   type args
@@ -538,7 +538,7 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans_Interface
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : ()
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
   type args
@@ -547,13 +547,13 @@ module CreusotContracts_Std1_Ops_Impl1_UnnestTrans
     type args = args,
     type f = f
   function unnest_trans (self : f) (b : f) (c : f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/ops.rs" 106 4 106 10] ()
   val unnest_trans (self : f) (b : f) (c : f) : ()
-    requires {Unnest0.unnest self b}
-    requires {Unnest0.unnest b c}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b}
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c}
     ensures { result = unnest_trans self b c }
     
-  axiom unnest_trans_spec : forall self : f, b : f, c : f . Unnest0.unnest self b -> Unnest0.unnest b c -> Unnest0.unnest self c
+  axiom unnest_trans_spec : forall self : f, b : f, c : f . ([#"../../../../../creusot-contracts/src/std/ops.rs" 107 15 107 29] Unnest0.unnest self b) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 108 15 108 26] Unnest0.unnest b c) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 109 14 109 28] Unnest0.unnest self c)
 end
 module CreusotContracts_Std1_Ops_Impl0_PostconditionOnce_Stub
   type args
@@ -634,7 +634,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce_Interface
     type f = f,
     type Output0.output = Output0.output
   function fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   type args
@@ -657,7 +657,7 @@ module CreusotContracts_Std1_Ops_Impl1_FnMutOnce
   val fn_mut_once (self : f) (args : args) (res : Output0.output) : ()
     ensures { result = fn_mut_once self args res }
     
-  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
+  axiom fn_mut_once_spec : forall self : f, args : args, res : Output0.output . [#"../../../../../creusot-contracts/src/std/ops.rs" 114 14 114 135] PostconditionOnce0.postcondition_once self args res = (exists s : borrowed f .  * s = self /\ PostconditionMut0.postcondition_mut s args res /\ Resolve0.resolve ( ^ s))
 end
 module C06MapPrecond_Impl1_PreservationInv_Stub
   type i
@@ -1627,7 +1627,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -1648,7 +1648,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -1994,8 +1994,8 @@ module Core_Ops_Function_FnMut_CallMut_Interface
     type args = args,
     type f = self
   val call_mut (self : borrowed self) (args : args) : Output0.output
-    requires {Precondition0.precondition ( * self) args}
-    ensures { PostconditionMut0.postcondition_mut self args result }
+    requires {[#"../../../../../creusot-contracts/src/std/ops.rs" 149 27 149 52] Precondition0.precondition ( * self) args}
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 137 0 161 1] PostconditionMut0.postcondition_mut self args result }
     
 end
 module C06MapPrecond_Impl0_Next_Interface

--- a/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
+++ b/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
@@ -112,7 +112,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -219,18 +219,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C07Fuse_Impl1_Produces_Stub
   type i
@@ -291,7 +291,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -343,7 +343,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -10,7 +10,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -31,7 +31,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -146,7 +146,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -160,7 +160,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -210,7 +210,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -269,7 +269,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -297,7 +297,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -316,7 +316,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -332,7 +332,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -372,9 +372,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -396,7 +396,7 @@ module Core_Iter_Traits_Iterator_Iterator_Next_Interface
     type t = self
   val next (self : borrowed self) : Core_Option_Option_Type.t_option Item0.item
     requires {Invariant0.invariant' self}
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -420,7 +420,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited_Stub
@@ -434,18 +434,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Stub
   type self
@@ -470,7 +470,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -487,7 +487,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -512,7 +512,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -526,14 +526,14 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
   type i
@@ -548,7 +548,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -564,7 +564,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -866,7 +866,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -901,7 +901,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -918,7 +918,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module C08CollectExtend_Collect_Interface
@@ -1233,7 +1233,7 @@ module Alloc_Vec_Impl9_Deref_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref (self : Alloc_Vec_Vec_Type.t_vec t a) : slice t
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 133 26 133 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     
 end
 module CreusotContracts_Std1_Vec_Impl3_IntoIterPre_Stub
@@ -1253,7 +1253,7 @@ module CreusotContracts_Std1_Vec_Impl3_IntoIterPre
   type a
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   predicate into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) =
-    true
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 153 20 153 24] true
   val into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) : bool
     ensures { result = into_iter_pre self }
     
@@ -1312,7 +1312,7 @@ module CreusotContracts_Std1_Vec_Impl3_IntoIterPost
     axiom .
   predicate into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)
    =
-    ShallowModel0.shallow_model self = ShallowModel1.shallow_model res
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 158 20 158 33] ShallowModel0.shallow_model self = ShallowModel1.shallow_model res
   val into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : bool
     ensures { result = into_iter_post self res }
     
@@ -1331,8 +1331,8 @@ module Alloc_Vec_Impl16_IntoIter_Interface
     type t = t,
     type a = a
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
-    requires {IntoIterPre0.into_iter_pre self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -1347,7 +1347,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -1379,7 +1379,7 @@ module CreusotContracts_Std1_Vec_Impl8_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
   predicate completed (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)) =
-    Resolve0.resolve self /\ ShallowModel0.shallow_model self = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 209 20 209 57] Resolve0.resolve self /\ ShallowModel0.shallow_model self = Seq.empty 
   val completed (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)) : bool
     ensures { result = completed self }
     
@@ -1411,7 +1411,7 @@ module CreusotContracts_Std1_Vec_Impl8_Produces
   predicate produces (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (visited : Seq.seq t) (rhs : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)
     
    =
-    ShallowModel0.shallow_model self = Seq.(++) visited (ShallowModel0.shallow_model rhs)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 215 12 215 41] ShallowModel0.shallow_model self = Seq.(++) visited (ShallowModel0.shallow_model rhs)
   val produces (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (visited : Seq.seq t) (rhs : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : bool
     ensures { result = produces self visited rhs }
     
@@ -1433,7 +1433,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -1446,7 +1446,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesRefl_Stub
   type t
@@ -1467,7 +1467,7 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesRefl_Interface
     type t = t,
     type a = a
   function produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
-  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 220 14 220 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesRefl
   type t
@@ -1478,11 +1478,11 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesRefl
     type t = t,
     type a = a
   function produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 219 4 219 10] ()
   val produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 220 14 220 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesTrans_Stub
   type t
@@ -1505,7 +1505,7 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesTrans_Interface
     type a = a
   function produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     
-  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 226 14 226 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesTrans
   type t
@@ -1518,13 +1518,13 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesTrans
   function produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 223 4 223 10] ()
   val produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 226 14 226 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C08CollectExtend_ExtendIndex_Interface
   use prelude.Int

--- a/creusot/tests/should_succeed/iterators/09_empty.mlcfg
+++ b/creusot/tests/should_succeed/iterators/09_empty.mlcfg
@@ -24,7 +24,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -238,7 +238,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -259,7 +259,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     

--- a/creusot/tests/should_succeed/iterators/10_once.mlcfg
+++ b/creusot/tests/should_succeed/iterators/10_once.mlcfg
@@ -29,7 +29,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -234,7 +234,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -255,7 +255,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -265,7 +265,7 @@ module Core_Option_Impl0_Take_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val take (self : borrowed (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option t
-    ensures { result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
     
 end
 module C10Once_Impl0_Next_Interface

--- a/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
+++ b/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
@@ -169,7 +169,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -178,7 +178,7 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' (self : self) : self
-    ensures { result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module C11Repeat_Impl0_Next_Interface
@@ -253,7 +253,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -274,7 +274,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     

--- a/creusot/tests/should_succeed/iterators/12_zip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/12_zip.mlcfg
@@ -98,7 +98,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -205,18 +205,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C12Zip_Impl0_Produces_Stub
   type i
@@ -588,7 +588,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -618,7 +618,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -656,7 +656,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
+++ b/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
@@ -126,7 +126,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -166,18 +166,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C13Cloned_Common_Iterator_ProducesRefl_Stub
   type self
@@ -474,7 +474,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -499,7 +499,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -534,8 +534,8 @@ module Core_Option_Impl2_Cloned_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val cloned (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 79 16 79 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
     
 end
 module C13Cloned_Impl0_Next_Interface

--- a/creusot/tests/should_succeed/iterators/14_copied.mlcfg
+++ b/creusot/tests/should_succeed/iterators/14_copied.mlcfg
@@ -126,7 +126,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -166,18 +166,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C14Copied_Common_Iterator_ProducesRefl_Stub
   type self
@@ -474,7 +474,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -499,7 +499,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -534,8 +534,8 @@ module Core_Option_Impl2_Copied_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val copied (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 73 16 73 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
     
 end
 module C14Copied_Impl0_Next_Interface

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -95,7 +95,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -202,18 +202,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module C15Enumerate_Impl0_Produces_Stub
   type i
@@ -272,7 +272,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -564,7 +564,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -176,7 +176,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -203,7 +203,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -277,7 +277,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -291,7 +291,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Resolve_Resolve_Resolve_Stub
   type self
@@ -322,7 +322,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -357,7 +357,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -379,8 +379,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -396,7 +396,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_InBounds_Stub
@@ -486,8 +486,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -513,7 +513,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -580,11 +580,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Vec_Impl0_WithCapacity_Interface
@@ -601,7 +601,7 @@ module Alloc_Vec_Impl0_WithCapacity_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val with_capacity (capacity : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 58 26 58 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -621,7 +621,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -644,7 +644,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -669,7 +669,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -694,7 +694,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -710,7 +710,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -379,7 +379,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -406,7 +406,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -475,7 +475,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -489,7 +489,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Alloc_Global_Type
   type t_global  =
@@ -536,7 +536,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -592,7 +592,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -611,7 +611,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -661,7 +661,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -741,7 +741,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -777,7 +777,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog_Interface
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   predicate is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   type idx
@@ -797,7 +797,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   val is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = is_empty_log self }
     
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use prelude.Int
@@ -861,7 +861,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
@@ -885,7 +885,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int =
-    if IsEmptyLog0.is_empty_log r then
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 42 4 45 5] if IsEmptyLog0.is_empty_log r then
       0
     else
       DeepModel0.deep_model (EndLog0.end_log r) - DeepModel0.deep_model (StartLog0.start_log r) + 1
@@ -893,7 +893,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   val range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
     ensures { result = range_inclusive_len r }
     
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub
   type idx
@@ -942,7 +942,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   predicate produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
     
    =
-    Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 58 8 64 9] Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
   val produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = produces self visited o }
     
@@ -964,8 +964,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module Alloc_Vec_Impl1_Len_Interface
@@ -981,7 +981,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -995,7 +995,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -1035,9 +1035,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -1101,7 +1101,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -1194,8 +1194,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Core_Ops_Range_Impl7_New_Interface
@@ -1221,9 +1221,9 @@ module Core_Ops_Range_Impl7_New_Interface
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     axiom .
   val new (start : idx) (end' : idx) : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx
-    ensures { StartLog0.start_log result = start }
-    ensures { EndLog0.end_log result = end' }
-    ensures { LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 210 26 210 53] StartLog0.start_log result = start }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 211 26 211 49] EndLog0.end_log result = end' }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 212 16 212 93] LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
     
 end
 module Core_Iter_Range_Impl12_Next_Interface
@@ -1240,7 +1240,7 @@ module Core_Iter_Range_Impl12_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a
   val next (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -1269,7 +1269,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1336,11 +1336,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Vec_Impl0_WithCapacity_Interface
@@ -1357,7 +1357,7 @@ module Alloc_Vec_Impl0_WithCapacity_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val with_capacity (capacity : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 58 26 58 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -1377,7 +1377,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -1393,7 +1393,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -1409,7 +1409,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -1425,18 +1425,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -1453,7 +1453,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -1462,11 +1462,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -1485,7 +1485,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -1496,13 +1496,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -1518,7 +1518,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -1547,7 +1547,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -1572,7 +1572,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1597,7 +1597,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -1617,7 +1617,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   type idx
@@ -1626,11 +1626,11 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 67 4 67 10] ()
   val produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Stub
   type idx
@@ -1649,7 +1649,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   type idx
@@ -1660,13 +1660,13 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 71 4 71 10] ()
   val produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Completed_Stub
   type idx
@@ -1703,7 +1703,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
     type DeepModelTy0.deepModelTy = int,
     axiom .
   predicate completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) =
-    IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 52 12 52 57] IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
   val completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) : bool
     ensures { result = completed self }
     
@@ -1728,7 +1728,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -1744,7 +1744,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
+++ b/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -173,7 +173,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -189,7 +189,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/lang/move_path.mlcfg
+++ b/creusot/tests/should_succeed/lang/move_path.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/lang/promoted_constants.mlcfg
+++ b/creusot/tests/should_succeed/lang/promoted_constants.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -54,7 +54,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/lang/while_let.mlcfg
+++ b/creusot/tests/should_succeed/lang/while_let.mlcfg
@@ -19,7 +19,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -134,7 +134,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -113,7 +113,7 @@ module CreusotContracts_Logic_Ops_Impl1_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : usize) : t =
-    Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int ix)
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 26 8 26 32] Seq.get (ShallowModel0.shallow_model self) (UIntSize.to_int ix)
   val index_logic [@inline:trivial] (self : s) (ix : usize) : t
     ensures { result = index_logic self ix }
     
@@ -179,7 +179,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -193,7 +193,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module ListReversalLasso_Impl3_NonnullPtr_Stub
   use prelude.Int
@@ -253,7 +253,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -345,8 +345,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -369,7 +369,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -394,7 +394,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -495,7 +495,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -523,7 +523,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -590,11 +590,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere_Stub
@@ -617,7 +617,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -970,8 +970,8 @@ module Core_Mem_Replace_Interface
   type t
   use prelude.Borrow
   val replace (dest : borrowed t) (src : t) : t
-    ensures {  ^ dest = src }
-    ensures { result =  * dest }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 7 22 7 34]  ^ dest = src }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 8 22 8 37] result =  * dest }
     
 end
 module ListReversalLasso_Impl4_ListReversalList_Interface

--- a/creusot/tests/should_succeed/loop.mlcfg
+++ b/creusot/tests/should_succeed/loop.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -92,7 +92,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -111,7 +111,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -139,7 +139,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -167,7 +167,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/mutex.mlcfg
+++ b/creusot/tests/should_succeed/mutex.mlcfg
@@ -440,7 +440,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/one_side_update.mlcfg
+++ b/creusot/tests/should_succeed/one_side_update.mlcfg
@@ -24,7 +24,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/option.mlcfg
+++ b/creusot/tests/should_succeed/option.mlcfg
@@ -19,7 +19,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -29,7 +29,7 @@ module Core_Option_Impl0_IsSome_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_some (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self <> Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 20 26 20 51] result = (self <> Core_Option_Option_Type.C_None) }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -37,23 +37,23 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap (self : Core_Option_Option_Type.t_option t) : t
-    requires {self <> Core_Option_Option_Type.C_None}
-    ensures { Core_Option_Option_Type.C_Some result = self }
+    requires {[#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self <> Core_Option_Option_Type.C_None}
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] Core_Option_Option_Type.C_Some result = self }
     
 end
 module Core_Option_Impl0_UnwrapOr_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap_or (self : Core_Option_Option_Type.t_option t) (default : t) : t
-    ensures { self = Core_Option_Option_Type.C_None -> result = default }
-    ensures { self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 34 16 34 62] self = Core_Option_Option_Type.C_None -> result = default }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
     
 end
 module Core_Option_Impl0_AsMut_Interface
@@ -61,8 +61,8 @@ module Core_Option_Impl0_AsMut_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val as_mut (self : borrowed (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option (borrowed t)
-    ensures {  * self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None /\  ^ self = Core_Option_Option_Type.C_None }
-    ensures {  * self = Core_Option_Option_Type.C_None \/ (exists r : borrowed t . result = Core_Option_Option_Type.C_Some r /\  * self = Core_Option_Option_Type.C_Some ( * r) /\  ^ self = Core_Option_Option_Type.C_Some ( ^ r)) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 38 16 38 77]  * self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None /\  ^ self = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 39 16 42 18]  * self = Core_Option_Option_Type.C_None \/ (exists r : borrowed t . result = Core_Option_Option_Type.C_Some r /\  * self = Core_Option_Option_Type.C_Some ( * r) /\  ^ self = Core_Option_Option_Type.C_Some ( ^ r)) }
     
 end
 module Core_Option_Impl0_AsRef_Interface
@@ -70,8 +70,8 @@ module Core_Option_Impl0_AsRef_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val as_ref (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists r : t . result = Core_Option_Option_Type.C_Some r /\ self = Core_Option_Option_Type.C_Some r) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 45 16 45 60] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 46 16 48 18] self = Core_Option_Option_Type.C_None \/ (exists r : t . result = Core_Option_Option_Type.C_Some r /\ self = Core_Option_Option_Type.C_Some r) }
     
 end
 module Core_Option_Impl0_And_Interface
@@ -79,16 +79,16 @@ module Core_Option_Impl0_And_Interface
   type u
   use Core_Option_Option_Type as Core_Option_Option_Type
   val and (self : Core_Option_Option_Type.t_option t) (optb : Core_Option_Option_Type.t_option u) : Core_Option_Option_Type.t_option u
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ result = optb }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 51 16 51 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ result = optb }
     
 end
 module Core_Option_Impl0_Or_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val or (self : Core_Option_Option_Type.t_option t) (optb : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = optb }
-    ensures { self = Core_Option_Option_Type.C_None \/ result = self }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 55 16 55 59] self = Core_Option_Option_Type.C_None -> result = optb }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ result = self }
     
 end
 module Core_Option_Impl0_Take_Interface
@@ -96,7 +96,7 @@ module Core_Option_Impl0_Take_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val take (self : borrowed (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option t
-    ensures { result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] result =  * self /\  ^ self = Core_Option_Option_Type.C_None }
     
 end
 module Core_Option_Impl0_Replace_Interface
@@ -104,7 +104,7 @@ module Core_Option_Impl0_Replace_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val replace (self : borrowed (Core_Option_Option_Type.t_option t)) (value : t) : Core_Option_Option_Type.t_option t
-    ensures { result =  * self /\  ^ self = Core_Option_Option_Type.C_Some value }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] result =  * self /\  ^ self = Core_Option_Option_Type.C_Some value }
     
 end
 module CreusotContracts_Std1_Default_Default_IsDefault_Stub
@@ -128,8 +128,8 @@ module Core_Option_Impl0_UnwrapOrDefault_Interface
     type self = t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap_or_default (self : Core_Option_Option_Type.t_option t) : t
-    ensures { self = Core_Option_Option_Type.C_None -> IsDefault0.is_default result }
-    ensures { self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 65 16 65 64] self = Core_Option_Option_Type.C_None -> IsDefault0.is_default result }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
     
 end
 module Core_Option_Impl2_Copied_Interface
@@ -137,8 +137,8 @@ module Core_Option_Impl2_Copied_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val copied (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 73 16 73 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
     
 end
 module Core_Option_Impl3_Copied_Interface
@@ -148,8 +148,8 @@ module Core_Option_Impl3_Copied_Interface
     type t = t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val copied (self : Core_Option_Option_Type.t_option (borrowed t)) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : borrowed t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some ( * t) /\ Resolve0.resolve t) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 87 16 87 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : borrowed t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl2_Cloned_Interface
@@ -157,8 +157,8 @@ module Core_Option_Impl2_Cloned_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val cloned (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 79 16 79 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some t) }
     
 end
 module Core_Option_Impl3_Cloned_Interface
@@ -168,16 +168,16 @@ module Core_Option_Impl3_Cloned_Interface
     type t = t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val cloned (self : Core_Option_Option_Type.t_option (borrowed t)) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists t : borrowed t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some ( * t) /\ Resolve0.resolve t) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 96 16 96 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ (exists t : borrowed t . self = Core_Option_Option_Type.C_Some t /\ result = Core_Option_Option_Type.C_Some ( * t) /\ Resolve0.resolve t) }
     
 end
 module Core_Option_Impl44_Flatten_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val flatten (self : Core_Option_Option_Type.t_option (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 107 16 107 59] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self = Core_Option_Option_Type.C_None \/ self = Core_Option_Option_Type.C_Some result }
     
 end
 module CreusotContracts_Std1_Num_Impl26_IsDefault_Stub
@@ -194,7 +194,7 @@ module CreusotContracts_Std1_Num_Impl26_IsDefault
   use prelude.Int
   use prelude.Int32
   predicate is_default (self : int32) =
-    self = (0 : int32)
+    [#"../../../../creusot-contracts/src/std/num.rs" 27 28 27 41] self = (0 : int32)
   val is_default (self : int32) : bool
     ensures { result = is_default self }
     

--- a/creusot/tests/should_succeed/ord_trait.mlcfg
+++ b/creusot/tests/should_succeed/ord_trait.mlcfg
@@ -62,7 +62,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -106,7 +106,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -126,7 +126,7 @@ module Core_Cmp_Impls_Impl10_Le_Interface
     type t = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val le (self : a) (other : b) : bool
-    ensures { result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 30 26 30 77] result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Stub
@@ -146,7 +146,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -159,7 +159,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub
   type self
@@ -175,7 +175,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -197,7 +197,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -210,7 +210,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -226,7 +226,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -248,7 +248,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -261,7 +261,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -277,7 +277,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -299,7 +299,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -312,7 +312,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -327,7 +327,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -338,7 +338,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -353,7 +353,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -362,11 +362,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -381,7 +381,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -390,10 +390,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -408,7 +408,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -417,10 +417,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -435,7 +435,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -446,7 +446,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module OrdTrait_X_Interface
   type t
@@ -573,7 +573,7 @@ module Core_Cmp_Impls_Impl10_Ge_Interface
     type t = a,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val ge (self : a) (other : b) : bool
-    ensures { result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 36 26 36 77] result = GeLog0.ge_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module OrdTrait_GtOrLe_Interface

--- a/creusot/tests/should_succeed/projection_toggle.mlcfg
+++ b/creusot/tests/should_succeed/projection_toggle.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/projections.mlcfg
+++ b/creusot/tests/should_succeed/projections.mlcfg
@@ -54,7 +54,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/prophecy.mlcfg
+++ b/creusot/tests/should_succeed/prophecy.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -420,7 +420,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 618 9 619 5] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -505,7 +505,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 609 10 610 18] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -527,7 +527,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 612 11 614 0] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -540,7 +540,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 612 11 614 0] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -559,7 +559,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 620 4 620 51] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -572,7 +572,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 620 4 620 51] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -588,7 +588,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 623 19 624 1] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -610,7 +610,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 624 36 627 32] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -623,7 +623,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 624 36 627 32] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -639,7 +639,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    [#"../red_black_tree.rs" 629 61 630 32] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -661,7 +661,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 631 22 632 19] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -674,7 +674,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../red_black_tree.rs" 631 22 632 19] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -689,7 +689,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 633 16 633 47] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -700,7 +700,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . [#"../red_black_tree.rs" 633 16 633 47] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -715,7 +715,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 633 99 634 11] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 634 29 634 46] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 634 63 635 5] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -724,11 +724,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {[#"../red_black_tree.rs" 633 99 634 11] CmpLog0.cmp_log x y = o}
-    requires {[#"../red_black_tree.rs" 634 29 634 46] CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../red_black_tree.rs" 633 99 634 11] CmpLog0.cmp_log x y = o) -> ([#"../red_black_tree.rs" 634 29 634 46] CmpLog0.cmp_log y z = o) -> ([#"../red_black_tree.rs" 634 63 635 5] CmpLog0.cmp_log x z = o)
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -743,7 +743,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 636 15 637 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 637 20 637 53] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -752,10 +752,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 636 15 637 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 636 15 637 3] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../red_black_tree.rs" 637 20 637 53] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -770,7 +770,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 639 3 639 36] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 639 53 640 22] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -779,10 +779,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {[#"../red_black_tree.rs" 639 3 639 36] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . ([#"../red_black_tree.rs" 639 3 639 36] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../red_black_tree.rs" 639 53 640 22] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -797,7 +797,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 643 12 644 17] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -808,7 +808,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . [#"../red_black_tree.rs" 643 12 644 17] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module RedBlackTree_Impl0_HasMappingModelAcc_Stub
   type k
@@ -2322,7 +2322,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -2348,24 +2348,24 @@ module Core_Mem_Take_Interface
   clone CreusotContracts_Std1_Default_Default_IsDefault_Stub as IsDefault0 with
     type self = t
   val take (dest : borrowed t) : t
-    ensures { result =  * dest }
-    ensures { IsDefault0.is_default ( ^ dest) }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 15 22 15 37] result =  * dest }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 16 22 16 42] IsDefault0.is_default ( ^ dest) }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap (self : Core_Option_Option_Type.t_option t) : t
-    requires {self <> Core_Option_Option_Type.C_None}
-    ensures { Core_Option_Option_Type.C_Some result = self }
+    requires {[#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self <> Core_Option_Option_Type.C_None}
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] Core_Option_Option_Type.C_Some result = self }
     
 end
 module Core_Mem_Swap_Interface
   type t
   use prelude.Borrow
   val swap (x : borrowed t) (y : borrowed t) : ()
-    ensures {  ^ x =  * y }
-    ensures {  ^ y =  * x }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 11 22 11 30]  ^ x =  * y }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 12 22 12 30]  ^ y =  * x }
     
 end
 module CreusotContracts_Std1_Option_Impl1_IsDefault_Stub
@@ -2382,7 +2382,7 @@ module CreusotContracts_Std1_Option_Impl1_IsDefault
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   predicate is_default (self : Core_Option_Option_Type.t_option t) =
-    self = Core_Option_Option_Type.C_None
+    [#"../../../../creusot-contracts/src/std/option.rs" 118 20 118 32] self = Core_Option_Option_Type.C_None
   val is_default (self : Core_Option_Option_Type.t_option t) : bool
     ensures { result = is_default self }
     
@@ -3064,8 +3064,8 @@ module Core_Option_Impl0_AsMut_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val as_mut (self : borrowed (Core_Option_Option_Type.t_option t)) : Core_Option_Option_Type.t_option (borrowed t)
-    ensures {  * self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None /\  ^ self = Core_Option_Option_Type.C_None }
-    ensures {  * self = Core_Option_Option_Type.C_None \/ (exists r : borrowed t . result = Core_Option_Option_Type.C_Some r /\  * self = Core_Option_Option_Type.C_Some ( * r) /\  ^ self = Core_Option_Option_Type.C_Some ( ^ r)) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 38 16 38 77]  * self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None /\  ^ self = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 39 16 42 18]  * self = Core_Option_Option_Type.C_None \/ (exists r : borrowed t . result = Core_Option_Option_Type.C_Some r /\  * self = Core_Option_Option_Type.C_Some ( * r) /\  ^ self = Core_Option_Option_Type.C_Some ( ^ r)) }
     
 end
 module RedBlackTree_Impl14_FlipColors_Interface
@@ -3333,8 +3333,8 @@ module Core_Option_Impl0_AsRef_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val as_ref (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option t
-    ensures { self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
-    ensures { self = Core_Option_Option_Type.C_None \/ (exists r : t . result = Core_Option_Option_Type.C_Some r /\ self = Core_Option_Option_Type.C_Some r) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 45 16 45 60] self = Core_Option_Option_Type.C_None -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 46 16 48 18] self = Core_Option_Option_Type.C_None \/ (exists r : t . result = Core_Option_Option_Type.C_Some r /\ self = Core_Option_Option_Type.C_Some r) }
     
 end
 module RedBlackTree_Impl14_Balance_Interface
@@ -4713,7 +4713,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 44 26 44 85] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module RedBlackTree_Impl15_InsertRec_Interface
@@ -5215,7 +5215,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -5533,7 +5533,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -5543,8 +5543,8 @@ module Alloc_Boxed_Impl55_AsMut_Interface
   type a
   use prelude.Borrow
   val as_mut (self : borrowed t) : borrowed t
-    ensures {  * self =  * result }
-    ensures {  ^ self =  ^ result }
+    ensures { [#"../../../../creusot-contracts/src/std/boxed.rs" 31 26 31 43]  * self =  * result }
+    ensures { [#"../../../../creusot-contracts/src/std/boxed.rs" 32 26 32 43]  ^ self =  ^ result }
     
 end
 module RedBlackTree_Impl15_DeleteMaxRec_Interface
@@ -7352,7 +7352,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -7362,7 +7362,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module RedBlackTree_Impl15_DeleteRec_Interface
@@ -8682,7 +8682,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -434,7 +434,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -874,7 +874,7 @@ module Core_Default_Default_Default_Interface
   clone CreusotContracts_Std1_Default_Default_IsDefault_Stub as IsDefault0 with
     type self = self
   val default (_1' : ()) : self
-    ensures { IsDefault0.is_default result }
+    ensures { [#"../../../../../creusot-contracts/src/std/default.rs" 13 26 13 45] IsDefault0.is_default result }
     
 end
 module Own_Impl0_UnwrapOrDefault_Interface
@@ -1282,7 +1282,7 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' (self : self) : self
-    ensures { result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module Own_Impl1_Cloned_Interface

--- a/creusot/tests/should_succeed/result/result.mlcfg
+++ b/creusot/tests/should_succeed/result/result.mlcfg
@@ -25,7 +25,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -36,7 +36,7 @@ module Core_Result_Impl0_IsOk_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val is_ok (self : Core_Result_Result_Type.t_result t e) : bool
-    ensures { result = (exists t : t . self = Core_Result_Result_Type.C_Ok t) }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 21 26 21 63] result = (exists t : t . self = Core_Result_Result_Type.C_Ok t) }
     
 end
 module Core_Result_Impl0_IsErr_Interface
@@ -45,7 +45,7 @@ module Core_Result_Impl0_IsErr_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val is_err (self : Core_Result_Result_Type.t_result t e) : bool
-    ensures { result = (exists e : e . self = Core_Result_Result_Type.C_Err e) }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 24 26 24 64] result = (exists e : e . self = Core_Result_Result_Type.C_Err e) }
     
 end
 module Core_Result_Impl0_Ok_Interface
@@ -54,16 +54,16 @@ module Core_Result_Impl0_Ok_Interface
   use Core_Option_Option_Type as Core_Option_Option_Type
   use Core_Result_Result_Type as Core_Result_Result_Type
   val ok (self : Core_Result_Result_Type.t_result t e) : Core_Option_Option_Type.t_option t
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Option_Option_Type.C_Some t }
-    ensures { (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 27 16 27 76] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Option_Option_Type.C_Some t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 28 16 28 76] (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = Core_Option_Option_Type.C_None }
     
 end
 module Core_Option_Impl0_Unwrap_Interface
   type t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val unwrap (self : Core_Option_Option_Type.t_option t) : t
-    requires {self <> Core_Option_Option_Type.C_None}
-    ensures { Core_Option_Option_Type.C_Some result = self }
+    requires {[#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] self <> Core_Option_Option_Type.C_None}
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 16 0 113 1] Core_Option_Option_Type.C_Some result = self }
     
 end
 module Core_Option_Impl0_IsNone_Interface
@@ -71,7 +71,7 @@ module Core_Option_Impl0_IsNone_Interface
   use prelude.Borrow
   use Core_Option_Option_Type as Core_Option_Option_Type
   val is_none (self : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (self = Core_Option_Option_Type.C_None) }
+    ensures { [#"../../../../../creusot-contracts/src/std/option.rs" 23 26 23 51] result = (self = Core_Option_Option_Type.C_None) }
     
 end
 module Core_Result_Impl0_Err_Interface
@@ -80,8 +80,8 @@ module Core_Result_Impl0_Err_Interface
   use Core_Option_Option_Type as Core_Option_Option_Type
   use Core_Result_Result_Type as Core_Result_Result_Type
   val err (self : Core_Result_Result_Type.t_result t e) : Core_Option_Option_Type.t_option e
-    ensures { (exists t : t . self = Core_Result_Result_Type.C_Ok t) -> result = Core_Option_Option_Type.C_None }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Option_Option_Type.C_Some e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 31 16 31 75] (exists t : t . self = Core_Result_Result_Type.C_Ok t) -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 32 16 32 77] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Option_Option_Type.C_Some e }
     
 end
 module Core_Result_Impl0_AsRef_Interface
@@ -90,8 +90,8 @@ module Core_Result_Impl0_AsRef_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val as_ref (self : Core_Result_Result_Type.t_result t e) : Core_Result_Result_Type.t_result t e
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 35 16 35 77] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 36 16 36 79] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl0_Unwrap_Interface
@@ -99,8 +99,8 @@ module Core_Result_Impl0_Unwrap_Interface
   type e
   use Core_Result_Result_Type as Core_Result_Result_Type
   val unwrap (self : Core_Result_Result_Type.t_result t e) : t
-    requires {exists t : t . self = Core_Result_Result_Type.C_Ok t}
-    ensures { Core_Result_Result_Type.C_Ok result = self }
+    requires {[#"../../../../../creusot-contracts/src/std/result.rs" 45 16 45 55] exists t : t . self = Core_Result_Result_Type.C_Ok t}
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 17 0 118 1] Core_Result_Result_Type.C_Ok result = self }
     
 end
 module Core_Result_Impl0_UnwrapErr_Interface
@@ -108,8 +108,8 @@ module Core_Result_Impl0_UnwrapErr_Interface
   type e
   use Core_Result_Result_Type as Core_Result_Result_Type
   val unwrap_err (self : Core_Result_Result_Type.t_result t e) : e
-    requires {exists e : e . self = Core_Result_Result_Type.C_Err e}
-    ensures { Core_Result_Result_Type.C_Err result = self }
+    requires {[#"../../../../../creusot-contracts/src/std/result.rs" 57 16 57 56] exists e : e . self = Core_Result_Result_Type.C_Err e}
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 17 0 118 1] Core_Result_Result_Type.C_Err result = self }
     
 end
 module Core_Result_Impl0_AsMut_Interface
@@ -118,7 +118,7 @@ module Core_Result_Impl0_AsMut_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val as_mut (self : borrowed (Core_Result_Result_Type.t_result t e)) : Core_Result_Result_Type.t_result (borrowed t) (borrowed e)
-    ensures { exists t : borrowed t .  * self = Core_Result_Result_Type.C_Ok ( * t) /\  ^ self = Core_Result_Result_Type.C_Ok ( ^ t) /\ result = Core_Result_Result_Type.C_Ok t \/ (exists e : borrowed e .  * self = Core_Result_Result_Type.C_Err ( * e) /\  ^ self = Core_Result_Result_Type.C_Err ( ^ e) /\ result = Core_Result_Result_Type.C_Err e) }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 39 16 42 18] exists t : borrowed t .  * self = Core_Result_Result_Type.C_Ok ( * t) /\  ^ self = Core_Result_Result_Type.C_Ok ( ^ t) /\ result = Core_Result_Result_Type.C_Ok t \/ (exists e : borrowed e .  * self = Core_Result_Result_Type.C_Err ( * e) /\  ^ self = Core_Result_Result_Type.C_Err ( ^ e) /\ result = Core_Result_Result_Type.C_Err e) }
     
 end
 module Core_Result_Impl0_UnwrapOr_Interface
@@ -126,8 +126,8 @@ module Core_Result_Impl0_UnwrapOr_Interface
   type e
   use Core_Result_Result_Type as Core_Result_Result_Type
   val unwrap_or (self : Core_Result_Result_Type.t_result t e) (default : t) : t
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = t }
-    ensures { (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = default }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 63 16 63 70] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 64 16 64 79] (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = default }
     
 end
 module CreusotContracts_Std1_Default_Default_IsDefault_Stub
@@ -152,8 +152,8 @@ module Core_Result_Impl0_UnwrapOrDefault_Interface
     type self = t
   use Core_Result_Result_Type as Core_Result_Result_Type
   val unwrap_or_default (self : Core_Result_Result_Type.t_result t e) : t
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = t }
-    ensures { (exists e : e . self = Core_Result_Result_Type.C_Err e) -> IsDefault0.is_default result }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 67 16 67 70] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 68 16 68 81] (exists e : e . self = Core_Result_Result_Type.C_Err e) -> IsDefault0.is_default result }
     
 end
 module Core_Result_Impl0_And_Interface
@@ -162,8 +162,8 @@ module Core_Result_Impl0_And_Interface
   type u
   use Core_Result_Result_Type as Core_Result_Result_Type
   val and (self : Core_Result_Result_Type.t_result t e) (res : Core_Result_Result_Type.t_result u e) : Core_Result_Result_Type.t_result u e
-    ensures { (exists t : t . self = Core_Result_Result_Type.C_Ok t) -> result = res }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 73 16 73 74] (exists t : t . self = Core_Result_Result_Type.C_Ok t) -> result = res }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 74 16 74 76] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl0_Or_Interface
@@ -172,8 +172,8 @@ module Core_Result_Impl0_Or_Interface
   type f
   use Core_Result_Result_Type as Core_Result_Result_Type
   val or (self : Core_Result_Result_Type.t_result t e) (res : Core_Result_Result_Type.t_result t f) : Core_Result_Result_Type.t_result t f
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
-    ensures { (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = res }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 77 16 77 74] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 78 16 78 75] (exists e : e . self = Core_Result_Result_Type.C_Err e) -> result = res }
     
 end
 module Core_Result_Impl1_Copied_Interface
@@ -182,8 +182,8 @@ module Core_Result_Impl1_Copied_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val copied (self : Core_Result_Result_Type.t_result t e) : Core_Result_Result_Type.t_result t e
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 83 16 83 76] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 84 16 84 76] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl2_Copied_Interface
@@ -194,8 +194,8 @@ module Core_Result_Impl2_Copied_Interface
     type t = t
   use Core_Result_Result_Type as Core_Result_Result_Type
   val copied (self : Core_Result_Result_Type.t_result (borrowed t) e) : Core_Result_Result_Type.t_result t e
-    ensures { forall t : borrowed t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok ( * t) /\ Resolve0.resolve t }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 97 16 97 95] forall t : borrowed t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok ( * t) /\ Resolve0.resolve t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 98 16 98 76] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl1_Cloned_Interface
@@ -204,8 +204,8 @@ module Core_Result_Impl1_Cloned_Interface
   use prelude.Borrow
   use Core_Result_Result_Type as Core_Result_Result_Type
   val cloned (self : Core_Result_Result_Type.t_result t e) : Core_Result_Result_Type.t_result t e
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 89 16 89 76] forall t : t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 90 16 90 76] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl2_Cloned_Interface
@@ -216,8 +216,8 @@ module Core_Result_Impl2_Cloned_Interface
     type t = t
   use Core_Result_Result_Type as Core_Result_Result_Type
   val cloned (self : Core_Result_Result_Type.t_result (borrowed t) e) : Core_Result_Result_Type.t_result t e
-    ensures { forall t : borrowed t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok ( * t) /\ Resolve0.resolve t }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 103 16 103 95] forall t : borrowed t . self = Core_Result_Result_Type.C_Ok t -> result = Core_Result_Result_Type.C_Ok ( * t) /\ Resolve0.resolve t }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 104 16 104 76] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Result_Result_Type.C_Err e }
     
 end
 module Core_Result_Impl3_Transpose_Interface
@@ -226,9 +226,9 @@ module Core_Result_Impl3_Transpose_Interface
   use Core_Result_Result_Type as Core_Result_Result_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   val transpose (self : Core_Result_Result_Type.t_result (Core_Option_Option_Type.t_option t) e) : Core_Option_Option_Type.t_option (Core_Result_Result_Type.t_result t e)
-    ensures { self = Core_Result_Result_Type.C_Ok (Core_Option_Option_Type.C_None) -> result = Core_Option_Option_Type.C_None }
-    ensures { forall t : t . self = Core_Result_Result_Type.C_Ok (Core_Option_Option_Type.C_Some t) -> result = Core_Option_Option_Type.C_Some (Core_Result_Result_Type.C_Ok t) }
-    ensures { forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Option_Option_Type.C_Some (Core_Result_Result_Type.C_Err e) }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 111 16 111 63] self = Core_Result_Result_Type.C_Ok (Core_Option_Option_Type.C_None) -> result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 112 16 112 86] forall t : t . self = Core_Result_Result_Type.C_Ok (Core_Option_Option_Type.C_Some t) -> result = Core_Option_Option_Type.C_Some (Core_Result_Result_Type.C_Ok t) }
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 113 16 113 82] forall e : e . self = Core_Result_Result_Type.C_Err e -> result = Core_Option_Option_Type.C_Some (Core_Result_Result_Type.C_Err e) }
     
 end
 module CreusotContracts_Std1_Num_Impl26_IsDefault_Stub
@@ -245,7 +245,7 @@ module CreusotContracts_Std1_Num_Impl26_IsDefault
   use prelude.Int
   use prelude.Int32
   predicate is_default (self : int32) =
-    self = (0 : int32)
+    [#"../../../../../creusot-contracts/src/std/num.rs" 27 28 27 41] self = (0 : int32)
   val is_default (self : int32) : bool
     ensures { result = is_default self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
@@ -21,7 +21,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -130,7 +130,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -186,7 +186,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -202,7 +202,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -242,9 +242,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -308,7 +308,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -327,7 +327,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -343,7 +343,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -359,18 +359,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -387,7 +387,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -396,11 +396,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -419,7 +419,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -430,13 +430,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl7_DeepModel_Stub
   use prelude.Int
@@ -452,7 +452,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     
@@ -481,7 +481,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -201,7 +201,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -220,7 +220,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -435,7 +435,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -242,7 +242,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -512,7 +512,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -201,7 +201,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -220,7 +220,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -242,7 +242,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -176,7 +176,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -190,7 +190,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -239,7 +239,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -312,7 +312,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Vec_Impl1_DeepModel
   type t
@@ -338,7 +338,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel
   val deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
   type t
@@ -363,7 +363,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -383,7 +383,7 @@ module CreusotContracts_Logic_Seq_Impl0_PermutationOf
   use seq.Seq
   use seq.Permut
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) =
-    Permut.permut self o 0 (Seq.length self)
+    [#"../../../../creusot-contracts/src/logic/seq.rs" 89 8 89 37] Permut.permut self o 0 (Seq.length self)
   val permutation_of (self : Seq.seq t) (o : Seq.seq t) : bool
     ensures { result = permutation_of self o }
     
@@ -428,7 +428,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -459,7 +459,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -487,7 +487,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -515,7 +515,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -543,7 +543,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -562,7 +562,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -595,7 +595,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -609,7 +609,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -649,9 +649,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -715,7 +715,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -808,8 +808,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_Impl0_DeepModel_Stub
@@ -835,7 +835,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -854,7 +854,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -874,7 +874,7 @@ module Core_Cmp_PartialOrd_Lt_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val lt (self : self) (other : rhs) : bool
-    ensures { result = LtLog0.lt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 27 26 27 76] result = LtLog0.lt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -894,7 +894,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -907,7 +907,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module Alloc_Vec_Impl10_DerefMut_Interface
   type t
@@ -934,8 +934,8 @@ module Alloc_Vec_Impl10_DerefMut_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : borrowed (slice t)
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
-    ensures { ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 138 26 138 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 139 26 139 48] ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
     
 end
 module Core_Slice_Impl0_Swap_Interface
@@ -956,9 +956,9 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
-    ensures { Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 213 19 213 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 214 19 214 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 215 8 215 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -974,7 +974,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -990,7 +990,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -1006,18 +1006,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -1034,7 +1034,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -1043,11 +1043,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -1066,7 +1066,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -1077,13 +1077,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -1099,7 +1099,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -1128,7 +1128,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -1150,7 +1150,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -1163,7 +1163,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -1182,7 +1182,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -1195,7 +1195,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -1211,7 +1211,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -1233,7 +1233,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -1246,7 +1246,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -1262,7 +1262,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -1284,7 +1284,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -1297,7 +1297,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -1312,7 +1312,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -1323,7 +1323,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -1338,7 +1338,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -1347,11 +1347,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -1366,7 +1366,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -1375,10 +1375,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -1393,7 +1393,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -1402,10 +1402,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -1420,7 +1420,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -1431,7 +1431,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
   type t
@@ -1453,7 +1453,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1478,7 +1478,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -80,7 +80,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -93,7 +93,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module C01_IndexSlice_Interface
   use seq.Seq
@@ -175,7 +175,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -202,7 +202,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -221,7 +221,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -329,7 +329,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : slice t) : usize
-    ensures { Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module C01_SliceFirst_Interface

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -74,7 +74,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -133,7 +133,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -177,7 +177,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -201,7 +201,7 @@ module CreusotContracts_Logic_Seq_Impl0_SortedRange
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = t
   predicate sorted_range (self : Seq.seq t) (l : int) (u : int) =
-    forall j : int . forall i : int . l <= i /\ i <= j /\ j < u -> LeLog0.le_log (Seq.get self i) (Seq.get self j)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 116 8 118 9] forall j : int . forall i : int . l <= i /\ i <= j /\ j < u -> LeLog0.le_log (Seq.get self i) (Seq.get self j)
   val sorted_range (self : Seq.seq t) (l : int) (u : int) : bool
     ensures { result = sorted_range self l u }
     
@@ -222,7 +222,7 @@ module CreusotContracts_Logic_Seq_Impl0_Sorted
   clone CreusotContracts_Logic_Seq_Impl0_SortedRange_Stub as SortedRange0 with
     type t = t
   predicate sorted (self : Seq.seq t) =
-    SortedRange0.sorted_range self 0 (Seq.length self)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 126 8 126 40] SortedRange0.sorted_range self 0 (Seq.length self)
   val sorted (self : Seq.seq t) : bool
     ensures { result = sorted self }
     
@@ -255,7 +255,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -268,7 +268,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl1_DeepModel_Stub
   type t
@@ -309,7 +309,7 @@ module CreusotContracts_Std1_Slice_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : slice t) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 30 4 30 95] forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 29 14 29 41] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Slice_Impl1_DeepModel
   type t
@@ -333,7 +333,7 @@ module CreusotContracts_Std1_Slice_Impl1_DeepModel
   val deep_model (self : slice t) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 30 4 30 95] forall i : int . 0 <= i /\ i < Seq.length (deep_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 29 14 29 41] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub
   type self
@@ -349,7 +349,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -398,11 +398,11 @@ module Core_Slice_Impl0_BinarySearch_Interface
     type t = slice t,
     type DeepModelTy0.deepModelTy = Seq.seq DeepModelTy0.deepModelTy
   val binary_search (self : slice t) (x : t) : Core_Result_Result_Type.t_result usize usize
-    requires {Sorted0.sorted (DeepModel0.deep_model self)}
-    ensures { forall i : usize . result = Core_Result_Result_Type.C_Ok i -> UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self) /\ Seq.get (DeepModel1.deep_model self) (UIntSize.to_int i) = DeepModel2.deep_model x }
-    ensures { forall i : usize . result = Core_Result_Result_Type.C_Err i -> UIntSize.to_int i <= Seq.length (ShallowModel0.shallow_model self) /\ (forall j : int . 0 <= j /\ j < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (DeepModel0.deep_model self) j <> DeepModel2.deep_model x) }
-    ensures { forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . j < i -> LtLog0.lt_log (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j)) (DeepModel2.deep_model x)) }
-    ensures { forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . i <= j /\ UIntSize.to_int j < Seq.length (ShallowModel0.shallow_model self) -> LtLog0.lt_log (DeepModel2.deep_model x) (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j))) }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 208 0 301 1] Sorted0.sorted (DeepModel0.deep_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 271 8 271 118] forall i : usize . result = Core_Result_Result_Type.C_Ok i -> UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self) /\ Seq.get (DeepModel1.deep_model self) (UIntSize.to_int i) = DeepModel2.deep_model x }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 272 8 273 96] forall i : usize . result = Core_Result_Result_Type.C_Err i -> UIntSize.to_int i <= Seq.length (ShallowModel0.shallow_model self) /\ (forall j : int . 0 <= j /\ j < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (DeepModel0.deep_model self) j <> DeepModel2.deep_model x) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 274 8 275 78] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . j < i -> LtLog0.lt_log (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j)) (DeepModel2.deep_model x)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 276 8 277 99] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . i <= j /\ UIntSize.to_int j < Seq.length (ShallowModel0.shallow_model self) -> LtLog0.lt_log (DeepModel2.deep_model x) (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j))) }
     
 end
 module Core_Result_Impl0_Unwrap_Interface
@@ -410,8 +410,8 @@ module Core_Result_Impl0_Unwrap_Interface
   type e
   use Core_Result_Result_Type as Core_Result_Result_Type
   val unwrap (self : Core_Result_Result_Type.t_result t e) : t
-    requires {exists t : t . self = Core_Result_Result_Type.C_Ok t}
-    ensures { Core_Result_Result_Type.C_Ok result = self }
+    requires {[#"../../../../../creusot-contracts/src/std/result.rs" 45 16 45 55] exists t : t . self = Core_Result_Result_Type.C_Ok t}
+    ensures { [#"../../../../../creusot-contracts/src/std/result.rs" 17 0 118 1] Core_Result_Result_Type.C_Ok result = self }
     
 end
 module CreusotContracts_Logic_Ord_Impl2_LtLog_Stub
@@ -445,7 +445,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -117,7 +117,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -246,7 +246,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -281,7 +281,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -295,7 +295,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module SparseArray_Impl1_SparseInv_Stub
   type t
@@ -447,8 +447,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -471,7 +471,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -496,7 +496,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -851,7 +851,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -870,7 +870,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -937,11 +937,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere_Stub
@@ -964,7 +964,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -1317,8 +1317,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module SparseArray_Create_Interface

--- a/creusot/tests/should_succeed/split_borrow.mlcfg
+++ b/creusot/tests/should_succeed/split_borrow.mlcfg
@@ -59,7 +59,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -78,7 +78,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -94,7 +94,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -26,7 +26,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -131,7 +131,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -167,7 +167,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog_Interface
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   predicate is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   type idx
@@ -187,7 +187,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   val is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = is_empty_log self }
     
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use prelude.Int
@@ -251,7 +251,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
@@ -275,7 +275,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int =
-    if IsEmptyLog0.is_empty_log r then
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 42 4 45 5] if IsEmptyLog0.is_empty_log r then
       0
     else
       DeepModel0.deep_model (EndLog0.end_log r) - DeepModel0.deep_model (StartLog0.start_log r) + 1
@@ -283,7 +283,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   val range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
     ensures { result = range_inclusive_len r }
     
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub
   type idx
@@ -332,7 +332,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   predicate produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
     
    =
-    Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 58 8 64 9] Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
   val produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = produces self visited o }
     
@@ -351,7 +351,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -379,9 +379,9 @@ module Core_Ops_Range_Impl7_New_Interface
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     axiom .
   val new (start : idx) (end' : idx) : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx
-    ensures { StartLog0.start_log result = start }
-    ensures { EndLog0.end_log result = end' }
-    ensures { LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 210 26 210 53] StartLog0.start_log result = start }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 211 26 211 49] EndLog0.end_log result = end' }
+    ensures { [#"../../../../creusot-contracts/src/std/ops.rs" 212 16 212 93] LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -395,7 +395,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -435,9 +435,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -501,7 +501,7 @@ module Core_Iter_Range_Impl12_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a
   val next (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -521,7 +521,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     
@@ -539,7 +539,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -555,7 +555,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -571,18 +571,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl_Stub
   type idx
@@ -599,7 +599,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   type idx
@@ -608,11 +608,11 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 67 4 67 10] ()
   val produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Stub
   type idx
@@ -631,7 +631,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   type idx
@@ -642,13 +642,13 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 71 4 71 10] ()
   val produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Completed_Stub
   type idx
@@ -685,7 +685,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
     type DeepModelTy0.deepModelTy = int,
     axiom .
   predicate completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) =
-    IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 52 12 52 57] IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
   val completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) : bool
     ensures { result = completed self }
     

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -140,7 +140,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -196,7 +196,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -215,7 +215,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -231,7 +231,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -271,9 +271,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -337,7 +337,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -356,7 +356,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -372,7 +372,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -388,18 +388,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -416,7 +416,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -425,11 +425,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -448,7 +448,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -459,13 +459,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl7_DeepModel_Stub
   use prelude.Int
@@ -481,7 +481,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     
@@ -510,7 +510,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     

--- a/creusot/tests/should_succeed/swap_borrows.mlcfg
+++ b/creusot/tests/should_succeed/swap_borrows.mlcfg
@@ -32,7 +32,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -103,7 +103,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -119,7 +119,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/switch.mlcfg
+++ b/creusot/tests/should_succeed/switch.mlcfg
@@ -90,7 +90,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -106,7 +106,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/syntax/04_assoc_prec.mlcfg
+++ b/creusot/tests/should_succeed/syntax/04_assoc_prec.mlcfg
@@ -32,7 +32,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -48,7 +48,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -80,7 +80,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -93,7 +93,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module C05Pearlite_HasLen3_Stub
   use seq.Seq

--- a/creusot/tests/should_succeed/syntax/09_maintains.mlcfg
+++ b/creusot/tests/should_succeed/syntax/09_maintains.mlcfg
@@ -111,7 +111,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/syntax/10_mutual_rec_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/10_mutual_rec_types.mlcfg
@@ -153,7 +153,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -172,7 +172,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -191,7 +191,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -210,11 +210,11 @@ module Core_Cmp_Ord_Max_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val max (self : self) (other : self) : self
-    ensures { GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model self) }
-    ensures { GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model other) }
-    ensures { result = self \/ result = other }
-    ensures { LeLog0.le_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) -> result = other }
-    ensures { LtLog0.lt_log (DeepModel0.deep_model other) (DeepModel0.deep_model self) -> result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 47 26 47 66] GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 48 26 48 63] GeLog0.ge_log (DeepModel0.deep_model result) (DeepModel0.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 7 0 56 1] result = self \/ result = other }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 50 16 50 79] LeLog0.le_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) -> result = other }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 51 16 51 81] LtLog0.lt_log (DeepModel0.deep_model other) (DeepModel0.deep_model self) -> result = self }
     
 end
 module CreusotContracts_Std1_Num_Impl10_DeepModel_Stub
@@ -231,7 +231,7 @@ module CreusotContracts_Std1_Num_Impl10_DeepModel
   use prelude.Int
   use prelude.UInt64
   function deep_model (self : uint64) : int =
-    UInt64.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt64.to_int self
   val deep_model (self : uint64) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
@@ -69,7 +69,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -100,7 +100,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -114,7 +114,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Vec_Impl0_New_Interface
   type t
@@ -128,7 +128,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module C12GhostCode_GhostVec_Interface
@@ -291,7 +291,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -341,7 +341,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -369,7 +369,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -391,7 +391,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Model_Impl1_ShallowModel_Stub
@@ -417,7 +417,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -435,7 +435,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -449,7 +449,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -607,7 +607,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -68,7 +68,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -82,7 +82,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Vec_Impl0_New_Interface
   type t
@@ -96,7 +96,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
@@ -146,7 +146,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -168,8 +168,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module CreusotContracts_Std1_Boxed_Impl1_ShallowModel_Stub
@@ -195,7 +195,7 @@ module CreusotContracts_Std1_Boxed_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/std/boxed.rs" 18 8 18 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -218,7 +218,7 @@ module Alloc_Slice_Impl0_IntoVec_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val into_vec (self : slice t) : Alloc_Vec_Vec_Type.t_vec t a
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 281 18 281 35] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -238,7 +238,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -251,7 +251,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module C13VecMacro_X_Interface
   val x [#"../13_vec_macro.rs" 5 0 5 10] (_1' : ()) : ()

--- a/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
+++ b/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
@@ -31,7 +31,7 @@ module Core_Clone_Clone_Clone_Interface
   type self
   use prelude.Borrow
   val clone' (self : self) : self
-    ensures { result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module DeriveMacros_Impl2_Clone_Interface
@@ -139,7 +139,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -157,7 +157,7 @@ module Core_Cmp_PartialEq_Eq_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : self) (other : rhs) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
     
 end
 module DeriveMacros_Impl0_DeepModel_Stub
@@ -454,7 +454,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -51,7 +51,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -100,7 +100,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -120,7 +120,7 @@ module CreusotContracts_Logic_Seq_Impl0_Tail
   use seq.Seq
   use seq_ext.SeqExt
   function tail (self : Seq.seq t) : Seq.seq t =
-    SeqExt.subsequence self 1 (Seq.length self)
+    [#"../../../../creusot-contracts/src/logic/seq.rs" 42 8 42 39] SeqExt.subsequence self 1 (Seq.length self)
   val tail (self : Seq.seq t) : Seq.seq t
     ensures { result = tail self }
     
@@ -139,7 +139,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -180,8 +180,8 @@ module Core_Mem_Take_Interface
   clone CreusotContracts_Std1_Default_Default_IsDefault_Stub as IsDefault0 with
     type self = t
   val take (dest : borrowed t) : t
-    ensures { result =  * dest }
-    ensures { IsDefault0.is_default ( ^ dest) }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 15 22 15 37] result =  * dest }
+    ensures { [#"../../../../creusot-contracts/src/std/mem.rs" 16 22 16 42] IsDefault0.is_default ( ^ dest) }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -207,7 +207,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -237,8 +237,8 @@ module Core_Slice_Impl0_SplitFirstMut_Interface
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   use Core_Option_Option_Type as Core_Option_Option_Type
   val split_first_mut (self : borrowed (slice t)) : Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t))
-    ensures { result = Core_Option_Option_Type.C_None -> Seq.length (ShallowModel0.shallow_model self) = 0 /\  ^ self =  * self /\ ShallowModel0.shallow_model self = Seq.empty  }
-    ensures { forall tail : borrowed (slice t) . forall first : borrowed t . result = Core_Option_Option_Type.C_Some (first, tail) /\  * first = IndexLogic0.index_logic self 0 /\  ^ first = IndexLogic1.index_logic ( ^ self) 0 /\ Seq.length (ShallowModel0.shallow_model self) > 0 /\ Seq.length (ShallowModel1.shallow_model ( ^ self)) > 0 /\ ShallowModel0.shallow_model tail = Tail0.tail (ShallowModel0.shallow_model self) /\ ShallowModel1.shallow_model ( ^ tail) = Tail0.tail (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 233 8 233 96] result = Core_Option_Option_Type.C_None -> Seq.length (ShallowModel0.shallow_model self) = 0 /\  ^ self =  * self /\ ShallowModel0.shallow_model self = Seq.empty  }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 234 8 239 48] forall tail : borrowed (slice t) . forall first : borrowed t . result = Core_Option_Option_Type.C_Some (first, tail) /\  * first = IndexLogic0.index_logic self 0 /\  ^ first = IndexLogic1.index_logic ( ^ self) 0 /\ Seq.length (ShallowModel0.shallow_model self) > 0 /\ Seq.length (ShallowModel1.shallow_model ( ^ self)) > 0 /\ ShallowModel0.shallow_model tail = Tail0.tail (ShallowModel0.shallow_model self) /\ ShallowModel1.shallow_model ( ^ tail) = Tail0.tail (ShallowModel1.shallow_model ( ^ self)) }
     
 end
 module CreusotContracts_Std1_Slice_Impl2_IsDefault_Stub
@@ -268,7 +268,7 @@ module CreusotContracts_Std1_Slice_Impl2_IsDefault
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   predicate is_default (self : borrowed (slice t)) =
-    ShallowModel0.shallow_model self = Seq.empty  /\ ShallowModel1.shallow_model ( ^ self) = Seq.empty 
+    [#"../../../../creusot-contracts/src/std/slice.rs" 46 20 46 65] ShallowModel0.shallow_model self = Seq.empty  /\ ShallowModel1.shallow_model ( ^ self) = Seq.empty 
   val is_default (self : borrowed (slice t)) : bool
     ensures { result = is_default self }
     

--- a/creusot/tests/should_succeed/trait_impl.mlcfg
+++ b/creusot/tests/should_succeed/trait_impl.mlcfg
@@ -32,7 +32,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
@@ -114,7 +114,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -133,7 +133,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
@@ -75,7 +75,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -96,7 +96,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -115,7 +115,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/unnest.mlcfg
+++ b/creusot/tests/should_succeed/unnest.mlcfg
@@ -13,7 +13,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -74,7 +74,7 @@ module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface
   use Alloc_Collections_VecDeque_VecDeque_Type as Alloc_Collections_VecDeque_VecDeque_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . [#"../../../../creusot-contracts/src/std/deque.rs" 9 14 9 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Deque_Impl0_ShallowModel
   type t
@@ -88,7 +88,7 @@ module CreusotContracts_Std1_Deque_Impl0_ShallowModel
   val shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . [#"../../../../creusot-contracts/src/std/deque.rs" 9 14 9 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface
   type t
@@ -104,7 +104,7 @@ module Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val with_capacity (capacity : usize) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 35 26 35 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
@@ -155,7 +155,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -171,7 +171,7 @@ module Alloc_Collections_VecDeque_Impl5_IsEmpty_Interface
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val is_empty (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : bool
-    ensures { result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 43 26 43 54] result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
     
 end
 module Alloc_Collections_VecDeque_Impl5_Len_Interface
@@ -187,7 +187,7 @@ module Alloc_Collections_VecDeque_Impl5_Len_Interface
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 40 26 40 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Collections_VecDeque_Impl4_New_Interface
@@ -202,7 +202,7 @@ module Alloc_Collections_VecDeque_Impl4_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 32 26 32 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -228,7 +228,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -252,7 +252,7 @@ module Alloc_Collections_VecDeque_Impl5_PopFront_Interface
     axiom .
   use Core_Option_Option_Type as Core_Option_Option_Type
   val pop_front (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 49 26 54 17] match (result) with
       | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 1 (Seq.length (ShallowModel1.shallow_model self)) /\ ShallowModel1.shallow_model self = Seq.(++) (Seq.singleton t) (ShallowModel0.shallow_model ( ^ self))
       | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
       end }
@@ -306,7 +306,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -321,7 +321,7 @@ module Core_Option_Impl14_Eq_Interface
     type t = Core_Option_Option_Type.t_option t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : Core_Option_Option_Type.t_option t) (other : Core_Option_Option_Type.t_option t) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
+    ensures { [#"../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel0.deep_model other) }
     
 end
 module Alloc_Collections_VecDeque_Impl5_PopBack_Interface
@@ -344,7 +344,7 @@ module Alloc_Collections_VecDeque_Impl5_PopBack_Interface
     axiom .
   use Core_Option_Option_Type as Core_Option_Option_Type
   val pop_back (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 57 26 62 17] match (result) with
       | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 0 (Seq.length (ShallowModel1.shallow_model self) - 1) /\ ShallowModel1.shallow_model self = Seq.snoc (ShallowModel0.shallow_model ( ^ self)) t
       | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
       end }
@@ -368,8 +368,8 @@ module Alloc_Collections_VecDeque_Impl5_PushFront_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push_front (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
-    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 65 26 65 59] Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 66 26 66 73] ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
     
 end
 module Alloc_Collections_VecDeque_Impl5_PushBack_Interface
@@ -389,7 +389,7 @@ module Alloc_Collections_VecDeque_Impl5_PushBack_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push_back (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 69 26 69 55] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module Alloc_Collections_VecDeque_Impl5_Clear_Interface
@@ -405,7 +405,7 @@ module Alloc_Collections_VecDeque_Impl5_Clear_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val clear (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : ()
-    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 46 26 46 45] Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
     
 end
 module CreusotContracts_Std1_Option_Impl0_DeepModel_Stub
@@ -435,7 +435,7 @@ module CreusotContracts_Std1_Option_Impl0_DeepModel
   function deep_model (self : Core_Option_Option_Type.t_option t) : Core_Option_Option_Type.t_option DeepModelTy0.deepModelTy
     
    =
-    match (self) with
+    [#"../../../../creusot-contracts/src/std/option.rs" 9 8 12 9] match (self) with
       | Core_Option_Option_Type.C_Some t -> Core_Option_Option_Type.C_Some (DeepModel0.deep_model t)
       | Core_Option_Option_Type.C_None -> Core_Option_Option_Type.C_None
       end
@@ -457,7 +457,7 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
   use prelude.Int
   use prelude.UInt32
   function deep_model (self : uint32) : int =
-    UInt32.to_int self
+    [#"../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UInt32.to_int self
   val deep_model (self : uint32) : int
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -63,7 +63,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -77,7 +77,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -126,7 +126,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -154,7 +154,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -199,7 +199,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -255,7 +255,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -283,7 +283,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -311,7 +311,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -330,7 +330,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -348,7 +348,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -362,7 +362,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -402,9 +402,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -468,7 +468,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -598,11 +598,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -618,7 +618,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -634,7 +634,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -650,18 +650,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -678,7 +678,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -687,11 +687,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -710,7 +710,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -721,13 +721,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -743,7 +743,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -772,7 +772,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -797,7 +797,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -822,7 +822,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -847,7 +847,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -152,7 +152,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -166,7 +166,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -215,7 +215,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -288,7 +288,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Vec_Impl1_DeepModel
   type t
@@ -314,7 +314,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel
   val deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
   type t
@@ -339,7 +339,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -359,7 +359,7 @@ module CreusotContracts_Logic_Seq_Impl0_PermutationOf
   use seq.Seq
   use seq.Permut
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) =
-    Permut.permut self o 0 (Seq.length self)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 89 8 89 37] Permut.permut self o 0 (Seq.length self)
   val permutation_of (self : Seq.seq t) (o : Seq.seq t) : bool
     ensures { result = permutation_of self o }
     
@@ -392,7 +392,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -420,7 +420,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -448,7 +448,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -482,7 +482,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -500,7 +500,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_InBounds_Stub
@@ -590,8 +590,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_Impl0_DeepModel_Stub
@@ -617,7 +617,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -637,7 +637,7 @@ module Core_Cmp_PartialOrd_Le_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val le (self : self) (other : rhs) : bool
-    ensures { result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 30 26 30 77] result = LeLog0.le_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -657,7 +657,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -670,7 +670,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module Alloc_Vec_Impl10_DerefMut_Interface
   type t
@@ -697,8 +697,8 @@ module Alloc_Vec_Impl10_DerefMut_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : borrowed (slice t)
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
-    ensures { ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 138 26 138 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 139 26 139 48] ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
     
 end
 module Core_Slice_Impl0_Swap_Interface
@@ -719,9 +719,9 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
-    ensures { Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 213 19 213 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 214 19 214 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 215 8 215 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -744,7 +744,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -769,7 +769,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -791,7 +791,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -804,7 +804,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub
   type self
@@ -820,7 +820,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -842,7 +842,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -855,7 +855,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -871,7 +871,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -893,7 +893,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -906,7 +906,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
   type self
@@ -922,7 +922,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -944,7 +944,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -957,7 +957,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -972,7 +972,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -983,7 +983,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -998,7 +998,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -1007,11 +1007,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -1026,7 +1026,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -1035,10 +1035,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -1053,7 +1053,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -1062,10 +1062,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -1080,7 +1080,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -1091,7 +1091,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module C02Gnome_GnomeSort_Interface
   type t

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -71,7 +71,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -85,7 +85,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -135,7 +135,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -155,7 +155,7 @@ module CreusotContracts_Logic_Seq_Impl0_PermutationOf
   use seq.Seq
   use seq.Permut
   predicate permutation_of (self : Seq.seq t) (o : Seq.seq t) =
-    Permut.permut self o 0 (Seq.length self)
+    [#"../../../../../creusot-contracts/src/logic/seq.rs" 89 8 89 37] Permut.permut self o 0 (Seq.length self)
   val permutation_of (self : Seq.seq t) (o : Seq.seq t) : bool
     ensures { result = permutation_of self o }
     
@@ -200,7 +200,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -256,7 +256,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -284,7 +284,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -312,7 +312,7 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     type t = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model (Ghost.inner self)
+    [#"../../../../../creusot-contracts/src/ghost.rs" 24 20 24 48] ShallowModel0.shallow_model (Ghost.inner self)
   val shallow_model (self : Ghost.ghost_ty t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -331,7 +331,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -349,7 +349,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -363,7 +363,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -403,9 +403,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -469,7 +469,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -492,7 +492,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -505,7 +505,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module Alloc_Vec_Impl10_DerefMut_Interface
   type t
@@ -532,8 +532,8 @@ module Alloc_Vec_Impl10_DerefMut_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val deref_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : borrowed (slice t)
-    ensures { ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
-    ensures { ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 138 26 138 42] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 139 26 139 48] ShallowModel2.shallow_model ( ^ result) = ShallowModel3.shallow_model ( ^ self) }
     
 end
 module Core_Slice_Impl0_Swap_Interface
@@ -554,9 +554,9 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
-    ensures { Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 213 19 213 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 214 19 214 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 215 8 215 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -572,7 +572,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -588,7 +588,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -604,18 +604,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -632,7 +632,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -641,11 +641,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -664,7 +664,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -675,13 +675,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -697,7 +697,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -726,7 +726,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -92,7 +92,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -125,7 +125,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -193,7 +193,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_InBounds_Stub
@@ -283,8 +283,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
@@ -306,7 +306,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -320,7 +320,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
   type t
@@ -342,7 +342,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -367,7 +367,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -38,7 +38,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -136,7 +136,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -189,7 +189,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -214,7 +214,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate lt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 19 20 19 53] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Less
   val lt_log (self : self) (o : self) : bool
     ensures { result = lt_log self o }
     
@@ -297,7 +297,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_SliceIndex_InBounds_Stub
@@ -387,8 +387,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub
@@ -405,7 +405,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GtLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate gt_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 37 20 37 56] CmpLog0.cmp_log self o = Core_Cmp_Ordering_Type.C_Greater
   val gt_log (self : self) (o : self) : bool
     ensures { result = gt_log self o }
     
@@ -425,7 +425,7 @@ module Core_Cmp_PartialOrd_Gt_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val gt (self : self) (other : rhs) : bool
-    ensures { result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 33 26 33 76] result = GtLog0.gt_log (DeepModel0.deep_model self) (DeepModel1.deep_model other) }
     
 end
 module Core_Cmp_Ord_Cmp_Interface
@@ -440,7 +440,7 @@ module Core_Cmp_Ord_Cmp_Interface
     type self = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val cmp (self : self) (other : self) : Core_Cmp_Ordering_Type.t_ordering
-    ensures { result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 44 26 44 85] result = CmpLog0.cmp_log (DeepModel0.deep_model self) (DeepModel0.deep_model other) }
     
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
@@ -462,7 +462,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -476,7 +476,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Logic_Ops_Impl0_IndexLogic_Stub
   type t
@@ -500,7 +500,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -548,7 +548,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   function deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Std1_Vec_Impl1_DeepModel
   type t
@@ -574,7 +574,7 @@ module CreusotContracts_Std1_Vec_Impl1_DeepModel
   val deep_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
-  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . (forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self)
+  axiom deep_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 29 4 30 53] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (deep_model self) i = DeepModel0.deep_model (IndexLogic0.index_logic self i)) && ([#"../../../../../creusot-contracts/src/std/vec.rs" 28 14 28 56] Seq.length (ShallowModel0.shallow_model self) = Seq.length (deep_model self))
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Stub
   type self
@@ -593,7 +593,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LeLog_Stub as LeLog0 with
     type self = self
   function cmp_le_log (x : self) (y : self) : ()
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   type self
@@ -606,7 +606,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog
   val cmp_le_log (x : self) (y : self) : ()
     ensures { result = cmp_le_log x y }
     
-  axiom cmp_le_log_spec : forall x : self, y : self . LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_le_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 14 14 14 64] LeLog0.le_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Stub
   type self
@@ -625,7 +625,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Stub as LtLog0 with
     type self = self
   function cmp_lt_log (x : self) (y : self) : ()
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   type self
@@ -638,7 +638,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog
   val cmp_lt_log (x : self) (y : self) : ()
     ensures { result = cmp_lt_log x y }
     
-  axiom cmp_lt_log_spec : forall x : self, y : self . LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_lt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 23 14 23 61] LtLog0.lt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub
   type self
@@ -654,7 +654,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_GeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate ge_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 28 20 28 53] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Less
   val ge_log (self : self) (o : self) : bool
     ensures { result = ge_log self o }
     
@@ -676,7 +676,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Stub as GeLog0 with
     type self = self
   function cmp_ge_log (x : self) (y : self) : ()
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   type self
@@ -689,7 +689,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog
   val cmp_ge_log (x : self) (y : self) : ()
     ensures { result = cmp_ge_log x y }
     
-  axiom cmp_ge_log_spec : forall x : self, y : self . GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
+  axiom cmp_ge_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 32 14 32 61] GeLog0.ge_log x y = (CmpLog0.cmp_log x y <> Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Stub
   type self
@@ -708,7 +708,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Stub as GtLog0 with
     type self = self
   function cmp_gt_log (x : self) (y : self) : ()
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   type self
@@ -721,7 +721,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog
   val cmp_gt_log (x : self) (y : self) : ()
     ensures { result = cmp_gt_log x y }
     
-  axiom cmp_gt_log_spec : forall x : self, y : self . GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
+  axiom cmp_gt_log_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 41 14 41 64] GtLog0.gt_log x y = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl_Stub
   type self
@@ -736,7 +736,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function refl (x : self) : ()
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Refl
   type self
@@ -747,7 +747,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Refl
   val refl (x : self) : ()
     ensures { result = refl x }
     
-  axiom refl_spec : forall x : self . CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
+  axiom refl_spec : forall x : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 45 14 45 45] CmpLog0.cmp_log x x = Core_Cmp_Ordering_Type.C_Equal
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans_Stub
   type self
@@ -762,7 +762,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Trans
   type self
@@ -771,11 +771,11 @@ module CreusotContracts_Logic_Ord_OrdLogic_Trans
     type self = self
   function trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
   val trans (x : self) (y : self) (z : self) (o : Core_Cmp_Ordering_Type.t_ordering) : ()
-    requires {CmpLog0.cmp_log x y = o}
-    requires {CmpLog0.cmp_log y z = o}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o}
     ensures { result = trans x y z o }
     
-  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . CmpLog0.cmp_log x y = o -> CmpLog0.cmp_log y z = o -> CmpLog0.cmp_log x z = o
+  axiom trans_spec : forall x : self, y : self, z : self, o : Core_Cmp_Ordering_Type.t_ordering . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 49 15 49 32] CmpLog0.cmp_log x y = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 50 15 50 32] CmpLog0.cmp_log y z = o) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 51 14 51 31] CmpLog0.cmp_log x z = o)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Stub
   type self
@@ -790,7 +790,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym1 (x : self) (y : self) : ()
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
   type self
@@ -799,10 +799,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym1
     type self = self
   function antisym1 (x : self) (y : self) : ()
   val antisym1 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less}
     ensures { result = antisym1 x y }
     
-  axiom antisym1_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater
+  axiom antisym1_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 55 15 55 45] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Less) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 56 14 56 47] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Greater)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Stub
   type self
@@ -817,7 +817,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function antisym2 (x : self) (y : self) : ()
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
   type self
@@ -826,10 +826,10 @@ module CreusotContracts_Logic_Ord_OrdLogic_Antisym2
     type self = self
   function antisym2 (x : self) (y : self) : ()
   val antisym2 (x : self) (y : self) : ()
-    requires {CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
+    requires {[#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater}
     ensures { result = antisym2 x y }
     
-  axiom antisym2_spec : forall x : self, y : self . CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater -> CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less
+  axiom antisym2_spec : forall x : self, y : self . ([#"../../../../../creusot-contracts/src/logic/ord.rs" 60 15 60 48] CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Greater) -> ([#"../../../../../creusot-contracts/src/logic/ord.rs" 61 14 61 44] CmpLog0.cmp_log y x = Core_Cmp_Ordering_Type.C_Less)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Stub
   type self
@@ -844,7 +844,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   function eq_cmp (x : self) (y : self) : ()
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   type self
@@ -855,7 +855,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_EqCmp
   val eq_cmp (x : self) (y : self) : ()
     ensures { result = eq_cmp x y }
     
-  axiom eq_cmp_spec : forall x : self, y : self . (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
+  axiom eq_cmp_spec : forall x : self, y : self . [#"../../../../../creusot-contracts/src/logic/ord.rs" 65 14 65 59] (x = y) = (CmpLog0.cmp_log x y = Core_Cmp_Ordering_Type.C_Equal)
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
   type t
@@ -877,7 +877,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -902,7 +902,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -19,7 +19,7 @@ module Core_Clone_Impls_Impl11_Clone_Interface
   use prelude.Int
   use prelude.IntSize
   val clone' (self : isize) : isize
-    ensures { result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/clone.rs" 7 0 20 1] result = self }
     
 end
 module C06KnightsTour_Impl3_Clone_Interface
@@ -207,7 +207,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -221,7 +221,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -270,7 +270,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -375,7 +375,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -425,7 +425,7 @@ module CreusotContracts_Std1_Vec_Impl10_Resolve
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 47 8 47 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (IndexLogic0.index_logic self i)
   val resolve (self : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = resolve self }
     
@@ -447,8 +447,8 @@ module Alloc_Vec_FromElem_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val from_elem (elem : t) (n : usize) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
-    ensures { forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 143 22 143 41] Seq.length (ShallowModel0.shallow_model result) = UIntSize.to_int n }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 144 12 144 78] forall i : int . 0 <= i /\ i < UIntSize.to_int n -> IndexLogic0.index_logic result i = elem }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub
@@ -462,7 +462,7 @@ end
 module CreusotContracts_Resolve_Impl2_Resolve
   type t
   predicate resolve (self : t) =
-    true
+    [#"../../../../../creusot-contracts/src/resolve.rs" 33 8 33 12] true
   val resolve (self : t) : bool
     ensures { result = resolve self }
     
@@ -620,7 +620,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -722,7 +722,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_Completed
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate completed (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)) =
-    Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced ( ^ self)) = Seq.empty  /\ Completed0.completed {current = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( * self); final = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ self)} /\ CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( * self) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ self)
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 14 8 17 9] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced ( ^ self)) = Seq.empty  /\ Completed0.completed {current = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( * self); final = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ self)} /\ CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( * self) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ self)
   val completed (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)) : bool
     ensures { result = completed self }
     
@@ -765,7 +765,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_NextPrecondition
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate next_precondition (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    forall i : i . Invariant0.invariant' i -> (forall e : Item0.item . Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.singleton e) i -> Precondition0.precondition (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (e, CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 105 8 109 9] forall i : i . Invariant0.invariant' i -> (forall e : Item0.item . Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.singleton e) i -> Precondition0.precondition (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (e, CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self))
   val next_precondition (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = next_precondition self }
     
@@ -844,7 +844,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_Preservation
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate preservation (iter : i) (func : f) =
-    forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest func ( * f) -> Produces0.produces iter (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new s) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new s) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc s e1)))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 138 8 145 9] forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest func ( * f) -> Produces0.produces iter (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new s) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new s) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc s e1)))
   val preservation (iter : i) (func : f) : bool
     ensures { result = preservation iter func }
     
@@ -886,7 +886,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_Reinitialize
     type f = f,
     type Item0.item = Item0.item
   predicate reinitialize (_1' : ()) =
-    forall reset : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) . Completed0.completed reset -> Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) -> NextPrecondition0.next_precondition ( ^ reset) /\ Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ reset))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 114 8 120 9] forall reset : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) . Completed0.completed reset -> Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) -> NextPrecondition0.next_precondition ( ^ reset) /\ Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter ( ^ reset)) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func ( ^ reset))
   val reinitialize (_1' : ()) : bool
     ensures { result = reinitialize _1' }
     
@@ -919,11 +919,11 @@ module CreusotContracts_Std1_Iter_Iterator_MapInv_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val map_inv (self : self) (func : f) : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv self Item0.item f
-    requires {forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
-    requires {Reinitialize0.reinitialize ()}
-    requires {Preservation0.preservation self func}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 39 4 39 138] forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 40 15 40 51] Reinitialize0.reinitialize ()}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 41 15 41 70] Preservation0.preservation self func}
     requires {Invariant0.invariant' self}
-    ensures { result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 42 14 42 85] result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
     
 end
 module CreusotContracts_Invariant_Impl1_Invariant_Stub
@@ -942,7 +942,7 @@ module CreusotContracts_Invariant_Impl1_Invariant
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = t
   predicate invariant' (self : borrowed t) =
-    Invariant0.invariant' ( * self)
+    [#"../../../../../creusot-contracts/src/invariant.rs" 34 20 34 39] Invariant0.invariant' ( * self)
   val invariant' (self : borrowed t) : bool
     ensures { result = invariant' self }
     
@@ -991,7 +991,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
     type self = self
   val collect (self : self) : b
     requires {Invariant0.invariant' self}
-    ensures { exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Stub
@@ -1017,7 +1017,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -1034,7 +1034,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     requires {Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -1059,7 +1059,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -1073,14 +1073,14 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
     requires {Invariant0.invariant' a}
     requires {Invariant0.invariant' b}
     requires {Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . Produces0.produces a ab b -> Produces0.produces b bc c -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
   type self
@@ -1133,7 +1133,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -1167,7 +1167,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv_Interface
     type f = f
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)
-  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 124 4 124 106] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv
   type i
@@ -1201,11 +1201,11 @@ module CreusotContracts_Std1_Iter_MapInv_Impl3_PreservationInv
     type f = f
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) ( * f) -> Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s) e1)))
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 126 8 133 9] forall i : i . Invariant0.invariant' i -> (forall b : b . forall f : borrowed f . forall e2 : Item0.item . forall e1 : Item0.item . forall s : Seq.seq Item0.item . Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) ( * f) -> Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (Seq.snoc (Seq.snoc s e1) e2) i -> Precondition0.precondition ( * f) (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) -> PostconditionMut0.postcondition_mut f (e1, Ghost.new (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s)) b -> Precondition0.precondition ( ^ f) (e2, Ghost.new (Seq.snoc (Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s) e1)))
   val preservation_inv (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = preservation_inv self }
     
-  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+  axiom preservation_inv_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 124 4 124 106] Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self) = Seq.empty  -> preservation_inv self = Preservation0.preservation (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl1_Invariant_Stub
   type i
@@ -1255,7 +1255,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl1_Invariant
     type b = b,
     type f = f
   predicate invariant' (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) =
-    Reinitialize0.reinitialize () /\ PreservationInv0.preservation_inv self /\ Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ NextPrecondition0.next_precondition self
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 64 8 69 9] Reinitialize0.reinitialize () /\ PreservationInv0.preservation_inv self /\ Invariant0.invariant' (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ NextPrecondition0.next_precondition self
   val invariant' (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : bool
     ensures { result = invariant' self }
     
@@ -1284,7 +1284,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl4_Resolve
     type self = i
   use CreusotContracts_Std1_Iter_MapInv_MapInv_Type as CreusotContracts_Std1_Iter_MapInv_MapInv_Type
   predicate resolve (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i b f) =
-    Resolve0.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ Resolve1.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 51 4 51 16] Resolve0.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) /\ Resolve1.resolve (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self)
   val resolve (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i b f) : bool
     ensures { result = resolve self }
     
@@ -1341,7 +1341,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_Produces
   predicate produces [@inline:trivial] (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (visited : Seq.seq b) (succ : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f)
     
    =
-    Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ) /\ (exists s : Seq.seq Item0.item . Seq.length s = Seq.length visited /\ Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) s (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter succ) /\ Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced succ) = Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s /\ (exists fs : Seq.seq (borrowed f) . Seq.length fs = Seq.length visited /\ (forall i : int . 1 <= i /\ i < Seq.length fs ->  ^ Seq.get fs (i - 1) =  * Seq.get fs i) /\ (if Seq.length visited = 0 then
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 33 8 45 9] Unnest0.unnest (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self) (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ) /\ (exists s : Seq.seq Item0.item . Seq.length s = Seq.length visited /\ Produces0.produces (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter self) s (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_iter succ) /\ Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced succ) = Seq.(++) (Ghost.inner (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_produced self)) s /\ (exists fs : Seq.seq (borrowed f) . Seq.length fs = Seq.length visited /\ (forall i : int . 1 <= i /\ i < Seq.length fs ->  ^ Seq.get fs (i - 1) =  * Seq.get fs i) /\ (if Seq.length visited = 0 then
       CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ
     else
        * Seq.get fs 0 = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func self /\  ^ Seq.get fs (Seq.length visited - 1) = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.mapinv_func succ
@@ -1376,7 +1376,7 @@ module CreusotContracts_Std1_Vec_Impl9_FromIterPost
     val Max0.mAX' = Max0.mAX',
     axiom .
   predicate from_iter_post (prod : Seq.seq t) (res : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) =
-    prod = ShallowModel0.shallow_model res
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 233 20 233 32] prod = ShallowModel0.shallow_model res
   val from_iter_post (prod : Seq.seq t) (res : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) : bool
     ensures { result = from_iter_post prod res }
     
@@ -1392,18 +1392,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Stub
   type idx
@@ -1420,7 +1420,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -1429,11 +1429,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -1452,7 +1452,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -1463,13 +1463,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -1485,7 +1485,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -1519,7 +1519,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl_Interface
     type f = f,
     type Item0.item = Item0.item
   function produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
-  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 21 14 21 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl
   type i
@@ -1535,11 +1535,11 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesRefl
     type f = f,
     type Item0.item = Item0.item
   function produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 20 4 20 10] ()
   val produces_refl (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 21 14 21 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans_Stub
   type i
@@ -1572,7 +1572,7 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     
-  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 27 14 27 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans
   type i
@@ -1590,13 +1590,13 @@ module CreusotContracts_Std1_Iter_MapInv_Impl0_ProducesTrans
   function produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 4 24 10] ()
   val produces_trans (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (ab : Seq.seq b) (b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) (bc : Seq.seq b) (c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, ab : Seq.seq b, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f, bc : Seq.seq b, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv i Item0.item f . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 25 15 25 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 26 15 26 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 27 14 27 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_Completed_Stub
   type idx
@@ -1622,7 +1622,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -1937,7 +1937,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -2029,8 +2029,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -2053,7 +2053,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -2078,7 +2078,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -2367,7 +2367,7 @@ module CreusotContracts_Std1_Vec_Impl8_Produces
   predicate produces (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (visited : Seq.seq t) (rhs : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)
     
    =
-    ShallowModel0.shallow_model self = Seq.(++) visited (ShallowModel0.shallow_model rhs)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 215 12 215 41] ShallowModel0.shallow_model self = Seq.(++) visited (ShallowModel0.shallow_model rhs)
   val produces (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (visited : Seq.seq t) (rhs : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : bool
     ensures { result = produces self visited rhs }
     
@@ -2396,7 +2396,7 @@ module CreusotContracts_Std1_Vec_Impl11_Resolve
     type t = t,
     type a = a
   predicate resolve (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) =
-    forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (Seq.get (ShallowModel0.shallow_model self) i)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 200 8 200 85] forall i : int . 0 <= i /\ i < Seq.length (ShallowModel0.shallow_model self) -> Resolve0.resolve (Seq.get (ShallowModel0.shallow_model self) i)
   val resolve (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : bool
     ensures { result = resolve self }
     
@@ -2419,7 +2419,7 @@ module CreusotContracts_Resolve_Impl0_Resolve
   clone CreusotContracts_Resolve_Resolve_Resolve_Stub as Resolve0 with
     type self = t1
   predicate resolve (self : (t1, t2)) =
-    Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
+    [#"../../../../../creusot-contracts/src/resolve.rs" 15 8 15 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
     ensures { result = resolve self }
     
@@ -2461,7 +2461,7 @@ module CreusotContracts_Std1_Vec_Impl3_IntoIterPre
   type a
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   predicate into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) =
-    true
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 153 20 153 24] true
   val into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) : bool
     ensures { result = into_iter_pre self }
     
@@ -2496,7 +2496,7 @@ module CreusotContracts_Std1_Vec_Impl3_IntoIterPost
     axiom .
   predicate into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)
    =
-    ShallowModel0.shallow_model self = ShallowModel1.shallow_model res
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 158 20 158 33] ShallowModel0.shallow_model self = ShallowModel1.shallow_model res
   val into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : bool
     ensures { result = into_iter_post self res }
     
@@ -2515,8 +2515,8 @@ module Alloc_Vec_Impl16_IntoIter_Interface
     type t = t,
     type a = a
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
-    requires {IntoIterPre0.into_iter_pre self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -2543,7 +2543,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -2575,7 +2575,7 @@ module CreusotContracts_Std1_Vec_Impl8_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
   predicate completed (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)) =
-    Resolve0.resolve self /\ ShallowModel0.shallow_model self = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 209 20 209 57] Resolve0.resolve self /\ ShallowModel0.shallow_model self = Seq.empty 
   val completed (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)) : bool
     ensures { result = completed self }
     
@@ -2596,7 +2596,7 @@ module Alloc_Vec_IntoIter_Impl5_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
   val next (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -2621,7 +2621,7 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesRefl_Interface
     type t = t,
     type a = a
   function produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
-  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 220 14 220 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesRefl
   type t
@@ -2632,11 +2632,11 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesRefl
     type t = t,
     type a = a
   function produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 219 4 219 10] ()
   val produces_refl (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 220 14 220 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesTrans_Stub
   type t
@@ -2659,7 +2659,7 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesTrans_Interface
     type a = a
   function produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     
-  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 226 14 226 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Vec_Impl8_ProducesTrans
   type t
@@ -2672,13 +2672,13 @@ module CreusotContracts_Std1_Vec_Impl8_ProducesTrans
   function produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 223 4 223 10] ()
   val produces_trans (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (ab : Seq.seq t) (b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) (bc : Seq.seq t) (c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, ab : Seq.seq t, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a, bc : Seq.seq t, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a . ([#"../../../../../creusot-contracts/src/std/vec.rs" 224 15 224 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 225 15 225 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 226 14 226 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C06KnightsTour_Impl1_CountDegree_Interface
   use prelude.Borrow
@@ -3017,11 +3017,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere_Stub
@@ -3044,7 +3044,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     
@@ -3260,7 +3260,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function to_ref_seq (self : slice t) : Seq.seq t
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   type t
@@ -3279,7 +3279,7 @@ module CreusotContracts_Std1_Slice_Impl4_ToRefSeq
   val to_ref_seq (self : slice t) : Seq.seq t
     ensures { result = to_ref_seq self }
     
-  axiom to_ref_seq_spec : forall self : slice t . (forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self)
+  axiom to_ref_seq_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 78 4 78 82] forall i : int . 0 <= i /\ i < Seq.length (to_ref_seq self) -> Seq.get (to_ref_seq self) i = IndexLogic0.index_logic self i) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 77 14 77 41] Seq.length (to_ref_seq self) = Seq.length (ShallowModel0.shallow_model self))
 end
 module CreusotContracts_Std1_Slice_Impl15_Produces_Stub
   type t
@@ -3320,7 +3320,7 @@ module CreusotContracts_Std1_Slice_Impl15_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 348 12 348 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -3345,7 +3345,7 @@ module CreusotContracts_Std1_Vec_Impl4_IntoIterPre
   use prelude.Borrow
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   predicate into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) =
-    true
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 165 20 165 24] true
   val into_iter_pre (self : Alloc_Vec_Vec_Type.t_vec t a) : bool
     ensures { result = into_iter_pre self }
     
@@ -3384,7 +3384,7 @@ module CreusotContracts_Std1_Vec_Impl4_IntoIterPost
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   predicate into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Core_Slice_Iter_Iter_Type.t_iter t) =
-    ShallowModel0.shallow_model self = ShallowModel2.shallow_model (ShallowModel1.shallow_model res)
+    [#"../../../../../creusot-contracts/src/std/vec.rs" 170 20 170 34] ShallowModel0.shallow_model self = ShallowModel2.shallow_model (ShallowModel1.shallow_model res)
   val into_iter_post (self : Alloc_Vec_Vec_Type.t_vec t a) (res : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = into_iter_post self res }
     
@@ -3404,8 +3404,8 @@ module Alloc_Vec_Impl17_IntoIter_Interface
     type t = t,
     type a = a
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
-    requires {IntoIterPre0.into_iter_pre self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -3426,7 +3426,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface
   use prelude.Slice
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : slice t) : Seq.seq t
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   type t
@@ -3439,7 +3439,7 @@ module CreusotContracts_Std1_Slice_Impl0_ShallowModel
   val shallow_model (self : slice t) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : slice t . shallow_model self = Slice.id self && Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : slice t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 18 14 18 41] shallow_model self = Slice.id self) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Slice_Impl15_Completed_Stub
   type t
@@ -3470,7 +3470,7 @@ module CreusotContracts_Std1_Slice_Impl15_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 342 20 342 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -3488,7 +3488,7 @@ module Core_Slice_Iter_Impl181_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Slice_Iter_Iter_Type.t_iter t
   val next (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : Core_Option_Option_Type.t_option t
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -3509,7 +3509,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl_Interface
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   type t
@@ -3518,11 +3518,11 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl15_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 352 4 352 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 353 14 353 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Stub
   type t
@@ -3543,7 +3543,7 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans_Interface
     type t = t
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   type t
@@ -3555,13 +3555,13 @@ module CreusotContracts_Std1_Slice_Impl15_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 356 4 356 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 357 15 357 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 358 15 358 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 359 14 359 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C06KnightsTour_Min_Interface
   use prelude.Borrow
@@ -3865,7 +3865,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -3905,9 +3905,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -3925,7 +3925,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -3943,7 +3943,7 @@ module Alloc_Vec_Impl0_New_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val new (_1' : ()) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    ensures { Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 55 26 55 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -3963,7 +3963,7 @@ module Alloc_Vec_Impl1_Push_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val push (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (value : t) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 65 26 65 51] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
@@ -3979,7 +3979,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -3995,7 +3995,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -120,7 +120,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -217,7 +217,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -231,7 +231,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Slice_SliceIndex_ResolveElswhere_Stub
   type self
@@ -295,11 +295,11 @@ module Alloc_Vec_Impl14_IndexMut_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index_mut (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (index : i) : borrowed Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
-    ensures { HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
-    ensures { ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
-    ensures { Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 118 27 118 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 119 26 119 54] HasValue0.has_value index (ShallowModel0.shallow_model self) ( * result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 120 26 120 57] HasValue0.has_value index (ShallowModel1.shallow_model ( ^ self)) ( ^ result) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 121 26 121 62] ResolveElswhere0.resolve_elswhere index (ShallowModel0.shallow_model self) (ShallowModel1.shallow_model ( ^ self)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 26 122 55] Seq.length (ShallowModel1.shallow_model ( ^ self)) = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module CreusotContracts_Model_Impl1_ShallowModel_Stub
@@ -325,7 +325,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -355,8 +355,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
@@ -407,7 +407,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -425,7 +425,7 @@ module Core_Cmp_PartialEq_Eq_Interface
     type t = self,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   val eq (self : self) (other : rhs) : bool
-    ensures { result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
+    ensures { [#"../../../../../creusot-contracts/src/std/cmp.rs" 11 26 11 75] result = (DeepModel0.deep_model self = DeepModel1.deep_model other) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub
@@ -448,7 +448,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -473,7 +473,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     
@@ -498,7 +498,7 @@ module CreusotContracts_Std1_Slice_Impl5_ResolveElswhere
   use prelude.UIntSize
   use seq.Seq
   predicate resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) =
-    forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 114 8 114 96] forall i : int . 0 <= i /\ i <> UIntSize.to_int self /\ i < Seq.length old' -> Seq.get old' i = Seq.get fin i
   val resolve_elswhere [@inline:trivial] (self : usize) (old' : Seq.seq t) (fin : Seq.seq t) : bool
     ensures { result = resolve_elswhere self old' fin }
     

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -86,7 +86,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -113,7 +113,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -198,7 +198,7 @@ end
 module CreusotContracts_Invariant_Invariant_Invariant
   type self
   predicate invariant' (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant' (self : self) : bool
     ensures { result = invariant' self }
     
@@ -303,7 +303,7 @@ module CreusotContracts_Logic_Ord_OrdLogic_LeLog
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Stub as CmpLog0 with
     type self = self
   predicate le_log (self : self) (o : self) =
-    CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
+    [#"../../../../../creusot-contracts/src/logic/ord.rs" 10 20 10 56] CmpLog0.cmp_log self o <> Core_Cmp_Ordering_Type.C_Greater
   val le_log (self : self) (o : self) : bool
     ensures { result = le_log self o }
     
@@ -339,7 +339,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog_Interface
   clone CreusotContracts_Std1_Ops_Impl5_StartLog_Stub as StartLog0 with
     type idx = idx
   predicate is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   type idx
@@ -359,7 +359,7 @@ module CreusotContracts_Std1_Ops_Impl5_IsEmptyLog
   val is_empty_log (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = is_empty_log self }
     
-  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
+  axiom is_empty_log_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/ops.rs" 196 4 196 88] not is_empty_log self -> LeLog0.le_log (DeepModel0.deep_model (StartLog0.start_log self)) (DeepModel0.deep_model (EndLog0.end_log self))
 end
 module CreusotContracts_Logic_Ord_Impl2_LeLog_Stub
   use prelude.Int
@@ -423,7 +423,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen_Interface
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   type idx
@@ -447,7 +447,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
     type DeepModelTy0.deepModelTy = int,
     axiom .
   function range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int =
-    if IsEmptyLog0.is_empty_log r then
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 42 4 45 5] if IsEmptyLog0.is_empty_log r then
       0
     else
       DeepModel0.deep_model (EndLog0.end_log r) - DeepModel0.deep_model (StartLog0.start_log r) + 1
@@ -455,7 +455,7 @@ module CreusotContracts_Std1_Iter_Range_RangeInclusiveLen
   val range_inclusive_len (r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : int
     ensures { result = range_inclusive_len r }
     
-  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
+  axiom range_inclusive_len_spec : forall r : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 10 40 43] IsEmptyLog0.is_empty_log r = (range_inclusive_len r = 0)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub
   type idx
@@ -504,7 +504,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
   predicate produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)
     
    =
-    Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 58 8 64 9] Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
   val produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = produces self visited o }
     
@@ -523,7 +523,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -554,7 +554,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
   predicate produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx)
     
    =
-    Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 19 8 25 9] Core_Ops_Range_Range_Type.range_end self = Core_Ops_Range_Range_Type.range_end o /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) /\ (Seq.length visited > 0 -> DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) <= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end o)) /\ Seq.length visited = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start o) - DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start self) + i)
   val produces (self : Core_Ops_Range_Range_Type.t_range idx) (visited : Seq.seq idx) (o : Core_Ops_Range_Range_Type.t_range idx) : bool
     ensures { result = produces self visited o }
     
@@ -572,7 +572,7 @@ module Alloc_Vec_Impl1_Len_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val len (self : Alloc_Vec_Vec_Type.t_vec t a) : usize
-    ensures { UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 62 26 62 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Core_Ops_Range_Impl7_New_Interface
@@ -598,9 +598,9 @@ module Core_Ops_Range_Impl7_New_Interface
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     axiom .
   val new (start : idx) (end' : idx) : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx
-    ensures { StartLog0.start_log result = start }
-    ensures { EndLog0.end_log result = end' }
-    ensures { LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 210 26 210 53] StartLog0.start_log result = start }
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 211 26 211 49] EndLog0.end_log result = end' }
+    ensures { [#"../../../../../creusot-contracts/src/std/ops.rs" 212 16 212 93] LeLog0.le_log (DeepModel0.deep_model start) (DeepModel0.deep_model end') -> not IsEmptyLog0.is_empty_log result }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -614,7 +614,7 @@ end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre
   type self
   predicate into_iter_pre (self : self) =
-    true
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 55 20 55 24] true
   val into_iter_pre (self : self) : bool
     ensures { result = into_iter_pre self }
     
@@ -654,9 +654,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
   clone CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub as IntoIterPre0 with
     type self = i
   val into_iter (self : i) : i
-    requires {IntoIterPre0.into_iter_pre self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     requires {Invariant0.invariant' self}
-    ensures { IntoIterPost0.into_iter_post self result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
     ensures { Invariant0.invariant' result }
     
 end
@@ -720,7 +720,7 @@ module Core_Iter_Range_Impl12_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a
   val next (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -740,7 +740,7 @@ module Core_Iter_Range_Impl3_Next_Interface
   clone Core_Iter_Traits_Iterator_Iterator_Item_Type as Item0 with
     type self = Core_Ops_Range_Range_Type.t_range a
   val next (self : borrowed (Core_Ops_Range_Range_Type.t_range a)) : Core_Option_Option_Type.t_option a
-    ensures { match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
@@ -833,8 +833,8 @@ module Alloc_Vec_Impl13_Index_Interface
     type t = Alloc_Vec_Vec_Type.t_vec t a,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val index (self : Alloc_Vec_Vec_Type.t_vec t a) (index : i) : Output0.output
-    requires {InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
-    ensures { HasValue0.has_value index (ShallowModel0.shallow_model self) result }
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 127 27 127 46] InBounds0.in_bounds index (ShallowModel0.shallow_model self)}
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 128 26 128 54] HasValue0.has_value index (ShallowModel0.shallow_model self) result }
     
 end
 module Core_Num_Impl11_Max_Stub
@@ -867,7 +867,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -881,7 +881,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Num_Impl16_DeepModel_Stub
   use prelude.Int
@@ -897,7 +897,7 @@ module CreusotContracts_Std1_Num_Impl16_DeepModel
   use prelude.Int
   use prelude.UIntSize
   function deep_model (self : usize) : int =
-    UIntSize.to_int self
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] UIntSize.to_int self
   val deep_model (self : usize) : int
     ensures { result = deep_model self }
     
@@ -915,7 +915,7 @@ module CreusotContracts_Std1_Iter_Impl0_IntoIterPre
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = i
   predicate into_iter_pre (self : i) =
-    Invariant0.invariant' self
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 65 8 65 24] Invariant0.invariant' self
   val into_iter_pre (self : i) : bool
     ensures { result = into_iter_pre self }
     
@@ -931,7 +931,7 @@ end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPost
   type i
   predicate into_iter_post (self : i) (res : i) =
-    self = res
+    [#"../../../../../creusot-contracts/src/std/iter.rs" 70 8 70 19] self = res
   val into_iter_post (self : i) (res : i) : bool
     ensures { result = into_iter_post self res }
     
@@ -947,18 +947,18 @@ module CreusotContracts_Invariant_Invariant_IsInhabited_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Invariant_Invariant_IsInhabited
   type self
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function is_inhabited (_1' : ()) : bool =
-    true
+    [#"../../../../../creusot-contracts/src/invariant.rs" 18 8 18 12] true
   val is_inhabited (_1' : ()) : bool
     ensures { result = is_inhabited _1' }
     
-  axiom is_inhabited_spec : forall _1' : () . is_inhabited _1' && (exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
+  axiom is_inhabited_spec : forall _1' : () . ([#"../../../../../creusot-contracts/src/invariant.rs" 13 14 13 20] is_inhabited _1') && ([#"../../../../../creusot-contracts/src/invariant.rs" 12 4 12 45] exists x : self . Invariant0.invariant' x /\ Invariant0.invariant' x)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl_Stub
   type idx
@@ -975,7 +975,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   type idx
@@ -984,11 +984,11 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl1_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 67 4 67 10] ()
   val produces_refl (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 68 14 68 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Stub
   type idx
@@ -1007,7 +1007,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   type idx
@@ -1018,13 +1018,13 @@ module CreusotContracts_Std1_Iter_Range_Impl1_ProducesTrans
   function produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 71 4 71 10] ()
   val produces_trans (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (ab : Seq.seq idx) (b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (bc : Seq.seq idx) (c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, ab : Seq.seq idx, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx, bc : Seq.seq idx, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 72 15 72 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 73 15 73 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 74 14 74 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl1_Completed_Stub
   type idx
@@ -1061,7 +1061,7 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Completed
     type DeepModelTy0.deepModelTy = int,
     axiom .
   predicate completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) =
-    IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 52 12 52 57] IsEmptyLog0.is_empty_log ( * self) /\ IsEmptyLog0.is_empty_log ( ^ self)
   val completed (self : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx)) : bool
     ensures { result = completed self }
     
@@ -1081,7 +1081,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   type idx
@@ -1090,11 +1090,11 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces_Stub as Produces0 with
     type idx = idx
   function produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : () =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 28 4 28 10] ()
   val produces_refl (a : Core_Ops_Range_Range_Type.t_range idx) : ()
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Ops_Range_Range_Type.t_range idx . [#"../../../../../creusot-contracts/src/std/iter/range.rs" 29 14 29 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Stub
   type idx
@@ -1113,7 +1113,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface
     type idx = idx
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   type idx
@@ -1124,13 +1124,13 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
   function produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
     
    =
-    ()
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 4 32 10] ()
   val produces_trans (a : Core_Ops_Range_Range_Type.t_range idx) (ab : Seq.seq idx) (b : Core_Ops_Range_Range_Type.t_range idx) (bc : Seq.seq idx) (c : Core_Ops_Range_Range_Type.t_range idx) : ()
-    requires {Produces0.produces a ab b}
-    requires {Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . Produces0.produces a ab b -> Produces0.produces b bc c -> Produces0.produces a (Seq.(++) ab bc) c
+  axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 15 33 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 34 15 34 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 35 14 35 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Range_Impl0_Completed_Stub
   type idx
@@ -1156,7 +1156,7 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Ops_Range_Range_Type.t_range idx
   predicate completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) =
-    Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
+    [#"../../../../../creusot-contracts/src/std/iter/range.rs" 13 12 13 78] Resolve0.resolve self /\ DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_start ( * self)) >= DeepModel0.deep_model (Core_Ops_Range_Range_Type.range_end ( * self))
   val completed (self : borrowed (Core_Ops_Range_Range_Type.t_range idx)) : bool
     ensures { result = completed self }
     
@@ -1181,7 +1181,7 @@ module CreusotContracts_Std1_Slice_Impl5_InBounds
   use prelude.UIntSize
   use seq.Seq
   predicate in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) =
-    UIntSize.to_int self < Seq.length seq
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 102 20 102 37] UIntSize.to_int self < Seq.length seq
   val in_bounds [@inline:trivial] (self : usize) (seq : Seq.seq t) : bool
     ensures { result = in_bounds self seq }
     
@@ -1206,7 +1206,7 @@ module CreusotContracts_Std1_Slice_Impl5_HasValue
   use prelude.UIntSize
   use seq.Seq
   predicate has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) =
-    Seq.get seq (UIntSize.to_int self) = out
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 108 20 108 37] Seq.get seq (UIntSize.to_int self) = out
   val has_value [@inline:trivial] (self : usize) (seq : Seq.seq t) (out : t) : bool
     ensures { result = has_value self seq out }
     

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -63,7 +63,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone Core_Num_Impl11_Max_Stub as Max0
   function shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   type t
@@ -77,7 +77,7 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
   val shallow_model (self : Alloc_Vec_Vec_Type.t_vec t a) : Seq.seq t
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
+  axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . [#"../../../../../creusot-contracts/src/std/vec.rs" 17 14 17 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX'
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self
@@ -127,7 +127,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -154,7 +154,7 @@ module CreusotContracts_Logic_Ops_Impl0_IndexLogic
     type self = s,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   function index_logic [@inline:trivial] (self : s) (ix : int) : t =
-    Seq.get (ShallowModel0.shallow_model self) ix
+    [#"../../../../../creusot-contracts/src/logic/ops.rs" 16 8 16 31] Seq.get (ShallowModel0.shallow_model self) ix
   val index_logic [@inline:trivial] (self : s) (ix : int) : t
     ensures { result = index_logic self ix }
     
@@ -178,7 +178,7 @@ module CreusotContracts_Resolve_Impl1_Resolve
   type t
   use prelude.Borrow
   predicate resolve (self : borrowed t) =
-     ^ self =  * self
+    [#"../../../../../creusot-contracts/src/resolve.rs" 23 20 23 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
@@ -202,7 +202,7 @@ module Alloc_Vec_Impl1_Reserve_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val reserve (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (additional : usize) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 91 26 91 43] ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
     
 end
 module Alloc_Vec_Impl1_ReserveExact_Interface
@@ -224,7 +224,7 @@ module Alloc_Vec_Impl1_ReserveExact_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val reserve_exact (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (additional : usize) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 94 26 94 43] ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
     
 end
 module Alloc_Vec_Impl1_ShrinkToFit_Interface
@@ -244,7 +244,7 @@ module Alloc_Vec_Impl1_ShrinkToFit_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val shrink_to_fit (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 97 26 97 43] ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
     
 end
 module Alloc_Vec_Impl1_ShrinkTo_Interface
@@ -266,7 +266,7 @@ module Alloc_Vec_Impl1_ShrinkTo_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val shrink_to (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) (min_capacity : usize) : ()
-    ensures { ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 100 26 100 43] ShallowModel0.shallow_model ( ^ self) = ShallowModel1.shallow_model self }
     
 end
 module C09Capacity_ChangeCapacity_Interface
@@ -413,7 +413,7 @@ module Alloc_Vec_Impl1_Clear_Interface
     val Max0.mAX' = Max0.mAX',
     axiom .
   val clear (self : borrowed (Alloc_Vec_Vec_Type.t_vec t a)) : ()
-    ensures { Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 103 26 103 45] Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
     
 end
 module C09Capacity_ClearVec_Interface


### PR DESCRIPTION
The previous encoding of `Span` was totally wrong, I attempted to fix it here, however, it turns out this is trickier as the 'real' implementation in rustc uses non-public apis. 
I came up with a best-effort approximation. 
