### PR TITLE
Check lower bound on index in Seq::get

### DIFF
--- a/creusot-contracts/src/logic/seq.rs
+++ b/creusot-contracts/src/logic/seq.rs
@@ -16,7 +16,7 @@ impl<T> Seq<T> {
 
     #[logic]
     pub fn get(self, ix: Int) -> Option<T> {
-        if ix < self.len() {
+        if 0 <= ix && ix < self.len() {
             Some(self.index_logic(ix))
         } else {
             None


### PR DESCRIPTION
Documentation [here](https://why3.lri.fr/stdlib/seq.html) confirms that this should have a lower bound

>     (* FIXME requires { 0 <= i < length s } *)