### PR TITLE
Do discard spans for files coming from stdlib.

### DIFF
--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -143,7 +143,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -374,9 +374,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -294,7 +294,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
+    (18446744073709551615 : uint64)
 end
 module Bdd_Hashmap_Impl2_HashLog_Stub
   type u
@@ -379,7 +379,7 @@ module Core_Num_Impl9_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 59 8 59 27] (64 : uint32)
+    (64 : uint32)
 end
 module Core_Num_Impl9_Min_Stub
   use prelude.Int
@@ -390,7 +390,7 @@ module Core_Num_Impl9_Min
   use prelude.Int
   use prelude.UInt64
   let constant mIN'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 36 8 36 27] (0 : uint64)
+    (0 : uint64)
 end
 module Core_Num_Impl9_WrappingMul_Interface
   use prelude.UInt64

--- a/creusot/tests/should_succeed/bug/206.mlcfg
+++ b/creusot/tests/should_succeed/bug/206.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -8,7 +8,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
+    (18446744073709551615 : uint64)
 end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -190,7 +190,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -480,7 +480,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/checked_ops.mlcfg
+++ b/creusot/tests/should_succeed/checked_ops.mlcfg
@@ -52,7 +52,7 @@ module Core_Num_Impl6_Min
   use prelude.Int
   use prelude.UInt8
   let constant mIN'  : uint8 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 36 8 36 27] (0 : uint8)
+    (0 : uint8)
 end
 module Core_Num_Impl6_Max_Stub
   use prelude.Int
@@ -63,7 +63,7 @@ module Core_Num_Impl6_Max
   use prelude.Int
   use prelude.UInt8
   let constant mAX'  : uint8 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (255 : uint8)
+    (255 : uint8)
 end
 module Core_Num_Impl6_CheckedAdd_Interface
   use prelude.UInt8
@@ -101,7 +101,7 @@ module Core_Num_Impl6_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 59 8 59 27] (8 : uint32)
+    (8 : uint32)
 end
 module Core_Num_Impl6_WrappingAdd_Interface
   use prelude.UInt8
@@ -2661,7 +2661,7 @@ module Core_Num_Impl0_Min
   use prelude.Int
   use prelude.Int8
   let constant mIN'  : int8 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 38 8 38 27] (-128 : int8)
+    (-128 : int8)
 end
 module Core_Num_Impl0_Max_Stub
   use prelude.Int
@@ -2672,7 +2672,7 @@ module Core_Num_Impl0_Max
   use prelude.Int
   use prelude.Int8
   let constant mAX'  : int8 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 51 8 51 27] (127 : int8)
+    (127 : int8)
 end
 module Core_Num_Impl0_CheckedAdd_Interface
   use prelude.Int8
@@ -2694,7 +2694,7 @@ module Core_Num_Impl0_Bits
   use prelude.Int
   use prelude.UInt32
   let constant bITS'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/int_macros.rs" 61 8 61 27] (8 : uint32)
+    (8 : uint32)
 end
 module Core_Num_Impl0_WrappingAdd_Interface
   use prelude.Int8

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -45,7 +45,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
+    (18446744073709551615 : uint64)
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
   use prelude.Int

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -186,7 +186,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -327,7 +327,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -668,7 +668,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1723,7 +1723,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module Alloc_Vec_Impl1_Len_Interface
   type t

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1199,9 +1199,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -2813,7 +2813,7 @@ module Core_Slice_Iter_Impl0_IntoIter_Interface
   val into_iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/slice/iter.rs" 25 4 25 37] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module Core_Num_Impl8_AbsDiff_Interface

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -101,7 +101,7 @@ module Core_Num_Impl9_Max
   use prelude.Int
   use prelude.UInt64
   let constant mAX'  : uint64 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : uint64)
+    (18446744073709551615 : uint64)
 end
 module CreusotContracts_Std1_Time_Impl0_ShallowModel_Stub
   use prelude.Int

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -72,7 +72,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -19,7 +19,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -341,9 +341,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -383,7 +383,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t
@@ -924,7 +924,7 @@ module Alloc_Vec_Impl17_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2778 4 2778 40] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
@@ -1989,9 +1989,9 @@ module Core_Iter_Traits_Iterator_Iterator_Take_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val take (self : self) (n : usize) : Core_Iter_Adapters_Take_Take_Type.t_take self
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1406 12 1406 16] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1406 4 1408 20] Invariant1.invariant' result }
+    ensures { Invariant1.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Skip_Impl0_N_Stub
@@ -2063,9 +2063,9 @@ module Core_Iter_Traits_Iterator_Iterator_Skip_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val skip (self : self) (n : usize) : Core_Iter_Adapters_Skip_Skip_Type.t_skip self
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1352 12 1352 16] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = UIntSize.to_int n }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1352 4 1354 20] Invariant1.invariant' result }
+    ensures { Invariant1.invariant' result }
     
 end
 module CreusotContracts_Invariant_Impl1_Invariant_Stub
@@ -2151,12 +2151,12 @@ module Core_Iter_Adapters_Skip_Impl1_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = Core_Iter_Adapters_Skip_Skip_Type.t_skip i
   val next (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip i)) : Core_Option_Option_Type.t_option Item1.item
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/skip.rs" 34 17 34 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/skip.rs" 34 17 34 21] Invariant1.invariant' ( ^ self) }
+    ensures { Invariant1.invariant' ( ^ self) }
     
 end
 module CreusotContracts_Std1_Iter_Take_Impl3_Resolve_Stub
@@ -3396,7 +3396,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val collect (self : self) : b
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1887 44 1887 48] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
@@ -4475,7 +4475,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl1_Invariant_Stub
   type i
@@ -4619,9 +4619,9 @@ module Core_Iter_Traits_Iterator_Iterator_Enumerate_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val enumerate (self : self) : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate self
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1011 17 1011 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] Iter0.iter result = self /\ N0.n result = 0 }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1011 4 1013 20] Invariant1.invariant' result }
+    ensures { Invariant1.invariant' result }
     
 end
 module Core_Iter_Adapters_Enumerate_Impl1_Next_Interface
@@ -4646,12 +4646,12 @@ module Core_Iter_Adapters_Enumerate_Impl1_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i
   val next (self : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate i)) : Core_Option_Option_Type.t_option (usize, Item1.item)
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/enumerate.rs" 45 17 45 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/adapters/enumerate.rs" 45 17 45 21] Invariant1.invariant' ( ^ self) }
+    ensures { Invariant1.invariant' ( ^ self) }
     
 end
 module CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesRefl_Stub

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -3202,7 +3202,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module C06MapPrecond_Counter_Closure3_Type
   use prelude.Borrow

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -125,7 +125,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -373,9 +373,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module Core_Iter_Traits_Iterator_Iterator_Next_Interface
@@ -395,12 +395,12 @@ module Core_Iter_Traits_Iterator_Iterator_Next_Interface
   clone CreusotContracts_Invariant_Impl1_Invariant_Stub as Invariant0 with
     type t = self
   val next (self : borrowed self) : Core_Option_Option_Type.t_option Item0.item
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 111 17 111 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 85 26 88 17] match (result) with
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 111 17 111 21] Invariant1.invariant' ( ^ self) }
+    ensures { Invariant1.invariant' ( ^ self) }
     
 end
 module Alloc_Vec_Impl1_Push_Interface
@@ -1333,7 +1333,7 @@ module Alloc_Vec_Impl16_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2750 4 2750 40] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Resolve_Impl2_Resolve_Stub

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -286,7 +286,7 @@ module Core_Usize_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/shells/int_macros.rs" 42 8 42 25] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module C15Enumerate_Impl1_Invariant_Stub
   type i

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -256,7 +256,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -454,7 +454,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -1036,9 +1036,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -158,7 +158,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/list_reversal_lasso/why3session.xml
+++ b/creusot/tests/should_succeed/list_reversal_lasso/why3session.xml
@@ -36,7 +36,7 @@
   <proof prover="0"><result status="valid" time="0.10" steps="15747"/></proof>
   </goal>
   <goal name="list_reversal_list&#39;vc.3" expl="postcondition" proved="true">
-  <proof prover="3"><result status="valid" time="0.07" steps="1240"/></proof>
+  <proof prover="3"><result status="valid" time="0.07" steps="1239"/></proof>
   </goal>
   <goal name="list_reversal_list&#39;vc.4" expl="precondition" proved="true">
   <proof prover="0"><result status="valid" time="0.11" steps="17237"/></proof>
@@ -45,10 +45,10 @@
   <proof prover="0"><result status="valid" time="0.11" steps="17753"/></proof>
   </goal>
   <goal name="list_reversal_list&#39;vc.6" expl="loop invariant preservation" proved="true">
-  <proof prover="3"><result status="valid" time="0.19" steps="3536"/></proof>
+  <proof prover="3"><result status="valid" time="0.19" steps="2005"/></proof>
   </goal>
   <goal name="list_reversal_list&#39;vc.7" expl="loop invariant preservation" proved="true">
-  <proof prover="3" timelimit="5"><result status="valid" time="0.68" steps="12589"/></proof>
+  <proof prover="3" timelimit="5"><result status="valid" time="1.43" steps="12596"/></proof>
   </goal>
  </transf>
  </goal>
@@ -69,7 +69,7 @@
   <proof prover="0"><result status="valid" time="0.14" steps="16608"/></proof>
   </goal>
   <goal name="list_reversal_loop&#39;vc.4" expl="assertion" proved="true">
-  <proof prover="3"><result status="valid" time="0.05" steps="964"/></proof>
+  <proof prover="3"><result status="valid" time="0.05" steps="959"/></proof>
   </goal>
   <goal name="list_reversal_loop&#39;vc.5" expl="postcondition" proved="true">
   <transf name="split_vc" proved="true" >
@@ -78,7 +78,7 @@
     <goal name="list_reversal_loop&#39;vc.5.0.0" expl="postcondition" proved="true">
     <transf name="split_all_full" proved="true" >
      <goal name="list_reversal_loop&#39;vc.5.0.0.0" expl="postcondition" proved="true">
-     <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="1.70" steps="35838"/></proof>
+     <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="3.07" steps="35100"/></proof>
      </goal>
     </transf>
     </goal>
@@ -98,7 +98,7 @@
   <goal name="list_reversal_loop&#39;vc.9" expl="loop invariant preservation" proved="true">
   <transf name="split_vc" proved="true" >
    <goal name="list_reversal_loop&#39;vc.9.0" expl="loop invariant preservation" proved="true">
-   <proof prover="3" timelimit="5"><result status="valid" time="0.02" steps="202"/></proof>
+   <proof prover="3" timelimit="5"><result status="valid" time="0.02" steps="201"/></proof>
    </goal>
    <goal name="list_reversal_loop&#39;vc.9.1" expl="loop invariant preservation" proved="true">
    <proof prover="0"><result status="valid" time="0.08" steps="18338"/></proof>
@@ -107,18 +107,18 @@
    <proof prover="0" timelimit="5"><result status="valid" time="0.04" steps="27627"/></proof>
    </goal>
    <goal name="list_reversal_loop&#39;vc.9.3" expl="loop invariant preservation" proved="true">
-   <proof prover="3"><result status="valid" time="0.05" steps="638"/></proof>
+   <proof prover="3"><result status="valid" time="0.05" steps="636"/></proof>
    </goal>
    <goal name="list_reversal_loop&#39;vc.9.4" expl="loop invariant preservation" proved="true">
-   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="0.40" steps="7091"/></proof>
+   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="0.56" steps="7096"/></proof>
    </goal>
   </transf>
   </goal>
   <goal name="list_reversal_loop&#39;vc.10" expl="loop invariant preservation" proved="true">
-  <proof prover="3"><result status="valid" time="0.19" steps="2971"/></proof>
+  <proof prover="3"><result status="valid" time="0.19" steps="2972"/></proof>
   </goal>
   <goal name="list_reversal_loop&#39;vc.11" expl="loop invariant preservation" proved="true">
-  <proof prover="3" timelimit="5"><result status="valid" time="0.68" steps="12433"/></proof>
+  <proof prover="3" timelimit="5"><result status="valid" time="1.03" steps="11837"/></proof>
   </goal>
  </transf>
  </goal>
@@ -151,10 +151,10 @@
     <goal name="list_reversal_lasso&#39;vc.4.0.2" expl="VC for list_reversal_lasso" proved="true">
     <transf name="replace" proved="true" arg1="mid" arg2="mid1">
      <goal name="list_reversal_lasso&#39;vc.4.0.2.0" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="0"><result status="valid" time="0.11" steps="43330"/></proof>
+     <proof prover="0"><result status="valid" time="0.25" steps="43330"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.4.0.2.1" expl="equality hypothesis" proved="true">
-     <proof prover="3"><result status="valid" time="0.04" steps="716"/></proof>
+     <proof prover="3"><result status="valid" time="0.04" steps="717"/></proof>
      </goal>
     </transf>
     </goal>
@@ -171,7 +171,7 @@
      </transf>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.4.0.3.1" expl="equality hypothesis" proved="true">
-     <proof prover="3"><result status="valid" time="0.04" steps="716"/></proof>
+     <proof prover="3"><result status="valid" time="0.04" steps="717"/></proof>
      </goal>
     </transf>
     </goal>
@@ -180,7 +180,7 @@
   </transf>
   </goal>
   <goal name="list_reversal_lasso&#39;vc.5" expl="precondition" proved="true">
-  <proof prover="3" timelimit="5"><result status="valid" time="0.08" steps="1388"/></proof>
+  <proof prover="3" timelimit="5"><result status="valid" time="0.20" steps="1387"/></proof>
   </goal>
   <goal name="list_reversal_lasso&#39;vc.6" expl="loop invariant preservation" proved="true">
   <proof prover="0" timelimit="5"><result status="valid" time="0.05" steps="20559"/></proof>
@@ -188,36 +188,36 @@
   <goal name="list_reversal_lasso&#39;vc.7" expl="loop invariant preservation" proved="true">
   <transf name="split_vc" proved="true" >
    <goal name="list_reversal_lasso&#39;vc.7.0" expl="loop invariant preservation" proved="true">
-   <proof prover="3"><result status="valid" time="0.43" steps="7069"/></proof>
+   <proof prover="3"><result status="valid" time="0.63" steps="7060"/></proof>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.7.1" expl="loop invariant preservation" proved="true">
-   <proof prover="0"><result status="valid" time="0.20" steps="65059"/></proof>
+   <proof prover="0"><result status="valid" time="0.43" steps="65059"/></proof>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.7.2" expl="loop invariant preservation" proved="true">
-   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="1.05" steps="18206"/></proof>
+   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="1.90" steps="18216"/></proof>
    </goal>
   </transf>
   </goal>
   <goal name="list_reversal_lasso&#39;vc.8" expl="loop invariant preservation" proved="true">
   <transf name="split_vc" proved="true" >
    <goal name="list_reversal_lasso&#39;vc.8.0" expl="loop invariant preservation" proved="true">
-   <proof prover="2" timelimit="1"><result status="valid" time="0.25" steps="947205"/></proof>
+   <proof prover="2" timelimit="1"><result status="valid" time="0.54" steps="954450"/></proof>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.8.1" expl="loop invariant preservation" proved="true">
-   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="2.05" steps="39006"/></proof>
+   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="3.38" steps="39224"/></proof>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.8.2" expl="loop invariant preservation" proved="true">
    <transf name="inline_goal" proved="true" >
     <goal name="list_reversal_lasso&#39;vc.8.2.0" expl="loop invariant preservation" proved="true">
     <transf name="split_all_full" proved="true" >
      <goal name="list_reversal_lasso&#39;vc.8.2.0.0" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3"><result status="valid" time="0.16" steps="2139"/></proof>
+     <proof prover="3"><result status="valid" time="0.28" steps="2146"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.8.2.0.1" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="0"><result status="valid" time="0.19" steps="55481"/></proof>
+     <proof prover="0"><result status="valid" time="0.32" steps="54478"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.8.2.0.2" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3"><result status="valid" time="0.32" steps="7243"/></proof>
+     <proof prover="3"><result status="valid" time="0.61" steps="7234"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.8.2.0.3" expl="VC for list_reversal_lasso" proved="true">
      <proof prover="0"><result status="valid" time="0.09" steps="28572"/></proof>
@@ -235,13 +235,13 @@
     <goal name="list_reversal_lasso&#39;vc.9.0.0" expl="loop invariant preservation" proved="true">
     <transf name="split_all_full" proved="true" >
      <goal name="list_reversal_lasso&#39;vc.9.0.0.0" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="1.36" steps="27485"/></proof>
+     <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="2.28" steps="25913"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.0.0.1" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="0"><result status="valid" time="0.35" steps="69589"/></proof>
+     <proof prover="0"><result status="valid" time="0.35" steps="68687"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.0.0.2" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3"><result status="valid" time="0.16" steps="2003"/></proof>
+     <proof prover="3"><result status="valid" time="0.28" steps="2013"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.0.0.3" expl="VC for list_reversal_lasso" proved="true">
      <proof prover="0"><result status="valid" time="0.23" steps="49599"/></proof>
@@ -251,20 +251,20 @@
    </transf>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.9.1" expl="loop invariant preservation" proved="true">
-   <proof prover="3" timelimit="5" memlimit="2000"><result status="valid" time="1.82" steps="31960"/></proof>
+   <proof prover="3" timelimit="10" memlimit="4000"><result status="valid" time="3.52" steps="68863"/></proof>
    </goal>
    <goal name="list_reversal_lasso&#39;vc.9.2" expl="loop invariant preservation" proved="true">
    <transf name="inline_goal" proved="true" >
     <goal name="list_reversal_lasso&#39;vc.9.2.0" expl="loop invariant preservation" proved="true">
     <transf name="split_all_full" proved="true" >
      <goal name="list_reversal_lasso&#39;vc.9.2.0.0" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3"><result status="valid" time="0.05" steps="585"/></proof>
+     <proof prover="3"><result status="valid" time="0.05" steps="593"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.2.0.1" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="0"><result status="valid" time="0.24" steps="63688"/></proof>
+     <proof prover="0"><result status="valid" time="0.24" steps="62575"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.2.0.2" expl="VC for list_reversal_lasso" proved="true">
-     <proof prover="3"><result status="valid" time="0.39" steps="5372"/></proof>
+     <proof prover="3"><result status="valid" time="0.39" steps="5143"/></proof>
      </goal>
      <goal name="list_reversal_lasso&#39;vc.9.2.0.3" expl="VC for list_reversal_lasso" proved="true">
      <proof prover="0"><result status="valid" time="0.13" steps="30685"/></proof>
@@ -290,7 +290,7 @@
 </theory>
 <theory name="ListReversalLasso_Impl4_FindLassoAux_Impl" proved="true">
  <goal name="find_lasso_aux&#39;vc" expl="VC for find_lasso_aux" proved="true">
- <proof prover="2"><result status="valid" time="1.43" steps="8645931"/></proof>
+ <proof prover="2"><result status="valid" time="1.02" steps="4087040"/></proof>
  </goal>
 </theory>
 <theory name="ListReversalLasso_Impl4_FindLasso_Impl" proved="true">

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -96,11 +96,11 @@ module Own_Impl0_IsOk
       end
   }
   BB1 {
-    _0 <- ([#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/macros/mod.rs" 346 17 346 22] false);
+    _0 <- false;
     goto BB3
   }
   BB2 {
-    _0 <- ([#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/macros/mod.rs" 345 47 345 51] true);
+    _0 <- true;
     goto BB3
   }
   BB3 {

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -243,9 +243,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -155,7 +155,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -650,9 +650,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -236,7 +236,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -260,7 +260,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -436,9 +436,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -272,9 +272,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/syntax/02_operators.mlcfg
+++ b/creusot/tests/should_succeed/syntax/02_operators.mlcfg
@@ -116,7 +116,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module C02Operators_Multiply_Interface
   use prelude.UIntSize

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -61,7 +61,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
+++ b/creusot/tests/should_succeed/syntax/11_array_types.mlcfg
@@ -20,7 +20,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
   type self

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -79,7 +79,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -47,7 +47,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -19,7 +19,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/type_invariants/non_zero.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/non_zero.mlcfg
@@ -109,7 +109,7 @@ module Core_Num_Impl8_Max
   use prelude.Int
   use prelude.UInt32
   let constant mAX'  : uint32 = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (4294967295 : uint32)
+    (4294967295 : uint32)
 end
 module NonZero_Impl1_Add_Interface
   use prelude.UInt32

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -53,7 +53,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -403,9 +403,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -131,7 +131,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -50,7 +50,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -419,9 +419,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -178,7 +178,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module Alloc_Vec_Impl1_Len_Interface
   type t

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -267,7 +267,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Resolve_Resolve_Resolve_Stub
   type self

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -186,7 +186,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t
@@ -930,7 +930,7 @@ module Core_Iter_Traits_Iterator_Iterator_Collect_Interface
   clone CreusotContracts_Invariant_Invariant_Invariant_Stub as Invariant0 with
     type self = self
   val collect (self : self) : b
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/iterator.rs" 1887 44 1887 48] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 111 16 112 84] exists prod : Seq.seq Item0.item . exists done_ : borrowed self . Invariant1.invariant' done_ /\ Resolve0.resolve ( ^ done_) /\ Completed0.completed done_ /\ Produces0.produces self prod ( * done_) /\ FromIterPost0.from_iter_post prod result }
     
 end
@@ -2454,7 +2454,7 @@ module Alloc_Vec_Impl16_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter t a
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2750 4 2750 40] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Model_Impl3_ShallowModel_Stub
@@ -3341,7 +3341,7 @@ module Alloc_Vec_Impl17_IntoIter_Interface
   val into_iter (self : Alloc_Vec_Vec_Type.t_vec t a) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/alloc/src/vec/mod.rs" 2778 4 2778 40] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Slice_Impl0_ShallowModel_Stub
@@ -3876,9 +3876,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module Core_Iter_Range_Impl3_Next_Interface

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -196,7 +196,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -655,9 +655,9 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     type self = i
   val into_iter (self : i) : i
     requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPre0.into_iter_pre self}
-    requires {[#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 17 272 21] Invariant0.invariant' self}
+    requires {Invariant0.invariant' self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 79 0 147 1] IntoIterPost0.into_iter_post self result }
-    ensures { [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/iter/traits/collect.rs" 272 4 272 27] Invariant0.invariant' result }
+    ensures { Invariant0.invariant' result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub
@@ -846,7 +846,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -42,7 +42,7 @@ module Core_Num_Impl11_Max
   use prelude.Int
   use prelude.UIntSize
   let constant mAX'  : usize = [@vc:do_not_keep_trace] [@vc:sp]
-    [#"/rustc/1716932743a7b3705cbf0c34db0c4e070ed1930d/library/core/src/num/uint_macros.rs" 49 8 49 27] (18446744073709551615 : usize)
+    (18446744073709551615 : usize)
 end
 module CreusotContracts_Std1_Vec_Impl0_ShallowModel_Stub
   type t


### PR DESCRIPTION
For span coming from the stdlib, if a relative path is required, we don't show any span info, because the stdlib is unlikely to be installed in a relatively stable directory.

I failed my last commit in #780, hence it does not include this change.