### PR TITLE
Better encoding of spans

### DIFF
--- a/creusot-metadata/Cargo.toml
+++ b/creusot-metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "creusot-metadata"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/creusot-metadata/src/decoder.rs
+++ b/creusot-metadata/src/decoder.rs
@@ -1,65 +1,44 @@
-use rustc_data_structures::{
-    fx::FxHashMap,
-    owning_ref::OwningRef,
-    rustc_erase_owner,
-    sync::{Lrc, MetadataRef},
+use crate::{
+    AbsoluteBytePos, EncodedSourceFileId, Footer, SourceFileIndex, SYMBOL_OFFSET,
+    SYMBOL_PREINTERNED, SYMBOL_STR, TAG_FULL_SPAN, TAG_PARTIAL_SPAN,
 };
+use rustc_data_structures::{fx::FxHashMap, sync::Lrc};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex, DefPathHash, StableCrateId};
 use rustc_middle::{
     implement_ty_decoder,
     ty::{codec::TyDecoder, Ty, TyCtxt},
 };
-use rustc_serialize::opaque;
-pub use rustc_serialize::{Decodable, Decoder};
-use rustc_span::{BytePos, Span, SyntaxContext};
-use std::{fs::File, io::Read, path::Path};
-
-// copied from rustc
-#[derive(Clone)]
-pub struct MetadataBlob(pub Lrc<MetadataRef>);
-
-impl MetadataBlob {
-    pub fn from_file(path: &Path) -> Result<Self, std::io::Error> {
-        let mut encoded = Vec::new();
-        let mut file = File::open(path)?;
-        file.read_to_end(&mut encoded)?;
-
-        let encoded_owned = OwningRef::new(encoded);
-        let metadat_ref: OwningRef<Box<_>, [u8]> = encoded_owned.map_owner_box();
-        Ok(MetadataBlob(Lrc::new(rustc_erase_owner!(metadat_ref))))
-    }
-}
+use rustc_serialize::{
+    opaque::{IntEncodedWithFixedSize, MemDecoder},
+    Decodable, Decoder,
+};
+use rustc_span::{
+    hygiene::{HygieneDecodeContext, SyntaxContextData},
+    BytePos, ExpnData, ExpnHash, ExpnId, SourceFile, Span, Symbol, SyntaxContext, DUMMY_SP,
+};
 
 // This is only safe to decode the metadata of a single crate or the `ty_rcache` might confuse shorthands (see #360)
 pub struct MetadataDecoder<'a, 'tcx> {
-    opaque: opaque::MemDecoder<'a>,
+    opaque: MemDecoder<'a>,
     tcx: TyCtxt<'tcx>,
     ty_rcache: FxHashMap<usize, Ty<'tcx>>,
+    file_index_to_file: FxHashMap<SourceFileIndex, Lrc<SourceFile>>,
+    file_index_to_stable_id: FxHashMap<SourceFileIndex, EncodedSourceFileId>,
+    syntax_contexts: &'a FxHashMap<u32, AbsoluteBytePos>,
+    expn_data: FxHashMap<(StableCrateId, u32), AbsoluteBytePos>,
+    hygiene_context: &'a HygieneDecodeContext,
 }
 
 impl<'a, 'tcx> MetadataDecoder<'a, 'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>, blob: &'a MetadataBlob) -> Self {
-        MetadataDecoder {
-            opaque: opaque::MemDecoder::new(&blob.0, 0),
-            tcx,
-            ty_rcache: Default::default(),
-        }
-    }
-
-    // From rustc
-    fn def_path_hash_to_def_id(&self, hash: DefPathHash) -> DefId {
-        self.tcx.def_path_hash_to_def_id(hash, &mut || panic!("testxxx"))
-    }
-}
-
-// the following two instances are from rustc
-// This impl makes sure that we get a runtime error when we try decode a
-// `DefIndex` that is not contained in a `DefId`. Such a case would be problematic
-// because we would not know how to transform the `DefIndex` to the current
-// context.
-impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefIndex {
-    fn decode(_: &mut MetadataDecoder<'a, 'tcx>) -> DefIndex {
-        panic!("trying to decode `DefIndex` outside the context of a `DefId`")
+    fn file_index_to_file(&mut self, index: SourceFileIndex) -> Lrc<SourceFile> {
+        self.file_index_to_file
+            .entry(index)
+            .or_insert_with(|| {
+                let stable_id = self.file_index_to_stable_id[&index].translate(self.tcx);
+                self.tcx.cstore_untracked().import_source_files(self.tcx.sess, stable_id.cnum);
+                self.tcx.sess.source_map().source_file_by_stable_id(stable_id).unwrap()
+            })
+            .clone()
     }
 }
 
@@ -69,7 +48,7 @@ impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefIndex {
 impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefId {
     fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Self {
         let def_path_hash = DefPathHash::decode(d);
-        d.def_path_hash_to_def_id(def_path_hash)
+        d.tcx.def_path_hash_to_def_id(def_path_hash, &mut || panic!("Cannot resolve crate."))
     }
 }
 
@@ -80,35 +59,107 @@ impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for CrateNum {
     }
 }
 
+// This impl makes sure that we get a runtime error when we try decode a
+// `DefIndex` that is not contained in a `DefId`. Such a case would be problematic
+// because we would not know how to transform the `DefIndex` to the current
+// context.
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for DefIndex {
+    fn decode(_: &mut MetadataDecoder<'a, 'tcx>) -> DefIndex {
+        panic!("trying to decode `DefIndex` outside the context of a `DefId`")
+    }
+}
+
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for SyntaxContext {
+    fn decode(decoder: &mut MetadataDecoder<'a, 'tcx>) -> Self {
+        let syntax_contexts = decoder.syntax_contexts;
+        rustc_span::hygiene::decode_syntax_context(decoder, &decoder.hygiene_context, |this, id| {
+            // This closure is invoked if we haven't already decoded the data for the `SyntaxContext` we are deserializing.
+            // We look up the position of the associated `SyntaxData` and decode it.
+            let pos = syntax_contexts.get(&id).unwrap();
+            this.with_position(pos.to_usize(), |decoder| SyntaxContextData::decode(decoder))
+        })
+    }
+}
+
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for ExpnId {
+    fn decode(decoder: &mut MetadataDecoder<'a, 'tcx>) -> Self {
+        let stable_id = StableCrateId::decode(decoder);
+        let cnum = decoder.tcx.stable_crate_id_to_crate_num(stable_id);
+        let index = u32::decode(decoder);
+
+        let expn_id = rustc_span::hygiene::decode_expn_id(cnum, index, |_| {
+            let pos = decoder.expn_data.get(&(stable_id, index)).unwrap();
+            decoder.with_position(pos.to_usize(), |decoder| {
+                let data = ExpnData::decode(decoder);
+                let hash = ExpnHash::decode(decoder);
+                (data, hash)
+            })
+        });
+        expn_id
+    }
+}
+
 impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for Span {
-    // KNOWN ISSUE: Currently we make no attempt to encode the `SyntaxContext`
-    // this may lead to issues?
-    fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Span {
-        let lo = BytePos::decode(d);
-        let len = BytePos::decode(d);
+    fn decode(decoder: &mut MetadataDecoder<'a, 'tcx>) -> Self {
+        let ctxt = SyntaxContext::decode(decoder);
+        let tag: u8 = Decodable::decode(decoder);
+
+        if tag == TAG_PARTIAL_SPAN {
+            return DUMMY_SP.with_ctxt(ctxt);
+        }
+
+        debug_assert!(tag == TAG_FULL_SPAN);
+
+        let source_file_index = SourceFileIndex::decode(decoder);
+        let lo = BytePos::decode(decoder);
+        let len = BytePos::decode(decoder);
+
+        let file = decoder.file_index_to_file(source_file_index);
+        let lo = file.start_pos + lo;
         let hi = lo + len;
 
-        use rustc_span::RealFileName;
-        let name = <Option<RealFileName>>::decode(d);
+        Span::new(lo, hi, ctxt, None)
+    }
+}
 
-        let source_map = d.tcx.sess.source_map();
+// copy&paste impl from rustc_metadata
+impl<'a, 'tcx> Decodable<MetadataDecoder<'a, 'tcx>> for Symbol {
+    fn decode(d: &mut MetadataDecoder<'a, 'tcx>) -> Self {
+        let tag = d.read_u8();
 
-        let start_pos = match name {
-            Some(rname) => source_map.load_file(rname.local_path_if_available()).unwrap().start_pos,
-            None => BytePos(0),
-        };
+        match tag {
+            SYMBOL_STR => {
+                let s = d.read_str();
+                Symbol::intern(s)
+            }
+            SYMBOL_OFFSET => {
+                // read str offset
+                let pos = d.read_usize();
+                let old_pos = d.opaque.position();
 
-        let lo = lo + start_pos;
-        let hi = hi + start_pos;
+                // move to str ofset and read
+                d.opaque.set_position(pos);
+                let s = d.read_str();
+                let sym = Symbol::intern(s);
 
-        // Do not try to decode parent for foreign spans.
-        Span::new(lo, hi, SyntaxContext::root(), None)
+                // restore position
+                d.opaque.set_position(old_pos);
+
+                sym
+            }
+            SYMBOL_PREINTERNED => {
+                let symbol_index = d.read_u32();
+                Symbol::new_from_decoded(symbol_index)
+            }
+            _ => unreachable!(),
+        }
     }
 }
 
 implement_ty_decoder!(MetadataDecoder<'a, 'tcx>);
 
 impl<'a, 'tcx> TyDecoder for MetadataDecoder<'a, 'tcx> {
+    // Whether crate-local information can be cleared while encoding
     const CLEAR_CROSS_CRATE: bool = true;
 
     type I = TyCtxt<'tcx>;
@@ -144,14 +195,39 @@ impl<'a, 'tcx> TyDecoder for MetadataDecoder<'a, 'tcx> {
     where
         F: FnOnce(&mut Self) -> R,
     {
-        let new_opaque = opaque::MemDecoder::new(self.opaque.data, pos);
-        let old_opaque = std::mem::replace(&mut self.opaque, new_opaque);
+        let new_decoder = MemDecoder::new(self.opaque.data, pos);
+        let old_decoder = std::mem::replace(&mut self.opaque, new_decoder);
         let r = f(self);
-        self.opaque = old_opaque;
+        self.opaque = old_decoder;
         r
     }
 
     fn decode_alloc_id(&mut self) -> rustc_middle::mir::interpret::AllocId {
         unimplemented!("decode_alloc_id")
     }
+}
+
+pub fn decode_metadata<'tcx, T: for<'a> Decodable<MetadataDecoder<'a, 'tcx>>>(
+    tcx: TyCtxt<'tcx>,
+    blob: &[u8],
+) -> T {
+    let footer = {
+        let mut decoder = MemDecoder::new(blob, 0);
+        decoder.set_position(blob.len() - IntEncodedWithFixedSize::ENCODED_SIZE);
+        let footer_pos = IntEncodedWithFixedSize::decode(&mut decoder).0 as usize;
+        decoder.set_position(footer_pos);
+        Footer::decode(&mut decoder)
+    };
+
+    let mut decoder = MetadataDecoder {
+        opaque: MemDecoder::new(blob, 0),
+        tcx,
+        ty_rcache: Default::default(),
+        file_index_to_stable_id: footer.file_index_to_stable_id,
+        file_index_to_file: Default::default(),
+        syntax_contexts: &footer.syntax_contexts,
+        expn_data: footer.expn_data,
+        hygiene_context: &Default::default(),
+    };
+    T::decode(&mut decoder)
 }

--- a/creusot-metadata/src/encoder.rs
+++ b/creusot-metadata/src/encoder.rs
@@ -1,36 +1,40 @@
-use rustc_middle::{
-    mir::interpret::AllocId,
-    ty::{self, codec::TyEncoder, PredicateKind, Ty},
+use crate::{
+    AbsoluteBytePos, EncodedSourceFileId, Footer, SourceFileIndex, SYMBOL_OFFSET,
+    SYMBOL_PREINTERNED, SYMBOL_STR, TAG_FULL_SPAN, TAG_PARTIAL_SPAN,
 };
-use rustc_serialize::opaque;
-pub use rustc_serialize::{Encodable, Encoder};
-
-use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
+use rustc_data_structures::{fx::FxHashMap, sync::Lrc};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
-use rustc_middle::ty::TyCtxt;
-use rustc_span::Span;
+use rustc_middle::{
+    dep_graph::DepContext,
+    ty::{self, codec::TyEncoder, PredicateKind, Ty, TyCtxt},
+};
+use rustc_serialize::{
+    opaque::{IntEncodedWithFixedSize, MemEncoder},
+    Encodable, Encoder,
+};
+use rustc_span::{
+    hygiene::{raw_encode_syntax_context, HygieneEncodeContext},
+    ExpnId, SourceFile, Span, Symbol, SyntaxContext,
+};
+use std::collections::hash_map::Entry;
 
-pub struct MetadataEncoder<'tcx> {
+pub struct MetadataEncoder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    opaque: opaque::MemEncoder,
+    pub opaque: MemEncoder,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<PredicateKind<'tcx>, usize>,
-    interpret_allocs: FxIndexSet<AllocId>,
+    file_to_file_index: FxHashMap<*const SourceFile, SourceFileIndex>,
+    hygiene_context: &'a HygieneEncodeContext,
+    symbol_table: FxHashMap<Symbol, usize>,
 }
 
-impl<'tcx> MetadataEncoder<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
-        MetadataEncoder {
-            tcx,
-            opaque: opaque::MemEncoder::new(),
-            type_shorthands: Default::default(),
-            predicate_shorthands: Default::default(),
-            interpret_allocs: Default::default(),
-        }
-    }
-
+impl<'a, 'tcx> MetadataEncoder<'a, 'tcx> {
     pub fn finish(self) -> Vec<u8> {
         self.opaque.finish()
+    }
+
+    fn source_file_index(&mut self, source_file: Lrc<SourceFile>) -> SourceFileIndex {
+        self.file_to_file_index[&(&*source_file as *const SourceFile)]
     }
 }
 
@@ -41,7 +45,7 @@ macro_rules! encoder_methods {
         })*
     }
 }
-impl<'tcx> Encoder for MetadataEncoder<'tcx> {
+impl<'a, 'tcx> Encoder for MetadataEncoder<'a, 'tcx> {
     encoder_methods! {
         emit_usize(usize);
         emit_u128(u128);
@@ -66,60 +70,94 @@ impl<'tcx> Encoder for MetadataEncoder<'tcx> {
     }
 }
 
-impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for DefId {
-    fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for DefId {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
         s.tcx.def_path_hash(*self).encode(s)
     }
 }
 
-impl<'a, 'tcx> Encodable<MetadataEncoder<'tcx>> for DefIndex {
-    fn encode(&self, _: &mut MetadataEncoder<'tcx>) {
-        panic!("encoding `DefIndex` without context");
-    }
-}
-
-impl<'tcx> Encodable<MetadataEncoder<'tcx>> for CrateNum {
-    fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for CrateNum {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
         s.tcx.stable_crate_id(*self).encode(s)
     }
 }
 
-impl<'tcx> Encodable<MetadataEncoder<'tcx>> for Span {
-    // KNOWN ISSUE: Currently we make no attempt to encode the `SyntaxContext`
-    // this may lead to issues?
-    fn encode(&self, s: &mut MetadataEncoder<'tcx>) {
-        let span = self.data();
-        // span.ctxt.encode(s);
-
-        let source_map = s.tcx.sess.source_map();
-
-        let source_file = source_map.lookup_source_file(span.lo);
-
-        let lo = span.lo - source_file.start_pos;
-        let len = span.hi - span.lo;
-
-        lo.encode(s);
-        len.encode(s);
-
-        let working_directory = &s.tcx.sess.opts.working_dir;
-        use rustc_span::FileName;
-
-        let path = match source_map.span_to_filename(*self) {
-            FileName::Real(r) => {
-                let fname =
-                    source_map.path_mapping().to_embeddable_absolute_path(r, working_directory);
-                Some(fname)
-            }
-            _ => None,
-        };
-
-        path.encode(s);
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for DefIndex {
+    fn encode(&self, _: &mut MetadataEncoder<'a, 'tcx>) {
+        panic!("encoding `DefIndex` without context");
     }
 }
 
-impl<'tcx> TyEncoder for MetadataEncoder<'tcx> {
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for SyntaxContext {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
+        raw_encode_syntax_context(*self, &s.hygiene_context, s);
+    }
+}
+
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for ExpnId {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
+        s.hygiene_context.schedule_expn_data_for_encoding(*self);
+        self.krate.encode(s);
+        self.local_id.as_u32().encode(s);
+    }
+}
+
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for Span {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
+        let span = self.data();
+        span.ctxt.encode(s);
+
+        if span.is_dummy() {
+            return TAG_PARTIAL_SPAN.encode(s);
+        }
+
+        let source_file = s.tcx.sess().source_map().lookup_source_file(span.lo);
+        if !source_file.contains(span.hi) {
+            // Unfortunately, macro expansion still sometimes generates Spans
+            // that malformed in this way.
+            return TAG_PARTIAL_SPAN.encode(s);
+        }
+
+        let lo = span.lo - source_file.start_pos;
+        let len = span.hi - span.lo;
+        let source_file_index = s.source_file_index(source_file);
+
+        TAG_FULL_SPAN.encode(s);
+        source_file_index.encode(s);
+        lo.encode(s);
+        len.encode(s);
+    }
+}
+
+impl<'a, 'tcx> Encodable<MetadataEncoder<'a, 'tcx>> for Symbol {
+    fn encode(&self, s: &mut MetadataEncoder<'a, 'tcx>) {
+        // if symbol preinterned, emit tag and symbol index
+        if self.is_preinterned() {
+            s.opaque.emit_u8(SYMBOL_PREINTERNED);
+            s.opaque.emit_u32(self.as_u32());
+        } else {
+            // otherwise write it as string or as offset to it
+            match s.symbol_table.entry(*self) {
+                Entry::Vacant(o) => {
+                    s.opaque.emit_u8(SYMBOL_STR);
+                    let pos = s.opaque.position();
+                    o.insert(pos);
+                    s.emit_str(self.as_str());
+                }
+                Entry::Occupied(o) => {
+                    let x = *o.get();
+                    s.emit_u8(SYMBOL_OFFSET);
+                    s.emit_usize(x);
+                }
+            }
+        }
+    }
+}
+
+impl<'a, 'tcx> TyEncoder for MetadataEncoder<'a, 'tcx> {
     type I = TyCtxt<'tcx>;
-    // What the fuck does this mean?
+
+    // Whether crate-local information can be cleared while encoding
     const CLEAR_CROSS_CRATE: bool = true;
 
     fn position(&self) -> usize {
@@ -134,9 +172,78 @@ impl<'tcx> TyEncoder for MetadataEncoder<'tcx> {
         &mut self.predicate_shorthands
     }
 
-    fn encode_alloc_id(&mut self, alloc_id: &rustc_middle::mir::interpret::AllocId) {
-        let (index, _) = self.interpret_allocs.insert_full(*alloc_id);
-
-        index.encode(self)
+    fn encode_alloc_id(&mut self, _alloc_id: &rustc_middle::mir::interpret::AllocId) {
+        unimplemented!("encode_alloc_id")
     }
+}
+
+pub fn encode_metadata<'tcx, T: for<'a> Encodable<MetadataEncoder<'a, 'tcx>>>(
+    tcx: TyCtxt<'tcx>,
+    x: T,
+) -> Vec<u8> {
+    let (file_to_file_index, file_index_to_stable_id) = {
+        let files = tcx.sess.source_map().files();
+        let mut file_to_file_index =
+            FxHashMap::with_capacity_and_hasher(files.len(), Default::default());
+        let mut file_index_to_stable_id =
+            FxHashMap::with_capacity_and_hasher(files.len(), Default::default());
+
+        for (index, file) in files.iter().enumerate() {
+            let index = SourceFileIndex(index as u32);
+            let file_ptr: *const SourceFile = &**file as *const _;
+            file_to_file_index.insert(file_ptr, index);
+            let source_file_id = EncodedSourceFileId::new(tcx, &file);
+            file_index_to_stable_id.insert(index, source_file_id);
+        }
+
+        (file_to_file_index, file_index_to_stable_id)
+    };
+
+    let hygiene_context = HygieneEncodeContext::default();
+
+    let mut encoder = MetadataEncoder {
+        tcx,
+        opaque: MemEncoder::new(),
+        type_shorthands: Default::default(),
+        predicate_shorthands: Default::default(),
+        hygiene_context: &hygiene_context,
+        symbol_table: Default::default(),
+        file_to_file_index,
+    };
+    x.encode(&mut encoder);
+
+    let mut syntax_contexts = FxHashMap::default();
+    let mut expn_data = FxHashMap::default();
+
+    // Encode all hygiene data (`SyntaxContextData` and `ExpnData`) from the current
+    // session.
+
+    encoder.hygiene_context.encode(
+        &mut encoder,
+        |encoder, index, ctxt_data| {
+            let pos = AbsoluteBytePos::new(encoder.position());
+            ctxt_data.encode(encoder);
+            syntax_contexts.insert(index, pos);
+        },
+        |encoder, expn_id, data, hash| {
+            let pos = AbsoluteBytePos::new(encoder.position());
+            data.encode(encoder);
+            hash.encode(encoder);
+            expn_data.insert((tcx.stable_crate_id(expn_id.krate), expn_id.local_id.as_u32()), pos);
+        },
+    );
+
+    // Encode the file footer.
+    let footer_pos = encoder.position() as u64;
+    let footer = Footer { file_index_to_stable_id, syntax_contexts, expn_data };
+    footer.encode(&mut encoder);
+
+    // Encode the position of the footer as the last 8 bytes of the
+    // file so we know where to look for it.
+    IntEncodedWithFixedSize(footer_pos).encode(&mut encoder.opaque);
+
+    // DO NOT WRITE ANYTHING TO THE ENCODER AFTER THIS POINT! The address
+    // of the footer must be the last thing in the data stream.
+
+    encoder.finish()
 }

--- a/creusot-metadata/src/lib.rs
+++ b/creusot-metadata/src/lib.rs
@@ -9,6 +9,98 @@ extern crate rustc_middle;
 extern crate rustc_serialize;
 extern crate rustc_session;
 extern crate rustc_span;
+#[macro_use]
+extern crate rustc_macros;
 
-pub mod decoder;
-pub mod encoder;
+// Tags used for encoding Spans:
+const TAG_FULL_SPAN: u8 = 0;
+const TAG_PARTIAL_SPAN: u8 = 1;
+
+// Tags for encoding Symbol's
+const SYMBOL_STR: u8 = 0;
+const SYMBOL_OFFSET: u8 = 1;
+const SYMBOL_PREINTERNED: u8 = 2;
+
+mod decoder;
+mod encoder;
+
+pub use decoder::decode_metadata;
+pub use encoder::encode_metadata;
+use rustc_data_structures::{fx::FxHashMap, stable_hasher::StableHasher};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::{
+    def_id::{StableCrateId, LOCAL_CRATE},
+    source_map::StableSourceFileId,
+    FileName, SourceFile,
+};
+use std::hash::Hash;
+
+#[derive(Encodable, Decodable, Eq, PartialEq, Hash, Clone, Copy)]
+struct SourceFileIndex(u32);
+
+#[derive(Encodable, Decodable, Clone, Copy)]
+pub struct AbsoluteBytePos(u64);
+
+impl AbsoluteBytePos {
+    fn new(pos: usize) -> AbsoluteBytePos {
+        AbsoluteBytePos(pos.try_into().unwrap())
+    }
+
+    fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// An `EncodedSourceFileId` is the same as a `StableSourceFileId` except that
+/// the source crate is represented as a [StableCrateId] instead of as a
+/// `CrateNum`. This way `EncodedSourceFileId` can be encoded and decoded
+/// without any additional context, i.e. with a simple `opaque::Decoder` (which
+/// is the only thing available when decoding the [Footer].
+#[derive(Encodable, Decodable, Clone, Debug)]
+struct EncodedSourceFileId {
+    file_name_hash: u64,
+    stable_crate_id: StableCrateId,
+}
+
+impl EncodedSourceFileId {
+    fn translate(&self, tcx: TyCtxt<'_>) -> StableSourceFileId {
+        let cnum = tcx.stable_crate_id_to_crate_num(self.stable_crate_id);
+        StableSourceFileId { file_name_hash: self.file_name_hash, cnum }
+    }
+
+    fn new(tcx: TyCtxt<'_>, file: &SourceFile) -> EncodedSourceFileId {
+        if file.cnum == LOCAL_CRATE {
+            /* Cf rustc_metadata::rmeta::encode_source_map */
+            if let FileName::Real(ref original_file_name) = file.name {
+                let adapted_file_name =
+                    tcx.sess.source_map().path_mapping().to_embeddable_absolute_path(
+                        original_file_name.clone(),
+                        &tcx.sess.opts.working_dir,
+                    );
+                if adapted_file_name != *original_file_name {
+                    let file_name_hash = {
+                        let mut hasher = StableHasher::new();
+                        FileName::Real(adapted_file_name).hash(&mut hasher);
+                        hasher.finish::<u64>()
+                    };
+                    return EncodedSourceFileId {
+                        file_name_hash,
+                        stable_crate_id: tcx.sess.local_stable_crate_id(),
+                    };
+                }
+            }
+        }
+        let source_file_id = StableSourceFileId::new(file);
+        EncodedSourceFileId {
+            file_name_hash: source_file_id.file_name_hash,
+            stable_crate_id: tcx.stable_crate_id(source_file_id.cnum),
+        }
+    }
+}
+
+#[derive(Decodable, Encodable)]
+struct Footer {
+    file_index_to_stable_id: FxHashMap<SourceFileIndex, EncodedSourceFileId>,
+    syntax_contexts: FxHashMap<u32, AbsoluteBytePos>,
+    expn_data: FxHashMap<(StableCrateId, u32), AbsoluteBytePos>,
+}

--- a/creusot/src/backend/term.rs
+++ b/creusot/src/backend/term.rs
@@ -21,11 +21,7 @@ pub(crate) fn lower_pure<'tcx>(
     let span = term.span;
     let mut term = Lower { ctx, names, pure: Purity::Logic }.lower_term(term);
     term.reassociate();
-    if !ctx.sess.source_map().is_imported(span) {
-        term = ctx.attach_span(span, term);
-    }
-
-    term
+    ctx.attach_span(span, term)
 }
 
 pub(crate) fn lower_impure<'tcx>(
@@ -36,11 +32,7 @@ pub(crate) fn lower_impure<'tcx>(
     let span = term.span;
     let mut term = Lower { ctx, names, pure: Purity::Program }.lower_term(term);
     term.reassociate();
-
-    if !ctx.sess.source_map().is_imported(span) {
-        term = ctx.attach_span(span, term);
-    }
-    term
+    ctx.attach_span(span, term)
 }
 
 pub(super) struct Lower<'a, 'tcx> {

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -143,7 +143,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -374,9 +374,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -294,7 +294,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : uint64)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
 end
 module Bdd_Hashmap_Impl2_HashLog_Stub
   type u
@@ -379,7 +379,7 @@ module Core_Num_Impl9_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    (64 : uint32)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 59 8 59 27] (64 : uint32)
 end
 module Core_Num_Impl9_Min_Stub
   use prelude.Int
@@ -390,7 +390,7 @@ module Core_Num_Impl9_Min
   use prelude.Int
   use prelude.UInt64
   let constant mIN'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    (0 : uint64)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 36 8 36 27] (0 : uint64)
 end
 module Core_Num_Impl9_WrappingMul_Interface
   use prelude.UInt64

--- a/creusot/tests/should_succeed/bug/206.mlcfg
+++ b/creusot/tests/should_succeed/bug/206.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -8,7 +8,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : uint64)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
 end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -190,7 +190,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -480,7 +480,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/checked_ops.mlcfg
+++ b/creusot/tests/should_succeed/checked_ops.mlcfg
@@ -52,7 +52,7 @@ module Core_Num_Impl6_Min
   use prelude.Int
   use prelude.UInt8
   let constant mIN'  : uint8 = [@vc:do_not_keep_trace] [@vc:sp]
-    (0 : uint8)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 36 8 36 27] (0 : uint8)
 end
 module Core_Num_Impl6_Max_Stub
   use prelude.Int
@@ -63,7 +63,7 @@ module Core_Num_Impl6_Max
   use prelude.Int
   use prelude.UInt8
   let constant mAX'  : uint8 = [@vc:do_not_keep_trace] [@vc:sp]
-    (255 : uint8)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (255 : uint8)
 end
 module Core_Num_Impl6_CheckedAdd_Interface
   use prelude.UInt8
@@ -101,7 +101,7 @@ module Core_Num_Impl6_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    (8 : uint32)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 59 8 59 27] (8 : uint32)
 end
 module Core_Num_Impl6_WrappingAdd_Interface
   use prelude.UInt8
@@ -2661,7 +2661,7 @@ module Core_Num_Impl0_Min
   use prelude.Int
   use prelude.Int8
   let constant mIN'  : int8 = [@vc:do_not_keep_trace] [@vc:sp]
-    (-128 : int8)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 38 8 38 27] (-128 : int8)
 end
 module Core_Num_Impl0_Max_Stub
   use prelude.Int
@@ -2672,7 +2672,7 @@ module Core_Num_Impl0_Max
   use prelude.Int
   use prelude.Int8
   let constant mAX'  : int8 = [@vc:do_not_keep_trace] [@vc:sp]
-    (127 : int8)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 51 8 51 27] (127 : int8)
 end
 module Core_Num_Impl0_CheckedAdd_Interface
   use prelude.Int8
@@ -2694,7 +2694,7 @@ module Core_Num_Impl0_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    (8 : uint32)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 61 8 61 27] (8 : uint32)
 end
 module Core_Num_Impl0_WrappingAdd_Interface
   use prelude.Int8

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -45,7 +45,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : uint64)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
   use prelude.Int

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -186,7 +186,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -327,7 +327,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -668,7 +668,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1723,7 +1723,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
 end
 module Alloc_Vec_Impl1_Len_Interface
   type t

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1199,9 +1199,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -2813,7 +2813,7 @@ module Core_Slice_Iter_Impl0_IntoIter_Interface
   val into_iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/slice/iter.rs" 25 4 25 37] Invariant0.invariant' result }
     
 end
 module Core_Num_Impl8_AbsDiff_Interface

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -101,7 +101,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : uint64)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
   use prelude.Int

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -72,7 +72,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -19,7 +19,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -341,9 +341,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -383,7 +383,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t
@@ -924,7 +924,7 @@ module Alloc_Vec_Impl17_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2778 4 2778 40] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
@@ -1989,9 +1989,9 @@ module Core_Iter_Traits_Iterator_Iterator_Take_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val take (self : self) (n : usize) : Core_Iter_Adapters_Take_Take_Type.t_take self
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1406 12 1406 16] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
-    ensures { Invariant1.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1406 4 1408 20] Invariant1.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Skip_Impl0_N_Stub
@@ -2063,9 +2063,9 @@ module Core_Iter_Traits_Iterator_Iterator_Skip_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val skip (self : self) (n : usize) : Core_Iter_Adapters_Skip_Skip_Type.t_skip self
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1352 12 1352 16] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
-    ensures { Invariant1.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1352 4 1354 20] Invariant1.invariant' result }
     
 end
 module CreusotContracts_Invariant_Impl1_Invariant_Stub
@@ -2151,12 +2151,12 @@ module Core_Iter_Adapters_Skip_Impl1_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = Core_Iter_Adapters_Skip_Skip_Type.t_skip i
   val next (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip i)) : Core_Option_Option_Type.t_option Item1.item
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/skip.rs" 34 17 34 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { Invariant1.invariant' ( ^ self) }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/skip.rs" 34 17 34 21] Invariant1.invariant' ( ^ self) }
     
 end
 module CreusotContracts_Std1_Iter_Take_Impl3_Resolve_Stub
@@ -2294,7 +2294,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Skip_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 71 21 71 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl
   type i
@@ -2310,10 +2310,10 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesRefl
   function produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : () =
     [#"../../../../../creusot-contracts/src/std/iter/skip.rs" 69 4 69 10] ()
   val produces_refl (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 71 21 71 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 71 21 71 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans_Stub
   type i
@@ -2342,7 +2342,7 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 22 77 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 52 77 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 82 77 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans
   type i
@@ -2362,12 +2362,12 @@ module CreusotContracts_Std1_Iter_Skip_Impl2_ProducesTrans
   val produces_trans (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 22 77 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 52 77 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 82 77 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip i . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 22 77 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 52 77 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 82 77 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_Produces_Stub
   type i
@@ -2504,7 +2504,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Take_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl
   type i
@@ -2520,10 +2520,10 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesRefl
   function produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : () =
     [#"../../../../../creusot-contracts/src/std/iter/take.rs" 69 4 69 10] ()
   val produces_refl (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans_Stub
   type i
@@ -2552,7 +2552,7 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Take_Take_Type.t_take i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Take_Take_Type.t_take i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 22 77 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 52 77 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 82 77 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans
   type i
@@ -2572,12 +2572,12 @@ module CreusotContracts_Std1_Iter_Take_Impl2_ProducesTrans
   val produces_trans (a : Core_Iter_Adapters_Take_Take_Type.t_take i) (ab : Seq.seq Item0.item) (b : Core_Iter_Adapters_Take_Take_Type.t_take i) (bc : Seq.seq Item0.item) (c : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 22 77 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 52 77 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 82 77 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq Item0.item, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq Item0.item, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 74 15 74 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 22 77 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 52 77 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 82 77 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 14 76 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Stub
   type self
@@ -2602,7 +2602,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -2616,10 +2616,10 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     type self = self
   function produces_refl (a : self) : ()
   val produces_refl (a : self) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -2644,7 +2644,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -2660,12 +2660,12 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_SkipTake_Interface
   type i
@@ -3349,7 +3349,7 @@ module CreusotContracts_Std1_Iter_Iterator_MapInv_Interface
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 39 4 39 138] forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 40 15 40 51] Reinitialize0.reinitialize ()}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 41 15 41 70] Preservation0.preservation self func}
-    requires {Invariant0.invariant' self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 43 21 43 25] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 42 14 42 85] result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
     
 end
@@ -3396,7 +3396,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val collect (self : self) : b
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1887 44 1887 48] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
@@ -4475,7 +4475,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant_Stub
   type i
@@ -4619,9 +4619,9 @@ module Core_Iter_Traits_Iterator_Iterator_Enumerate_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val enumerate (self : self) : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate self
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1011 17 1011 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = 0 }
-    ensures { Invariant1.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1011 4 1013 20] Invariant1.invariant' result }
     
 end
 module Core_Iter_Adapters_Enumerate_Impl1_Next_Interface
@@ -4646,12 +4646,12 @@ module Core_Iter_Adapters_Enumerate_Impl1_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i
   val next (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)) : Core_Option_Option_Type.t_option (usize, Item1.item)
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/enumerate.rs" 45 17 45 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { Invariant1.invariant' ( ^ self) }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/enumerate.rs" 45 17 45 21] Invariant1.invariant' ( ^ self) }
     
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl_Stub
@@ -4679,7 +4679,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl_Interface
   clone CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant_Stub as Invariant0 with
     type i = i
   function produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 67 21 67 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl
   type i
@@ -4695,10 +4695,10 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl
   function produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : () =
     [#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 65 4 65 10] ()
   val produces_refl (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 67 21 67 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 67 21 67 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 66 14 66 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans_Stub
   type i
@@ -4731,7 +4731,7 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans_Interface
     type Item0.item = Item0.item
   function produces_trans (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (ab : Seq.seq (usize, Item0.item)) (b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (bc : Seq.seq (usize, Item0.item)) (c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 22 73 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 52 73 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 82 73 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans
   type i
@@ -4753,12 +4753,12 @@ module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans
   val produces_trans (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (ab : Seq.seq (usize, Item0.item)) (b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) (bc : Seq.seq (usize, Item0.item)) (c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 22 73 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 52 73 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 82 73 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, ab : Seq.seq (usize, Item0.item), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i, bc : Seq.seq (usize, Item0.item), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 70 15 70 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 71 15 71 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 22 73 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 52 73 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 82 73 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_Completed_Stub
   type i

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -3202,7 +3202,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module C06MapPrecond_Counter_Closure3_Type
   use prelude.Borrow

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -125,7 +125,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -373,9 +373,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module Core_Iter_Traits_Iterator_Iterator_Next_Interface
@@ -395,12 +395,12 @@ module Core_Iter_Traits_Iterator_Iterator_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = self
   val next (self : borrowed self) : Core_Option_Option_Type.t_option Item0.item
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 111 17 111 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { Invariant1.invariant' ( ^ self) }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 111 17 111 21] Invariant1.invariant' ( ^ self) }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -470,7 +470,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -484,10 +484,10 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     type self = self
   function produces_refl (a : self) : ()
   val produces_refl (a : self) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -512,7 +512,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -528,12 +528,12 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub
   type i
@@ -1333,7 +1333,7 @@ module Alloc_Vec_Impl16_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2750 4 2750 40] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -286,7 +286,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
 end
 module C15Enumerate_Impl1_Invariant_Stub
   type i

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -256,7 +256,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -454,7 +454,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1036,9 +1036,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -158,7 +158,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -96,11 +96,11 @@ module Own_Impl0_IsOk
       end
   }
   BB1 {
-    _0 <- false;
+    _0 <- ([#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/macros/mod.rs" 346 17 346 22] false);
     goto BB3
   }
   BB2 {
-    _0 <- true;
+    _0 <- ([#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/macros/mod.rs" 345 47 345 51] true);
     goto BB3
   }
   BB3 {

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -243,9 +243,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -155,7 +155,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -650,9 +650,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -236,7 +236,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -260,7 +260,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -436,9 +436,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -272,9 +272,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/syntax/02_operators.mlcfg
+++ b/creusot/tests/should_succeed/syntax/02_operators.mlcfg
@@ -116,7 +116,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module C02Operators_Multiply_Interface
   use prelude.UIntSize

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
@@ -20,7 +20,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -79,7 +79,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -47,7 +47,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -19,7 +19,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/type_invariants/non_zero.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/non_zero.mlcfg
@@ -109,7 +109,7 @@ module Core_Num_Impl8_Max
   use prelude.Int
   use prelude.UInt32
   let constant mAX'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    (4294967295 : uint32)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (4294967295 : uint32)
 end
 module NonZero_Impl1_Add_Interface
   use prelude.UInt32

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -53,7 +53,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -403,9 +403,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -131,7 +131,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -50,7 +50,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -419,9 +419,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -178,7 +178,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module Alloc_Vec_Impl1_Len_Interface
   type t

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -267,7 +267,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Resolve_Resolve_Resolve_Stub
   type self

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -186,7 +186,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -847,7 +847,7 @@ module CreusotContracts_Std1_Iter_Iterator_MapInv_Interface
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 39 4 39 138] forall i2 : self . Invariant0.invariant' i2 -> (forall e : Item0.item . Produces0.produces self (Seq.singleton e) i2 -> Precondition0.precondition func (e, Ghost.new (Seq.empty )))}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 40 15 40 51] Reinitialize0.reinitialize ()}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 41 15 41 70] Preservation0.preservation self func}
-    requires {Invariant0.invariant' self}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 43 21 43 25] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 42 14 42 85] result = CreusotContracts_Std1_Iter_MapInv_MapInv_Type.C_MapInv self func (Ghost.new (Seq.empty )) }
     
 end
@@ -930,7 +930,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val collect (self : self) : b
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1887 44 1887 48] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
@@ -957,7 +957,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   function produces_refl (a : self) : ()
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
   type self
@@ -971,10 +971,10 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesRefl
     type self = self
   function produces_refl (a : self) : ()
   val produces_refl (a : self) : ()
-    requires {Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a}
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : self . Invariant0.invariant' a -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
+  axiom produces_refl_spec : forall a : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 31 21 31 22] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 30 14 30 39] Produces0.produces a (Seq.empty ) a)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Stub
   type self
@@ -999,7 +999,7 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans_Interface
     type self = self,
     type Item0.item = Item0.item
   function produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   type self
@@ -1015,12 +1015,12 @@ module CreusotContracts_Std1_Iter_Iterator_ProducesTrans
   val produces_trans (a : self) (ab : Seq.seq Item0.item) (b : self) (bc : Seq.seq Item0.item) (c : self) : ()
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b}
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c}
-    requires {Invariant0.invariant' a}
-    requires {Invariant0.invariant' b}
-    requires {Invariant0.invariant' c}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b}
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c}
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> Invariant0.invariant' a -> Invariant0.invariant' b -> Invariant0.invariant' c -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : self, ab : Seq.seq Item0.item, b : self, bc : Seq.seq Item0.item, c : self . ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 15 34 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 15 35 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 22 37 23] Invariant0.invariant' a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 52 37 53] Invariant0.invariant' b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 37 82 37 83] Invariant0.invariant' c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 36 14 36 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
   type self
@@ -2454,7 +2454,7 @@ module Alloc_Vec_Impl16_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2750 4 2750 40] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -3341,7 +3341,7 @@ module Alloc_Vec_Impl17_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2778 4 2778 40] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -3876,9 +3876,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module Core_Iter_Range_Impl3_Next_Interface

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -196,7 +196,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -655,9 +655,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {Invariant0.invariant' self}
+    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { Invariant0.invariant' result }
+    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub
@@ -846,7 +846,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    (18446744073709551615 : usize)
+    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t


### PR DESCRIPTION
Use already imported files instead of loading new files, and support SyntaxtContext serialization.

A lot of the encoding/decoding machinery is taken from rustc.

Also, removed a test that made imported never used for spans in generated mlcfg files. For span comming from the stdlib, if a relative path is required, then use a "virtual path" instead, because the stdlib is unlikely to be installed in a relatively stable directory.