### PR TITLE
Add a DeepModel derive

### DIFF
--- a/creusot-contracts-proc/src/derive.rs
+++ b/creusot-contracts-proc/src/derive.rs
@@ -1,7 +1,9 @@
 mod clone;
+mod deep_model;
 mod invariant;
 mod partial_eq;
 
 pub use clone::*;
+pub use deep_model::*;
 pub use invariant::*;
 pub use partial_eq::*;

--- a/creusot-contracts-proc/src/derive/deep_model.rs
+++ b/creusot-contracts-proc/src/derive/deep_model.rs
@@ -1,0 +1,186 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+use syn::{
+    parse_macro_input, parse_quote, spanned::Spanned, Data, DeriveInput, Fields, GenericParam,
+    Generics, Index,
+};
+
+pub fn derive_deep_model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+
+    let generics = add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let deep_model_ty_name =
+        Ident::new(&format!("{}DeepModel", name.to_string()), proc_macro::Span::def_site().into());
+    let deep_model_ty = deep_model_ty(&deep_model_ty_name, &input.data);
+    let eq = deep_model(&name, &deep_model_ty_name, &input.data);
+
+    let expanded = quote! {
+        #deep_model_ty
+
+        impl #impl_generics ::creusot_contracts::DeepModel for #name #ty_generics #where_clause {
+            type DeepModelTy = #deep_model_ty_name;
+
+            #[logic]
+            fn deep_model(self) -> Self::DeepModelTy {
+                #eq
+            }
+        }
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}
+
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(parse_quote!(::creusot_contracts::DeepModel));
+            // type_param.bounds.push(parse_quote!(::creusot_contracts::model::DeepModel));
+        }
+    }
+    generics
+}
+
+fn deep_model_ty_fields(base_ident: &Ident, fields: &Fields) -> TokenStream {
+    match fields {
+        Fields::Named(ref fields) => {
+            let recurse = fields.named.iter().map(|f| {
+                let name = &f.ident;
+                let ty = &f.ty;
+                quote_spanned! {f.span()=>
+                    #name: < #ty as creusot_contracts::DeepModel> :: DeepModelTy
+                }
+            });
+            quote! {
+                #base_ident { #(#recurse),*}
+            }
+        }
+        Fields::Unnamed(ref fields) => {
+            let recurse = fields.unnamed.iter().enumerate().map(|(_, f)| {
+                let ty = &f.ty;
+                quote_spanned! {f.span()=>
+                    #ty :: DeepModelTy
+                }
+            });
+            quote! {
+                #base_ident (#(#recurse),*)
+            }
+        }
+        Fields::Unit => quote! {
+            #base_ident
+        },
+    }
+}
+
+fn deep_model_ty(base_ident: &Ident, data: &Data) -> TokenStream {
+    match data {
+        Data::Struct(ref data) => {
+            let data = deep_model_ty_fields(base_ident, &data.fields);
+            quote! { struct  #data }
+        }
+        Data::Enum(ref data) => {
+            let arms = data.variants.iter().map(|v| {
+                let ident = &v.ident;
+                deep_model_ty_fields(ident, &v.fields)
+            });
+
+            quote! {
+                enum #base_ident {
+                    #(#arms),*
+                }
+            }
+        }
+        Data::Union(_) => todo!(),
+    }
+}
+
+fn deep_model(src_ident: &Ident, tgt_ident: &Ident, data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let recurse = fields.named.iter().map(|f| {
+                    let name = &f.ident;
+                    quote_spanned! {f.span()=>
+                        #name: self.#name.deep_model()
+                    }
+                });
+                quote! {
+                    #tgt_ident { #(#recurse),*}
+                }
+            }
+            Fields::Unnamed(ref fields) => {
+                let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                    let index = Index::from(i);
+                    quote_spanned! {f.span()=>
+                        self.#index.deep_model()
+                    }
+                });
+                quote! {
+                    #tgt_ident (#(#recurse),*)
+                }
+            }
+            Fields::Unit => quote! {
+                #tgt_ident
+            },
+        },
+        Data::Enum(ref data) => {
+            let arms = data.variants.iter().map(|v| {
+                let ident = &v.ident;
+                match &v.fields {
+                    Fields::Named(fields) => {
+                        let arm = gen_match_arm(fields.named.iter());
+                        let fields1 = arm.fields;
+                        let body = arm.body;
+                        quote! { #src_ident::#ident{#(#fields1),* } => #tgt_ident::#ident{#(#body),* }}
+                    }
+                    Fields::Unnamed(fields) => {
+                        let arm = gen_match_arm(fields.unnamed.iter());
+                        let fields1 = arm.fields;
+                        let body = arm.body;
+                        quote! { #src_ident::#ident(#(#fields1),*) => #tgt_ident::#ident(#(#body),* ) }
+                    }
+                    Fields::Unit => quote! {#src_ident::#ident => #tgt_ident::#ident},
+                }
+            });
+
+            quote! {
+                match self {
+                    #(#arms),*
+                }
+            }
+        }
+        Data::Union(_) => todo!(),
+    }
+}
+
+struct ArmAcc {
+    fields: Vec<TokenStream>,
+    body: Vec<TokenStream>,
+}
+
+fn gen_match_arm<'a, I: Iterator<Item = &'a syn::Field>>(fields: I) -> ArmAcc {
+    let mut acc = ArmAcc { fields: Vec::new(), body: Vec::new() };
+
+    for (i, field) in fields.enumerate() {
+        let named = field.ident.is_some();
+        let name_base = match &field.ident {
+            Some(ident) => format_ident!("{}", ident),
+            None => format_ident!("v{}", i),
+        };
+        let name_1 = format_ident!("{}_1", name_base);
+
+        let call = quote!(#name_1.deep_model());
+        if named {
+            acc.fields.push(quote!(#name_base: #name_1));
+            acc.body.push(quote!(#name_base: #call));
+        } else {
+            acc.fields.push(quote!(#name_1));
+            acc.body.push(quote!(#call));
+        }
+    }
+
+    acc
+}

--- a/creusot-contracts-proc/src/lib.rs
+++ b/creusot-contracts-proc/src/lib.rs
@@ -646,3 +646,8 @@ pub fn derive_clone(tokens: TS1) -> TS1 {
 pub fn derive_invariant(tokens: TS1) -> TS1 {
     derive::derive_invariant(tokens)
 }
+
+#[proc_macro_derive(DeepModel)]
+pub fn derive_deep_model(tokens: TS1) -> TS1 {
+    derive::derive_deep_model(tokens)
+}

--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -10,6 +10,9 @@ pub trait ShallowModel {
     fn shallow_model(self) -> Self::ShallowModelTy;
 }
 
+#[cfg(creusot)]
+pub use creusot_contracts_proc::DeepModel;
+
 /// The deep model corresponds to the model used for specifying
 /// operations such as equality, hash function or ordering, which are
 /// computed deeply in a data structure.

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -147,7 +147,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -468,7 +468,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -587,7 +587,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -133,7 +133,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -189,7 +189,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -217,7 +217,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -66,7 +66,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 46 8 46 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/eq_panic.mlcfg
+++ b/creusot/tests/should_succeed/bug/eq_panic.mlcfg
@@ -62,7 +62,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -160,7 +160,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -375,7 +375,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/constrained_types.mlcfg
+++ b/creusot/tests/should_succeed/constrained_types.mlcfg
@@ -85,7 +85,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -157,7 +157,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -367,7 +367,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -523,7 +523,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -157,7 +157,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -827,7 +827,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -889,7 +889,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -567,7 +567,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 46 8 46 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -620,7 +620,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -866,7 +866,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1032,7 +1032,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -127,7 +127,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -202,7 +202,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -860,7 +860,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 46 8 46 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -1113,7 +1113,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -174,7 +174,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -424,7 +424,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -209,7 +209,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -359,7 +359,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -234,7 +234,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -67,7 +67,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -120,7 +120,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -205,7 +205,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -146,7 +146,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -369,7 +369,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -210,7 +210,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -269,7 +269,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -176,7 +176,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -513,7 +513,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -379,7 +379,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1269,7 +1269,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -253,7 +253,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -523,7 +523,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -92,7 +92,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -139,7 +139,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/ord_trait.mlcfg
+++ b/creusot/tests/should_succeed/ord_trait.mlcfg
@@ -62,7 +62,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -5208,7 +5208,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -7285,7 +7285,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -8599,7 +8599,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -201,7 +201,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -201,7 +201,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -363,7 +363,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -502,7 +502,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -558,7 +558,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 46 8 46 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -835,7 +835,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -175,7 +175,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -133,7 +133,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -246,7 +246,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -851,7 +851,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/specification/model.mlcfg
+++ b/creusot/tests/should_succeed/specification/model.mlcfg
@@ -7,26 +7,26 @@ end
 module Model_Impl0_ShallowModel_Stub
   use prelude.Int
   use Model_Seven_Type as Model_Seven_Type
-  function shallow_model [#"../model.rs" 11 4 11 50] (self : Model_Seven_Type.t_seven) : int
+  function shallow_model [#"../model.rs" 12 4 12 50] (self : Model_Seven_Type.t_seven) : int
 end
 module Model_Impl0_ShallowModel_Interface
   use prelude.Int
   use Model_Seven_Type as Model_Seven_Type
-  function shallow_model [#"../model.rs" 11 4 11 50] (self : Model_Seven_Type.t_seven) : int
+  function shallow_model [#"../model.rs" 12 4 12 50] (self : Model_Seven_Type.t_seven) : int
 end
 module Model_Impl0_ShallowModel
   use prelude.Int
   use Model_Seven_Type as Model_Seven_Type
-  function shallow_model [#"../model.rs" 11 4 11 50] (self : Model_Seven_Type.t_seven) : int
-  val shallow_model [#"../model.rs" 11 4 11 50] (self : Model_Seven_Type.t_seven) : int
+  function shallow_model [#"../model.rs" 12 4 12 50] (self : Model_Seven_Type.t_seven) : int
+  val shallow_model [#"../model.rs" 12 4 12 50] (self : Model_Seven_Type.t_seven) : int
     ensures { result = shallow_model self }
     
 end
 module Model_Seven_Interface
   use Model_Seven_Type as Model_Seven_Type
   clone Model_Impl0_ShallowModel_Stub as ShallowModel0
-  val seven [#"../model.rs" 18 0 18 23] (_1' : ()) : Model_Seven_Type.t_seven
-    ensures { [#"../model.rs" 17 10 17 22] ShallowModel0.shallow_model result = 7 }
+  val seven [#"../model.rs" 19 0 19 23] (_1' : ()) : Model_Seven_Type.t_seven
+    ensures { [#"../model.rs" 18 10 18 22] ShallowModel0.shallow_model result = 7 }
     
 end
 module Model_Pair_Type
@@ -38,20 +38,20 @@ module Model_Impl1_ShallowModel_Stub
   type t
   type u
   use Model_Pair_Type as Model_Pair_Type
-  function shallow_model [#"../model.rs" 29 4 29 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
+  function shallow_model [#"../model.rs" 30 4 30 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
 end
 module Model_Impl1_ShallowModel_Interface
   type t
   type u
   use Model_Pair_Type as Model_Pair_Type
-  function shallow_model [#"../model.rs" 29 4 29 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
+  function shallow_model [#"../model.rs" 30 4 30 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
 end
 module Model_Impl1_ShallowModel
   type t
   type u
   use Model_Pair_Type as Model_Pair_Type
-  function shallow_model [#"../model.rs" 29 4 29 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
-  val shallow_model [#"../model.rs" 29 4 29 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
+  function shallow_model [#"../model.rs" 30 4 30 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
+  val shallow_model [#"../model.rs" 30 4 30 50] (self : Model_Pair_Type.t_pair t u) : (t, u)
     ensures { result = shallow_model self }
     
 end
@@ -62,8 +62,127 @@ module Model_Pair_Interface
   clone Model_Impl1_ShallowModel_Stub as ShallowModel0 with
     type t = t,
     type u = u
-  val pair [#"../model.rs" 36 0 36 43] (a : t) (b : u) : Model_Pair_Type.t_pair t u
-    ensures { [#"../model.rs" 35 10 35 27] ShallowModel0.shallow_model result = (a, b) }
+  val pair [#"../model.rs" 37 0 37 43] (a : t) (b : u) : Model_Pair_Type.t_pair t u
+    ensures { [#"../model.rs" 36 10 36 27] ShallowModel0.shallow_model result = (a, b) }
+    
+end
+module Model_T_Type
+  use prelude.Int
+  use prelude.Int32
+  type t_t  =
+    | C_T bool int32
+    
+  let function t_b (self : t_t) : bool = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_T a _ -> a
+      end
+  let function t_i (self : t_t) : int32 = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_T _ a -> a
+      end
+end
+module Model_TDeepModel_Type
+  use prelude.Int
+  type t_tdeepmodel  =
+    | C_TDeepModel bool int
+    
+end
+module CreusotContracts_Model_Impl4_DeepModel_Stub
+  function deep_model (self : bool) : bool
+end
+module CreusotContracts_Model_Impl4_DeepModel_Interface
+  function deep_model (self : bool) : bool
+end
+module CreusotContracts_Model_Impl4_DeepModel
+  function deep_model (self : bool) : bool =
+    [#"../../../../../creusot-contracts/src/model.rs" 63 8 63 12] self
+  val deep_model (self : bool) : bool
+    ensures { result = deep_model self }
+    
+end
+module CreusotContracts_Std1_Num_Impl25_DeepModel_Stub
+  use prelude.Int
+  use prelude.Int32
+  function deep_model (self : int32) : int
+end
+module CreusotContracts_Std1_Num_Impl25_DeepModel_Interface
+  use prelude.Int
+  use prelude.Int32
+  function deep_model (self : int32) : int
+end
+module CreusotContracts_Std1_Num_Impl25_DeepModel
+  use prelude.Int
+  use prelude.Int32
+  function deep_model (self : int32) : int =
+    [#"../../../../../creusot-contracts/src/std/num.rs" 20 16 20 35] Int32.to_int self
+  val deep_model (self : int32) : int
+    ensures { result = deep_model self }
+    
+end
+module Model_Impl2_DeepModel_Stub
+  use Model_TDeepModel_Type as Model_TDeepModel_Type
+  use Model_T_Type as Model_T_Type
+  function deep_model [#"../model.rs" 43 9 43 18] (self : Model_T_Type.t_t) : Model_TDeepModel_Type.t_tdeepmodel
+end
+module Model_Impl2_DeepModel_Interface
+  use Model_TDeepModel_Type as Model_TDeepModel_Type
+  use Model_T_Type as Model_T_Type
+  function deep_model [#"../model.rs" 43 9 43 18] (self : Model_T_Type.t_t) : Model_TDeepModel_Type.t_tdeepmodel
+end
+module Model_Impl2_DeepModel
+  clone CreusotContracts_Std1_Num_Impl25_DeepModel_Stub as DeepModel1
+  clone CreusotContracts_Model_Impl4_DeepModel_Stub as DeepModel0
+  use Model_TDeepModel_Type as Model_TDeepModel_Type
+  use Model_T_Type as Model_T_Type
+  function deep_model [#"../model.rs" 43 9 43 18] (self : Model_T_Type.t_t) : Model_TDeepModel_Type.t_tdeepmodel =
+    [#"../model.rs" 43 9 651 44] Model_TDeepModel_Type.C_TDeepModel (DeepModel0.deep_model (Model_T_Type.t_b self)) (DeepModel1.deep_model (Model_T_Type.t_i self))
+  val deep_model [#"../model.rs" 43 9 43 18] (self : Model_T_Type.t_t) : Model_TDeepModel_Type.t_tdeepmodel
+    ensures { result = deep_model self }
+    
+end
+module Model_U_Type
+  use prelude.Int
+  use prelude.Int32
+  type t_u  =
+    | C_A
+    | C_B bool
+    | C_C int32
+    | C_D
+    
+end
+module Model_UDeepModel_Type
+  use prelude.Int
+  type t_udeepmodel  =
+    | C_A
+    | C_B bool
+    | C_C int
+    | C_D
+    
+end
+module Model_Impl3_DeepModel_Stub
+  use Model_UDeepModel_Type as Model_UDeepModel_Type
+  use Model_U_Type as Model_U_Type
+  function deep_model [#"../model.rs" 49 9 49 18] (self : Model_U_Type.t_u) : Model_UDeepModel_Type.t_udeepmodel
+end
+module Model_Impl3_DeepModel_Interface
+  use Model_UDeepModel_Type as Model_UDeepModel_Type
+  use Model_U_Type as Model_U_Type
+  function deep_model [#"../model.rs" 49 9 49 18] (self : Model_U_Type.t_u) : Model_UDeepModel_Type.t_udeepmodel
+end
+module Model_Impl3_DeepModel
+  clone CreusotContracts_Std1_Num_Impl25_DeepModel_Stub as DeepModel1
+  clone CreusotContracts_Model_Impl4_DeepModel_Stub as DeepModel0
+  use Model_UDeepModel_Type as Model_UDeepModel_Type
+  use Model_U_Type as Model_U_Type
+  function deep_model [#"../model.rs" 49 9 49 18] (self : Model_U_Type.t_u) : Model_UDeepModel_Type.t_udeepmodel =
+    [#"../model.rs" 49 9 49 18] match (self) with
+      | Model_U_Type.C_A -> Model_UDeepModel_Type.C_A
+      | Model_U_Type.C_B b_1 -> Model_UDeepModel_Type.C_B (DeepModel0.deep_model b_1)
+      | Model_U_Type.C_C b_1 -> Model_UDeepModel_Type.C_C (DeepModel1.deep_model b_1)
+      | Model_U_Type.C_D -> Model_UDeepModel_Type.C_D
+      end
+  val deep_model [#"../model.rs" 49 9 49 18] (self : Model_U_Type.t_u) : Model_UDeepModel_Type.t_udeepmodel
+    ensures { result = deep_model self }
     
 end
 module Model_Impl0
@@ -72,4 +191,10 @@ end
 module Model_Impl1
   type t
   type u
+end
+module Model_Impl2
+  
+end
+module Model_Impl3
+  
 end

--- a/creusot/tests/should_succeed/specification/model.rs
+++ b/creusot/tests/should_succeed/specification/model.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 extern crate creusot_contracts;
 use creusot_contracts::{logic::Int, *};
 
@@ -35,4 +36,20 @@ impl<T, U> ShallowModel for Pair<T, U> {
 #[ensures(result@ == (a, b))]
 pub fn pair<T, U>(a: T, b: U) -> Pair<T, U> {
     Pair(a, b)
+}
+
+// Deep Model should be derivable on monomorphic types
+
+#[derive(DeepModel)]
+struct T {
+    b: bool,
+    i: i32,
+}
+
+#[derive(DeepModel)]
+enum U {
+    A,
+    B { b: bool },
+    C { b: i32 },
+    D,
 }

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -399,7 +399,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -447,7 +447,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
+++ b/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
@@ -139,7 +139,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -207,7 +207,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
@@ -114,7 +114,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -155,7 +155,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -228,7 +228,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -306,7 +306,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -154,7 +154,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -283,7 +283,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -339,7 +339,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -407,7 +407,7 @@ module CreusotContracts_Model_Impl2_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 43 8 43 28] DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 46 8 46 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -435,7 +435,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -617,7 +617,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -135,7 +135,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -299,7 +299,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -92,7 +92,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -136,7 +136,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -189,7 +189,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -1874,7 +1874,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -2480,7 +2480,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -47,7 +47,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -325,7 +325,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -407,7 +407,7 @@ module CreusotContracts_Model_Impl0_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 27 8 27 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 30 8 30 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -86,7 +86,7 @@ module CreusotContracts_Model_Impl1_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 35 8 35 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 38 8 38 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -127,7 +127,7 @@ module CreusotContracts_Model_Impl3_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 51 8 51 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 54 8 54 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     


### PR DESCRIPTION
This PR adds a derive macro for `DeepModel`. This macro currently will only work for monomorphic types as it needs to use associated types in its output. 

Nonetheless, this is of benefit for CreuSAT and CDSAT.