### PR TITLE
Fix #850

### DIFF
--- a/creusot/src/backend/program.rs
+++ b/creusot/src/backend/program.rs
@@ -631,7 +631,10 @@ impl<'tcx> Statement<'tcx> {
     ) -> Vec<mlcfg::Statement> {
         match self {
             Statement::Assignment(lhs, RValue::Borrow(rhs)) => {
-                let borrow = Exp::BorrowMut(Box::new(rhs.as_rplace(ctx, names, locals)));
+                let borrow = Exp::Call(
+                    Box::new(Exp::impure_qvar(QName::from_string("Borrow.borrow_mut").unwrap())),
+                    vec![rhs.as_rplace(ctx, names, locals)],
+                );
                 let reassign = Exp::Final(Box::new(lhs.as_rplace(ctx, names, locals)));
 
                 vec![

--- a/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
+++ b/creusot/tests/should_fail/bug/01_resolve_unsoundness.mlcfg
@@ -330,7 +330,7 @@ module C01ResolveUnsoundness_MakeVecOfSize
       end
   }
   BB4 {
-    _13 <- borrow_mut out;
+    _13 <- Borrow.borrow_mut out;
     out <-  ^ _13;
     _12 <- ([#"../01_resolve_unsoundness.rs" 14 8 14 23] Push0.push _13 ([#"../01_resolve_unsoundness.rs" 14 17 14 22] false));
     _13 <- any borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_fail/bug/222.mlcfg
+++ b/creusot/tests/should_fail/bug/222.mlcfg
@@ -258,7 +258,7 @@ module C222_UsesInvariant
     goto BB0
   }
   BB0 {
-    _5 <- borrow_mut (C222_Once_Type.once_0 ( * x));
+    _5 <- Borrow.borrow_mut (C222_Once_Type.once_0 ( * x));
     x <- { x with current = (let C222_Once_Type.C_Once a =  * x in C222_Once_Type.C_Once ( ^ _5)) };
     assume { Inv0.inv ( ^ _5) };
     _4 <- ([#"../222.rs" 41 4 41 14] Take0.take _5);

--- a/creusot/tests/should_fail/bug/492.mlcfg
+++ b/creusot/tests/should_fail/bug/492.mlcfg
@@ -99,7 +99,7 @@ module C492_ReborrowTuple
     goto BB0
   }
   BB0 {
-    _3 <- borrow_mut ( * x);
+    _3 <- Borrow.borrow_mut ( * x);
     x <- { x with current = ( ^ _3) };
     assume { Inv0.inv ( ^ _3) };
     _0 <- (_3, [#"../492.rs" 6 8 6 10] (32 : uint32));
@@ -223,9 +223,9 @@ module C492_Test
   }
   BB0 {
     x <- ([#"../492.rs" 11 16 11 17] (5 : int32));
-    _6 <- borrow_mut x;
+    _6 <- Borrow.borrow_mut x;
     x <-  ^ _6;
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- ([#"../492.rs" 12 19 12 41] ReborrowTuple0.reborrow_tuple _5);
     _5 <- any borrowed int32;

--- a/creusot/tests/should_fail/bug/692.mlcfg
+++ b/creusot/tests/should_fail/bug/692.mlcfg
@@ -1077,7 +1077,7 @@ module C692_ValidNormal
   BB0 {
     r <- ([#"../692.rs" 12 16 12 20] (0 : uint32));
     cond <- Closure10.C692_ValidNormal_Closure1 n;
-    _7 <- borrow_mut r;
+    _7 <- Borrow.borrow_mut r;
     r <-  ^ _7;
     branch <- Closure20.C692_ValidNormal_Closure2 _7;
     _7 <- any borrowed uint32;

--- a/creusot/tests/should_fail/bug/695.mlcfg
+++ b/creusot/tests/should_fail/bug/695.mlcfg
@@ -1276,7 +1276,7 @@ module C695_Valid
   BB0 {
     r <- ([#"../695.rs" 16 16 16 20] (0 : uint32));
     cond <- Closure10.C695_Valid_Closure1 n;
-    _7 <- borrow_mut r;
+    _7 <- Borrow.borrow_mut r;
     r <-  ^ _7;
     branch <- Closure20.C695_Valid_Closure2 _7;
     _7 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -1300,9 +1300,9 @@ module C100doors_F
     goto BB7
   }
   BB7 {
-    _14 <- borrow_mut iter;
+    _14 <- Borrow.borrow_mut iter;
     iter <-  ^ _14;
-    _13 <- borrow_mut ( * _14);
+    _13 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
     _12 <- ([#"../100doors.rs" 20 4 20 41] Next0.next _13);
     _13 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -1358,7 +1358,7 @@ module C100doors_F
     goto BB18
   }
   BB18 {
-    _31 <- borrow_mut door_open;
+    _31 <- Borrow.borrow_mut door_open;
     door_open <-  ^ _31;
     _30 <- ([#"../100doors.rs" 26 12 26 31] IndexMut0.index_mut _31 ([#"../100doors.rs" 26 22 26 30] door - ([#"../100doors.rs" 26 29 26 30] (1 : usize))));
     _31 <- any borrowed (Alloc_Vec_Vec_Type.t_vec bool (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/all_zero.mlcfg
+++ b/creusot/tests/should_succeed/all_zero.mlcfg
@@ -172,13 +172,13 @@ module AllZero_AllZero
     goto BB5
   }
   BB5 {
-    value <- borrow_mut (AllZero_List_Type.cons_0 ( * loop_l));
+    value <- Borrow.borrow_mut (AllZero_List_Type.cons_0 ( * loop_l));
     loop_l <- { loop_l with current = (let AllZero_List_Type.C_Cons a b =  * loop_l in AllZero_List_Type.C_Cons ( ^ value) b) };
-    next <- borrow_mut (AllZero_List_Type.cons_1 ( * loop_l));
+    next <- Borrow.borrow_mut (AllZero_List_Type.cons_1 ( * loop_l));
     loop_l <- { loop_l with current = (let AllZero_List_Type.C_Cons a b =  * loop_l in AllZero_List_Type.C_Cons a ( ^ next)) };
     value <- { value with current = ([#"../all_zero.rs" 44 17 44 18] (0 : uint32)) };
     assume { Resolve0.resolve value };
-    _13 <- borrow_mut ( * next);
+    _13 <- Borrow.borrow_mut ( * next);
     next <- { next with current = ( ^ _13) };
     assume { Resolve1.resolve loop_l };
     loop_l <- _13;

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -2797,7 +2797,7 @@ module Bdd_Impl10_Hashcons
   BB5 {
     r1 <- Bdd_Bdd_Type.C_Bdd ( * _21) (Bdd_Context_Type.context_cnt ( * self));
     assume { Resolve1.resolve _21 };
-    _26 <- borrow_mut (Bdd_Context_Type.context_hashcons ( * self));
+    _26 <- Borrow.borrow_mut (Bdd_Context_Type.context_hashcons ( * self));
     self <- { self with current = (let Bdd_Context_Type.C_Context a b c d e f =  * self in Bdd_Context_Type.C_Context a ( ^ _26) c d e f) };
     _25 <- ([#"../bdd.rs" 449 8 449 31] Add0.add _26 n r1);
     _26 <- any borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Node_Type.t_node) (Bdd_Bdd_Type.t_bdd));
@@ -2980,7 +2980,7 @@ module Bdd_Impl10_Node
     goto BB5
   }
   BB3 {
-    _19 <- borrow_mut ( * self);
+    _19 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _19) };
     _0 <- ([#"../bdd.rs" 471 8 471 50] Hashcons0.hashcons _19 (Bdd_Node_Type.C_If x childt childf));
     _19 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3098,7 +3098,7 @@ module Bdd_Impl10_True
     goto BB0
   }
   BB0 {
-    _8 <- borrow_mut ( * self);
+    _8 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _8) };
     _0 <- ([#"../bdd.rs" 481 8 481 27] Hashcons0.hashcons _8 (Bdd_Node_Type.C_True));
     _8 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3213,7 +3213,7 @@ module Bdd_Impl10_False
     goto BB0
   }
   BB0 {
-    _8 <- borrow_mut ( * self);
+    _8 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _8) };
     _0 <- ([#"../bdd.rs" 491 8 491 28] Hashcons0.hashcons _8 (Bdd_Node_Type.C_False));
     _8 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3344,21 +3344,21 @@ module Bdd_Impl10_V
     goto BB0
   }
   BB0 {
-    _9 <- borrow_mut ( * self);
+    _9 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _9) };
     t <- ([#"../bdd.rs" 500 16 500 28] True0.true_ _9);
     _9 <- any borrowed (Bdd_Context_Type.t_context);
     goto BB1
   }
   BB1 {
-    _11 <- borrow_mut ( * self);
+    _11 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _11) };
     f <- ([#"../bdd.rs" 501 16 501 29] False0.false_ _11);
     _11 <- any borrowed (Bdd_Context_Type.t_context);
     goto BB2
   }
   BB2 {
-    _12 <- borrow_mut ( * self);
+    _12 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _12) };
     _0 <- ([#"../bdd.rs" 502 8 502 26] Node0.node _12 x t f);
     _12 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3606,14 +3606,14 @@ module Bdd_Impl10_Not
     v <- Bdd_Node_Type.if_v (Bdd_Bdd_Type.bdd_0 x);
     childt <- Bdd_Node_Type.if_childt (Bdd_Bdd_Type.bdd_0 x);
     childf <- Bdd_Node_Type.if_childf (Bdd_Bdd_Type.bdd_0 x);
-    _27 <- borrow_mut ( * self);
+    _27 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _27) };
     childt1 <- ([#"../bdd.rs" 521 29 521 45] not' _27 childt);
     _27 <- any borrowed (Bdd_Context_Type.t_context);
     goto BB13
   }
   BB9 {
-    _21 <- borrow_mut ( * self);
+    _21 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _21) };
     r1 <- ([#"../bdd.rs" 518 20 518 33] False0.false_ _21);
     _21 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3623,7 +3623,7 @@ module Bdd_Impl10_Not
     goto BB16
   }
   BB11 {
-    _22 <- borrow_mut ( * self);
+    _22 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _22) };
     r1 <- ([#"../bdd.rs" 519 21 519 33] True0.true_ _22);
     _22 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3633,14 +3633,14 @@ module Bdd_Impl10_Not
     goto BB16
   }
   BB13 {
-    _30 <- borrow_mut ( * self);
+    _30 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _30) };
     childf1 <- ([#"../bdd.rs" 522 29 522 45] not' _30 childf);
     _30 <- any borrowed (Bdd_Context_Type.t_context);
     goto BB14
   }
   BB14 {
-    _32 <- borrow_mut ( * self);
+    _32 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _32) };
     r1 <- ([#"../bdd.rs" 523 16 523 44] Node0.node _32 v childt1 childf1);
     _32 <- any borrowed (Bdd_Context_Type.t_context);
@@ -3650,7 +3650,7 @@ module Bdd_Impl10_Not
     goto BB16
   }
   BB16 {
-    _37 <- borrow_mut (Bdd_Context_Type.context_not_memo ( * self));
+    _37 <- Borrow.borrow_mut (Bdd_Context_Type.context_not_memo ( * self));
     self <- { self with current = (let Bdd_Context_Type.C_Context a b c d e f =  * self in Bdd_Context_Type.C_Context a b c ( ^ _37) e f) };
     _36 <- ([#"../bdd.rs" 526 8 526 31] Add0.add _37 x r1);
     _37 <- any borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd));
@@ -4045,7 +4045,7 @@ module Bdd_Impl10_And
   }
   BB17 {
     assume { Resolve2.resolve _25 };
-    _33 <- borrow_mut ( * self);
+    _33 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _33) };
     r1 <- ([#"../bdd.rs" 546 39 546 52] False0.false_ _33);
     _33 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4066,7 +4066,7 @@ module Bdd_Impl10_And
   }
   BB21 {
     v <- va;
-    _69 <- borrow_mut ( * self);
+    _69 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _69) };
     _68 <- ([#"../bdd.rs" 565 33 565 59] and _69 childta childtb);
     _69 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4077,7 +4077,7 @@ module Bdd_Impl10_And
   }
   BB23 {
     v <- vb;
-    _51 <- borrow_mut ( * self);
+    _51 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _51) };
     _50 <- ([#"../bdd.rs" 555 33 555 53] and _51 a childtb);
     _51 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4086,7 +4086,7 @@ module Bdd_Impl10_And
   BB24 {
     childt <- _50;
     _50 <- any Bdd_Bdd_Type.t_bdd;
-    _55 <- borrow_mut ( * self);
+    _55 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _55) };
     _54 <- ([#"../bdd.rs" 556 33 556 53] and _55 a childfb);
     _55 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4100,7 +4100,7 @@ module Bdd_Impl10_And
   }
   BB26 {
     v <- va;
-    _60 <- borrow_mut ( * self);
+    _60 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _60) };
     _59 <- ([#"../bdd.rs" 560 33 560 53] and _60 childta b);
     _60 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4109,7 +4109,7 @@ module Bdd_Impl10_And
   BB27 {
     childt <- _59;
     _59 <- any Bdd_Bdd_Type.t_bdd;
-    _64 <- borrow_mut ( * self);
+    _64 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _64) };
     _63 <- ([#"../bdd.rs" 561 33 561 53] and _64 childfa b);
     _64 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4124,7 +4124,7 @@ module Bdd_Impl10_And
   BB29 {
     childt <- _68;
     _68 <- any Bdd_Bdd_Type.t_bdd;
-    _73 <- borrow_mut ( * self);
+    _73 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _73) };
     _72 <- ([#"../bdd.rs" 566 33 566 59] and _73 childfa childfb);
     _73 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4137,7 +4137,7 @@ module Bdd_Impl10_And
     goto BB31
   }
   BB31 {
-    _76 <- borrow_mut ( * self);
+    _76 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _76) };
     r1 <- ([#"../bdd.rs" 569 16 569 44] Node0.node _76 v childt childf);
     _76 <- any borrowed (Bdd_Context_Type.t_context);
@@ -4147,7 +4147,7 @@ module Bdd_Impl10_And
     goto BB33
   }
   BB33 {
-    _81 <- borrow_mut (Bdd_Context_Type.context_and_memo ( * self));
+    _81 <- Borrow.borrow_mut (Bdd_Context_Type.context_and_memo ( * self));
     self <- { self with current = (let Bdd_Context_Type.C_Context a b c d e f =  * self in Bdd_Context_Type.C_Context a b c d ( ^ _81) f) };
     _80 <- ([#"../bdd.rs" 572 8 572 36] Add0.add _81 (a, b) r1);
     _81 <- any borrowed (Bdd_Hashmap_MyHashMap_Type.t_myhashmap (Bdd_Bdd_Type.t_bdd, Bdd_Bdd_Type.t_bdd) (Bdd_Bdd_Type.t_bdd));

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -104,7 +104,7 @@ module C682_Foo
     goto BB1
   }
   BB1 {
-    _7 <- borrow_mut ( * a);
+    _7 <- Borrow.borrow_mut ( * a);
     a <- { a with current = ( ^ _7) };
     _6 <- ([#"../682.rs" 14 4 14 15] AddSome0.add_some _7);
     _7 <- any borrowed uint64;

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -189,7 +189,7 @@ module C766_Trait_Goo
     goto BB0
   }
   BB0 {
-    _2 <- borrow_mut ( * self);
+    _2 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _2) };
     assume { Inv0.inv ( ^ _2) };
     _0 <- ([#"../766.rs" 11 8 11 16] F0.f _2);

--- a/creusot/tests/should_succeed/bug/two_phase.mlcfg
+++ b/creusot/tests/should_succeed/bug/two_phase.mlcfg
@@ -420,7 +420,7 @@ module TwoPhase_Test
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut ( * v);
+    _4 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _4) };
     _5 <- ([#"../two_phase.rs" 7 11 7 18] Len0.len ( * _4));
     goto BB1

--- a/creusot/tests/should_succeed/closures/01_basic.mlcfg
+++ b/creusot/tests/should_succeed/closures/01_basic.mlcfg
@@ -366,18 +366,18 @@ module C01Basic_MoveClosure
   }
   BB0 {
     _2 <- ([#"../01_basic.rs" 17 17 17 21] (0 : int32));
-    a <- borrow_mut _2;
+    a <- Borrow.borrow_mut _2;
     _2 <-  ^ a;
     x <- Closure00.C01Basic_MoveClosure_Closure0 a;
     a <- any borrowed int32;
-    _5 <- borrow_mut x;
+    _5 <- Borrow.borrow_mut x;
     x <-  ^ _5;
     _4 <- ([#"../01_basic.rs" 23 4 23 9] let () = () in Closure00.c01Basic_MoveClosure_Closure0 _5);
     _5 <- any borrowed Closure00.c01basic_moveclosure_closure0;
     goto BB1
   }
   BB1 {
-    _8 <- borrow_mut x;
+    _8 <- Borrow.borrow_mut x;
     x <-  ^ _8;
     _7 <- ([#"../01_basic.rs" 24 4 24 9] let () = () in Closure00.c01Basic_MoveClosure_Closure0 _8);
     _8 <- any borrowed Closure00.c01basic_moveclosure_closure0;
@@ -508,7 +508,7 @@ module C01Basic_MoveMut_Closure0
     goto BB1
   }
   BB1 {
-    _2 <- borrow_mut ( * _3);
+    _2 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _2) };
     _1 <- { _1 with current = (let C01Basic_MoveMut_Closure0 a =  * _1 in C01Basic_MoveMut_Closure0 _2) };
     _2 <- any borrowed uint32;
@@ -546,18 +546,18 @@ module C01Basic_MoveMut
   }
   BB0 {
     _2 <- ([#"../01_basic.rs" 33 21 33 25] (0 : uint32));
-    x <- borrow_mut _2;
+    x <- Borrow.borrow_mut _2;
     _2 <-  ^ x;
     a <- Closure00.C01Basic_MoveMut_Closure0 x;
     x <- any borrowed uint32;
-    _5 <- borrow_mut a;
+    _5 <- Borrow.borrow_mut a;
     a <-  ^ _5;
     _4 <- ([#"../01_basic.rs" 38 4 38 9] let () = () in Closure00.c01Basic_MoveMut_Closure0 _5);
     _5 <- any borrowed Closure00.c01basic_movemut_closure0;
     goto BB1
   }
   BB1 {
-    _8 <- borrow_mut a;
+    _8 <- Borrow.borrow_mut a;
     a <-  ^ _8;
     _7 <- ([#"../01_basic.rs" 39 4 39 9] let () = () in Closure00.c01Basic_MoveMut_Closure0 _8);
     _8 <- any borrowed Closure00.c01basic_movemut_closure0;

--- a/creusot/tests/should_succeed/closures/05_map.mlcfg
+++ b/creusot/tests/should_succeed/closures/05_map.mlcfg
@@ -962,7 +962,7 @@ module C05Map_Impl0_Next
     goto BB0
   }
   BB0 {
-    _3 <- borrow_mut (C05Map_Map_Type.map_iter ( * self));
+    _3 <- Borrow.borrow_mut (C05Map_Map_Type.map_iter ( * self));
     self <- { self with current = (let C05Map_Map_Type.C_Map a b =  * self in C05Map_Map_Type.C_Map ( ^ _3) b) };
     assume { Inv0.inv ( ^ _3) };
     _2 <- ([#"../05_map.rs" 18 14 18 30] Next0.next _3);

--- a/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
+++ b/creusot/tests/should_succeed/closures/07_mutable_capture.mlcfg
@@ -187,18 +187,18 @@ module C07MutableCapture_TestFnmut
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut x;
+    _4 <- Borrow.borrow_mut x;
     x <-  ^ _4;
     c <- Closure10.C07MutableCapture_TestFnmut_Closure1 _4;
     _4 <- any borrowed uint32;
-    _6 <- borrow_mut c;
+    _6 <- Borrow.borrow_mut c;
     c <-  ^ _6;
     _5 <- ([#"../07_mutable_capture.rs" 14 4 14 7] let () = () in Closure10.c07MutableCapture_TestFnmut_Closure1 _6);
     _6 <- any borrowed Closure10.c07mutablecapture_testfnmut_closure1;
     goto BB1
   }
   BB1 {
-    _9 <- borrow_mut c;
+    _9 <- Borrow.borrow_mut c;
     c <-  ^ _9;
     _8 <- ([#"../07_mutable_capture.rs" 15 4 15 7] let () = () in Closure10.c07MutableCapture_TestFnmut_Closure1 _9);
     _9 <- any borrowed Closure10.c07mutablecapture_testfnmut_closure1;

--- a/creusot/tests/should_succeed/drop_pair.mlcfg
+++ b/creusot/tests/should_succeed/drop_pair.mlcfg
@@ -163,7 +163,7 @@ module DropPair_Drop
   }
   BB0 {
     assume { Resolve0.resolve _x };
-    _3 <- borrow_mut ( * y);
+    _3 <- Borrow.borrow_mut ( * y);
     y <- { y with current = ( ^ _3) };
     _x <- _3;
     _3 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/filter_positive.mlcfg
+++ b/creusot/tests/should_succeed/filter_positive.mlcfg
@@ -1093,7 +1093,7 @@ module FilterPositive_M
     goto BB23
   }
   BB23 {
-    _47 <- borrow_mut u;
+    _47 <- Borrow.borrow_mut u;
     u <-  ^ _47;
     _46 <- ([#"../filter_positive.rs" 113 12 113 20] IndexMut0.index_mut _47 count);
     _47 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -1694,17 +1694,17 @@ module Hashmap_Impl5_Add
     index <- ([#"../hashmap.rs" 110 27 110 55] UIntSize.of_int (UInt64.to_int _13) % _15);
     _13 <- any uint64;
     _15 <- any usize;
-    _20 <- borrow_mut (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self));
+    _20 <- Borrow.borrow_mut (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self));
     self <- { self with current = (let Hashmap_MyHashMap_Type.C_MyHashMap a =  * self in Hashmap_MyHashMap_Type.C_MyHashMap ( ^ _20)) };
     _19 <- ([#"../hashmap.rs" 111 39 111 58] IndexMut0.index_mut _20 index);
     _20 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global));
     goto BB5
   }
   BB5 {
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     assume { Inv0.inv ( ^ _18) };
-    l <- borrow_mut ( * _18);
+    l <- Borrow.borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ l) };
     assume { Inv0.inv ( ^ l) };
     assert { [@expl:type invariant] Inv1.inv _18 };
@@ -1736,13 +1736,13 @@ module Hashmap_Impl5_Add
     goto BB10
   }
   BB10 {
-    k <- borrow_mut (let (a, _) = Hashmap_List_Type.cons_0 ( * l) in a);
+    k <- Borrow.borrow_mut (let (a, _) = Hashmap_List_Type.cons_0 ( * l) in a);
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons (let (a, b) = Hashmap_List_Type.cons_0 ( * l) in ( ^ k, b)) b) };
     assume { Inv3.inv ( ^ k) };
-    v <- borrow_mut (let (_, a) = Hashmap_List_Type.cons_0 ( * l) in a);
+    v <- Borrow.borrow_mut (let (_, a) = Hashmap_List_Type.cons_0 ( * l) in a);
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons (let (a, b) = Hashmap_List_Type.cons_0 ( * l) in (a,  ^ v)) b) };
     assume { Inv4.inv ( ^ v) };
-    tl <- borrow_mut (Hashmap_List_Type.cons_1 ( * l));
+    tl <- Borrow.borrow_mut (Hashmap_List_Type.cons_1 ( * l));
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons a ( ^ tl)) };
     assume { Inv5.inv ( ^ tl) };
     tl1 <- tl;
@@ -1782,10 +1782,10 @@ module Hashmap_Impl5_Add
   BB13 {
     assert { [@expl:type invariant] Inv7.inv v };
     assume { Resolve4.resolve v };
-    _47 <- borrow_mut ( * tl1);
+    _47 <- Borrow.borrow_mut ( * tl1);
     tl1 <- { tl1 with current = ( ^ _47) };
     assume { Inv0.inv ( ^ _47) };
-    _46 <- borrow_mut ( * _47);
+    _46 <- Borrow.borrow_mut ( * _47);
     _47 <- { _47 with current = ( ^ _46) };
     assume { Inv0.inv ( ^ _46) };
     assert { [@expl:type invariant] Inv1.inv l };
@@ -2622,17 +2622,17 @@ module Hashmap_Impl5_Resize
       end
   }
   BB9 {
-    _30 <- borrow_mut (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self));
+    _30 <- Borrow.borrow_mut (Hashmap_MyHashMap_Type.myhashmap_buckets ( * self));
     self <- { self with current = (let Hashmap_MyHashMap_Type.C_MyHashMap a =  * self in Hashmap_MyHashMap_Type.C_MyHashMap ( ^ _30)) };
     _29 <- ([#"../hashmap.rs" 178 56 178 71] IndexMut0.index_mut _30 i);
     _30 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global));
     goto BB10
   }
   BB10 {
-    _28 <- borrow_mut ( * _29);
+    _28 <- Borrow.borrow_mut ( * _29);
     _29 <- { _29 with current = ( ^ _28) };
     assume { Inv1.inv ( ^ _28) };
-    _27 <- borrow_mut ( * _28);
+    _27 <- Borrow.borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _27) };
     assume { Inv1.inv ( ^ _27) };
     l <- ([#"../hashmap.rs" 178 33 178 83] Replace0.replace _27 (Hashmap_List_Type.C_Nil));
@@ -2689,7 +2689,7 @@ module Hashmap_Impl5_Resize
     l <- (let Hashmap_List_Type.C_Cons a b = l in Hashmap_List_Type.C_Cons a (any Hashmap_List_Type.t_list (k, v)));
     assert { [@expl:type invariant] Inv1.inv l };
     assume { Resolve4.resolve l };
-    _45 <- borrow_mut new;
+    _45 <- Borrow.borrow_mut new;
     new <-  ^ _45;
     assert { [@expl:type invariant] Inv3.inv k };
     assume { Resolve5.resolve k };
@@ -2942,7 +2942,7 @@ module Hashmap_Main
     goto BB6
   }
   BB6 {
-    _12 <- borrow_mut h1;
+    _12 <- Borrow.borrow_mut h1;
     h1 <-  ^ _12;
     _11 <- ([#"../hashmap.rs" 234 4 234 17] Add0.add _12 ([#"../hashmap.rs" 234 11 234 12] (1 : usize)) ([#"../hashmap.rs" 234 14 234 16] (17 : isize)));
     _12 <- any borrowed (Hashmap_MyHashMap_Type.t_myhashmap usize isize);
@@ -2973,7 +2973,7 @@ module Hashmap_Main
   BB11 {
     _t <- _19;
     _19 <- any Core_Option_Option_Type.t_option isize;
-    _22 <- borrow_mut h2;
+    _22 <- Borrow.borrow_mut h2;
     h2 <-  ^ _22;
     _21 <- ([#"../hashmap.rs" 241 4 241 17] Add0.add _22 ([#"../hashmap.rs" 241 11 241 12] (1 : usize)) ([#"../hashmap.rs" 241 14 241 16] (42 : isize)));
     _22 <- any borrowed (Hashmap_MyHashMap_Type.t_myhashmap usize isize);

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -2003,14 +2003,14 @@ module HeapsortGeneric_SiftDown
     goto BB23
   }
   BB20 {
-    _63 <- borrow_mut ( * v);
+    _63 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _63) };
     _62 <- ([#"../heapsort_generic.rs" 71 8 71 24] DerefMut0.deref_mut _63);
     _63 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB21
   }
   BB21 {
-    _61 <- borrow_mut ( * _62);
+    _61 <- Borrow.borrow_mut ( * _62);
     _62 <- { _62 with current = ( ^ _61) };
     assume { Inv2.inv ( ^ _61) };
     _60 <- ([#"../heapsort_generic.rs" 71 8 71 24] Swap0.swap _61 i child);
@@ -2448,7 +2448,7 @@ module HeapsortGeneric_HeapSort
   }
   BB6 {
     start <- ([#"../heapsort_generic.rs" 104 8 104 18] start - ([#"../heapsort_generic.rs" 104 17 104 18] (1 : usize)));
-    _19 <- borrow_mut ( * v);
+    _19 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _19) };
     _21 <- ([#"../heapsort_generic.rs" 105 28 105 35] Len0.len ( * _19));
     goto BB7
@@ -2486,14 +2486,14 @@ module HeapsortGeneric_HeapSort
   }
   BB13 {
     end' <- ([#"../heapsort_generic.rs" 116 8 116 16] end' - ([#"../heapsort_generic.rs" 116 15 116 16] (1 : usize)));
-    _38 <- borrow_mut ( * v);
+    _38 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _38) };
     _37 <- ([#"../heapsort_generic.rs" 117 8 117 22] DerefMut0.deref_mut _38);
     _38 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB14
   }
   BB14 {
-    _36 <- borrow_mut ( * _37);
+    _36 <- Borrow.borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     assume { Inv0.inv ( ^ _36) };
     _35 <- ([#"../heapsort_generic.rs" 117 8 117 22] Swap0.swap _36 ([#"../heapsort_generic.rs" 117 15 117 16] (0 : usize)) end');
@@ -2504,7 +2504,7 @@ module HeapsortGeneric_HeapSort
     assert { [@expl:type invariant] Inv1.inv _37 };
     assume { Resolve2.resolve _37 };
     assert { [@expl:assertion] [#"../heapsort_generic.rs" 119 12 119 59] let _ = HeapFragMax0.heap_frag_max (DeepModel0.deep_model v) 0 (UIntSize.to_int end') in forall j : int . forall i : int . 0 <= i /\ i < UIntSize.to_int end' /\ UIntSize.to_int end' <= j /\ j < Seq.length (ShallowModel0.shallow_model v) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v) i) (Seq.get (DeepModel0.deep_model v) j) };
-    _43 <- borrow_mut ( * v);
+    _43 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _43) };
     _42 <- ([#"../heapsort_generic.rs" 123 8 123 28] SiftDown0.sift_down _43 ([#"../heapsort_generic.rs" 123 21 123 22] (0 : usize)) end');
     _43 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -537,7 +537,7 @@ module Hillel_RightPad
       end
   }
   BB5 {
-    _23 <- borrow_mut ( * str);
+    _23 <- Borrow.borrow_mut ( * str);
     str <- { str with current = ( ^ _23) };
     _22 <- ([#"../hillel.rs" 25 8 25 21] Push0.push _23 pad);
     _23 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -796,7 +796,7 @@ module Hillel_LeftPad
       end
   }
   BB6 {
-    _24 <- borrow_mut ( * str);
+    _24 <- Borrow.borrow_mut ( * str);
     str <- { str with current = ( ^ _24) };
     _23 <- ([#"../hillel.rs" 44 8 44 26] Insert0.insert _24 ([#"../hillel.rs" 44 19 44 20] (0 : usize)) pad);
     _24 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -2096,9 +2096,9 @@ module Hillel_InsertUnique
     goto BB12
   }
   BB12 {
-    _28 <- borrow_mut iter;
+    _28 <- Borrow.borrow_mut iter;
     iter <-  ^ _28;
-    _27 <- borrow_mut ( * _28);
+    _27 <- Borrow.borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _27) };
     _26 <- ([#"../hillel.rs" 83 4 83 111] Next0.next _27);
     _27 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
@@ -2175,7 +2175,7 @@ module Hillel_InsertUnique
     goto BB11
   }
   BB23 {
-    _47 <- borrow_mut ( * vec);
+    _47 <- Borrow.borrow_mut ( * vec);
     vec <- { vec with current = ( ^ _47) };
     _46 <- ([#"../hillel.rs" 93 4 93 18] Push0.push _47 elem);
     _47 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -2973,9 +2973,9 @@ module Hillel_Unique
     goto BB11
   }
   BB11 {
-    _25 <- borrow_mut iter;
+    _25 <- Borrow.borrow_mut iter;
     iter <-  ^ _25;
-    _24 <- borrow_mut ( * _25);
+    _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
     _23 <- ([#"../hillel.rs" 103 4 103 48] Next0.next _24);
     _24 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -3019,9 +3019,9 @@ module Hillel_Unique
   }
   BB18 {
     elem <- Slice.get str _32;
-    _37 <- borrow_mut unique;
+    _37 <- Borrow.borrow_mut unique;
     unique <-  ^ _37;
-    _36 <- borrow_mut ( * _37);
+    _36 <- Borrow.borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     assert { [@expl:type invariant] Inv1.inv elem };
     assume { Resolve2.resolve elem };
@@ -3583,9 +3583,9 @@ module Hillel_Fulcrum
     goto BB5
   }
   BB5 {
-    _21 <- borrow_mut iter;
+    _21 <- Borrow.borrow_mut iter;
     iter <-  ^ _21;
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     _19 <- ([#"../hillel.rs" 158 4 158 60] Next0.next _20);
     _20 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
@@ -3652,9 +3652,9 @@ module Hillel_Fulcrum
     goto BB17
   }
   BB17 {
-    _52 <- borrow_mut iter1;
+    _52 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _52;
-    _51 <- borrow_mut ( * _52);
+    _51 <- Borrow.borrow_mut ( * _52);
     _52 <- { _52 with current = ( ^ _51) };
     _50 <- ([#"../hillel.rs" 170 4 170 58] Next1.next _51);
     _51 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);

--- a/creusot/tests/should_succeed/immut.mlcfg
+++ b/creusot/tests/should_succeed/immut.mlcfg
@@ -41,7 +41,7 @@ module Immut_F
   }
   BB0 {
     a <- ([#"../immut.rs" 4 16 4 18] (10 : uint32));
-    b <- borrow_mut a;
+    b <- Borrow.borrow_mut a;
     a <-  ^ b;
     _c <-  * b;
     _0 <- ();

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -369,35 +369,35 @@ module IndexRange_CreateArr
     goto BB1
   }
   BB1 {
-    _4 <- borrow_mut arr;
+    _4 <- Borrow.borrow_mut arr;
     arr <-  ^ _4;
     _3 <- ([#"../index_range.rs" 17 4 17 15] Push0.push _4 ([#"../index_range.rs" 17 13 17 14] (0 : int32)));
     _4 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB2
   }
   BB2 {
-    _6 <- borrow_mut arr;
+    _6 <- Borrow.borrow_mut arr;
     arr <-  ^ _6;
     _5 <- ([#"../index_range.rs" 18 4 18 15] Push0.push _6 ([#"../index_range.rs" 18 13 18 14] (1 : int32)));
     _6 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB3
   }
   BB3 {
-    _8 <- borrow_mut arr;
+    _8 <- Borrow.borrow_mut arr;
     arr <-  ^ _8;
     _7 <- ([#"../index_range.rs" 19 4 19 15] Push0.push _8 ([#"../index_range.rs" 19 13 19 14] (2 : int32)));
     _8 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB4
   }
   BB4 {
-    _10 <- borrow_mut arr;
+    _10 <- Borrow.borrow_mut arr;
     arr <-  ^ _10;
     _9 <- ([#"../index_range.rs" 20 4 20 15] Push0.push _10 ([#"../index_range.rs" 20 13 20 14] (3 : int32)));
     _10 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB5
   }
   BB5 {
-    _12 <- borrow_mut arr;
+    _12 <- Borrow.borrow_mut arr;
     arr <-  ^ _12;
     _11 <- ([#"../index_range.rs" 21 4 21 15] Push0.push _12 ([#"../index_range.rs" 21 13 21 14] (4 : int32)));
     _12 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
@@ -1583,14 +1583,14 @@ module IndexRange_TestRange
     absurd
   }
   BB53 {
-    _106 <- borrow_mut arr;
+    _106 <- Borrow.borrow_mut arr;
     arr <-  ^ _106;
     _105 <- ([#"../index_range.rs" 59 17 59 26] IndexMut0.index_mut _106 (Core_Ops_Range_Range_Type.C_Range ([#"../index_range.rs" 59 21 59 22] (1 : usize)) ([#"../index_range.rs" 59 24 59 25] (4 : usize))));
     _106 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB54
   }
   BB54 {
-    s2 <- borrow_mut ( * _105);
+    s2 <- Borrow.borrow_mut ( * _105);
     _105 <- { _105 with current = ( ^ s2) };
     _111 <- ([#"../index_range.rs" 60 12 60 19] Len0.len ( * s2));
     goto BB55
@@ -2194,14 +2194,14 @@ module IndexRange_TestRangeTo
     absurd
   }
   BB22 {
-    _45 <- borrow_mut arr;
+    _45 <- Borrow.borrow_mut arr;
     arr <-  ^ _45;
     _44 <- ([#"../index_range.rs" 99 17 99 25] IndexMut0.index_mut _45 (Core_Ops_Range_RangeTo_Type.C_RangeTo ([#"../index_range.rs" 99 23 99 24] (3 : usize))));
     _45 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB23
   }
   BB23 {
-    s1 <- borrow_mut ( * _44);
+    s1 <- Borrow.borrow_mut ( * _44);
     _44 <- { _44 with current = ( ^ s1) };
     _50 <- ([#"../index_range.rs" 100 12 100 19] Len0.len ( * s1));
     goto BB24
@@ -2835,14 +2835,14 @@ module IndexRange_TestRangeFrom
     absurd
   }
   BB27 {
-    _55 <- borrow_mut arr;
+    _55 <- Borrow.borrow_mut arr;
     arr <-  ^ _55;
     _54 <- ([#"../index_range.rs" 138 17 138 25] IndexMut0.index_mut _55 (Core_Ops_Range_RangeFrom_Type.C_RangeFrom ([#"../index_range.rs" 138 21 138 22] (2 : usize))));
     _55 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB28
   }
   BB28 {
-    s1 <- borrow_mut ( * _54);
+    s1 <- Borrow.borrow_mut ( * _54);
     _54 <- { _54 with current = ( ^ s1) };
     _60 <- ([#"../index_range.rs" 139 12 139 19] Len0.len ( * s1));
     goto BB29
@@ -3412,14 +3412,14 @@ module IndexRange_TestRangeFull
     absurd
   }
   BB25 {
-    _44 <- borrow_mut arr;
+    _44 <- Borrow.borrow_mut arr;
     arr <-  ^ _44;
     _43 <- ([#"../index_range.rs" 165 17 165 24] IndexMut0.index_mut _44 (Core_Ops_Range_RangeFull_Type.C_RangeFull));
     _44 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB26
   }
   BB26 {
-    s1 <- borrow_mut ( * _43);
+    s1 <- Borrow.borrow_mut ( * _43);
     _43 <- { _43 with current = ( ^ s1) };
     _49 <- ([#"../index_range.rs" 166 12 166 19] Len0.len ( * s1));
     goto BB27
@@ -3996,14 +3996,14 @@ module IndexRange_TestRangeToInclusive
     absurd
   }
   BB18 {
-    _36 <- borrow_mut arr;
+    _36 <- Borrow.borrow_mut arr;
     arr <-  ^ _36;
     _35 <- ([#"../index_range.rs" 195 17 195 26] IndexMut0.index_mut _36 (Core_Ops_Range_RangeToInclusive_Type.C_RangeToInclusive ([#"../index_range.rs" 195 24 195 25] (2 : usize))));
     _36 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));
     goto BB19
   }
   BB19 {
-    s1 <- borrow_mut ( * _35);
+    s1 <- Borrow.borrow_mut ( * _35);
     _35 <- { _35 with current = ( ^ s1) };
     _41 <- ([#"../index_range.rs" 196 12 196 19] Len0.len ( * s1));
     goto BB20

--- a/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
+++ b/creusot/tests/should_succeed/inplace_list_reversal.mlcfg
@@ -185,7 +185,7 @@ module InplaceListReversal_Rev
   BB1 {
     assume { Resolve0.resolve old_l };
     prev <- InplaceListReversal_List_Type.C_Nil;
-    _7 <- borrow_mut ( * l);
+    _7 <- Borrow.borrow_mut ( * l);
     l <- { l with current = ( ^ _7) };
     assume { Inv0.inv ( ^ _7) };
     head <- ([#"../inplace_list_reversal.rs" 27 19 27 34] Replace0.replace _7 (InplaceListReversal_List_Type.C_Nil));

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -454,9 +454,9 @@ module InvariantMoves_TestInvariantMove
     goto BB3
   }
   BB3 {
-    _6 <- borrow_mut x;
+    _6 <- Borrow.borrow_mut x;
     x <-  ^ _6;
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- ([#"../invariant_moves.rs" 7 26 7 40] Pop0.pop _5);
     _5 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/ite_normalize.mlcfg
+++ b/creusot/tests/should_succeed/ite_normalize.mlcfg
@@ -1299,7 +1299,7 @@ module IteNormalize_Impl5_SimplifyHelper
     goto BB20
   }
   BB20 {
-    _27 <- borrow_mut state_t;
+    _27 <- Borrow.borrow_mut state_t;
     state_t <-  ^ _27;
     _26 <- ([#"../ite_normalize.rs" 203 28 203 51] Insert0.insert _27 v ([#"../ite_normalize.rs" 203 46 203 50] true));
     _27 <- any borrowed (IteNormalize_BTreeMap_Type.t_btreemap usize bool);
@@ -1316,7 +1316,7 @@ module IteNormalize_Impl5_SimplifyHelper
     goto BB23
   }
   BB23 {
-    _35 <- borrow_mut state_e;
+    _35 <- Borrow.borrow_mut state_e;
     state_e <-  ^ _35;
     _34 <- ([#"../ite_normalize.rs" 208 28 208 52] Insert0.insert _35 v ([#"../ite_normalize.rs" 208 46 208 51] false));
     _35 <- any borrowed (IteNormalize_BTreeMap_Type.t_btreemap usize bool);

--- a/creusot/tests/should_succeed/iterators/01_range.mlcfg
+++ b/creusot/tests/should_succeed/iterators/01_range.mlcfg
@@ -391,7 +391,7 @@ module C01Range_SumRange
     goto BB5
   }
   BB5 {
-    _18 <- borrow_mut it;
+    _18 <- Borrow.borrow_mut it;
     it <-  ^ _18;
     _17 <- ([#"../01_range.rs" 88 14 88 23] Next0.next _18);
     _18 <- any borrowed (C01Range_Range_Type.t_range);

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -865,7 +865,7 @@ module C02IterMut_Impl1_Next
     goto BB0
   }
   BB0 {
-    _3 <- borrow_mut (C02IterMut_IterMut_Type.itermut_inner ( * self));
+    _3 <- Borrow.borrow_mut (C02IterMut_IterMut_Type.itermut_inner ( * self));
     self <- { self with current = (let C02IterMut_IterMut_Type.C_IterMut a =  * self in C02IterMut_IterMut_Type.C_IterMut ( ^ _3)) };
     assume { Inv0.inv ( ^ _3) };
     _0 <- ([#"../02_iter_mut.rs" 58 8 58 37] TakeFirstMut0.take_first_mut _3);
@@ -1447,17 +1447,17 @@ module C02IterMut_IterMut
     goto BB0
   }
   BB0 {
-    _9 <- borrow_mut ( * v);
+    _9 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _9) };
     _8 <- ([#"../02_iter_mut.rs" 74 26 74 31] IndexMut0.index_mut _9 (Core_Ops_Range_RangeFull_Type.C_RangeFull));
     _9 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     assume { Inv0.inv ( ^ _7) };
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     assume { Inv0.inv ( ^ _6) };
     _0 <- C02IterMut_IterMut_Type.C_IterMut _6;
@@ -1738,7 +1738,7 @@ module C02IterMut_AllZero
     goto BB0
   }
   BB0 {
-    _6 <- borrow_mut ( * v);
+    _6 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _6) };
     _5 <- ([#"../02_iter_mut.rs" 80 17 80 28] IterMut0.iter_mut _6);
     _6 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -1767,7 +1767,7 @@ module C02IterMut_AllZero
     goto BB6
   }
   BB6 {
-    _16 <- borrow_mut it;
+    _16 <- Borrow.borrow_mut it;
     it <-  ^ _16;
     assume { Inv0.inv ( ^ _16) };
     _15 <- ([#"../02_iter_mut.rs" 87 14 87 23] Next0.next _16);

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -873,9 +873,9 @@ module C03StdIterators_SliceIter
     goto BB6
   }
   BB6 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     _17 <- ([#"../03_std_iterators.rs" 8 4 8 38] Next0.next _18);
     _18 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
@@ -1304,9 +1304,9 @@ module C03StdIterators_VecIter
     goto BB5
   }
   BB5 {
-    _18 <- borrow_mut iter;
+    _18 <- Borrow.borrow_mut iter;
     iter <-  ^ _18;
-    _17 <- borrow_mut ( * _18);
+    _17 <- Borrow.borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ _17) };
     _16 <- ([#"../03_std_iterators.rs" 19 4 19 38] Next0.next _17);
     _17 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
@@ -2182,14 +2182,14 @@ module C03StdIterators_AllZero
     goto BB0
   }
   BB0 {
-    _8 <- borrow_mut ( * v);
+    _8 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _8) };
     _7 <- ([#"../03_std_iterators.rs" 30 13 30 25] DerefMut0.deref_mut _8);
     _8 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     _5 <- ([#"../03_std_iterators.rs" 30 13 30 25] IterMut0.iter_mut _6);
     _6 <- any borrowed (slice usize);
@@ -2219,10 +2219,10 @@ module C03StdIterators_AllZero
     goto BB7
   }
   BB7 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
     assume { Inv0.inv ( ^ _19) };
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     assume { Inv0.inv ( ^ _18) };
     _17 <- ([#"../03_std_iterators.rs" 29 4 29 87] Next0.next _18);
@@ -3425,7 +3425,7 @@ module C03StdIterators_SkipTake
     goto BB2
   }
   BB2 {
-    _4 <- borrow_mut _5;
+    _4 <- Borrow.borrow_mut _5;
     _5 <-  ^ _4;
     assume { Inv0.inv ( ^ _4) };
     res <- ([#"../03_std_iterators.rs" 36 14 36 41] Next0.next _4);
@@ -4635,7 +4635,7 @@ module C03StdIterators_Counter
     goto BB2
   }
   BB2 {
-    _10 <- borrow_mut cnt;
+    _10 <- Borrow.borrow_mut cnt;
     cnt <-  ^ _10;
     _4 <- ([#"../03_std_iterators.rs" 44 22 53 9] MapInv0.map_inv _5 (Closure00.C03StdIterators_Counter_Closure0 _10));
     _5 <- any Core_Slice_Iter_Iter_Type.t_iter uint32;
@@ -5039,9 +5039,9 @@ module C03StdIterators_SumRange
     goto BB5
   }
   BB5 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     _17 <- ([#"../03_std_iterators.rs" 65 4 65 48] Next0.next _18);
     _18 <- any borrowed (Core_Ops_Range_Range_Type.t_range isize);
@@ -5642,10 +5642,10 @@ module C03StdIterators_EnumerateRange
     goto BB6
   }
   BB6 {
-    _14 <- borrow_mut iter;
+    _14 <- Borrow.borrow_mut iter;
     iter <-  ^ _14;
     assume { Inv0.inv ( ^ _14) };
-    _13 <- borrow_mut ( * _14);
+    _13 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
     assume { Inv0.inv ( ^ _13) };
     _12 <- ([#"../03_std_iterators.rs" 73 4 73 96] Next0.next _13);

--- a/creusot/tests/should_succeed/iterators/04_skip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/04_skip.mlcfg
@@ -848,9 +848,9 @@ module C04Skip_Impl1_Next
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _7 <- borrow_mut (C04Skip_Skip_Type.skip_n ( * self));
+    _7 <- Borrow.borrow_mut (C04Skip_Skip_Type.skip_n ( * self));
     self <- { self with current = (let C04Skip_Skip_Type.C_Skip a b =  * self in C04Skip_Skip_Type.C_Skip a ( ^ _7)) };
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     n <- ([#"../04_skip.rs" 70 20 70 47] Take0.take _6);
     _6 <- any borrowed usize;
@@ -874,7 +874,7 @@ module C04Skip_Impl1_Next
     goto BB5
   }
   BB5 {
-    _18 <- borrow_mut (C04Skip_Skip_Type.skip_iter ( * self));
+    _18 <- Borrow.borrow_mut (C04Skip_Skip_Type.skip_iter ( * self));
     self <- { self with current = (let C04Skip_Skip_Type.C_Skip a b =  * self in C04Skip_Skip_Type.C_Skip ( ^ _18) b) };
     assume { Inv1.inv ( ^ _18) };
     r <- ([#"../04_skip.rs" 78 20 78 36] Next0.next _18);

--- a/creusot/tests/should_succeed/iterators/05_map.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_map.mlcfg
@@ -2660,7 +2660,7 @@ module C05Map_Impl0_Next
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _6 <- borrow_mut (C05Map_Map_Type.map_iter ( * self));
+    _6 <- Borrow.borrow_mut (C05Map_Map_Type.map_iter ( * self));
     self <- { self with current = (let C05Map_Map_Type.C_Map a b =  * self in C05Map_Map_Type.C_Map ( ^ _6) b) };
     assume { Inv0.inv ( ^ _6) };
     _5 <- ([#"../05_map.rs" 66 14 66 30] Next0.next _6);
@@ -2700,7 +2700,7 @@ module C05Map_Impl0_Next
     goto BB7
   }
   BB7 {
-    _12 <- borrow_mut (C05Map_Map_Type.map_func ( * self));
+    _12 <- Borrow.borrow_mut (C05Map_Map_Type.map_func ( * self));
     self <- { self with current = (let C05Map_Map_Type.C_Map a b =  * self in C05Map_Map_Type.C_Map a ( ^ _12)) };
     assume { Inv2.inv ( ^ _12) };
     r <- ([#"../05_map.rs" 69 24 69 38] CallMut0.call_mut _12 (v));

--- a/creusot/tests/should_succeed/iterators/05_take.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_take.mlcfg
@@ -676,7 +676,7 @@ module C05Take_Impl0_Next
   }
   BB1 {
     self <- { self with current = (let C05Take_Take_Type.C_Take a b =  * self in C05Take_Take_Type.C_Take a ([#"../05_take.rs" 55 12 55 23] C05Take_Take_Type.take_n ( * self) - ([#"../05_take.rs" 55 22 55 23] (1 : usize)))) };
-    _5 <- borrow_mut (C05Take_Take_Type.take_iter ( * self));
+    _5 <- Borrow.borrow_mut (C05Take_Take_Type.take_iter ( * self));
     self <- { self with current = (let C05Take_Take_Type.C_Take a b =  * self in C05Take_Take_Type.C_Take ( ^ _5) b) };
     assume { Inv1.inv ( ^ _5) };
     _0 <- ([#"../05_take.rs" 56 12 56 28] Next0.next _5);

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -2822,7 +2822,7 @@ module C06MapPrecond_Impl0_Next
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _6 <- borrow_mut (C06MapPrecond_Map_Type.map_iter ( * self));
+    _6 <- Borrow.borrow_mut (C06MapPrecond_Map_Type.map_iter ( * self));
     self <- { self with current = (let C06MapPrecond_Map_Type.C_Map a b c =  * self in C06MapPrecond_Map_Type.C_Map ( ^ _6) b c) };
     assume { Inv0.inv ( ^ _6) };
     _5 <- ([#"../06_map_precond.rs" 72 14 72 30] Next0.next _6);
@@ -2864,7 +2864,7 @@ module C06MapPrecond_Impl0_Next
     goto BB8
   }
   BB8 {
-    _14 <- borrow_mut (C06MapPrecond_Map_Type.map_func ( * self));
+    _14 <- Borrow.borrow_mut (C06MapPrecond_Map_Type.map_func ( * self));
     self <- { self with current = (let C06MapPrecond_Map_Type.C_Map a b c =  * self in C06MapPrecond_Map_Type.C_Map a ( ^ _14) c) };
     assume { Inv2.inv ( ^ _14) };
     _17 <- ([#"../06_map_precond.rs" 76 39 76 68] Ghost.new (Ghost.inner (C06MapPrecond_Map_Type.map_produced ( * self))));
@@ -4210,7 +4210,7 @@ module C06MapPrecond_Counter
   }
   BB1 {
     cnt <- ([#"../06_map_precond.rs" 213 18 213 19] (0 : usize));
-    _8 <- borrow_mut cnt;
+    _8 <- Borrow.borrow_mut cnt;
     cnt <-  ^ _8;
     _5 <- ([#"../06_map_precond.rs" 214 4 222 5] Map0.map iter (Closure20.C06MapPrecond_Counter_Closure2 _8));
     iter <- any i;

--- a/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
+++ b/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
@@ -577,7 +577,7 @@ module C07Fuse_Impl1_Next
     goto BB0
   }
   BB0 {
-    _3 <- borrow_mut (C07Fuse_Fuse_Type.fuse_iter ( * self));
+    _3 <- Borrow.borrow_mut (C07Fuse_Fuse_Type.fuse_iter ( * self));
     self <- { self with current = (let C07Fuse_Fuse_Type.C_Fuse a =  * self in C07Fuse_Fuse_Type.C_Fuse ( ^ _3)) };
     assume { Inv0.inv ( ^ _3) };
     switch ( * _3)
@@ -586,10 +586,10 @@ module C07Fuse_Impl1_Next
       end
   }
   BB1 {
-    iter <- borrow_mut (Core_Result_Result_Type.ok_0 ( * _3));
+    iter <- Borrow.borrow_mut (Core_Result_Result_Type.ok_0 ( * _3));
     _3 <- { _3 with current = (let Core_Result_Result_Type.C_Ok a =  * _3 in Core_Result_Result_Type.C_Ok ( ^ iter)) };
     assume { Inv3.inv ( ^ iter) };
-    _7 <- borrow_mut ( * iter);
+    _7 <- Borrow.borrow_mut ( * iter);
     iter <- { iter with current = ( ^ _7) };
     assume { Inv3.inv ( ^ _7) };
     _6 <- ([#"../07_fuse.rs" 48 30 48 41] Next0.next _7);

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -844,10 +844,10 @@ module C08CollectExtend_Extend
     goto BB9
   }
   BB9 {
-    _20 <- borrow_mut iter1;
+    _20 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _20;
     assume { Inv0.inv ( ^ _20) };
-    _19 <- borrow_mut ( * _20);
+    _19 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
     assume { Inv0.inv ( ^ _19) };
     _18 <- ([#"../08_collect_extend.rs" 29 4 29 35] Next0.next _19);
@@ -896,7 +896,7 @@ module C08CollectExtend_Extend
     assume { Resolve2.resolve produced };
     x <- __creusot_proc_iter_elem;
     __creusot_proc_iter_elem <- any t;
-    _27 <- borrow_mut ( * vec);
+    _27 <- Borrow.borrow_mut ( * vec);
     vec <- { vec with current = ( ^ _27) };
     _26 <- ([#"../08_collect_extend.rs" 32 8 32 19] Push0.push _27 x);
     _27 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -1249,10 +1249,10 @@ module C08CollectExtend_Collect
     goto BB10
   }
   BB10 {
-    _17 <- borrow_mut iter1;
+    _17 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _17;
     assume { Inv0.inv ( ^ _17) };
-    _16 <- borrow_mut ( * _17);
+    _16 <- Borrow.borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _16) };
     assume { Inv0.inv ( ^ _16) };
     _15 <- ([#"../08_collect_extend.rs" 47 4 47 40] Next0.next _16);
@@ -1299,7 +1299,7 @@ module C08CollectExtend_Collect
     assume { Resolve1.resolve produced };
     x <- __creusot_proc_iter_elem;
     __creusot_proc_iter_elem <- any Item0.item;
-    _24 <- borrow_mut res;
+    _24 <- Borrow.borrow_mut res;
     res <-  ^ _24;
     _23 <- ([#"../08_collect_extend.rs" 49 8 49 19] Push0.push _24 x);
     _24 <- any borrowed (Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global));
@@ -1931,9 +1931,9 @@ module C08CollectExtend_ExtendIndex
     goto BB2
   }
   BB2 {
-    _9 <- borrow_mut v1;
+    _9 <- Borrow.borrow_mut v1;
     v1 <-  ^ _9;
-    _8 <- borrow_mut ( * _9);
+    _8 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _8) };
     _10 <- ([#"../08_collect_extend.rs" 57 20 57 34] IntoIter0.into_iter v2);
     v2 <- any Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global);

--- a/creusot/tests/should_succeed/iterators/10_once.mlcfg
+++ b/creusot/tests/should_succeed/iterators/10_once.mlcfg
@@ -373,7 +373,7 @@ module C10Once_Impl0_Next
     goto BB0
   }
   BB0 {
-    _3 <- borrow_mut (C10Once_Once_Type.once_0 ( * self));
+    _3 <- Borrow.borrow_mut (C10Once_Once_Type.once_0 ( * self));
     self <- { self with current = (let C10Once_Once_Type.C_Once a =  * self in C10Once_Once_Type.C_Once ( ^ _3)) };
     assume { Inv0.inv ( ^ _3) };
     _0 <- ([#"../10_once.rs" 45 8 45 21] Take0.take _3);

--- a/creusot/tests/should_succeed/iterators/12_zip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/12_zip.mlcfg
@@ -902,7 +902,7 @@ module C12Zip_Impl0_Next
     goto BB0
   }
   BB0 {
-    _5 <- borrow_mut (C12Zip_Zip_Type.zip_iter1 ( * self));
+    _5 <- Borrow.borrow_mut (C12Zip_Zip_Type.zip_iter1 ( * self));
     self <- { self with current = (let C12Zip_Zip_Type.C_Zip a b =  * self in C12Zip_Zip_Type.C_Zip ( ^ _5) b) };
     assume { Inv0.inv ( ^ _5) };
     _4 <- ([#"../12_zip.rs" 51 15 51 32] Next0.next _5);
@@ -910,7 +910,7 @@ module C12Zip_Impl0_Next
     goto BB1
   }
   BB1 {
-    _7 <- borrow_mut (C12Zip_Zip_Type.zip_iter2 ( * self));
+    _7 <- Borrow.borrow_mut (C12Zip_Zip_Type.zip_iter2 ( * self));
     self <- { self with current = (let C12Zip_Zip_Type.C_Zip a b =  * self in C12Zip_Zip_Type.C_Zip a ( ^ _7)) };
     assume { Inv1.inv ( ^ _7) };
     _6 <- ([#"../12_zip.rs" 51 34 51 51] Next1.next _7);

--- a/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
+++ b/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
@@ -685,7 +685,7 @@ module C13Cloned_Impl0_Next
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut (C13Cloned_Cloned_Type.cloned_iter ( * self));
+    _4 <- Borrow.borrow_mut (C13Cloned_Cloned_Type.cloned_iter ( * self));
     self <- { self with current = (let C13Cloned_Cloned_Type.C_Cloned a =  * self in C13Cloned_Cloned_Type.C_Cloned ( ^ _4)) };
     assume { Inv0.inv ( ^ _4) };
     _3 <- ([#"../13_cloned.rs" 53 8 53 24] Next0.next _4);

--- a/creusot/tests/should_succeed/iterators/14_copied.mlcfg
+++ b/creusot/tests/should_succeed/iterators/14_copied.mlcfg
@@ -685,7 +685,7 @@ module C14Copied_Impl0_Next
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut (C14Copied_Copied_Type.copied_iter ( * self));
+    _4 <- Borrow.borrow_mut (C14Copied_Copied_Type.copied_iter ( * self));
     self <- { self with current = (let C14Copied_Copied_Type.C_Copied a =  * self in C14Copied_Copied_Type.C_Copied ( ^ _4)) };
     assume { Inv0.inv ( ^ _4) };
     _3 <- ([#"../14_copied.rs" 53 8 53 24] Next0.next _4);

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -813,7 +813,7 @@ module C15Enumerate_Impl0_Next
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut (C15Enumerate_Enumerate_Type.enumerate_iter ( * self));
+    _4 <- Borrow.borrow_mut (C15Enumerate_Enumerate_Type.enumerate_iter ( * self));
     self <- { self with current = (let C15Enumerate_Enumerate_Type.C_Enumerate a b =  * self in C15Enumerate_Enumerate_Type.C_Enumerate ( ^ _4) b) };
     assume { Inv0.inv ( ^ _4) };
     _3 <- ([#"../15_enumerate.rs" 54 14 54 30] Next0.next _4);

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -1343,14 +1343,14 @@ module Knapsack_Knapsack01Dyn
     goto BB30
   }
   BB30 {
-    _69 <- borrow_mut best_value;
+    _69 <- Borrow.borrow_mut best_value;
     best_value <-  ^ _69;
     _68 <- ([#"../knapsack.rs" 77 12 77 29] IndexMut0.index_mut _69 ([#"../knapsack.rs" 77 23 77 28] i + ([#"../knapsack.rs" 77 27 77 28] (1 : usize))));
     _69 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
     goto BB31
   }
   BB31 {
-    _67 <- borrow_mut ( * _68);
+    _67 <- Borrow.borrow_mut ( * _68);
     _68 <- { _68 with current = ( ^ _67) };
     _66 <- ([#"../knapsack.rs" 77 12 77 32] IndexMut1.index_mut _67 w);
     _67 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -1431,7 +1431,7 @@ module Knapsack_Knapsack01Dyn
       end
   }
   BB46 {
-    _111 <- borrow_mut result;
+    _111 <- Borrow.borrow_mut result;
     result <-  ^ _111;
     _110 <- ([#"../knapsack.rs" 97 12 97 27] Push0.push _111 it1);
     _111 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -2658,9 +2658,9 @@ module KnapsackFull_Knapsack01Dyn
     goto BB13
   }
   BB13 {
-    _34 <- borrow_mut iter;
+    _34 <- Borrow.borrow_mut iter;
     iter <-  ^ _34;
-    _33 <- borrow_mut ( * _34);
+    _33 <- Borrow.borrow_mut ( * _34);
     _34 <- { _34 with current = ( ^ _33) };
     _32 <- ([#"../knapsack_full.rs" 88 4 88 55] Next0.next _33);
     _33 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -2744,9 +2744,9 @@ module KnapsackFull_Knapsack01Dyn
     goto BB31
   }
   BB31 {
-    _60 <- borrow_mut iter1;
+    _60 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _60;
-    _59 <- borrow_mut ( * _60);
+    _59 <- Borrow.borrow_mut ( * _60);
     _60 <- { _60 with current = ( ^ _59) };
     _58 <- ([#"../knapsack_full.rs" 98 8 98 59] Next1.next _59);
     _59 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
@@ -2818,14 +2818,14 @@ module KnapsackFull_Knapsack01Dyn
     goto BB46
   }
   BB46 {
-    _97 <- borrow_mut best_value;
+    _97 <- Borrow.borrow_mut best_value;
     best_value <-  ^ _97;
     _96 <- ([#"../knapsack_full.rs" 111 12 111 29] IndexMut0.index_mut _97 ([#"../knapsack_full.rs" 111 23 111 28] i + ([#"../knapsack_full.rs" 111 27 111 28] (1 : usize))));
     _97 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
     goto BB47
   }
   BB47 {
-    _95 <- borrow_mut ( * _96);
+    _95 <- Borrow.borrow_mut ( * _96);
     _96 <- { _96 with current = ( ^ _95) };
     _94 <- ([#"../knapsack_full.rs" 111 12 111 32] IndexMut1.index_mut _95 w);
     _95 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -2906,7 +2906,7 @@ module KnapsackFull_Knapsack01Dyn
       end
   }
   BB63 {
-    _138 <- borrow_mut result;
+    _138 <- Borrow.borrow_mut result;
     result <-  ^ _138;
     _137 <- ([#"../knapsack_full.rs" 144 12 144 27] Push0.push _138 it1);
     _138 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
+++ b/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
@@ -50,11 +50,11 @@ module BranchBorrow2_F
     a <- ([#"../branch_borrow_2.rs" 4 16 4 18] (10 : int32));
     b <- ([#"../branch_borrow_2.rs" 5 16 5 18] (10 : int32));
     c <- ([#"../branch_borrow_2.rs" 6 16 6 18] (10 : int32));
-    x <- borrow_mut a;
+    x <- Borrow.borrow_mut a;
     a <-  ^ x;
-    y <- borrow_mut b;
+    y <- Borrow.borrow_mut b;
     b <-  ^ y;
-    z <- borrow_mut c;
+    z <- Borrow.borrow_mut c;
     c <-  ^ z;
     switch (([#"../branch_borrow_2.rs" 13 10 13 11] (3 : int32)) = 1)
       | True -> goto BB1
@@ -72,7 +72,7 @@ module BranchBorrow2_F
   }
   BB3 {
     z <- { z with current = ([#"../branch_borrow_2.rs" 23 17 23 18] (8 : int32)) };
-    _12 <- borrow_mut ( * z);
+    _12 <- Borrow.borrow_mut ( * z);
     z <- { z with current = ( ^ _12) };
     w <- _12;
     _12 <- any borrowed int32;
@@ -91,7 +91,7 @@ module BranchBorrow2_F
   BB5 {
     assume { Resolve0.resolve z };
     y <- { y with current = ([#"../branch_borrow_2.rs" 19 17 19 18] (7 : int32)) };
-    _11 <- borrow_mut ( * y);
+    _11 <- Borrow.borrow_mut ( * y);
     y <- { y with current = ( ^ _11) };
     w <- _11;
     _11 <- any borrowed int32;
@@ -235,11 +235,11 @@ module BranchBorrow2_G
   }
   BB0 {
     a <- (BranchBorrow2_MyInt_Type.C_MyInt ([#"../branch_borrow_2.rs" 36 23 36 25] (10 : usize)), BranchBorrow2_MyInt_Type.C_MyInt ([#"../branch_borrow_2.rs" 36 34 36 35] (5 : usize)));
-    b <- borrow_mut a;
+    b <- Borrow.borrow_mut a;
     a <-  ^ b;
-    c <- borrow_mut (let (_, a) =  * b in a);
+    c <- Borrow.borrow_mut (let (_, a) =  * b in a);
     b <- { b with current = (let (a, b) =  * b in (a,  ^ c)) };
-    d <- borrow_mut (let (a, _) =  * b in a);
+    d <- Borrow.borrow_mut (let (a, _) =  * b in a);
     b <- { b with current = (let (a, b) =  * b in ( ^ d, b)) };
     assume { Resolve0.resolve c };
     assume { Resolve0.resolve d };
@@ -275,9 +275,9 @@ module BranchBorrow2_H
   BB0 {
     a <- ([#"../branch_borrow_2.rs" 46 16 46 18] (10 : int32));
     b <- ([#"../branch_borrow_2.rs" 47 16 47 18] (10 : int32));
-    x <- borrow_mut a;
+    x <- Borrow.borrow_mut a;
     a <-  ^ x;
-    y <- borrow_mut b;
+    y <- Borrow.borrow_mut b;
     b <-  ^ y;
     switch ([#"../branch_borrow_2.rs" 52 7 52 11] true)
       | False -> goto BB2
@@ -295,7 +295,7 @@ module BranchBorrow2_H
   BB2 {
     assume { Resolve0.resolve x };
     y <- { y with current = ([#"../branch_borrow_2.rs" 56 13 56 14] (6 : int32)) };
-    _9 <- borrow_mut ( * y);
+    _9 <- Borrow.borrow_mut ( * y);
     y <- { y with current = ( ^ _9) };
     w <- _9;
     _9 <- any borrowed int32;

--- a/creusot/tests/should_succeed/lang/move_path.mlcfg
+++ b/creusot/tests/should_succeed/lang/move_path.mlcfg
@@ -42,7 +42,7 @@ module MovePath_F
   }
   BB0 {
     x <- ([#"../move_path.rs" 4 16 4 17] (1 : int32));
-    y <- borrow_mut x;
+    y <- Borrow.borrow_mut x;
     x <-  ^ y;
     d <- y;
     y <- any borrowed int32;

--- a/creusot/tests/should_succeed/lang/while_let.mlcfg
+++ b/creusot/tests/should_succeed/lang/while_let.mlcfg
@@ -47,7 +47,7 @@ module WhileLet_F
   }
   BB0 {
     a <- Core_Option_Option_Type.C_Some ([#"../while_let.rs" 5 21 5 23] (10 : int32));
-    b <- borrow_mut a;
+    b <- Borrow.borrow_mut a;
     a <-  ^ b;
     goto BB1
   }

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -209,9 +209,9 @@ module ListIndexMut_IndexMut
     absurd
   }
   BB8 {
-    n <- borrow_mut (ListIndexMut_Option_Type.some_0 (ListIndexMut_List_Type.list_1 ( * l)));
+    n <- Borrow.borrow_mut (ListIndexMut_Option_Type.some_0 (ListIndexMut_List_Type.list_1 ( * l)));
     l <- { l with current = (let ListIndexMut_List_Type.C_List a b =  * l in ListIndexMut_List_Type.C_List a (let ListIndexMut_Option_Type.C_Some a = ListIndexMut_List_Type.list_1 ( * l) in ListIndexMut_Option_Type.C_Some ( ^ n))) };
-    _25 <- borrow_mut ( * n);
+    _25 <- Borrow.borrow_mut ( * n);
     n <- { n with current = ( ^ _25) };
     assume { Resolve0.resolve l };
     l <- _25;
@@ -221,12 +221,12 @@ module ListIndexMut_IndexMut
     goto BB2
   }
   BB9 {
-    _30 <- borrow_mut (ListIndexMut_List_Type.list_0 ( * l));
+    _30 <- Borrow.borrow_mut (ListIndexMut_List_Type.list_0 ( * l));
     l <- { l with current = (let ListIndexMut_List_Type.C_List a b =  * l in ListIndexMut_List_Type.C_List ( ^ _30) b) };
-    _3 <- borrow_mut ( * _30);
+    _3 <- Borrow.borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _3) };
     assume { Resolve0.resolve l };
-    _0 <- borrow_mut ( * _3);
+    _0 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve1.resolve _30 };
     assume { Resolve1.resolve _3 };
@@ -283,7 +283,7 @@ module ListIndexMut_Write
     goto BB0
   }
   BB0 {
-    _10 <- borrow_mut ( * l);
+    _10 <- Borrow.borrow_mut ( * l);
     l <- { l with current = ( ^ _10) };
     _9 <- ([#"../list_index_mut.rs" 75 5 75 21] IndexMut0.index_mut _10 ix);
     _10 <- any borrowed (ListIndexMut_List_Type.t_list);
@@ -339,9 +339,9 @@ module ListIndexMut_F
     goto BB4
   }
   BB4 {
-    _8 <- borrow_mut l;
+    _8 <- Borrow.borrow_mut l;
     l <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     _6 <- ([#"../list_index_mut.rs" 80 4 80 23] Write0.write _7 ([#"../list_index_mut.rs" 80 18 80 19] (0 : usize)) ([#"../list_index_mut.rs" 80 21 80 22] (2 : uint32)));
     _7 <- any borrowed (ListIndexMut_List_Type.t_list);

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -883,18 +883,18 @@ module ListReversalLasso_Impl2_IndexMut
     goto BB0
   }
   BB0 {
-    _11 <- borrow_mut (ListReversalLasso_Memory_Type.memory_0 ( * self));
+    _11 <- Borrow.borrow_mut (ListReversalLasso_Memory_Type.memory_0 ( * self));
     self <- { self with current = (let ListReversalLasso_Memory_Type.C_Memory a =  * self in ListReversalLasso_Memory_Type.C_Memory ( ^ _11)) };
     _10 <- ([#"../list_reversal_lasso.rs" 42 13 42 22] IndexMut0.index_mut _11 i);
     _11 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _9 <- borrow_mut ( * _10);
+    _9 <- Borrow.borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _9) };
-    _3 <- borrow_mut ( * _9);
+    _3 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _3) };
-    _0 <- borrow_mut ( * _3);
+    _0 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve0.resolve _10 };
     assume { Resolve0.resolve _9 };
@@ -1031,7 +1031,7 @@ module ListReversalLasso_Impl4_ListReversalSafe
   }
   BB4 {
     l <- _16;
-    _21 <- borrow_mut ( * self);
+    _21 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _21) };
     _20 <- ([#"../list_reversal_lasso.rs" 74 12 74 21] IndexMut0.index_mut _21 tmp);
     _21 <- any borrowed (ListReversalLasso_Memory_Type.t_memory);
@@ -1267,20 +1267,20 @@ module ListReversalLasso_Impl4_ListReversalList
       end
   }
   BB4 {
-    _21 <- borrow_mut ( * self);
+    _21 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _21) };
     _20 <- ([#"../list_reversal_lasso.rs" 108 39 108 46] IndexMut0.index_mut _21 l);
     _21 <- any borrowed (ListReversalLasso_Memory_Type.t_memory);
     goto BB5
   }
   BB5 {
-    _19 <- borrow_mut ( * _20);
+    _19 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
-    _25 <- borrow_mut r;
+    _25 <- Borrow.borrow_mut r;
     r <-  ^ _25;
-    _24 <- borrow_mut ( * _25);
+    _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
     _23 <- ([#"../list_reversal_lasso.rs" 108 48 108 76] Replace0.replace _24 l);
     _24 <- any borrowed usize;
@@ -1509,20 +1509,20 @@ module ListReversalLasso_Impl4_ListReversalLoop
   }
   BB4 {
     assert { [@expl:assertion] [#"../list_reversal_lasso.rs" 138 12 138 77] Ghost.inner n = Seq.length (Ghost.inner s) -> l = Seq.get (Reverse.reverse (Ghost.inner s)) (Seq.length (Ghost.inner s) - 1) };
-    _25 <- borrow_mut ( * self);
+    _25 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _25) };
     _24 <- ([#"../list_reversal_lasso.rs" 139 39 139 46] IndexMut0.index_mut _25 l);
     _25 <- any borrowed (ListReversalLasso_Memory_Type.t_memory);
     goto BB5
   }
   BB5 {
-    _23 <- borrow_mut ( * _24);
+    _23 <- Borrow.borrow_mut ( * _24);
     _24 <- { _24 with current = ( ^ _23) };
-    _22 <- borrow_mut ( * _23);
+    _22 <- Borrow.borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _22) };
-    _29 <- borrow_mut r;
+    _29 <- Borrow.borrow_mut r;
     r <-  ^ _29;
-    _28 <- borrow_mut ( * _29);
+    _28 <- Borrow.borrow_mut ( * _29);
     _29 <- { _29 with current = ( ^ _28) };
     _27 <- ([#"../list_reversal_lasso.rs" 139 48 139 76] Replace0.replace _28 l);
     _28 <- any borrowed usize;
@@ -1734,20 +1734,20 @@ module ListReversalLasso_Impl4_ListReversalLasso
       end
   }
   BB4 {
-    _23 <- borrow_mut ( * self);
+    _23 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _23) };
     _22 <- ([#"../list_reversal_lasso.rs" 191 39 191 46] IndexMut0.index_mut _23 l);
     _23 <- any borrowed (ListReversalLasso_Memory_Type.t_memory);
     goto BB5
   }
   BB5 {
-    _21 <- borrow_mut ( * _22);
+    _21 <- Borrow.borrow_mut ( * _22);
     _22 <- { _22 with current = ( ^ _21) };
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
-    _27 <- borrow_mut r;
+    _27 <- Borrow.borrow_mut r;
     r <-  ^ _27;
-    _26 <- borrow_mut ( * _27);
+    _26 <- Borrow.borrow_mut ( * _27);
     _27 <- { _27 with current = ( ^ _26) };
     _25 <- ([#"../list_reversal_lasso.rs" 191 48 191 76] Replace0.replace _26 l);
     _26 <- any borrowed usize;

--- a/creusot/tests/should_succeed/loop.mlcfg
+++ b/creusot/tests/should_succeed/loop.mlcfg
@@ -40,7 +40,7 @@ module Loop_F
   }
   BB0 {
     a <- ([#"../loop.rs" 4 16 4 18] (10 : int32));
-    b <- borrow_mut a;
+    b <- Borrow.borrow_mut a;
     a <-  ^ b;
     b <- { b with current = ([#"../loop.rs" 6 9 6 10] (5 : int32)) };
     assume { Resolve0.resolve b };

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -305,9 +305,9 @@ module MappingTest_F
     x <- MappingTest_T_Type.C_T ([#"../mapping_test.rs" 39 23 39 25] (42 : int32));
     assert { [@expl:assertion] [#"../mapping_test.rs" 40 19 40 34] Map.get (ShallowModel0.shallow_model x) 13 = 1 };
     assert { [@expl:assertion] [#"../mapping_test.rs" 41 19 41 34] Map.get (ShallowModel0.shallow_model x) 42 = 0 };
-    _8 <- borrow_mut x;
+    _8 <- Borrow.borrow_mut x;
     x <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     _6 <- ([#"../mapping_test.rs" 42 4 42 16] Incr0.incr _7);
     _7 <- any borrowed (MappingTest_T_Type.t_t);

--- a/creusot/tests/should_succeed/mutex.mlcfg
+++ b/creusot/tests/should_succeed/mutex.mlcfg
@@ -371,7 +371,7 @@ module Mutex_Impl3_Call
       end
   }
   BB3 {
-    _10 <- borrow_mut v;
+    _10 <- Borrow.borrow_mut v;
     v <-  ^ _10;
     _9 <- ([#"../mutex.rs" 104 12 104 26] Set0.set _10 ([#"../mutex.rs" 104 18 104 25] val' + ([#"../mutex.rs" 104 24 104 25] (2 : uint32))));
     _10 <- any borrowed (Mutex_MutexGuard_Type.t_mutexguard uint32 (Mutex_Even_Type.t_even));
@@ -382,7 +382,7 @@ module Mutex_Impl3_Call
     goto BB7
   }
   BB5 {
-    _14 <- borrow_mut v;
+    _14 <- Borrow.borrow_mut v;
     v <-  ^ _14;
     _13 <- ([#"../mutex.rs" 106 12 106 20] Set0.set _14 ([#"../mutex.rs" 106 18 106 19] (0 : uint32)));
     _14 <- any borrowed (Mutex_MutexGuard_Type.t_mutexguard uint32 (Mutex_Even_Type.t_even));

--- a/creusot/tests/should_succeed/one_side_update.mlcfg
+++ b/creusot/tests/should_succeed/one_side_update.mlcfg
@@ -48,7 +48,7 @@ module OneSideUpdate_F
   }
   BB0 {
     a <- OneSideUpdate_MyInt_Type.C_MyInt ([#"../one_side_update.rs" 6 22 6 24] (10 : usize));
-    b <- borrow_mut a;
+    b <- Borrow.borrow_mut a;
     a <-  ^ b;
     switch ([#"../one_side_update.rs" 8 7 8 11] true)
       | False -> goto BB2

--- a/creusot/tests/should_succeed/option.mlcfg
+++ b/creusot/tests/should_succeed/option.mlcfg
@@ -705,7 +705,7 @@ module Option_TestOption
     absurd
   }
   BB23 {
-    _44 <- borrow_mut none;
+    _44 <- Borrow.borrow_mut none;
     none <-  ^ _44;
     _43 <- ([#"../option.rs" 23 12 23 25] AsMut0.as_mut _44);
     _44 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -725,7 +725,7 @@ module Option_TestOption
     absurd
   }
   BB27 {
-    _48 <- borrow_mut some;
+    _48 <- Borrow.borrow_mut some;
     some <-  ^ _48;
     _47 <- ([#"../option.rs" 24 5 24 18] AsMut0.as_mut _48);
     _48 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -752,7 +752,7 @@ module Option_TestOption
     absurd
   }
   BB32 {
-    _57 <- borrow_mut some;
+    _57 <- Borrow.borrow_mut some;
     some <-  ^ _57;
     _56 <- ([#"../option.rs" 26 5 26 18] AsMut0.as_mut _57);
     _57 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -954,7 +954,7 @@ module Option_TestOption
     absurd
   }
   BB77 {
-    _148 <- borrow_mut none;
+    _148 <- Borrow.borrow_mut none;
     none <-  ^ _148;
     _147 <- ([#"../option.rs" 44 12 44 23] Take0.take _148);
     _148 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -987,7 +987,7 @@ module Option_TestOption
     absurd
   }
   BB84 {
-    _160 <- borrow_mut some;
+    _160 <- Borrow.borrow_mut some;
     some <-  ^ _160;
     _159 <- ([#"../option.rs" 46 12 46 23] Take0.take _160);
     _160 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1022,7 +1022,7 @@ module Option_TestOption
   }
   BB91 {
     some <- Core_Option_Option_Type.C_Some ([#"../option.rs" 48 16 48 17] (1 : int32));
-    _173 <- borrow_mut none;
+    _173 <- Borrow.borrow_mut none;
     none <-  ^ _173;
     _172 <- ([#"../option.rs" 50 12 50 27] Replace0.replace _173 ([#"../option.rs" 50 25 50 26] (2 : int32)));
     _173 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1056,7 +1056,7 @@ module Option_TestOption
   }
   BB98 {
     none <- Core_Option_Option_Type.C_None;
-    _187 <- borrow_mut some;
+    _187 <- Borrow.borrow_mut some;
     some <-  ^ _187;
     _186 <- ([#"../option.rs" 53 12 53 27] Replace0.replace _187 ([#"../option.rs" 53 25 53 26] (2 : int32)));
     _187 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1090,7 +1090,7 @@ module Option_TestOption
     absurd
   }
   BB105 {
-    _200 <- borrow_mut some;
+    _200 <- Borrow.borrow_mut some;
     some <-  ^ _200;
     _199 <- ([#"../option.rs" 55 12 55 27] Replace0.replace _200 ([#"../option.rs" 55 25 55 26] (1 : int32)));
     _200 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1195,7 +1195,7 @@ module Option_TestOption
     absurd
   }
   BB128 {
-    _242 <- borrow_mut none;
+    _242 <- Borrow.borrow_mut none;
     none <-  ^ _242;
     _241 <- ([#"../option.rs" 65 12 65 25] AsMut0.as_mut _242);
     _242 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1220,7 +1220,7 @@ module Option_TestOption
     absurd
   }
   BB133 {
-    _250 <- borrow_mut some;
+    _250 <- Borrow.borrow_mut some;
     some <-  ^ _250;
     _249 <- ([#"../option.rs" 66 12 66 25] AsMut0.as_mut _250);
     _250 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1291,7 +1291,7 @@ module Option_TestOption
     absurd
   }
   BB148 {
-    _274 <- borrow_mut none;
+    _274 <- Borrow.borrow_mut none;
     none <-  ^ _274;
     _273 <- ([#"../option.rs" 70 12 70 25] AsMut0.as_mut _274);
     _274 <- any borrowed (Core_Option_Option_Type.t_option int32);
@@ -1316,7 +1316,7 @@ module Option_TestOption
     absurd
   }
   BB153 {
-    _282 <- borrow_mut some;
+    _282 <- Borrow.borrow_mut some;
     some <-  ^ _282;
     _281 <- ([#"../option.rs" 71 12 71 25] AsMut0.as_mut _282);
     _282 <- any borrowed (Core_Option_Option_Type.t_option int32);

--- a/creusot/tests/should_succeed/projection_toggle.mlcfg
+++ b/creusot/tests/should_succeed/projection_toggle.mlcfg
@@ -109,10 +109,10 @@ module ProjectionToggle_ProjToggle
   BB1 {
     assert { [@expl:type invariant] Inv0.inv b };
     assume { Resolve0.resolve b };
-    _8 <- borrow_mut ( * a);
+    _8 <- Borrow.borrow_mut ( * a);
     a <- { a with current = ( ^ _8) };
     assume { Inv1.inv ( ^ _8) };
-    _6 <- borrow_mut ( * _8);
+    _6 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _6) };
     assume { Inv1.inv ( ^ _6) };
     assert { [@expl:type invariant] Inv0.inv _8 };
@@ -122,16 +122,16 @@ module ProjectionToggle_ProjToggle
   BB2 {
     assert { [@expl:type invariant] Inv0.inv a };
     assume { Resolve0.resolve a };
-    _6 <- borrow_mut ( * b);
+    _6 <- Borrow.borrow_mut ( * b);
     b <- { b with current = ( ^ _6) };
     assume { Inv1.inv ( ^ _6) };
     goto BB3
   }
   BB3 {
-    _4 <- borrow_mut ( * _6);
+    _4 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _4) };
     assume { Inv1.inv ( ^ _4) };
-    _0 <- borrow_mut ( * _4);
+    _0 <- Borrow.borrow_mut ( * _4);
     _4 <- { _4 with current = ( ^ _0) };
     assume { Inv1.inv ( ^ _0) };
     assert { [@expl:type invariant] Inv0.inv _6 };
@@ -180,13 +180,13 @@ module ProjectionToggle_F
   BB0 {
     a <- ([#"../projection_toggle.rs" 14 16 14 18] (10 : int32));
     b <- ([#"../projection_toggle.rs" 15 16 15 17] (5 : int32));
-    _5 <- borrow_mut a;
+    _5 <- Borrow.borrow_mut a;
     a <-  ^ _5;
-    _4 <- borrow_mut ( * _5);
+    _4 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
-    _7 <- borrow_mut b;
+    _7 <- Borrow.borrow_mut b;
     b <-  ^ _7;
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     x <- ([#"../projection_toggle.rs" 17 12 17 45] ProjToggle0.proj_toggle ([#"../projection_toggle.rs" 17 24 17 28] true) _4 _6);
     _4 <- any borrowed int32;

--- a/creusot/tests/should_succeed/projections.mlcfg
+++ b/creusot/tests/should_succeed/projections.mlcfg
@@ -172,7 +172,7 @@ module Projections_WriteIntoSum
     absurd
   }
   BB4 {
-    y <- borrow_mut (Core_Option_Option_Type.some_0 ( * x));
+    y <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * x));
     x <- { x with current = (let Core_Option_Option_Type.C_Some a =  * x in Core_Option_Option_Type.C_Some ( ^ y)) };
     y <- { y with current = ([#"../projections.rs" 18 24 18 26] (10 : uint32)) };
     assume { Resolve0.resolve y };

--- a/creusot/tests/should_succeed/prophecy.mlcfg
+++ b/creusot/tests/should_succeed/prophecy.mlcfg
@@ -40,7 +40,7 @@ module Prophecy_F
   }
   BB0 {
     x <- ([#"../prophecy.rs" 4 16 4 17] (0 : int32));
-    y <- borrow_mut x;
+    y <- Borrow.borrow_mut x;
     x <-  ^ y;
     y <- { y with current = ([#"../prophecy.rs" 9 9 9 10] (5 : int32)) };
     assume { Resolve0.resolve y };

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -3395,10 +3395,10 @@ module RedBlackTree_Impl14_RotateRight
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _16 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
+    _16 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_left ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _16)) b c d e) };
     assume { Inv0.inv ( ^ _16) };
-    _15 <- borrow_mut ( * _16);
+    _15 <- Borrow.borrow_mut ( * _16);
     _16 <- { _16 with current = ( ^ _15) };
     assume { Inv0.inv ( ^ _15) };
     _14 <- ([#"../red_black_tree.rs" 421 20 421 55] Take0.take _15);
@@ -3413,16 +3413,16 @@ module RedBlackTree_Impl14_RotateRight
     goto BB3
   }
   BB3 {
-    _19 <- borrow_mut (RedBlackTree_Node_Type.node_left ( * self));
+    _19 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node ( ^ _19) b c d e) };
     assume { Inv2.inv ( ^ _19) };
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     assume { Inv2.inv ( ^ _18) };
-    _21 <- borrow_mut (RedBlackTree_Node_Type.node_right x);
+    _21 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a b c d ( ^ _21));
     assume { Inv2.inv ( ^ _21) };
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     assume { Inv2.inv ( ^ _20) };
     _17 <- ([#"../red_black_tree.rs" 428 8 428 52] Swap0.swap _18 _20);
@@ -3435,13 +3435,13 @@ module RedBlackTree_Impl14_RotateRight
     assume { Resolve2.resolve _21 };
     assert { [@expl:type invariant] Inv3.inv _19 };
     assume { Resolve2.resolve _19 };
-    _23 <- borrow_mut ( * self);
+    _23 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _23) };
     assume { Inv4.inv ( ^ _23) };
-    _25 <- borrow_mut x;
+    _25 <- Borrow.borrow_mut x;
     x <-  ^ _25;
     assume { Inv5.inv ( ^ _25) };
-    _24 <- borrow_mut ( * _25);
+    _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
     assume { Inv4.inv ( ^ _24) };
     _22 <- ([#"../red_black_tree.rs" 434 8 434 36] Swap1.swap _23 _24);
@@ -3452,13 +3452,13 @@ module RedBlackTree_Impl14_RotateRight
   BB5 {
     assert { [@expl:type invariant] Inv6.inv _25 };
     assume { Resolve3.resolve _25 };
-    _28 <- borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
+    _28 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _28) c d e) };
-    _27 <- borrow_mut ( * _28);
+    _27 <- Borrow.borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _27) };
-    _30 <- borrow_mut (RedBlackTree_Node_Type.node_color x);
+    _30 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a ( ^ _30) c d e);
-    _29 <- borrow_mut ( * _30);
+    _29 <- Borrow.borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
     _26 <- ([#"../red_black_tree.rs" 435 8 435 53] Swap2.swap _27 _29);
     _27 <- any borrowed (RedBlackTree_Color_Type.t_color);
@@ -3851,10 +3851,10 @@ module RedBlackTree_Impl14_RotateLeft
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _16 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
+    _16 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _16))) };
     assume { Inv0.inv ( ^ _16) };
-    _15 <- borrow_mut ( * _16);
+    _15 <- Borrow.borrow_mut ( * _16);
     _16 <- { _16 with current = ( ^ _15) };
     assume { Inv0.inv ( ^ _15) };
     _14 <- ([#"../red_black_tree.rs" 464 20 464 56] Take0.take _15);
@@ -3869,16 +3869,16 @@ module RedBlackTree_Impl14_RotateLeft
     goto BB3
   }
   BB3 {
-    _19 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * self));
+    _19 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d ( ^ _19)) };
     assume { Inv2.inv ( ^ _19) };
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     assume { Inv2.inv ( ^ _18) };
-    _21 <- borrow_mut (RedBlackTree_Node_Type.node_left x);
+    _21 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node ( ^ _21) b c d e);
     assume { Inv2.inv ( ^ _21) };
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     assume { Inv2.inv ( ^ _20) };
     _17 <- ([#"../red_black_tree.rs" 465 8 465 52] Swap0.swap _18 _20);
@@ -3891,13 +3891,13 @@ module RedBlackTree_Impl14_RotateLeft
     assume { Resolve2.resolve _21 };
     assert { [@expl:type invariant] Inv3.inv _19 };
     assume { Resolve2.resolve _19 };
-    _23 <- borrow_mut ( * self);
+    _23 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _23) };
     assume { Inv4.inv ( ^ _23) };
-    _25 <- borrow_mut x;
+    _25 <- Borrow.borrow_mut x;
     x <-  ^ _25;
     assume { Inv5.inv ( ^ _25) };
-    _24 <- borrow_mut ( * _25);
+    _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
     assume { Inv4.inv ( ^ _24) };
     _22 <- ([#"../red_black_tree.rs" 466 8 466 36] Swap1.swap _23 _24);
@@ -3908,13 +3908,13 @@ module RedBlackTree_Impl14_RotateLeft
   BB5 {
     assert { [@expl:type invariant] Inv6.inv _25 };
     assume { Resolve3.resolve _25 };
-    _28 <- borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
+    _28 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _28) c d e) };
-    _27 <- borrow_mut ( * _28);
+    _27 <- Borrow.borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _27) };
-    _30 <- borrow_mut (RedBlackTree_Node_Type.node_color x);
+    _30 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a ( ^ _30) c d e);
-    _29 <- borrow_mut ( * _30);
+    _29 <- Borrow.borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
     _26 <- ([#"../red_black_tree.rs" 467 8 467 53] Swap2.swap _27 _29);
     _27 <- any borrowed (RedBlackTree_Color_Type.t_color);
@@ -4288,7 +4288,7 @@ module RedBlackTree_Impl14_FlipColors
     goto BB0
   }
   BB0 {
-    _15 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
+    _15 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_left ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _15)) b c d e) };
     assume { Inv0.inv ( ^ _15) };
     _14 <- ([#"../red_black_tree.rs" 487 8 487 31] AsMut0.as_mut _15);
@@ -4304,11 +4304,11 @@ module RedBlackTree_Impl14_FlipColors
     _13 <- { _13 with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * _13 in RedBlackTree_Node_Type.C_Node a (RedBlackTree_Node_Type.node_color ( * self)) c d e) };
     assert { [@expl:type invariant] Inv1.inv _13 };
     assume { Resolve0.resolve _13 };
-    _18 <- borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
+    _18 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _18) c d e) };
-    _17 <- borrow_mut ( * _18);
+    _17 <- Borrow.borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ _17) };
-    _23 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
+    _23 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _23))) };
     assume { Inv0.inv ( ^ _23) };
     _22 <- ([#"../red_black_tree.rs" 488 45 488 69] AsMut0.as_mut _23);
@@ -4321,9 +4321,9 @@ module RedBlackTree_Impl14_FlipColors
     goto BB4
   }
   BB4 {
-    _20 <- borrow_mut (RedBlackTree_Node_Type.node_color ( * _21));
+    _20 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * _21));
     _21 <- { _21 with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * _21 in RedBlackTree_Node_Type.C_Node a ( ^ _20) c d e) };
-    _19 <- borrow_mut ( * _20);
+    _19 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
     _16 <- ([#"../red_black_tree.rs" 488 8 488 85] Swap0.swap _17 _19);
     _17 <- any borrowed (RedBlackTree_Color_Type.t_color);
@@ -4790,7 +4790,7 @@ module RedBlackTree_Impl14_Balance
     goto BB3
   }
   BB6 {
-    _22 <- borrow_mut ( * self);
+    _22 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _22) };
     assume { Inv0.inv ( ^ _22) };
     _21 <- ([#"../red_black_tree.rs" 512 12 512 30] RotateLeft0.rotate_left _22);
@@ -4846,7 +4846,7 @@ module RedBlackTree_Impl14_Balance
     goto BB12
   }
   BB17 {
-    _33 <- borrow_mut ( * self);
+    _33 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _33) };
     assume { Inv0.inv ( ^ _33) };
     _32 <- ([#"../red_black_tree.rs" 516 12 516 31] RotateRight0.rotate_right _33);
@@ -4891,7 +4891,7 @@ module RedBlackTree_Impl14_Balance
     goto BB23
   }
   BB26 {
-    _40 <- borrow_mut ( * self);
+    _40 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _40) };
     assume { Inv0.inv ( ^ _40) };
     _39 <- ([#"../red_black_tree.rs" 520 12 520 30] FlipColors0.flip_colors _40);
@@ -5346,7 +5346,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB0
   }
   BB0 {
-    _16 <- borrow_mut ( * self);
+    _16 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _16) };
     assume { Inv0.inv ( ^ _16) };
     _15 <- ([#"../red_black_tree.rs" 543 8 543 26] FlipColors0.flip_colors _16);
@@ -5354,7 +5354,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB1
   }
   BB1 {
-    _22 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
+    _22 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _22))) };
     assume { Inv1.inv ( ^ _22) };
     _21 <- ([#"../red_black_tree.rs" 544 11 544 35] AsMut0.as_mut _22);
@@ -5379,7 +5379,7 @@ module RedBlackTree_Impl14_MoveRedLeft
       end
   }
   BB5 {
-    _28 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
+    _28 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _28))) };
     assume { Inv1.inv ( ^ _28) };
     _27 <- ([#"../red_black_tree.rs" 545 12 545 36] AsMut0.as_mut _28);
@@ -5392,7 +5392,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB7
   }
   BB7 {
-    _25 <- borrow_mut ( * _26);
+    _25 <- Borrow.borrow_mut ( * _26);
     _26 <- { _26 with current = ( ^ _25) };
     assume { Inv0.inv ( ^ _25) };
     _24 <- ([#"../red_black_tree.rs" 545 12 545 60] RotateRight0.rotate_right _25);
@@ -5402,7 +5402,7 @@ module RedBlackTree_Impl14_MoveRedLeft
   BB8 {
     assert { [@expl:type invariant] Inv2.inv _26 };
     assume { Resolve0.resolve _26 };
-    _30 <- borrow_mut ( * self);
+    _30 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _30) };
     assume { Inv0.inv ( ^ _30) };
     _29 <- ([#"../red_black_tree.rs" 546 12 546 30] RotateLeft0.rotate_left _30);
@@ -5410,7 +5410,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB9
   }
   BB9 {
-    _32 <- borrow_mut ( * self);
+    _32 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _32) };
     assume { Inv0.inv ( ^ _32) };
     _31 <- ([#"../red_black_tree.rs" 547 12 547 30] FlipColors0.flip_colors _32);
@@ -5418,7 +5418,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB10
   }
   BB10 {
-    _35 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
+    _35 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_left ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _35)) b c d e) };
     assume { Inv1.inv ( ^ _35) };
     _34 <- ([#"../red_black_tree.rs" 548 19 548 42] AsMut0.as_mut _35);
@@ -5431,7 +5431,7 @@ module RedBlackTree_Impl14_MoveRedLeft
     goto BB12
   }
   BB12 {
-    _0 <- borrow_mut ( * _33);
+    _0 <- Borrow.borrow_mut ( * _33);
     _33 <- { _33 with current = ( ^ _0) };
     assume { Inv0.inv ( ^ _0) };
     assert { [@expl:type invariant] Inv2.inv _33 };
@@ -5864,7 +5864,7 @@ module RedBlackTree_Impl14_MoveRedRight
     goto BB0
   }
   BB0 {
-    _16 <- borrow_mut ( * self);
+    _16 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _16) };
     assume { Inv0.inv ( ^ _16) };
     _15 <- ([#"../red_black_tree.rs" 572 8 572 26] FlipColors0.flip_colors _16);
@@ -5872,7 +5872,7 @@ module RedBlackTree_Impl14_MoveRedRight
     goto BB1
   }
   BB1 {
-    _22 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
+    _22 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_left ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _22)) b c d e) };
     assume { Inv1.inv ( ^ _22) };
     _21 <- ([#"../red_black_tree.rs" 573 11 573 34] AsMut0.as_mut _22);
@@ -5897,7 +5897,7 @@ module RedBlackTree_Impl14_MoveRedRight
       end
   }
   BB5 {
-    _25 <- borrow_mut ( * self);
+    _25 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _25) };
     assume { Inv0.inv ( ^ _25) };
     _24 <- ([#"../red_black_tree.rs" 574 12 574 31] RotateRight0.rotate_right _25);
@@ -5905,7 +5905,7 @@ module RedBlackTree_Impl14_MoveRedRight
     goto BB6
   }
   BB6 {
-    _27 <- borrow_mut ( * self);
+    _27 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _27) };
     assume { Inv0.inv ( ^ _27) };
     _26 <- ([#"../red_black_tree.rs" 575 12 575 30] FlipColors0.flip_colors _27);
@@ -5913,7 +5913,7 @@ module RedBlackTree_Impl14_MoveRedRight
     goto BB7
   }
   BB7 {
-    _30 <- borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
+    _30 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _30))) };
     assume { Inv1.inv ( ^ _30) };
     _29 <- ([#"../red_black_tree.rs" 576 19 576 43] AsMut0.as_mut _30);
@@ -5926,7 +5926,7 @@ module RedBlackTree_Impl14_MoveRedRight
     goto BB9
   }
   BB9 {
-    _0 <- borrow_mut ( * _28);
+    _0 <- Borrow.borrow_mut ( * _28);
     _28 <- { _28 with current = ( ^ _0) };
     assume { Inv0.inv ( ^ _0) };
     assert { [@expl:type invariant] Inv2.inv _28 };
@@ -6548,7 +6548,7 @@ module RedBlackTree_Impl15_InsertRec
     goto BB2
   }
   BB2 {
-    _11 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _11 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _11)) };
     assume { Inv0.inv ( ^ _11) };
     switch ( * _11)
@@ -6560,7 +6560,7 @@ module RedBlackTree_Impl15_InsertRec
     goto BB4
   }
   BB4 {
-    node <- borrow_mut (Core_Option_Option_Type.some_0 ( * _11));
+    node <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _11));
     _11 <- { _11 with current = (let Core_Option_Option_Type.C_Some a =  * _11 in Core_Option_Option_Type.C_Some ( ^ node)) };
     assume { Inv1.inv ( ^ node) };
     _18 <- RedBlackTree_Node_Type.node_key ( * node);
@@ -6583,7 +6583,7 @@ module RedBlackTree_Impl15_InsertRec
     goto BB12
   }
   BB8 {
-    _25 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _25 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _25)) };
     assume { Inv3.inv ( ^ _25) };
     _14 <- ([#"../red_black_tree.rs" 608 27 608 58] insert_rec _25 key val');
@@ -6606,7 +6606,7 @@ module RedBlackTree_Impl15_InsertRec
     absurd
   }
   BB10 {
-    _20 <- borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
+    _20 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _20) b c d e) };
     assume { Inv3.inv ( ^ _20) };
     _14 <- ([#"../red_black_tree.rs" 603 24 603 54] insert_rec _20 key val');
@@ -6644,7 +6644,7 @@ module RedBlackTree_Impl15_InsertRec
     goto BB17
   }
   BB17 {
-    _29 <- borrow_mut ( * node);
+    _29 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _29) };
     assume { Inv9.inv ( ^ _29) };
     _28 <- ([#"../red_black_tree.rs" 610 12 610 26] Balance0.balance _29);
@@ -7125,7 +7125,7 @@ module RedBlackTree_Impl15_Insert
     goto BB1
   }
   BB1 {
-    _8 <- borrow_mut ( * self);
+    _8 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _8) };
     assume { Inv0.inv ( ^ _8) };
     _7 <- ([#"../red_black_tree.rs" 627 8 627 33] InsertRec0.insert_rec _8 key val');
@@ -7135,7 +7135,7 @@ module RedBlackTree_Impl15_Insert
     goto BB2
   }
   BB2 {
-    _14 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _14 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _14)) };
     assume { Inv1.inv ( ^ _14) };
     _13 <- ([#"../red_black_tree.rs" 628 8 628 26] AsMut0.as_mut _14);
@@ -7671,7 +7671,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB0
   }
   BB0 {
-    _15 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _15 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _15)) };
     assume { Inv0.inv ( ^ _15) };
     _14 <- ([#"../red_black_tree.rs" 644 23 644 41] AsMut0.as_mut _15);
@@ -7684,7 +7684,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB2
   }
   BB2 {
-    _12 <- borrow_mut ( * _13);
+    _12 <- Borrow.borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _12) };
     assume { Inv1.inv ( ^ _12) };
     node <- ([#"../red_black_tree.rs" 644 23 644 59] AsMut1.as_mut _12);
@@ -7704,7 +7704,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
       end
   }
   BB5 {
-    _19 <- borrow_mut ( * node);
+    _19 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _19) };
     assume { Inv3.inv ( ^ _19) };
     _16 <- ([#"../red_black_tree.rs" 646 12 646 31] RotateRight0.rotate_right _19);
@@ -7730,10 +7730,10 @@ module RedBlackTree_Impl15_DeleteMaxRec
   BB10 {
     assert { [@expl:type invariant] Inv4.inv node };
     assume { Resolve1.resolve node };
-    _26 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _26 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _26)) };
     assume { Inv0.inv ( ^ _26) };
-    _25 <- borrow_mut ( * _26);
+    _25 <- Borrow.borrow_mut ( * _26);
     _26 <- { _26 with current = ( ^ _25) };
     assume { Inv0.inv ( ^ _25) };
     _24 <- ([#"../red_black_tree.rs" 649 23 649 53] Take0.take _25);
@@ -7804,7 +7804,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB18
   }
   BB23 {
-    _42 <- borrow_mut ( * node);
+    _42 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _42) };
     assume { Inv3.inv ( ^ _42) };
     _41 <- ([#"../red_black_tree.rs" 653 19 653 40] MoveRedRight0.move_red_right _42);
@@ -7812,7 +7812,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB24
   }
   BB24 {
-    _40 <- borrow_mut ( * _41);
+    _40 <- Borrow.borrow_mut ( * _41);
     _41 <- { _41 with current = ( ^ _40) };
     assume { Inv3.inv ( ^ _40) };
     assert { [@expl:type invariant] Inv4.inv node };
@@ -7829,7 +7829,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB26
   }
   BB26 {
-    _44 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _44 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _44)) };
     assume { Inv8.inv ( ^ _44) };
     r <- ([#"../red_black_tree.rs" 655 16 655 43] delete_max_rec _44);
@@ -7837,7 +7837,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB27
   }
   BB27 {
-    _46 <- borrow_mut ( * node);
+    _46 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _46) };
     assume { Inv3.inv ( ^ _46) };
     _45 <- ([#"../red_black_tree.rs" 656 8 656 22] Balance0.balance _46);
@@ -8256,7 +8256,7 @@ module RedBlackTree_Impl15_DeleteMax
   }
   BB1 {
     assume { Resolve0.resolve old_self };
-    _8 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _8 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _8)) };
     assume { Inv0.inv ( ^ _8) };
     switch ( * _8)
@@ -8268,7 +8268,7 @@ module RedBlackTree_Impl15_DeleteMax
     goto BB3
   }
   BB3 {
-    node <- borrow_mut (Core_Option_Option_Type.some_0 ( * _8));
+    node <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _8));
     _8 <- { _8 with current = (let Core_Option_Option_Type.C_Some a =  * _8 in Core_Option_Option_Type.C_Some ( ^ node)) };
     assume { Inv1.inv ( ^ node) };
     _12 <- ([#"../red_black_tree.rs" 670 16 670 34] IsRed0.is_red (RedBlackTree_Node_Type.node_left ( * node)));
@@ -8299,7 +8299,7 @@ module RedBlackTree_Impl15_DeleteMax
   }
   BB7 {
     assert { [@expl:assertion] [#"../red_black_tree.rs" 676 24 676 53] SameMappings0.same_mappings ( * Ghost.inner old_self) ( * self) };
-    _19 <- borrow_mut ( * self);
+    _19 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _19) };
     assume { Inv4.inv ( ^ _19) };
     r <- ([#"../red_black_tree.rs" 677 16 677 37] DeleteMaxRec0.delete_max_rec _19);
@@ -8325,7 +8325,7 @@ module RedBlackTree_Impl15_DeleteMax
       end
   }
   BB11 {
-    _26 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _26 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _26)) };
     assume { Inv0.inv ( ^ _26) };
     _25 <- ([#"../red_black_tree.rs" 679 12 679 30] AsMut0.as_mut _26);
@@ -8842,7 +8842,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB0
   }
   BB0 {
-    _15 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _15 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _15)) };
     assume { Inv0.inv ( ^ _15) };
     _14 <- ([#"../red_black_tree.rs" 697 23 697 41] AsMut0.as_mut _15);
@@ -8855,7 +8855,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB2
   }
   BB2 {
-    _12 <- borrow_mut ( * _13);
+    _12 <- Borrow.borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _12) };
     assume { Inv1.inv ( ^ _12) };
     node <- ([#"../red_black_tree.rs" 697 23 697 59] AsMut1.as_mut _12);
@@ -8876,10 +8876,10 @@ module RedBlackTree_Impl15_DeleteMinRec
   BB5 {
     assert { [@expl:type invariant] Inv3.inv node };
     assume { Resolve1.resolve node };
-    _22 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _22 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _22)) };
     assume { Inv0.inv ( ^ _22) };
-    _21 <- borrow_mut ( * _22);
+    _21 <- Borrow.borrow_mut ( * _22);
     _22 <- { _22 with current = ( ^ _21) };
     assume { Inv0.inv ( ^ _21) };
     _20 <- ([#"../red_black_tree.rs" 699 23 699 53] Take0.take _21);
@@ -8950,7 +8950,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB13
   }
   BB18 {
-    _38 <- borrow_mut ( * node);
+    _38 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _38) };
     assume { Inv7.inv ( ^ _38) };
     _37 <- ([#"../red_black_tree.rs" 703 19 703 39] MoveRedLeft0.move_red_left _38);
@@ -8958,7 +8958,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB19
   }
   BB19 {
-    _36 <- borrow_mut ( * _37);
+    _36 <- Borrow.borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     assume { Inv7.inv ( ^ _36) };
     assert { [@expl:type invariant] Inv3.inv node };
@@ -8975,7 +8975,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB21
   }
   BB21 {
-    _40 <- borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
+    _40 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _40) b c d e) };
     assume { Inv8.inv ( ^ _40) };
     r <- ([#"../red_black_tree.rs" 705 16 705 42] delete_min_rec _40);
@@ -8983,7 +8983,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB22
   }
   BB22 {
-    _42 <- borrow_mut ( * node);
+    _42 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _42) };
     assume { Inv7.inv ( ^ _42) };
     _41 <- ([#"../red_black_tree.rs" 706 8 706 22] Balance0.balance _42);
@@ -9392,7 +9392,7 @@ module RedBlackTree_Impl15_DeleteMin
   }
   BB1 {
     assume { Resolve0.resolve _5 };
-    _8 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _8 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _8)) };
     assume { Inv0.inv ( ^ _8) };
     switch ( * _8)
@@ -9404,7 +9404,7 @@ module RedBlackTree_Impl15_DeleteMin
     goto BB3
   }
   BB3 {
-    node <- borrow_mut (Core_Option_Option_Type.some_0 ( * _8));
+    node <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _8));
     _8 <- { _8 with current = (let Core_Option_Option_Type.C_Some a =  * _8 in Core_Option_Option_Type.C_Some ( ^ node)) };
     assume { Inv1.inv ( ^ node) };
     _12 <- ([#"../red_black_tree.rs" 723 16 723 34] IsRed0.is_red (RedBlackTree_Node_Type.node_left ( * node)));
@@ -9434,7 +9434,7 @@ module RedBlackTree_Impl15_DeleteMin
     goto BB7
   }
   BB7 {
-    _17 <- borrow_mut ( * self);
+    _17 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _17) };
     assume { Inv4.inv ( ^ _17) };
     r <- ([#"../red_black_tree.rs" 729 16 729 37] DeleteMinRec0.delete_min_rec _17);
@@ -9460,7 +9460,7 @@ module RedBlackTree_Impl15_DeleteMin
       end
   }
   BB11 {
-    _24 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _24 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _24)) };
     assume { Inv0.inv ( ^ _24) };
     _23 <- ([#"../red_black_tree.rs" 731 12 731 30] AsMut0.as_mut _24);
@@ -10232,7 +10232,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB0
   }
   BB0 {
-    _16 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _16 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _16)) };
     assume { Inv0.inv ( ^ _16) };
     _15 <- ([#"../red_black_tree.rs" 750 23 750 41] AsMut0.as_mut _16);
@@ -10245,7 +10245,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB2
   }
   BB2 {
-    _13 <- borrow_mut ( * _14);
+    _13 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
     assume { Inv1.inv ( ^ _13) };
     node <- ([#"../red_black_tree.rs" 750 23 750 59] AsMut1.as_mut _13);
@@ -10336,7 +10336,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB13
   }
   BB18 {
-    _40 <- borrow_mut ( * node);
+    _40 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _40) };
     assume { Inv5.inv ( ^ _40) };
     _39 <- ([#"../red_black_tree.rs" 757 27 757 47] MoveRedLeft0.move_red_left _40);
@@ -10344,7 +10344,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB19
   }
   BB19 {
-    _38 <- borrow_mut ( * _39);
+    _38 <- Borrow.borrow_mut ( * _39);
     _39 <- { _39 with current = ( ^ _38) };
     assume { Inv5.inv ( ^ _38) };
     assert { [@expl:type invariant] Inv6.inv node };
@@ -10361,7 +10361,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB21
   }
   BB21 {
-    _42 <- borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
+    _42 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _42) b c d e) };
     assume { Inv7.inv ( ^ _42) };
     assert { [@expl:type invariant] Inv3.inv key };
@@ -10389,7 +10389,7 @@ module RedBlackTree_Impl15_DeleteRec
       end
   }
   BB27 {
-    _48 <- borrow_mut ( * node);
+    _48 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _48) };
     assume { Inv5.inv ( ^ _48) };
     _47 <- ([#"../red_black_tree.rs" 763 20 763 39] RotateRight0.rotate_right _48);
@@ -10397,7 +10397,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB28
   }
   BB28 {
-    _50 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _50 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _50)) };
     assume { Inv7.inv ( ^ _50) };
     assert { [@expl:type invariant] Inv3.inv key };
@@ -10448,10 +10448,10 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB73
   }
   BB38 {
-    _62 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _62 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _62)) };
     assume { Inv0.inv ( ^ _62) };
-    _61 <- borrow_mut ( * _62);
+    _61 <- Borrow.borrow_mut ( * _62);
     _62 <- { _62 with current = ( ^ _61) };
     assume { Inv0.inv ( ^ _61) };
     _60 <- ([#"../red_black_tree.rs" 770 35 770 65] Take0.take _61);
@@ -10506,7 +10506,7 @@ module RedBlackTree_Impl15_DeleteRec
       end
   }
   BB48 {
-    _75 <- borrow_mut ( * node);
+    _75 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _75) };
     assume { Inv5.inv ( ^ _75) };
     _74 <- ([#"../red_black_tree.rs" 774 31 774 52] MoveRedRight0.move_red_right _75);
@@ -10514,7 +10514,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB49
   }
   BB49 {
-    _73 <- borrow_mut ( * _74);
+    _73 <- Borrow.borrow_mut ( * _74);
     _74 <- { _74 with current = ( ^ _73) };
     assume { Inv5.inv ( ^ _73) };
     assert { [@expl:type invariant] Inv6.inv node };
@@ -10542,7 +10542,7 @@ module RedBlackTree_Impl15_DeleteRec
   BB53 {
     assert { [@expl:type invariant] Inv3.inv key };
     assume { Resolve1.resolve key };
-    _78 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _78 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _78)) };
     assume { Inv7.inv ( ^ _78) };
     kv <- ([#"../red_black_tree.rs" 777 37 777 64] DeleteMinRec0.delete_min_rec _78);
@@ -10555,16 +10555,16 @@ module RedBlackTree_Impl15_DeleteRec
   }
   BB55 {
     assume { Resolve5.resolve _79 };
-    _83 <- borrow_mut (RedBlackTree_Node_Type.node_key ( * node));
+    _83 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_key ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b ( ^ _83) d e) };
     assume { Inv9.inv ( ^ _83) };
-    _82 <- borrow_mut ( * _83);
+    _82 <- Borrow.borrow_mut ( * _83);
     _83 <- { _83 with current = ( ^ _82) };
     assume { Inv9.inv ( ^ _82) };
-    _85 <- borrow_mut (let (a, _) = kv in a);
+    _85 <- Borrow.borrow_mut (let (a, _) = kv in a);
     kv <- (let (a, b) = kv in ( ^ _85, b));
     assume { Inv9.inv ( ^ _85) };
-    _84 <- borrow_mut ( * _85);
+    _84 <- Borrow.borrow_mut ( * _85);
     _85 <- { _85 with current = ( ^ _84) };
     assume { Inv9.inv ( ^ _84) };
     _81 <- ([#"../red_black_tree.rs" 779 24 779 64] Swap0.swap _82 _84);
@@ -10577,16 +10577,16 @@ module RedBlackTree_Impl15_DeleteRec
     assume { Resolve6.resolve _85 };
     assert { [@expl:type invariant] Inv10.inv _83 };
     assume { Resolve6.resolve _83 };
-    _88 <- borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
+    _88 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c ( ^ _88) e) };
     assume { Inv11.inv ( ^ _88) };
-    _87 <- borrow_mut ( * _88);
+    _87 <- Borrow.borrow_mut ( * _88);
     _88 <- { _88 with current = ( ^ _87) };
     assume { Inv11.inv ( ^ _87) };
-    _90 <- borrow_mut (let (_, a) = kv in a);
+    _90 <- Borrow.borrow_mut (let (_, a) = kv in a);
     kv <- (let (a, b) = kv in (a,  ^ _90));
     assume { Inv11.inv ( ^ _90) };
-    _89 <- borrow_mut ( * _90);
+    _89 <- Borrow.borrow_mut ( * _90);
     _90 <- { _90 with current = ( ^ _89) };
     assume { Inv11.inv ( ^ _89) };
     _86 <- ([#"../red_black_tree.rs" 780 24 780 64] Swap1.swap _87 _89);
@@ -10617,7 +10617,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB68
   }
   BB63 {
-    _94 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _94 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _94)) };
     assume { Inv7.inv ( ^ _94) };
     assert { [@expl:type invariant] Inv3.inv key };
@@ -10642,7 +10642,7 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB69
   }
   BB69 {
-    _97 <- borrow_mut ( * node);
+    _97 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _97) };
     assume { Inv5.inv ( ^ _97) };
     _96 <- ([#"../red_black_tree.rs" 788 8 788 22] Balance0.balance _97);
@@ -11071,7 +11071,7 @@ module RedBlackTree_Impl15_Delete
   }
   BB1 {
     assume { Resolve0.resolve _7 };
-    _10 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _10 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _10)) };
     assume { Inv0.inv ( ^ _10) };
     switch ( * _10)
@@ -11083,7 +11083,7 @@ module RedBlackTree_Impl15_Delete
     goto BB3
   }
   BB3 {
-    node <- borrow_mut (Core_Option_Option_Type.some_0 ( * _10));
+    node <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _10));
     _10 <- { _10 with current = (let Core_Option_Option_Type.C_Some a =  * _10 in Core_Option_Option_Type.C_Some ( ^ node)) };
     assume { Inv1.inv ( ^ node) };
     _14 <- ([#"../red_black_tree.rs" 804 16 804 34] IsRed0.is_red (RedBlackTree_Node_Type.node_left ( * node)));
@@ -11113,7 +11113,7 @@ module RedBlackTree_Impl15_Delete
     goto BB7
   }
   BB7 {
-    _19 <- borrow_mut ( * self);
+    _19 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _19) };
     assume { Inv4.inv ( ^ _19) };
     assert { [@expl:type invariant] Inv5.inv key };
@@ -11143,7 +11143,7 @@ module RedBlackTree_Impl15_Delete
       end
   }
   BB11 {
-    _27 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
+    _27 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _27)) };
     assume { Inv0.inv ( ^ _27) };
     _26 <- ([#"../red_black_tree.rs" 812 12 812 30] AsMut0.as_mut _27);
@@ -12023,7 +12023,7 @@ module RedBlackTree_Impl15_GetMut
     goto BB4
   }
   BB4 {
-    _23 <- borrow_mut (RedBlackTree_Tree_Type.tree_node ( * tree));
+    _23 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * tree));
     tree <- { tree with current = (let RedBlackTree_Tree_Type.C_Tree a =  * tree in RedBlackTree_Tree_Type.C_Tree ( ^ _23)) };
     assume { Inv2.inv ( ^ _23) };
     switch ( * _23)
@@ -12035,7 +12035,7 @@ module RedBlackTree_Impl15_GetMut
     goto BB6
   }
   BB6 {
-    node <- borrow_mut (Core_Option_Option_Type.some_0 ( * _23));
+    node <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _23));
     _23 <- { _23 with current = (let Core_Option_Option_Type.C_Some a =  * _23 in Core_Option_Option_Type.C_Some ( ^ node)) };
     assume { Inv3.inv ( ^ node) };
     _29 <- RedBlackTree_Node_Type.node_key ( * node);
@@ -12058,10 +12058,10 @@ module RedBlackTree_Impl15_GetMut
     goto BB13
   }
   BB10 {
-    _37 <- borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
+    _37 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _37)) };
     assume { Inv5.inv ( ^ _37) };
-    _36 <- borrow_mut ( * _37);
+    _36 <- Borrow.borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     assume { Inv5.inv ( ^ _36) };
     assert { [@expl:type invariant] Inv6.inv tree };
@@ -12085,10 +12085,10 @@ module RedBlackTree_Impl15_GetMut
     absurd
   }
   BB12 {
-    _32 <- borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
+    _32 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _32) b c d e) };
     assume { Inv5.inv ( ^ _32) };
-    _31 <- borrow_mut ( * _32);
+    _31 <- Borrow.borrow_mut ( * _32);
     _32 <- { _32 with current = ( ^ _31) };
     assume { Inv5.inv ( ^ _31) };
     assert { [@expl:type invariant] Inv6.inv tree };
@@ -12103,10 +12103,10 @@ module RedBlackTree_Impl15_GetMut
   BB13 {
     assert { [@expl:type invariant] Inv4.inv key };
     assume { Resolve2.resolve key };
-    _35 <- borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
+    _35 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c ( ^ _35) e) };
     assume { Inv0.inv ( ^ _35) };
-    _34 <- borrow_mut ( * _35);
+    _34 <- Borrow.borrow_mut ( * _35);
     _35 <- { _35 with current = ( ^ _34) };
     assume { Inv0.inv ( ^ _34) };
     _0 <- Core_Option_Option_Type.C_Some _34;

--- a/creusot/tests/should_succeed/resolve_uninit.mlcfg
+++ b/creusot/tests/should_succeed/resolve_uninit.mlcfg
@@ -217,16 +217,16 @@ module ResolveUninit_InitJoin
       end
   }
   BB1 {
-    _8 <- borrow_mut x;
+    _8 <- Borrow.borrow_mut x;
     x <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     z <- _7;
     _7 <- any borrowed int32;
     assume { Resolve0.resolve _8 };
-    _10 <- borrow_mut ( * z);
+    _10 <- Borrow.borrow_mut ( * z);
     z <- { z with current = ( ^ _10) };
-    _9 <- borrow_mut ( * _10);
+    _9 <- Borrow.borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _9) };
     y <- _9;
     _9 <- any borrowed int32;
@@ -235,9 +235,9 @@ module ResolveUninit_InitJoin
     goto BB7
   }
   BB2 {
-    _12 <- borrow_mut x;
+    _12 <- Borrow.borrow_mut x;
     x <-  ^ _12;
-    _11 <- borrow_mut ( * _12);
+    _11 <- Borrow.borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _11) };
     y <- _11;
     _11 <- any borrowed int32;

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -711,10 +711,10 @@ module Own_Impl0_AsMut
     goto BB4
   }
   BB2 {
-    x1 <- borrow_mut (Own_OwnResult_Type.err_0 ( * self));
+    x1 <- Borrow.borrow_mut (Own_OwnResult_Type.err_0 ( * self));
     self <- { self with current = (let Own_OwnResult_Type.C_Err a =  * self in Own_OwnResult_Type.C_Err ( ^ x1)) };
     assume { Inv2.inv ( ^ x1) };
-    _7 <- borrow_mut ( * x1);
+    _7 <- Borrow.borrow_mut ( * x1);
     x1 <- { x1 with current = ( ^ _7) };
     assume { Inv2.inv ( ^ _7) };
     _0 <- Own_OwnResult_Type.C_Err _7;
@@ -729,10 +729,10 @@ module Own_Impl0_AsMut
     absurd
   }
   BB4 {
-    x <- borrow_mut (Own_OwnResult_Type.ok_0 ( * self));
+    x <- Borrow.borrow_mut (Own_OwnResult_Type.ok_0 ( * self));
     self <- { self with current = (let Own_OwnResult_Type.C_Ok a =  * self in Own_OwnResult_Type.C_Ok ( ^ x)) };
     assume { Inv0.inv ( ^ x) };
-    _5 <- borrow_mut ( * x);
+    _5 <- Borrow.borrow_mut ( * x);
     x <- { x with current = ( ^ _5) };
     assume { Inv0.inv ( ^ _5) };
     _0 <- Own_OwnResult_Type.C_Ok _5;

--- a/creusot/tests/should_succeed/result/result.mlcfg
+++ b/creusot/tests/should_succeed/result/result.mlcfg
@@ -990,7 +990,7 @@ module Result_TestResult
     absurd
   }
   BB38 {
-    _67 <- borrow_mut ok;
+    _67 <- Borrow.borrow_mut ok;
     ok <-  ^ _67;
     _66 <- ([#"../result.rs" 23 5 23 16] AsMut0.as_mut _67);
     _67 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1017,7 +1017,7 @@ module Result_TestResult
     absurd
   }
   BB43 {
-    _76 <- borrow_mut ok;
+    _76 <- Borrow.borrow_mut ok;
     ok <-  ^ _76;
     _75 <- ([#"../result.rs" 25 5 25 16] AsMut0.as_mut _76);
     _76 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1044,7 +1044,7 @@ module Result_TestResult
     absurd
   }
   BB48 {
-    _85 <- borrow_mut err;
+    _85 <- Borrow.borrow_mut err;
     err <-  ^ _85;
     _84 <- ([#"../result.rs" 27 5 27 17] AsMut0.as_mut _85);
     _85 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1071,7 +1071,7 @@ module Result_TestResult
     absurd
   }
   BB53 {
-    _94 <- borrow_mut err;
+    _94 <- Borrow.borrow_mut err;
     err <-  ^ _94;
     _93 <- ([#"../result.rs" 29 5 29 17] AsMut0.as_mut _94);
     _94 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1366,7 +1366,7 @@ module Result_TestResult
     absurd
   }
   BB118 {
-    _224 <- borrow_mut ok;
+    _224 <- Borrow.borrow_mut ok;
     ok <-  ^ _224;
     _223 <- ([#"../result.rs" 61 12 61 23] AsMut0.as_mut _224);
     _224 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1392,7 +1392,7 @@ module Result_TestResult
     absurd
   }
   BB123 {
-    _233 <- borrow_mut err;
+    _233 <- Borrow.borrow_mut err;
     err <-  ^ _233;
     _232 <- ([#"../result.rs" 62 13 62 25] AsMut0.as_mut _233);
     _233 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1465,7 +1465,7 @@ module Result_TestResult
     absurd
   }
   BB138 {
-    _258 <- borrow_mut ok;
+    _258 <- Borrow.borrow_mut ok;
     ok <-  ^ _258;
     _257 <- ([#"../result.rs" 66 12 66 23] AsMut0.as_mut _258);
     _258 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);
@@ -1491,7 +1491,7 @@ module Result_TestResult
     absurd
   }
   BB143 {
-    _267 <- borrow_mut err;
+    _267 <- Borrow.borrow_mut err;
     err <-  ^ _267;
     _266 <- ([#"../result.rs" 67 13 67 25] AsMut0.as_mut _267);
     _267 <- any borrowed (Core_Result_Result_Type.t_result int32 int32);

--- a/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
@@ -64,23 +64,23 @@ module IncMax_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- borrow_mut ( * ma);
+    _9 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _9) };
-    _5 <- borrow_mut ( * _9);
+    _5 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _5) };
     assume { Resolve0.resolve _9 };
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- borrow_mut ( * mb);
+    _5 <- Borrow.borrow_mut ( * mb);
     mb <- { mb with current = ( ^ _5) };
     goto BB3
   }
   BB3 {
-    _3 <- borrow_mut ( * _5);
+    _3 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _3) };
-    _0 <- borrow_mut ( * _3);
+    _0 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _3 };
@@ -120,13 +120,13 @@ module IncMax_IncMax
     goto BB0
   }
   BB0 {
-    _6 <- borrow_mut a;
+    _6 <- Borrow.borrow_mut a;
     a <-  ^ _6;
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
-    _8 <- borrow_mut b;
+    _8 <- Borrow.borrow_mut b;
     b <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     mc <- ([#"../inc_max.rs" 16 13 16 37] TakeMax0.take_max _5 _7);
     _5 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
@@ -84,13 +84,13 @@ module IncMax3_IncMax3
       end
   }
   BB1 {
-    _12 <- borrow_mut ma;
+    _12 <- Borrow.borrow_mut ma;
     ma <-  ^ _12;
-    _11 <- borrow_mut ( * _12);
+    _11 <- Borrow.borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _11) };
-    _14 <- borrow_mut mb;
+    _14 <- Borrow.borrow_mut mb;
     mb <-  ^ _14;
-    _13 <- borrow_mut ( * _14);
+    _13 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
     _10 <- ([#"../inc_max_3.rs" 14 8 14 30] Swap0.swap _11 _13);
     _11 <- any borrowed (borrowed uint32);
@@ -114,13 +114,13 @@ module IncMax3_IncMax3
       end
   }
   BB5 {
-    _21 <- borrow_mut mb;
+    _21 <- Borrow.borrow_mut mb;
     mb <-  ^ _21;
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
-    _23 <- borrow_mut mc;
+    _23 <- Borrow.borrow_mut mc;
     mc <-  ^ _23;
-    _22 <- borrow_mut ( * _23);
+    _22 <- Borrow.borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _22) };
     _19 <- ([#"../inc_max_3.rs" 17 8 17 30] Swap0.swap _20 _22);
     _20 <- any borrowed (borrowed uint32);
@@ -146,13 +146,13 @@ module IncMax3_IncMax3
       end
   }
   BB9 {
-    _30 <- borrow_mut ma;
+    _30 <- Borrow.borrow_mut ma;
     ma <-  ^ _30;
-    _29 <- borrow_mut ( * _30);
+    _29 <- Borrow.borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
-    _32 <- borrow_mut mb;
+    _32 <- Borrow.borrow_mut mb;
     mb <-  ^ _32;
-    _31 <- borrow_mut ( * _32);
+    _31 <- Borrow.borrow_mut ( * _32);
     _32 <- { _32 with current = ( ^ _31) };
     _28 <- ([#"../inc_max_3.rs" 20 8 20 30] Swap0.swap _29 _31);
     _29 <- any borrowed (borrowed uint32);
@@ -214,17 +214,17 @@ module IncMax3_TestIncMax3
     goto BB0
   }
   BB0 {
-    _7 <- borrow_mut a;
+    _7 <- Borrow.borrow_mut a;
     a <-  ^ _7;
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
-    _9 <- borrow_mut b;
+    _9 <- Borrow.borrow_mut b;
     b <-  ^ _9;
-    _8 <- borrow_mut ( * _9);
+    _8 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _8) };
-    _11 <- borrow_mut c;
+    _11 <- Borrow.borrow_mut c;
     c <-  ^ _11;
-    _10 <- borrow_mut ( * _11);
+    _10 <- Borrow.borrow_mut ( * _11);
     _11 <- { _11 with current = ( ^ _10) };
     _5 <- ([#"../inc_max_3.rs" 28 4 28 37] IncMax30.inc_max_3 _6 _8 _10);
     _6 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
@@ -64,23 +64,23 @@ module IncMaxMany_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- borrow_mut ( * ma);
+    _9 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _9) };
-    _5 <- borrow_mut ( * _9);
+    _5 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _5) };
     assume { Resolve0.resolve _9 };
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- borrow_mut ( * mb);
+    _5 <- Borrow.borrow_mut ( * mb);
     mb <- { mb with current = ( ^ _5) };
     goto BB3
   }
   BB3 {
-    _3 <- borrow_mut ( * _5);
+    _3 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _3) };
-    _0 <- borrow_mut ( * _3);
+    _0 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _3 };
@@ -122,13 +122,13 @@ module IncMaxMany_IncMaxMany
     goto BB0
   }
   BB0 {
-    _7 <- borrow_mut a;
+    _7 <- Borrow.borrow_mut a;
     a <-  ^ _7;
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
-    _9 <- borrow_mut b;
+    _9 <- Borrow.borrow_mut b;
     b <-  ^ _9;
-    _8 <- borrow_mut ( * _9);
+    _8 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _8) };
     mc <- ([#"../inc_max_many.rs" 16 13 16 37] TakeMax0.take_max _6 _8);
     _6 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -64,23 +64,23 @@ module IncMaxRepeat_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- borrow_mut ( * ma);
+    _9 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _9) };
-    _5 <- borrow_mut ( * _9);
+    _5 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _5) };
     assume { Resolve0.resolve _9 };
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- borrow_mut ( * mb);
+    _5 <- Borrow.borrow_mut ( * mb);
     mb <- { mb with current = ( ^ _5) };
     goto BB3
   }
   BB3 {
-    _3 <- borrow_mut ( * _5);
+    _3 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _3) };
-    _0 <- borrow_mut ( * _3);
+    _0 <- Borrow.borrow_mut ( * _3);
     _3 <- { _3 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _3 };
@@ -653,9 +653,9 @@ module IncMaxRepeat_IncMaxRepeat
     goto BB5
   }
   BB5 {
-    _20 <- borrow_mut iter;
+    _20 <- Borrow.borrow_mut iter;
     iter <-  ^ _20;
-    _19 <- borrow_mut ( * _20);
+    _19 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
     _18 <- ([#"../inc_max_repeat.rs" 16 4 16 86] Next0.next _19);
     _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);
@@ -688,13 +688,13 @@ module IncMaxRepeat_IncMaxRepeat
   BB11 {
     produced <- _23;
     _23 <- any Ghost.ghost_ty (Seq.seq uint32);
-    _27 <- borrow_mut a;
+    _27 <- Borrow.borrow_mut a;
     a <-  ^ _27;
-    _26 <- borrow_mut ( * _27);
+    _26 <- Borrow.borrow_mut ( * _27);
     _27 <- { _27 with current = ( ^ _26) };
-    _29 <- borrow_mut b;
+    _29 <- Borrow.borrow_mut b;
     b <-  ^ _29;
-    _28 <- borrow_mut ( * _29);
+    _28 <- Borrow.borrow_mut ( * _29);
     _29 <- { _29 with current = ( ^ _28) };
     mc <- ([#"../inc_max_repeat.rs" 19 17 19 41] TakeMax0.take_max _26 _28);
     _26 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -336,9 +336,9 @@ module IncSome2List_Impl0_TakeSomeRest
     absurd
   }
   BB4 {
-    ma <- borrow_mut (IncSome2List_List_Type.cons_0 ( * self));
+    ma <- Borrow.borrow_mut (IncSome2List_List_Type.cons_0 ( * self));
     self <- { self with current = (let IncSome2List_List_Type.C_Cons a b =  * self in IncSome2List_List_Type.C_Cons ( ^ ma) b) };
-    ml <- borrow_mut (IncSome2List_List_Type.cons_1 ( * self));
+    ml <- Borrow.borrow_mut (IncSome2List_List_Type.cons_1 ( * self));
     self <- { self with current = (let IncSome2List_List_Type.C_Cons a b =  * self in IncSome2List_List_Type.C_Cons a ( ^ ml)) };
     _8 <- ([#"../inc_some_2_list.rs" 57 16 57 45] Ghost.new (LemmaSumNonneg0.lemma_sum_nonneg ( * ml)));
     goto BB5
@@ -354,9 +354,9 @@ module IncSome2List_Impl0_TakeSomeRest
       end
   }
   BB7 {
-    _11 <- borrow_mut ( * ma);
+    _11 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _11) };
-    _12 <- borrow_mut ( * ml);
+    _12 <- Borrow.borrow_mut ( * ml);
     ml <- { ml with current = ( ^ _12) };
     _0 <- (_11, _12);
     _11 <- any borrowed uint32;
@@ -365,7 +365,7 @@ module IncSome2List_Impl0_TakeSomeRest
   }
   BB8 {
     assume { Resolve0.resolve ma };
-    _13 <- borrow_mut ( * ml);
+    _13 <- Borrow.borrow_mut ( * ml);
     ml <- { ml with current = ( ^ _13) };
     _0 <- ([#"../inc_some_2_list.rs" 61 20 61 39] take_some_rest _13);
     _13 <- any borrowed (IncSome2List_List_Type.t_list);
@@ -495,7 +495,7 @@ module IncSome2List_IncSome2List
     goto BB2
   }
   BB2 {
-    _10 <- borrow_mut l;
+    _10 <- Borrow.borrow_mut l;
     l <-  ^ _10;
     _9 <- ([#"../inc_some_2_list.rs" 72 19 72 37] TakeSomeRest0.take_some_rest _10);
     _10 <- any borrowed (IncSome2List_List_Type.t_list);
@@ -507,7 +507,7 @@ module IncSome2List_IncSome2List
     ml <- (let (_, a) = _9 in a);
     _9 <- (let (a, b) = _9 in (a, any borrowed (IncSome2List_List_Type.t_list)));
     assume { Resolve0.resolve _9 };
-    _13 <- borrow_mut ( * ml);
+    _13 <- Borrow.borrow_mut ( * ml);
     ml <- { ml with current = ( ^ _13) };
     _12 <- ([#"../inc_some_2_list.rs" 73 18 73 37] TakeSomeRest0.take_some_rest _13);
     _13 <- any borrowed (IncSome2List_List_Type.t_list);

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -357,11 +357,11 @@ module IncSome2Tree_Impl0_TakeSomeRest
     absurd
   }
   BB4 {
-    mtl <- borrow_mut (IncSome2Tree_Tree_Type.node_0 ( * self));
+    mtl <- Borrow.borrow_mut (IncSome2Tree_Tree_Type.node_0 ( * self));
     self <- { self with current = (let IncSome2Tree_Tree_Type.C_Node a b c =  * self in IncSome2Tree_Tree_Type.C_Node ( ^ mtl) b c) };
-    ma <- borrow_mut (IncSome2Tree_Tree_Type.node_1 ( * self));
+    ma <- Borrow.borrow_mut (IncSome2Tree_Tree_Type.node_1 ( * self));
     self <- { self with current = (let IncSome2Tree_Tree_Type.C_Node a b c =  * self in IncSome2Tree_Tree_Type.C_Node a ( ^ ma) c) };
-    mtr <- borrow_mut (IncSome2Tree_Tree_Type.node_2 ( * self));
+    mtr <- Borrow.borrow_mut (IncSome2Tree_Tree_Type.node_2 ( * self));
     self <- { self with current = (let IncSome2Tree_Tree_Type.C_Node a b c =  * self in IncSome2Tree_Tree_Type.C_Node a b ( ^ mtr)) };
     assert { [@expl:assertion] [#"../inc_some_2_tree.rs" 67 20 67 42] let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtl) in let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtr) in true };
     _11 <- ([#"../inc_some_2_tree.rs" 71 19 71 27] Random0.random ());
@@ -374,7 +374,7 @@ module IncSome2Tree_Impl0_TakeSomeRest
       end
   }
   BB6 {
-    _12 <- borrow_mut ( * ma);
+    _12 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _12) };
     _15 <- ([#"../inc_some_2_tree.rs" 72 28 72 36] Random0.random ());
     goto BB7
@@ -387,21 +387,21 @@ module IncSome2Tree_Impl0_TakeSomeRest
   }
   BB8 {
     assume { Resolve1.resolve mtr };
-    _16 <- borrow_mut ( * mtl);
+    _16 <- Borrow.borrow_mut ( * mtl);
     mtl <- { mtl with current = ( ^ _16) };
-    _14 <- borrow_mut ( * _16);
+    _14 <- Borrow.borrow_mut ( * _16);
     _16 <- { _16 with current = ( ^ _14) };
     assume { Resolve2.resolve _16 };
     goto BB10
   }
   BB9 {
     assume { Resolve1.resolve mtl };
-    _14 <- borrow_mut ( * mtr);
+    _14 <- Borrow.borrow_mut ( * mtr);
     mtr <- { mtr with current = ( ^ _14) };
     goto BB10
   }
   BB10 {
-    _13 <- borrow_mut ( * _14);
+    _13 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _13) };
     _0 <- (_12, _13);
     _12 <- any borrowed uint32;
@@ -422,7 +422,7 @@ module IncSome2Tree_Impl0_TakeSomeRest
   }
   BB13 {
     assume { Resolve1.resolve mtr };
-    _18 <- borrow_mut ( * mtl);
+    _18 <- Borrow.borrow_mut ( * mtl);
     mtl <- { mtl with current = ( ^ _18) };
     _0 <- ([#"../inc_some_2_tree.rs" 74 20 74 40] take_some_rest _18);
     _18 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
@@ -433,7 +433,7 @@ module IncSome2Tree_Impl0_TakeSomeRest
   }
   BB15 {
     assume { Resolve1.resolve mtl };
-    _19 <- borrow_mut ( * mtr);
+    _19 <- Borrow.borrow_mut ( * mtr);
     mtr <- { mtr with current = ( ^ _19) };
     _0 <- ([#"../inc_some_2_tree.rs" 76 20 76 40] take_some_rest _19);
     _19 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
@@ -567,7 +567,7 @@ module IncSome2Tree_IncSome2Tree
     goto BB2
   }
   BB2 {
-    _10 <- borrow_mut t;
+    _10 <- Borrow.borrow_mut t;
     t <-  ^ _10;
     _9 <- ([#"../inc_some_2_tree.rs" 87 19 87 37] TakeSomeRest0.take_some_rest _10);
     _10 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
@@ -579,7 +579,7 @@ module IncSome2Tree_IncSome2Tree
     mt <- (let (_, a) = _9 in a);
     _9 <- (let (a, b) = _9 in (a, any borrowed (IncSome2Tree_Tree_Type.t_tree)));
     assume { Resolve0.resolve _9 };
-    _13 <- borrow_mut ( * mt);
+    _13 <- Borrow.borrow_mut ( * mt);
     mt <- { mt with current = ( ^ _13) };
     _12 <- ([#"../inc_some_2_tree.rs" 88 18 88 37] TakeSomeRest0.take_some_rest _13);
     _13 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -338,9 +338,9 @@ module IncSomeList_Impl0_TakeSome
     absurd
   }
   BB4 {
-    ma <- borrow_mut (IncSomeList_List_Type.cons_0 ( * self));
+    ma <- Borrow.borrow_mut (IncSomeList_List_Type.cons_0 ( * self));
     self <- { self with current = (let IncSomeList_List_Type.C_Cons a b =  * self in IncSomeList_List_Type.C_Cons ( ^ ma) b) };
-    ml <- borrow_mut (IncSomeList_List_Type.cons_1 ( * self));
+    ml <- Borrow.borrow_mut (IncSomeList_List_Type.cons_1 ( * self));
     self <- { self with current = (let IncSomeList_List_Type.C_Cons a b =  * self in IncSomeList_List_Type.C_Cons a ( ^ ml)) };
     _10 <- ([#"../inc_some_list.rs" 54 16 54 45] Ghost.new (LemmaSumNonneg0.lemma_sum_nonneg ( * ml)));
     goto BB5
@@ -357,39 +357,39 @@ module IncSomeList_Impl0_TakeSome
   }
   BB7 {
     assume { Resolve1.resolve ml };
-    _14 <- borrow_mut ( * ma);
+    _14 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _14) };
-    _12 <- borrow_mut ( * _14);
+    _12 <- Borrow.borrow_mut ( * _14);
     _14 <- { _14 with current = ( ^ _12) };
     assume { Resolve0.resolve _14 };
     goto BB10
   }
   BB8 {
     assume { Resolve0.resolve ma };
-    _16 <- borrow_mut ( * ml);
+    _16 <- Borrow.borrow_mut ( * ml);
     ml <- { ml with current = ( ^ _16) };
     _15 <- ([#"../inc_some_list.rs" 58 20 58 34] take_some _16);
     _16 <- any borrowed (IncSomeList_List_Type.t_list);
     goto BB9
   }
   BB9 {
-    _12 <- borrow_mut ( * _15);
+    _12 <- Borrow.borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _12) };
     assume { Resolve0.resolve _15 };
     goto BB10
   }
   BB10 {
-    _9 <- borrow_mut ( * _12);
+    _9 <- Borrow.borrow_mut ( * _12);
     _12 <- { _12 with current = ( ^ _9) };
-    _5 <- borrow_mut ( * _9);
+    _5 <- Borrow.borrow_mut ( * _9);
     _9 <- { _9 with current = ( ^ _5) };
     assume { Resolve0.resolve _12 };
     assume { Resolve0.resolve _9 };
     assume { Resolve1.resolve ml };
     assume { Resolve0.resolve ma };
-    _2 <- borrow_mut ( * _5);
+    _2 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _2) };
-    _0 <- borrow_mut ( * _2);
+    _0 <- Borrow.borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _2 };
@@ -454,7 +454,7 @@ module IncSomeList_IncSomeList
     goto BB2
   }
   BB2 {
-    _7 <- borrow_mut l;
+    _7 <- Borrow.borrow_mut l;
     l <-  ^ _7;
     ma <- ([#"../inc_some_list.rs" 69 13 69 26] TakeSome0.take_some _7);
     _7 <- any borrowed (IncSomeList_List_Type.t_list);

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -358,11 +358,11 @@ module IncSomeTree_Impl0_TakeSome
     absurd
   }
   BB4 {
-    mtl <- borrow_mut (IncSomeTree_Tree_Type.node_0 ( * self));
+    mtl <- Borrow.borrow_mut (IncSomeTree_Tree_Type.node_0 ( * self));
     self <- { self with current = (let IncSomeTree_Tree_Type.C_Node a b c =  * self in IncSomeTree_Tree_Type.C_Node ( ^ mtl) b c) };
-    ma <- borrow_mut (IncSomeTree_Tree_Type.node_1 ( * self));
+    ma <- Borrow.borrow_mut (IncSomeTree_Tree_Type.node_1 ( * self));
     self <- { self with current = (let IncSomeTree_Tree_Type.C_Node a b c =  * self in IncSomeTree_Tree_Type.C_Node a ( ^ ma) c) };
-    mtr <- borrow_mut (IncSomeTree_Tree_Type.node_2 ( * self));
+    mtr <- Borrow.borrow_mut (IncSomeTree_Tree_Type.node_2 ( * self));
     self <- { self with current = (let IncSomeTree_Tree_Type.C_Node a b c =  * self in IncSomeTree_Tree_Type.C_Node a b ( ^ mtr)) };
     assert { [@expl:assertion] [#"../inc_some_tree.rs" 65 20 65 42] let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtl) in let _ = LemmaSumNonneg0.lemma_sum_nonneg ( * mtr) in true };
     _14 <- ([#"../inc_some_tree.rs" 69 19 69 27] Random0.random ());
@@ -377,9 +377,9 @@ module IncSomeTree_Impl0_TakeSome
   BB6 {
     assume { Resolve1.resolve mtr };
     assume { Resolve1.resolve mtl };
-    _15 <- borrow_mut ( * ma);
+    _15 <- Borrow.borrow_mut ( * ma);
     ma <- { ma with current = ( ^ _15) };
-    _13 <- borrow_mut ( * _15);
+    _13 <- Borrow.borrow_mut ( * _15);
     _15 <- { _15 with current = ( ^ _13) };
     assume { Resolve0.resolve _15 };
     goto BB14
@@ -397,16 +397,16 @@ module IncSomeTree_Impl0_TakeSome
   }
   BB9 {
     assume { Resolve1.resolve mtr };
-    _19 <- borrow_mut ( * mtl);
+    _19 <- Borrow.borrow_mut ( * mtl);
     mtl <- { mtl with current = ( ^ _19) };
     _18 <- ([#"../inc_some_tree.rs" 72 20 72 35] take_some _19);
     _19 <- any borrowed (IncSomeTree_Tree_Type.t_tree);
     goto BB10
   }
   BB10 {
-    _17 <- borrow_mut ( * _18);
+    _17 <- Borrow.borrow_mut ( * _18);
     _18 <- { _18 with current = ( ^ _17) };
-    _13 <- borrow_mut ( * _17);
+    _13 <- Borrow.borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _13) };
     assume { Resolve0.resolve _18 };
     assume { Resolve0.resolve _17 };
@@ -414,14 +414,14 @@ module IncSomeTree_Impl0_TakeSome
   }
   BB11 {
     assume { Resolve1.resolve mtl };
-    _21 <- borrow_mut ( * mtr);
+    _21 <- Borrow.borrow_mut ( * mtr);
     mtr <- { mtr with current = ( ^ _21) };
     _20 <- ([#"../inc_some_tree.rs" 74 20 74 35] take_some _21);
     _21 <- any borrowed (IncSomeTree_Tree_Type.t_tree);
     goto BB12
   }
   BB12 {
-    _13 <- borrow_mut ( * _20);
+    _13 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _13) };
     assume { Resolve0.resolve _20 };
     goto BB13
@@ -430,18 +430,18 @@ module IncSomeTree_Impl0_TakeSome
     goto BB14
   }
   BB14 {
-    _10 <- borrow_mut ( * _13);
+    _10 <- Borrow.borrow_mut ( * _13);
     _13 <- { _13 with current = ( ^ _10) };
-    _5 <- borrow_mut ( * _10);
+    _5 <- Borrow.borrow_mut ( * _10);
     _10 <- { _10 with current = ( ^ _5) };
     assume { Resolve0.resolve _13 };
     assume { Resolve0.resolve _10 };
     assume { Resolve1.resolve mtr };
     assume { Resolve0.resolve ma };
     assume { Resolve1.resolve mtl };
-    _2 <- borrow_mut ( * _5);
+    _2 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _2) };
-    _0 <- borrow_mut ( * _2);
+    _0 <- Borrow.borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _2 };
@@ -506,7 +506,7 @@ module IncSomeTree_IncSomeTree
     goto BB2
   }
   BB2 {
-    _7 <- borrow_mut t;
+    _7 <- Borrow.borrow_mut t;
     t <-  ^ _7;
     ma <- ([#"../inc_some_tree.rs" 85 13 85 26] TakeSome0.take_some _7);
     _7 <- any borrowed (IncSomeTree_Tree_Type.t_tree);

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -2254,9 +2254,9 @@ module SelectionSortGeneric_SelectionSort
     goto BB7
   }
   BB7 {
-    _22 <- borrow_mut iter;
+    _22 <- Borrow.borrow_mut iter;
     iter <-  ^ _22;
-    _21 <- borrow_mut ( * _22);
+    _21 <- Borrow.borrow_mut ( * _22);
     _22 <- { _22 with current = ( ^ _21) };
     _20 <- ([#"../selection_sort_generic.rs" 35 4 35 43] Next0.next _21);
     _21 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -2317,9 +2317,9 @@ module SelectionSortGeneric_SelectionSort
     goto BB19
   }
   BB19 {
-    _46 <- borrow_mut iter1;
+    _46 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _46;
-    _45 <- borrow_mut ( * _46);
+    _45 <- Borrow.borrow_mut ( * _46);
     _46 <- { _46 with current = ( ^ _45) };
     _44 <- ([#"../selection_sort_generic.rs" 41 8 41 121] Next0.next _45);
     _45 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -2333,7 +2333,7 @@ module SelectionSortGeneric_SelectionSort
       end
   }
   BB21 {
-    _66 <- borrow_mut ( * v);
+    _66 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _66) };
     _65 <- ([#"../selection_sort_generic.rs" 48 8 48 22] DerefMut0.deref_mut _66);
     _66 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -2385,7 +2385,7 @@ module SelectionSortGeneric_SelectionSort
     goto BB18
   }
   BB31 {
-    _64 <- borrow_mut ( * _65);
+    _64 <- Borrow.borrow_mut ( * _65);
     _65 <- { _65 with current = ( ^ _64) };
     assume { Inv2.inv ( ^ _64) };
     _63 <- ([#"../selection_sort_generic.rs" 48 8 48 22] Swap0.swap _64 i min);

--- a/creusot/tests/should_succeed/sparse_array.mlcfg
+++ b/creusot/tests/should_succeed/sparse_array.mlcfg
@@ -1432,7 +1432,7 @@ module SparseArray_Impl1_Set
     goto BB1
   }
   BB1 {
-    _12 <- borrow_mut (SparseArray_Sparse_Type.sparse_values ( * self));
+    _12 <- Borrow.borrow_mut (SparseArray_Sparse_Type.sparse_values ( * self));
     self <- { self with current = (let SparseArray_Sparse_Type.C_Sparse a b c d e =  * self in SparseArray_Sparse_Type.C_Sparse a b ( ^ _12) d e) };
     _11 <- ([#"../sparse_array.rs" 120 8 120 22] IndexMut0.index_mut _12 i);
     _12 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -1486,7 +1486,7 @@ module SparseArray_Impl1_Set
   BB12 {
     assume { Resolve3.resolve _29 };
     assert { [@expl:assertion] [#"../sparse_array.rs" 125 26 125 46] UIntSize.to_int (SparseArray_Sparse_Type.sparse_n ( * self)) < UIntSize.to_int (SparseArray_Sparse_Type.sparse_size ( * self)) };
-    _35 <- borrow_mut (SparseArray_Sparse_Type.sparse_idx ( * self));
+    _35 <- Borrow.borrow_mut (SparseArray_Sparse_Type.sparse_idx ( * self));
     self <- { self with current = (let SparseArray_Sparse_Type.C_Sparse a b c d e =  * self in SparseArray_Sparse_Type.C_Sparse a b c ( ^ _35) e) };
     _34 <- ([#"../sparse_array.rs" 127 12 127 23] IndexMut1.index_mut _35 i);
     _35 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -1495,7 +1495,7 @@ module SparseArray_Impl1_Set
   BB13 {
     _34 <- { _34 with current = SparseArray_Sparse_Type.sparse_n ( * self) };
     assume { Resolve4.resolve _34 };
-    _39 <- borrow_mut (SparseArray_Sparse_Type.sparse_back ( * self));
+    _39 <- Borrow.borrow_mut (SparseArray_Sparse_Type.sparse_back ( * self));
     self <- { self with current = (let SparseArray_Sparse_Type.C_Sparse a b c d e =  * self in SparseArray_Sparse_Type.C_Sparse a b c d ( ^ _39)) };
     _38 <- ([#"../sparse_array.rs" 128 12 128 29] IndexMut1.index_mut _39 (SparseArray_Sparse_Type.sparse_n ( * self)));
     _39 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -1901,14 +1901,14 @@ module SparseArray_F
   }
   BB4 {
     assert { [@expl:assertion] [#"../sparse_array.rs" 154 18 154 40] x = Core_Option_Option_Type.C_None /\ y = Core_Option_Option_Type.C_None };
-    _13 <- borrow_mut a;
+    _13 <- Borrow.borrow_mut a;
     a <-  ^ _13;
     _12 <- ([#"../sparse_array.rs" 156 4 156 15] Set0.set _13 ([#"../sparse_array.rs" 156 10 156 11] (5 : usize)) ([#"../sparse_array.rs" 156 13 156 14] (1 : int32)));
     _13 <- any borrowed (SparseArray_Sparse_Type.t_sparse int32);
     goto BB5
   }
   BB5 {
-    _15 <- borrow_mut b;
+    _15 <- Borrow.borrow_mut b;
     b <-  ^ _15;
     _14 <- ([#"../sparse_array.rs" 157 4 157 15] Set0.set _15 ([#"../sparse_array.rs" 157 10 157 11] (7 : usize)) ([#"../sparse_array.rs" 157 13 157 14] (2 : int32)));
     _15 <- any borrowed (SparseArray_Sparse_Type.t_sparse int32);

--- a/creusot/tests/should_succeed/split_borrow.mlcfg
+++ b/creusot/tests/should_succeed/split_borrow.mlcfg
@@ -137,7 +137,7 @@ module SplitBorrow_F
   }
   BB0 {
     x <- (SplitBorrow_MyInt_Type.C_MyInt ([#"../split_borrow.rs" 10 23 10 24] (1 : usize)), SplitBorrow_MyInt_Type.C_MyInt ([#"../split_borrow.rs" 10 33 10 34] (2 : usize)));
-    y <- borrow_mut x;
+    y <- Borrow.borrow_mut x;
     x <-  ^ y;
     _6 <- ([#"../split_borrow.rs" 13 7 13 10] Z0.z ());
     goto BB1
@@ -196,9 +196,9 @@ module SplitBorrow_G
   }
   BB0 {
     a <- (SplitBorrow_MyInt_Type.C_MyInt ([#"../split_borrow.rs" 24 23 24 24] (1 : usize)), SplitBorrow_MyInt_Type.C_MyInt ([#"../split_borrow.rs" 24 33 24 34] (2 : usize)));
-    x <- borrow_mut a;
+    x <- Borrow.borrow_mut a;
     a <-  ^ x;
-    _z <- borrow_mut (let (_, a) =  * x in a);
+    _z <- Borrow.borrow_mut (let (_, a) =  * x in a);
     x <- { x with current = (let (a, b) =  * x in (a,  ^ _z)) };
     assume { Resolve0.resolve _z };
     x <- { x with current = (let (a, b) =  * x in (SplitBorrow_MyInt_Type.C_MyInt ([#"../split_borrow.rs" 29 19 29 20] (3 : usize)), b)) };

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -972,9 +972,9 @@ module Sum_SumFirstN
     goto BB6
   }
   BB6 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     _17 <- ([#"../sum.rs" 8 4 8 67] Next0.next _18);
     _18 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -707,9 +707,9 @@ module SumOfOdds_ComputeSumOfOdd
     goto BB5
   }
   BB5 {
-    _20 <- borrow_mut iter;
+    _20 <- Borrow.borrow_mut iter;
     iter <-  ^ _20;
-    _19 <- borrow_mut ( * _20);
+    _19 <- Borrow.borrow_mut ( * _20);
     _20 <- { _20 with current = ( ^ _19) };
     _18 <- ([#"../sum_of_odds.rs" 38 4 38 50] Next0.next _19);
     _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);

--- a/creusot/tests/should_succeed/swap_borrows.mlcfg
+++ b/creusot/tests/should_succeed/swap_borrows.mlcfg
@@ -215,11 +215,11 @@ module SwapBorrows_F
     a <- (let (a, _) = _3 in a);
     b <- (let (_, a) = _3 in a);
     assume { Resolve0.resolve _3 };
-    _6 <- borrow_mut a;
+    _6 <- Borrow.borrow_mut a;
     a <-  ^ _6;
-    _8 <- borrow_mut b;
+    _8 <- Borrow.borrow_mut b;
     b <-  ^ _8;
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     p <- ([#"../swap_borrows.rs" 12 12 12 34] Swap0.swap (_6, _7));
     _6 <- any borrowed uint32;

--- a/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
+++ b/creusot/tests/should_succeed/syntax/12_ghost_code.mlcfg
@@ -668,7 +668,7 @@ module C12GhostCode_GhostCheck
     goto BB2
   }
   BB2 {
-    _5 <- borrow_mut x;
+    _5 <- Borrow.borrow_mut x;
     x <-  ^ _5;
     _4 <- ([#"../12_ghost_code.rs" 32 4 32 13] Push0.push _5 ([#"../12_ghost_code.rs" 32 11 32 12] (0 : int32)));
     _5 <- any borrowed (Alloc_Vec_Vec_Type.t_vec int32 (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -508,7 +508,7 @@ module TakeFirstMut_TakeFirstMut
     goto BB0
   }
   BB0 {
-    _6 <- borrow_mut ( * self_);
+    _6 <- Borrow.borrow_mut ( * self_);
     self_ <- { self_ with current = ( ^ _6) };
     assume { Inv0.inv ( ^ _6) };
     _5 <- ([#"../take_first_mut.rs" 15 10 15 26] Take0.take _6);
@@ -516,7 +516,7 @@ module TakeFirstMut_TakeFirstMut
     goto BB1
   }
   BB1 {
-    _4 <- borrow_mut ( * _5);
+    _4 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
     assume { Inv1.inv ( ^ _4) };
     _3 <- ([#"../take_first_mut.rs" 15 10 15 44] SplitFirstMut0.split_first_mut _4);
@@ -539,7 +539,7 @@ module TakeFirstMut_TakeFirstMut
     _3 <- (let Core_Option_Option_Type.C_Some a = _3 in Core_Option_Option_Type.C_Some (let (a, b) = Core_Option_Option_Type.some_0 _3 in (a, any borrowed (slice t))));
     assert { [@expl:type invariant] Inv2.inv _3 };
     assume { Resolve0.resolve _3 };
-    _11 <- borrow_mut ( * rem);
+    _11 <- Borrow.borrow_mut ( * rem);
     rem <- { rem with current = ( ^ _11) };
     assume { Inv1.inv ( ^ _11) };
     self_ <- { self_ with current = _11 };
@@ -548,7 +548,7 @@ module TakeFirstMut_TakeFirstMut
     assume { Resolve2.resolve ( * self_) };
     assert { [@expl:type invariant] Inv3.inv self_ };
     assume { Resolve1.resolve self_ };
-    _12 <- borrow_mut ( * first);
+    _12 <- Borrow.borrow_mut ( * first);
     first <- { first with current = ( ^ _12) };
     assume { Inv4.inv ( ^ _12) };
     _0 <- Core_Option_Option_Type.C_Some _12;

--- a/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
@@ -177,11 +177,11 @@ module Borrows_Impl1_InnerMut
     goto BB0
   }
   BB0 {
-    _5 <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * self));
+    _5 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * self));
     self <- { self with current = (let Borrows_NonZero_Type.C_NonZero a =  * self in Borrows_NonZero_Type.C_NonZero ( ^ _5)) };
-    _2 <- borrow_mut ( * _5);
+    _2 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _2) };
-    _0 <- borrow_mut ( * _2);
+    _0 <- Borrow.borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
     assume { Resolve0.resolve _5 };
     assume { Resolve0.resolve _2 };
@@ -390,9 +390,9 @@ module Borrows_Simple
     goto BB0
   }
   BB0 {
-    _6 <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
+    _6 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
     x <- { x with current = (let Borrows_NonZero_Type.C_NonZero a =  * x in Borrows_NonZero_Type.C_NonZero ( ^ _6)) };
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- ([#"../borrows.rs" 32 4 32 17] Inc0.inc _5);
     _5 <- any borrowed int32;
@@ -472,7 +472,7 @@ module Borrows_Hard
     goto BB0
   }
   BB0 {
-    _7 <- borrow_mut ( * x);
+    _7 <- Borrow.borrow_mut ( * x);
     x <- { x with current = ( ^ _7) };
     assume { Inv0.inv ( ^ _7) };
     _6 <- ([#"../borrows.rs" 39 8 39 21] InnerMut0.inner_mut _7);
@@ -480,7 +480,7 @@ module Borrows_Hard
     goto BB1
   }
   BB1 {
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- ([#"../borrows.rs" 39 4 39 22] Inc0.inc _5);
     _5 <- any borrowed int32;
@@ -648,9 +648,9 @@ module Borrows_Tuple
   }
   BB0 {
     x <- (let (a, b) = x in (let Borrows_NonZero_Type.C_NonZero a = let (a, _) = x in a in Borrows_NonZero_Type.C_NonZero ([#"../borrows.rs" 46 13 46 14] (0 : int32)), b));
-    _6 <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
+    _6 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
     x <- (let (a, b) = x in (a, { (let (_, a) = x in a) with current = (let Borrows_NonZero_Type.C_NonZero a =  * (let (_, a) = x in a) in Borrows_NonZero_Type.C_NonZero ( ^ _6)) }));
-    _5 <- borrow_mut ( * _6);
+    _5 <- Borrow.borrow_mut ( * _6);
     _6 <- { _6 with current = ( ^ _5) };
     _4 <- ([#"../borrows.rs" 47 4 47 20] Inc0.inc _5);
     _5 <- any borrowed int32;
@@ -746,9 +746,9 @@ module Borrows_PartialMove
   BB0 {
     a <- (let (a, _) = x in a);
     x <- (let (a, b) = x in (any Borrows_NonZero_Type.t_nonzero, b));
-    _7 <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
+    _7 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
     x <- (let (a, b) = x in (a, { (let (_, a) = x in a) with current = (let Borrows_NonZero_Type.C_NonZero a =  * (let (_, a) = x in a) in Borrows_NonZero_Type.C_NonZero ( ^ _7)) }));
-    _6 <- borrow_mut ( * _7);
+    _6 <- Borrow.borrow_mut ( * _7);
     _7 <- { _7 with current = ( ^ _6) };
     _5 <- ([#"../borrows.rs" 55 4 55 20] Inc0.inc _6);
     _6 <- any borrowed int32;
@@ -851,9 +851,9 @@ module Borrows_Destruct
     assert { [@expl:type invariant] Inv0.inv x };
     assume { Resolve0.resolve x };
     a <- (let Borrows_NonZero_Type.C_NonZero a = a in Borrows_NonZero_Type.C_NonZero ([#"../borrows.rs" 63 10 63 11] (0 : int32)));
-    _8 <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * b));
+    _8 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * b));
     b <- { b with current = (let Borrows_NonZero_Type.C_NonZero a =  * b in Borrows_NonZero_Type.C_NonZero ( ^ _8)) };
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     _6 <- ([#"../borrows.rs" 64 4 64 17] Inc0.inc _7);
     _7 <- any borrowed int32;
@@ -934,9 +934,9 @@ module Borrows_FrozenDead
     goto BB0
   }
   BB0 {
-    _a <- borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
+    _a <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
     x <- { x with current = (let Borrows_NonZero_Type.C_NonZero a =  * x in Borrows_NonZero_Type.C_NonZero ( ^ _a)) };
-    _6 <- borrow_mut ( * y);
+    _6 <- Borrow.borrow_mut ( * y);
     y <- { y with current = ( ^ _6) };
     assume { Inv0.inv ( ^ _6) };
     assert { [@expl:type invariant] Inv1.inv x };
@@ -945,7 +945,7 @@ module Borrows_FrozenDead
     _6 <- any borrowed (Borrows_NonZero_Type.t_nonzero);
     assert { [@expl:type invariant] Inv1.inv x };
     assume { Resolve0.resolve x };
-    _8 <- borrow_mut ( * _a);
+    _8 <- Borrow.borrow_mut ( * _a);
     _a <- { _a with current = ( ^ _8) };
     _7 <- ([#"../borrows.rs" 75 4 75 11] Inc0.inc _8);
     _8 <- any borrowed int32;
@@ -1126,9 +1126,9 @@ module Borrows_Impl3_Foo
     goto BB0
   }
   BB0 {
-    _5 <- borrow_mut (Borrows_SumTo10_Type.sumto10_a ( * self));
+    _5 <- Borrow.borrow_mut (Borrows_SumTo10_Type.sumto10_a ( * self));
     self <- { self with current = (let Borrows_SumTo10_Type.C_SumTo10 a b =  * self in Borrows_SumTo10_Type.C_SumTo10 ( ^ _5) b) };
-    _4 <- borrow_mut ( * _5);
+    _4 <- Borrow.borrow_mut ( * _5);
     _5 <- { _5 with current = ( ^ _4) };
     _3 <- ([#"../borrows.rs" 94 8 94 24] Inc0.inc _4);
     _4 <- any borrowed int32;
@@ -1136,9 +1136,9 @@ module Borrows_Impl3_Foo
   }
   BB1 {
     assume { Resolve0.resolve _5 };
-    _8 <- borrow_mut (Borrows_SumTo10_Type.sumto10_b ( * self));
+    _8 <- Borrow.borrow_mut (Borrows_SumTo10_Type.sumto10_b ( * self));
     self <- { self with current = (let Borrows_SumTo10_Type.C_SumTo10 a b =  * self in Borrows_SumTo10_Type.C_SumTo10 a ( ^ _8)) };
-    _7 <- borrow_mut ( * _8);
+    _7 <- Borrow.borrow_mut ( * _8);
     _8 <- { _8 with current = ( ^ _7) };
     _6 <- ([#"../borrows.rs" 95 8 95 24] Dec0.dec _7);
     _7 <- any borrowed int32;

--- a/creusot/tests/should_succeed/unnest.mlcfg
+++ b/creusot/tests/should_succeed/unnest.mlcfg
@@ -52,9 +52,9 @@ module Unnest_Unnest
     goto BB0
   }
   BB0 {
-    _2 <- borrow_mut ( *  * x);
+    _2 <- Borrow.borrow_mut ( *  * x);
     x <- { x with current = { ( * x) with current = ( ^ _2) } };
-    _0 <- borrow_mut ( * _2);
+    _0 <- Borrow.borrow_mut ( * _2);
     _2 <- { _2 with current = ( ^ _0) };
     assume { Resolve0.resolve _2 };
     assume { Resolve1.resolve x };

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -831,7 +831,7 @@ module Vecdeque_TestDeque
     absurd
   }
   BB14 {
-    _30 <- borrow_mut deque1;
+    _30 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _30;
     _29 <- ([#"../vecdeque.rs" 16 12 16 29] PopFront0.pop_front _30);
     _30 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
@@ -852,7 +852,7 @@ module Vecdeque_TestDeque
     absurd
   }
   BB18 {
-    _39 <- borrow_mut deque1;
+    _39 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _39;
     _38 <- ([#"../vecdeque.rs" 17 12 17 28] PopBack0.pop_back _39);
     _39 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
@@ -873,28 +873,28 @@ module Vecdeque_TestDeque
     absurd
   }
   BB22 {
-    _44 <- borrow_mut deque1;
+    _44 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _44;
     _43 <- ([#"../vecdeque.rs" 19 4 19 23] PushFront0.push_front _44 ([#"../vecdeque.rs" 19 21 19 22] (1 : uint32)));
     _44 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
     goto BB23
   }
   BB23 {
-    _46 <- borrow_mut deque1;
+    _46 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _46;
     _45 <- ([#"../vecdeque.rs" 20 4 20 23] PushFront0.push_front _46 ([#"../vecdeque.rs" 20 21 20 22] (2 : uint32)));
     _46 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
     goto BB24
   }
   BB24 {
-    _48 <- borrow_mut deque1;
+    _48 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _48;
     _47 <- ([#"../vecdeque.rs" 21 4 21 22] PushBack0.push_back _48 ([#"../vecdeque.rs" 21 20 21 21] (3 : uint32)));
     _48 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
     goto BB25
   }
   BB25 {
-    _54 <- borrow_mut deque1;
+    _54 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _54;
     _53 <- ([#"../vecdeque.rs" 23 12 23 29] PopFront0.pop_front _54);
     _54 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
@@ -915,7 +915,7 @@ module Vecdeque_TestDeque
     absurd
   }
   BB29 {
-    _63 <- borrow_mut deque1;
+    _63 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _63;
     _62 <- ([#"../vecdeque.rs" 24 12 24 28] PopBack0.pop_back _63);
     _63 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));
@@ -936,7 +936,7 @@ module Vecdeque_TestDeque
     absurd
   }
   BB33 {
-    _68 <- borrow_mut deque1;
+    _68 <- Borrow.borrow_mut deque1;
     deque1 <-  ^ _68;
     _67 <- ([#"../vecdeque.rs" 25 4 25 17] Clear0.clear _68);
     _68 <- any borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque uint32 (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -1214,9 +1214,9 @@ module C01_AllZero
     goto BB7
   }
   BB7 {
-    _21 <- borrow_mut iter;
+    _21 <- Borrow.borrow_mut iter;
     iter <-  ^ _21;
-    _20 <- borrow_mut ( * _21);
+    _20 <- Borrow.borrow_mut ( * _21);
     _21 <- { _21 with current = ( ^ _20) };
     _19 <- ([#"../01.rs" 9 4 9 42] Next0.next _20);
     _20 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -1250,7 +1250,7 @@ module C01_AllZero
     produced <- _24;
     _24 <- any Ghost.ghost_ty (Seq.seq usize);
     i <- __creusot_proc_iter_elem;
-    _28 <- borrow_mut ( * v);
+    _28 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _28) };
     _27 <- ([#"../01.rs" 12 8 12 12] IndexMut0.index_mut _28 i);
     _28 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -1797,14 +1797,14 @@ module C02Gnome_GnomeSort
     goto BB16
   }
   BB13 {
-    _31 <- borrow_mut ( * v);
+    _31 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _31) };
     _30 <- ([#"../02_gnome.rs" 34 12 34 28] DerefMut0.deref_mut _31);
     _31 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB14
   }
   BB14 {
-    _29 <- borrow_mut ( * _30);
+    _29 <- Borrow.borrow_mut ( * _30);
     _30 <- { _30 with current = ( ^ _29) };
     assume { Inv1.inv ( ^ _29) };
     _28 <- ([#"../02_gnome.rs" 34 12 34 28] Swap0.swap _29 ([#"../02_gnome.rs" 34 19 34 24] i - ([#"../02_gnome.rs" 34 23 34 24] (1 : usize))) i);

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -1115,9 +1115,9 @@ module C03KnuthShuffle_KnuthShuffle
     goto BB7
   }
   BB7 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     _17 <- ([#"../03_knuth_shuffle.rs" 16 4 16 43] Next0.next _18);
     _18 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -1161,14 +1161,14 @@ module C03KnuthShuffle_KnuthShuffle
     goto BB15
   }
   BB15 {
-    _34 <- borrow_mut ( * v);
+    _34 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _34) };
     _33 <- ([#"../03_knuth_shuffle.rs" 22 8 22 28] DerefMut0.deref_mut _34);
     _34 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB16
   }
   BB16 {
-    _32 <- borrow_mut ( * _33);
+    _32 <- Borrow.borrow_mut ( * _33);
     _33 <- { _33 with current = ( ^ _32) };
     assume { Inv1.inv ( ^ _32) };
     _31 <- ([#"../03_knuth_shuffle.rs" 22 8 22 28] Swap0.swap _32 i ([#"../03_knuth_shuffle.rs" 22 18 22 27] upper - ([#"../03_knuth_shuffle.rs" 22 26 22 27] (1 : usize))));

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -3054,9 +3054,9 @@ module C06KnightsTour_Impl1_CountDegree
     goto BB8
   }
   BB8 {
-    _19 <- borrow_mut iter;
+    _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- borrow_mut ( * _19);
+    _18 <- Borrow.borrow_mut ( * _19);
     _19 <- { _19 with current = ( ^ _18) };
     _17 <- ([#"../06_knights_tour.rs" 73 8 73 46] Next0.next _18);
     _18 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
@@ -3399,14 +3399,14 @@ module C06KnightsTour_Impl1_Set
     goto BB0
   }
   BB0 {
-    _12 <- borrow_mut (C06KnightsTour_Board_Type.board_field ( * self));
+    _12 <- Borrow.borrow_mut (C06KnightsTour_Board_Type.board_field ( * self));
     self <- { self with current = (let C06KnightsTour_Board_Type.C_Board a b =  * self in C06KnightsTour_Board_Type.C_Board a ( ^ _12)) };
     _11 <- ([#"../06_knights_tour.rs" 88 8 88 32] IndexMut0.index_mut _12 (UIntSize.of_int (IntSize.to_int (C06KnightsTour_Point_Type.point_x p))));
     _12 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _10 <- borrow_mut ( * _11);
+    _10 <- Borrow.borrow_mut ( * _11);
     _11 <- { _11 with current = ( ^ _10) };
     _9 <- ([#"../06_knights_tour.rs" 88 8 88 46] IndexMut1.index_mut _10 (UIntSize.of_int (IntSize.to_int (C06KnightsTour_Point_Type.point_y p))));
     _10 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
@@ -4088,9 +4088,9 @@ module C06KnightsTour_Min
     goto BB5
   }
   BB5 {
-    _17 <- borrow_mut iter;
+    _17 <- Borrow.borrow_mut iter;
     iter <-  ^ _17;
-    _16 <- borrow_mut ( * _17);
+    _16 <- Borrow.borrow_mut ( * _17);
     _17 <- { _17 with current = ( ^ _16) };
     _15 <- ([#"../06_knights_tour.rs" 113 4 114 74] Next0.next _16);
     _16 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
@@ -4787,7 +4787,7 @@ module C06KnightsTour_KnightsTour
   }
   BB1 {
     p <- C06KnightsTour_Point_Type.C_Point (IntSize.of_int (UIntSize.to_int x)) (IntSize.of_int (UIntSize.to_int y));
-    _15 <- borrow_mut board;
+    _15 <- Borrow.borrow_mut board;
     board <-  ^ _15;
     _14 <- ([#"../06_knights_tour.rs" 139 4 139 19] Set0.set _15 p ([#"../06_knights_tour.rs" 139 17 139 18] (1 : usize)));
     _15 <- any borrowed (C06KnightsTour_Board_Type.t_board);
@@ -4827,9 +4827,9 @@ module C06KnightsTour_KnightsTour
     goto BB10
   }
   BB10 {
-    _37 <- borrow_mut iter;
+    _37 <- Borrow.borrow_mut iter;
     iter <-  ^ _37;
-    _36 <- borrow_mut ( * _37);
+    _36 <- Borrow.borrow_mut ( * _37);
     _37 <- { _37 with current = ( ^ _36) };
     _35 <- ([#"../06_knights_tour.rs" 142 4 142 36] Next0.next _36);
     _36 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
@@ -4901,9 +4901,9 @@ module C06KnightsTour_KnightsTour
     goto BB26
   }
   BB26 {
-    _56 <- borrow_mut iter1;
+    _56 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _56;
-    _55 <- borrow_mut ( * _56);
+    _55 <- Borrow.borrow_mut ( * _56);
     _56 <- { _56 with current = ( ^ _55) };
     _54 <- ([#"../06_knights_tour.rs" 148 8 149 54] Next1.next _55);
     _55 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
@@ -4953,7 +4953,7 @@ module C06KnightsTour_KnightsTour
     goto BB35
   }
   BB35 {
-    _73 <- borrow_mut candidates;
+    _73 <- Borrow.borrow_mut candidates;
     candidates <-  ^ _73;
     _72 <- ([#"../06_knights_tour.rs" 154 16 154 46] Push0.push _73 (degree, adj));
     _73 <- any borrowed (Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global));
@@ -4993,7 +4993,7 @@ module C06KnightsTour_KnightsTour
     adj1 <- (let (_, a) = Core_Option_Option_Type.some_0 _79 in a);
     assume { Resolve4.resolve candidates };
     p <- adj1;
-    _87 <- borrow_mut board;
+    _87 <- Borrow.borrow_mut board;
     board <-  ^ _87;
     _86 <- ([#"../06_knights_tour.rs" 161 8 161 26] Set0.set _87 p step);
     _87 <- any borrowed (C06KnightsTour_Board_Type.t_board);

--- a/creusot/tests/should_succeed/vector/07_read_write.mlcfg
+++ b/creusot/tests/should_succeed/vector/07_read_write.mlcfg
@@ -766,7 +766,7 @@ module C07ReadWrite_ReadWrite
     goto BB0
   }
   BB0 {
-    _7 <- borrow_mut ( * a);
+    _7 <- Borrow.borrow_mut ( * a);
     a <- { a with current = ( ^ _7) };
     _6 <- ([#"../07_read_write.rs" 7 4 7 8] IndexMut0.index_mut _7 i);
     _7 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -1741,9 +1741,9 @@ module C08Haystack_Search
     goto BB8
   }
   BB8 {
-    _26 <- borrow_mut iter;
+    _26 <- Borrow.borrow_mut iter;
     iter <-  ^ _26;
-    _25 <- borrow_mut ( * _26);
+    _25 <- Borrow.borrow_mut ( * _26);
     _26 <- { _26 with current = ( ^ _25) };
     _24 <- ([#"../08_haystack.rs" 22 4 22 112] Next0.next _25);
     _25 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
@@ -1801,9 +1801,9 @@ module C08Haystack_Search
     goto BB20
   }
   BB20 {
-    _47 <- borrow_mut iter1;
+    _47 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _47;
-    _46 <- borrow_mut ( * _47);
+    _46 <- Borrow.borrow_mut ( * _47);
     _47 <- { _47 with current = ( ^ _46) };
     _45 <- ([#"../08_haystack.rs" 24 8 24 68] Next1.next _46);
     _46 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -470,28 +470,28 @@ module C09Capacity_ChangeCapacity
     goto BB0
   }
   BB0 {
-    _5 <- borrow_mut ( * v);
+    _5 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _5) };
     _4 <- ([#"../09_capacity.rs" 7 4 7 18] Reserve0.reserve _5 ([#"../09_capacity.rs" 7 14 7 17] (100 : usize)));
     _5 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _7 <- borrow_mut ( * v);
+    _7 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _7) };
     _6 <- ([#"../09_capacity.rs" 8 4 8 24] ReserveExact0.reserve_exact _7 ([#"../09_capacity.rs" 8 20 8 23] (200 : usize)));
     _7 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB2
   }
   BB2 {
-    _9 <- borrow_mut ( * v);
+    _9 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _9) };
     _8 <- ([#"../09_capacity.rs" 9 4 9 21] ShrinkToFit0.shrink_to_fit _9);
     _9 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB3
   }
   BB3 {
-    _11 <- borrow_mut ( * v);
+    _11 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _11) };
     _10 <- ([#"../09_capacity.rs" 10 4 10 18] ShrinkTo0.shrink_to _11 ([#"../09_capacity.rs" 10 16 10 17] (1 : usize)));
     _11 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
@@ -591,7 +591,7 @@ module C09Capacity_ClearVec
     goto BB0
   }
   BB0 {
-    _4 <- borrow_mut ( * v);
+    _4 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _4) };
     _3 <- ([#"../09_capacity.rs" 15 4 15 13] Clear0.clear _4);
     _4 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));

--- a/why3/src/exp.rs
+++ b/why3/src/exp.rs
@@ -99,7 +99,9 @@ pub enum Purity {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Exp {
     Any(Type),
+    // TODO: Remove
     Current(Box<Exp>),
+    // TODO: Remove
     Final(Box<Exp>),
     Let { pattern: Pattern, arg: Box<Exp>, body: Box<Exp> },
     Var(Ident, Purity),
@@ -109,7 +111,6 @@ pub enum Exp {
     RecField { record: Box<Exp>, label: String },
     Tuple(Vec<Exp>),
     Constructor { ctor: QName, args: Vec<Exp> },
-    BorrowMut(Box<Exp>),
     Const(Constant),
     BinaryOp(BinOp, Box<Exp>, Box<Exp>),
     UnaryOp(UnOp, Box<Exp>),
@@ -165,7 +166,6 @@ pub fn super_visit_mut<T: ExpMutVisitor>(f: &mut T, exp: &mut Exp) {
         Exp::RecField { record, label: _ } => f.visit_mut(record),
         Exp::Tuple(exps) => exps.iter_mut().for_each(|e| f.visit_mut(e)),
         Exp::Constructor { ctor: _, args } => args.iter_mut().for_each(|e| f.visit_mut(e)),
-        Exp::BorrowMut(e) => f.visit_mut(e),
         Exp::Const(_) => {}
         Exp::BinaryOp(_, l, r) => {
             f.visit_mut(l);
@@ -229,7 +229,6 @@ pub fn super_visit<T: ExpVisitor>(f: &mut T, exp: &Exp) {
         Exp::RecField { record, label: _ } => f.visit(record),
         Exp::Tuple(exps) => exps.iter().for_each(|e| f.visit(e)),
         Exp::Constructor { ctor: _, args } => args.iter().for_each(|e| f.visit(e)),
-        Exp::BorrowMut(e) => f.visit(e),
         Exp::Const(_) => {}
         Exp::BinaryOp(_, l, r) => {
             f.visit(l);
@@ -541,7 +540,6 @@ impl Exp {
             // Exp::Seq(_, _) => { Term }
             Exp::Match(_, _) => Abs,
             Exp::IfThenElse(_, _, _) => IfLet,
-            Exp::BorrowMut(_) => App,
             Exp::Const(_) => Atom,
             Exp::UnaryOp(UnOp::Neg | UnOp::FloatNeg, _) => Prefix,
             Exp::UnaryOp(UnOp::Not, _) => Not,

--- a/why3/src/mlcfg/printer.rs
+++ b/why3/src/mlcfg/printer.rs
@@ -662,11 +662,6 @@ impl Print for Exp {
                     " ",
                 ))
             }),
-
-            Exp::BorrowMut(box exp) => {
-                alloc.text("borrow_mut ").append(parens!(alloc, env, self.precedence().next(), exp))
-            }
-
             Exp::Const(c) => c.pretty(alloc, env),
 
             Exp::UnaryOp(UnOp::Not, box op) => {


### PR DESCRIPTION
Fixes #850. 

I cleaned up one of the oldest pieces of tech debt: `BorrowMut` was hardcoded as a constructor of the Why3 expression type. 
I've replaced it with a normal function call like it always should have been. 
