### PR TITLE
Fix Rc and Arc models

### DIFF
--- a/creusot-contracts/src/model.rs
+++ b/creusot-contracts/src/model.rs
@@ -25,39 +25,41 @@ pub trait DeepModel {
     fn deep_model(self) -> Self::DeepModelTy;
 }
 
-impl<T: DeepModel + ?Sized> DeepModel for Rc<T> {
+impl<T: DeepModel> DeepModel for Rc<T> {
     type DeepModelTy = T::DeepModelTy;
     #[logic]
     #[open]
     fn deep_model(self) -> Self::DeepModelTy {
-        (*self).deep_model()
+        pearlite! { self.shallow_model().deep_model() }
     }
 }
 
-impl<T: ShallowModel + ?Sized> ShallowModel for Rc<T> {
-    type ShallowModelTy = T::ShallowModelTy;
+impl<T> ShallowModel for Rc<T> {
+    type ShallowModelTy = T;
     #[logic]
     #[open]
+    #[trusted]
     fn shallow_model(self) -> Self::ShallowModelTy {
-        (*self).shallow_model()
+        pearlite! { absurd }
     }
 }
 
-impl<T: DeepModel + ?Sized> DeepModel for Arc<T> {
+impl<T: DeepModel> DeepModel for Arc<T> {
     type DeepModelTy = T::DeepModelTy;
     #[logic]
     #[open]
     fn deep_model(self) -> Self::DeepModelTy {
-        (*self).deep_model()
+        pearlite! { self@.deep_model() }
     }
 }
 
-impl<T: ShallowModel + ?Sized> ShallowModel for Arc<T> {
-    type ShallowModelTy = T::ShallowModelTy;
+impl<T> ShallowModel for Arc<T> {
+    type ShallowModelTy = T;
     #[logic]
     #[open]
+    #[trusted]
     fn shallow_model(self) -> Self::ShallowModelTy {
-        (*self).shallow_model()
+        pearlite! { absurd }
     }
 }
 

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -158,7 +158,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -519,7 +519,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -647,7 +647,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -145,7 +145,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -204,7 +204,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -235,7 +235,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -75,7 +75,7 @@ module CreusotContracts_Model_Impl6_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 87 8 87 28] DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 89 8 89 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/eq_panic.mlcfg
+++ b/creusot/tests/should_succeed/bug/eq_panic.mlcfg
@@ -71,7 +71,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -175,7 +175,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/cell/02.mlcfg
+++ b/creusot/tests/should_succeed/cell/02.mlcfg
@@ -407,7 +407,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/constrained_types.mlcfg
+++ b/creusot/tests/should_succeed/constrained_types.mlcfg
@@ -97,7 +97,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/duration.mlcfg
+++ b/creusot/tests/should_succeed/duration.mlcfg
@@ -168,7 +168,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -406,7 +406,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -571,7 +571,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -169,7 +169,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -867,7 +867,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -938,7 +938,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -650,7 +650,7 @@ module CreusotContracts_Model_Impl6_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 87 8 87 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 89 8 89 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -709,7 +709,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -979,7 +979,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1160,7 +1160,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -138,7 +138,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -222,7 +222,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -873,7 +873,7 @@ module CreusotContracts_Model_Impl6_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 87 8 87 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 89 8 89 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -1141,7 +1141,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -188,7 +188,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -449,7 +449,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/instant.mlcfg
+++ b/creusot/tests/should_succeed/instant.mlcfg
@@ -222,7 +222,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -393,7 +393,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -257,7 +257,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -73,7 +73,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -132,7 +132,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -165,7 +165,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -416,7 +416,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -209,7 +209,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -263,7 +263,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -181,7 +181,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -544,7 +544,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -401,7 +401,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -1380,7 +1380,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -273,7 +273,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -555,7 +555,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -111,7 +111,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -164,7 +164,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/ord_trait.mlcfg
+++ b/creusot/tests/should_succeed/ord_trait.mlcfg
@@ -71,7 +71,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -5194,7 +5194,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -7164,7 +7164,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -8388,7 +8388,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -209,7 +209,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -209,7 +209,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -223,7 +223,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -402,7 +402,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -545,7 +545,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -607,7 +607,7 @@ module CreusotContracts_Model_Impl6_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 87 8 87 28] DeepModel0.deep_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 89 8 89 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -926,7 +926,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -188,7 +188,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -142,7 +142,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -273,7 +273,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -883,7 +883,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/specification/model.mlcfg
+++ b/creusot/tests/should_succeed/specification/model.mlcfg
@@ -72,6 +72,180 @@ module Model_Pair_Interface
     ensures { [#"../model.rs" 37 10 37 27] ShallowModel0.shallow_model result = (a, b) }
     
 end
+module Core_Ptr_NonNull_NonNull_Type
+  use prelude.Opaque
+  type t_nonnull 't =
+    | C_NonNull opaque_ptr
+    
+end
+module Core_Cell_UnsafeCell_Type
+  type t_unsafecell 't =
+    | C_UnsafeCell 't
+    
+end
+module Core_Sync_Atomic_AtomicUsize_Type
+  use prelude.Int
+  use prelude.UIntSize
+  use Core_Cell_UnsafeCell_Type as Core_Cell_UnsafeCell_Type
+  type t_atomicusize  =
+    | C_AtomicUsize (Core_Cell_UnsafeCell_Type.t_unsafecell usize)
+    
+end
+module Alloc_Sync_ArcInner_Type
+  use Core_Sync_Atomic_AtomicUsize_Type as Core_Sync_Atomic_AtomicUsize_Type
+  type t_arcinner 't =
+    | C_ArcInner (Core_Sync_Atomic_AtomicUsize_Type.t_atomicusize) (Core_Sync_Atomic_AtomicUsize_Type.t_atomicusize) 't
+    
+end
+module Core_Marker_PhantomData_Type
+  type t_phantomdata 't =
+    | C_PhantomData
+    
+end
+module Alloc_Sync_Arc_Type
+  use Alloc_Sync_ArcInner_Type as Alloc_Sync_ArcInner_Type
+  use Core_Marker_PhantomData_Type as Core_Marker_PhantomData_Type
+  use Core_Ptr_NonNull_NonNull_Type as Core_Ptr_NonNull_NonNull_Type
+  type t_arc 't =
+    | C_Arc (Core_Ptr_NonNull_NonNull_Type.t_nonnull (Alloc_Sync_ArcInner_Type.t_arcinner 't)) (Core_Marker_PhantomData_Type.t_phantomdata (Alloc_Sync_ArcInner_Type.t_arcinner 't))
+    
+end
+module CreusotContracts_Model_Impl3_ShallowModel_Stub
+  type t
+  use Alloc_Sync_Arc_Type as Alloc_Sync_Arc_Type
+  function shallow_model (self : Alloc_Sync_Arc_Type.t_arc t) : t
+end
+module CreusotContracts_Model_Impl3_ShallowModel_Interface
+  type t
+  use Alloc_Sync_Arc_Type as Alloc_Sync_Arc_Type
+  function shallow_model (self : Alloc_Sync_Arc_Type.t_arc t) : t
+  val shallow_model (self : Alloc_Sync_Arc_Type.t_arc t) : t
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Model_Impl3_ShallowModel
+  type t
+  use Alloc_Sync_Arc_Type as Alloc_Sync_Arc_Type
+  function shallow_model (self : Alloc_Sync_Arc_Type.t_arc t) : t
+  val shallow_model (self : Alloc_Sync_Arc_Type.t_arc t) : t
+    ensures { result = shallow_model self }
+    
+end
+module Model_TestArc_Interface
+  use prelude.UIntSize
+  use prelude.Int
+  use Alloc_Sync_Arc_Type as Alloc_Sync_Arc_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel_Stub as ShallowModel0 with
+    type t = usize
+  val test_arc [#"../model.rs" 43 0 43 41] (a : Alloc_Sync_Arc_Type.t_arc usize) : ()
+    requires {[#"../model.rs" 42 11 42 19] UIntSize.to_int (ShallowModel0.shallow_model a) = 0}
+    
+end
+module Model_TestArc
+  use prelude.UIntSize
+  use prelude.Int
+  use Alloc_Sync_Arc_Type as Alloc_Sync_Arc_Type
+  clone CreusotContracts_Model_Impl3_ShallowModel as ShallowModel0 with
+    type t = usize
+  let rec cfg test_arc [#"../model.rs" 43 0 43 41] [@cfg:stackify] [@cfg:subregion_analysis] (a : Alloc_Sync_Arc_Type.t_arc usize) : ()
+    requires {[#"../model.rs" 42 11 42 19] UIntSize.to_int (ShallowModel0.shallow_model a) = 0}
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    _0 <- ();
+    goto BB2
+  }
+  BB2 {
+    return _0
+  }
+  
+end
+module Core_Cell_Cell_Type
+  use Core_Cell_UnsafeCell_Type as Core_Cell_UnsafeCell_Type
+  type t_cell 't =
+    | C_Cell (Core_Cell_UnsafeCell_Type.t_unsafecell 't)
+    
+end
+module Alloc_Rc_RcBox_Type
+  use prelude.Int
+  use prelude.UIntSize
+  use Core_Cell_Cell_Type as Core_Cell_Cell_Type
+  type t_rcbox 't =
+    | C_RcBox (Core_Cell_Cell_Type.t_cell usize) (Core_Cell_Cell_Type.t_cell usize) 't
+    
+end
+module Alloc_Rc_Rc_Type
+  use Alloc_Rc_RcBox_Type as Alloc_Rc_RcBox_Type
+  use Core_Marker_PhantomData_Type as Core_Marker_PhantomData_Type
+  use Core_Ptr_NonNull_NonNull_Type as Core_Ptr_NonNull_NonNull_Type
+  type t_rc 't =
+    | C_Rc (Core_Ptr_NonNull_NonNull_Type.t_nonnull (Alloc_Rc_RcBox_Type.t_rcbox 't)) (Core_Marker_PhantomData_Type.t_phantomdata (Alloc_Rc_RcBox_Type.t_rcbox 't))
+    
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Stub
+  type t
+  use Alloc_Rc_Rc_Type as Alloc_Rc_Rc_Type
+  function shallow_model (self : Alloc_Rc_Rc_Type.t_rc t) : t
+end
+module CreusotContracts_Model_Impl1_ShallowModel_Interface
+  type t
+  use Alloc_Rc_Rc_Type as Alloc_Rc_Rc_Type
+  function shallow_model (self : Alloc_Rc_Rc_Type.t_rc t) : t
+  val shallow_model (self : Alloc_Rc_Rc_Type.t_rc t) : t
+    ensures { result = shallow_model self }
+    
+end
+module CreusotContracts_Model_Impl1_ShallowModel
+  type t
+  use Alloc_Rc_Rc_Type as Alloc_Rc_Rc_Type
+  function shallow_model (self : Alloc_Rc_Rc_Type.t_rc t) : t
+  val shallow_model (self : Alloc_Rc_Rc_Type.t_rc t) : t
+    ensures { result = shallow_model self }
+    
+end
+module Model_TestRc_Interface
+  use prelude.UIntSize
+  use prelude.Int
+  use Alloc_Rc_Rc_Type as Alloc_Rc_Rc_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel_Stub as ShallowModel0 with
+    type t = usize
+  val test_rc [#"../model.rs" 46 0 46 37] (v : Alloc_Rc_Rc_Type.t_rc usize) : ()
+    requires {[#"../model.rs" 45 11 45 19] UIntSize.to_int (ShallowModel0.shallow_model v) = 0}
+    
+end
+module Model_TestRc
+  use prelude.UIntSize
+  use prelude.Int
+  use Alloc_Rc_Rc_Type as Alloc_Rc_Rc_Type
+  clone CreusotContracts_Model_Impl1_ShallowModel as ShallowModel0 with
+    type t = usize
+  let rec cfg test_rc [#"../model.rs" 46 0 46 37] [@cfg:stackify] [@cfg:subregion_analysis] (v : Alloc_Rc_Rc_Type.t_rc usize) : ()
+    requires {[#"../model.rs" 45 11 45 19] UIntSize.to_int (ShallowModel0.shallow_model v) = 0}
+    
+   = [@vc:do_not_keep_trace] [@vc:sp]
+  var _0 : ();
+  {
+    goto BB0
+  }
+  BB0 {
+    goto BB1
+  }
+  BB1 {
+    _0 <- ();
+    goto BB2
+  }
+  BB2 {
+    return _0
+  }
+  
+end
 module Model_Impl0
   
 end

--- a/creusot/tests/should_succeed/specification/model.rs
+++ b/creusot/tests/should_succeed/specification/model.rs
@@ -38,3 +38,9 @@ impl<T, U> ShallowModel for Pair<T, U> {
 pub fn pair<T, U>(a: T, b: U) -> Pair<T, U> {
     Pair(a, b)
 }
+
+#[requires(a@@ == 0)]
+pub fn test_arc(a: std::sync::Arc<usize>) {}
+
+#[requires(v@@ == 0)]
+pub fn test_rc(v: std::rc::Rc<usize>) {}

--- a/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
+++ b/creusot/tests/should_succeed/syntax/05_pearlite.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -419,7 +419,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -470,7 +470,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
+++ b/creusot/tests/should_succeed/syntax/derive_macros.mlcfg
@@ -149,7 +149,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -235,7 +235,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
+++ b/creusot/tests/should_succeed/traits/16_impl_cloning.mlcfg
@@ -123,7 +123,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -166,7 +166,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -242,7 +242,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -326,7 +326,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -168,7 +168,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -298,7 +298,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -375,7 +375,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -452,7 +452,7 @@ module CreusotContracts_Model_Impl6_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : borrowed t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 87 8 87 28] DeepModel0.deep_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 89 8 89 28] DeepModel0.deep_model ( * self)
   val deep_model (self : borrowed t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     
@@ -483,7 +483,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -680,7 +680,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -146,7 +146,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -317,7 +317,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
+++ b/creusot/tests/should_succeed/vector/04_binary_search.mlcfg
@@ -104,7 +104,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
+++ b/creusot/tests/should_succeed/vector/05_binary_search_generic.mlcfg
@@ -154,7 +154,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -213,7 +213,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -1838,7 +1838,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -2439,7 +2439,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -53,7 +53,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -354,7 +354,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     
@@ -442,7 +442,7 @@ module CreusotContracts_Model_Impl4_DeepModel
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   function deep_model (self : t) : DeepModelTy0.deepModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 69 8 69 28] DeepModel0.deep_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 71 8 71 28] DeepModel0.deep_model self
   val deep_model (self : t) : DeepModelTy0.deepModelTy
     ensures { result = deep_model self }
     

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -92,7 +92,7 @@ module CreusotContracts_Model_Impl5_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 78 8 78 31] ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/model.rs" 80 8 80 31] ShallowModel0.shallow_model self
   val shallow_model (self : t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -138,7 +138,7 @@ module CreusotContracts_Model_Impl7_ShallowModel
     type self = t,
     type ShallowModelTy0.shallowModelTy = ShallowModelTy0.shallowModelTy
   function shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy =
-    [#"../../../../../creusot-contracts/src/model.rs" 96 8 96 31] ShallowModel0.shallow_model ( * self)
+    [#"../../../../../creusot-contracts/src/model.rs" 98 8 98 31] ShallowModel0.shallow_model ( * self)
   val shallow_model (self : borrowed t) : ShallowModelTy0.shallowModelTy
     ensures { result = shallow_model self }
     


### PR DESCRIPTION
This gives definitions of `ShallowModel` and `DeepModel` which don't crash for `Arc` and `Rc`. Whether those are the *right* definitions is another question. In particular should the shallow model of `Rc` return the shallow model of `T` like `&` and `Box`? If so, how do we implement that?
