### PR TITLE
Some miscellaneous specifications

### DIFF
--- a/creusot-contracts/src/std/ops.rs
+++ b/creusot-contracts/src/std/ops.rs
@@ -243,12 +243,12 @@ extern_spec! {
 extern_spec! {
     mod std {
         mod ops {
-            trait IndexMut<Idx>  {
+            trait IndexMut<Idx>  where Idx : ?Sized, Self : ?Sized {
                 #[requires(false)]
                 fn index_mut(&mut self, _ix : Idx) -> &mut Self::Output;
             }
 
-            trait Index<Idx> {
+            trait Index<Idx>  where Idx : ?Sized,  Self : ?Sized {
                 #[requires(false)]
                 fn index(&self, _ix : Idx) -> &Self::Output;
             }

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -230,6 +230,10 @@ impl<T> SliceIndex<[T]> for RangeToInclusive<usize> {
 
 extern_spec! {
     impl<T> [T] {
+        #[requires(self@.len() == src@.len())]
+        #[ensures((^self)@ == src@)]
+        fn copy_from_slice(&mut self, src: &[T]) where T : Copy;
+
         #[ensures(self@.len() == result@)]
         fn len(&self) -> usize;
 

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -1562,10 +1562,10 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 236 19 236 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 237 19 237 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 240 19 240 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 241 19 241 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 238 8 238 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 242 8 242 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -1459,7 +1459,7 @@ module CreusotContracts_Std1_Slice_Impl14_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 375 12 375 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../creusot-contracts/src/std/slice.rs" 379 12 379 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -1569,7 +1569,7 @@ module Core_Slice_Impl0_Iter_Interface
     type t = slice t
   val iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] ShallowModel0.shallow_model result = self }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -1674,7 +1674,7 @@ module CreusotContracts_Std1_Slice_Impl14_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 368 20 368 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../creusot-contracts/src/std/slice.rs" 372 20 372 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -1781,10 +1781,10 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl_Interface
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   type t
@@ -1793,12 +1793,12 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl14_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 379 4 379 10] ()
+    [#"../../../../creusot-contracts/src/std/slice.rs" 383 4 383 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Stub
   type t
@@ -1826,14 +1826,14 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Interface
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   type t
@@ -1848,16 +1848,16 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 384 4 384 10] ()
+    [#"../../../../creusot-contracts/src/std/slice.rs" 388 4 388 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module Hillel_InsertUnique_Interface
   type t
@@ -2528,7 +2528,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t
   val len (self : slice t) : usize
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module CreusotContracts_Std1_Iter_Iterator_Completed_Stub
@@ -3540,7 +3540,7 @@ module CreusotContracts_Std1_Slice_Impl11_IntoIterPre
   use prelude.Borrow
   use prelude.Slice
   predicate into_iter_pre (self : slice t) =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 329 20 329 24] true
+    [#"../../../../creusot-contracts/src/std/slice.rs" 333 20 333 24] true
   val into_iter_pre (self : slice t) : bool
     ensures { result = into_iter_pre self }
     
@@ -3570,7 +3570,7 @@ module CreusotContracts_Std1_Slice_Impl11_IntoIterPost
   clone CreusotContracts_Std1_Slice_Impl13_ShallowModel_Stub as ShallowModel0 with
     type t = t
   predicate into_iter_post (self : slice t) (res : Core_Slice_Iter_Iter_Type.t_iter t) =
-    [#"../../../../creusot-contracts/src/std/slice.rs" 335 20 335 32] self = ShallowModel0.shallow_model res
+    [#"../../../../creusot-contracts/src/std/slice.rs" 339 20 339 32] self = ShallowModel0.shallow_model res
   val into_iter_post (self : slice t) (res : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = into_iter_post self res }
     

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -706,7 +706,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t
   val len (self : slice t) : usize
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module Alloc_Vec_Impl8_Deref_Interface
@@ -767,8 +767,8 @@ module Core_Slice_Impl0_Get_Interface
   val get (self : slice t) (index : i) : Core_Option_Option_Type.t_option Output0.output
     requires {Inv0.inv self}
     requires {Inv1.inv index}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 241 8 241 102] InBounds0.in_bounds index (ShallowModel0.shallow_model self) -> (exists r : Output0.output . Inv2.inv r /\ result = Core_Option_Option_Type.C_Some r /\ HasValue0.has_value index (ShallowModel0.shallow_model self) r) }
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 242 18 242 55] InBounds0.in_bounds index (ShallowModel0.shallow_model self) \/ result = Core_Option_Option_Type.C_None }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 245 8 245 102] InBounds0.in_bounds index (ShallowModel0.shallow_model self) -> (exists r : Output0.output . Inv2.inv r /\ result = Core_Option_Option_Type.C_Some r /\ HasValue0.has_value index (ShallowModel0.shallow_model self) r) }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 246 18 246 55] InBounds0.in_bounds index (ShallowModel0.shallow_model self) \/ result = Core_Option_Option_Type.C_None }
     ensures { Inv3.inv result }
     
 end

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -791,7 +791,7 @@ module Core_Slice_Impl0_TakeFirstMut_Interface
     type t = borrowed (borrowed (slice t))
   val take_first_mut (self : borrowed (borrowed (slice t))) : Core_Option_Option_Type.t_option (borrowed t)
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 267 18 274 9] match (result) with
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 271 18 278 9] match (result) with
       | Core_Option_Option_Type.C_Some r ->  * r = IndexLogic0.index_logic ( *  * self) 0 /\  ^ r = IndexLogic0.index_logic ( ^  * self) 0 /\ Seq.length (ShallowModel0.shallow_model ( *  * self)) > 0 /\ Seq.length (ShallowModel0.shallow_model ( ^  * self)) > 0 /\ ShallowModel0.shallow_model ( *  ^ self) = Tail0.tail (ShallowModel0.shallow_model ( *  * self)) /\ ShallowModel0.shallow_model ( ^  ^ self) = Tail0.tail (ShallowModel0.shallow_model ( ^  * self))
       | Core_Option_Option_Type.C_None ->  ^ self =  * self /\ Seq.length (ShallowModel0.shallow_model ( *  * self)) = 0
       end }

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -366,7 +366,7 @@ module CreusotContracts_Std1_Slice_Impl14_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 375 12 375 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 379 12 379 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -421,7 +421,7 @@ module Core_Slice_Impl0_Iter_Interface
     type t = slice t
   val iter (self : slice t) : Core_Slice_Iter_Iter_Type.t_iter t
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] ShallowModel0.shallow_model result = self }
     
 end
 module CreusotContracts_Std1_Iter_IntoIterator_IntoIterPre_Stub
@@ -557,7 +557,7 @@ module CreusotContracts_Std1_Slice_Impl14_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 368 20 368 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 372 20 372 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -642,10 +642,10 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl_Interface
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   type t
@@ -654,12 +654,12 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl14_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 379 4 379 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 383 4 383 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Stub
   type t
@@ -687,14 +687,14 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Interface
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   type t
@@ -709,16 +709,16 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 384 4 384 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 388 4 388 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_SliceIter_Interface
   type t
@@ -1556,11 +1556,11 @@ module CreusotContracts_Std1_Slice_Impl15_ShallowModel_Interface
     axiom .
   function shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
   val shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 398 14 398 50] Seq.length (ShallowModel0.shallow_model ( ^ result)) = Seq.length (ShallowModel0.shallow_model ( * result)) }
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 399 4 399 50] Inv0.inv result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 402 14 402 50] Seq.length (ShallowModel0.shallow_model ( ^ result)) = Seq.length (ShallowModel0.shallow_model ( * result)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 403 4 403 50] Inv0.inv result }
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 4 399 50] Inv0.inv (shallow_model self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 14 398 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self)))
+  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 403 4 403 50] Inv0.inv (shallow_model self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 402 14 402 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self)))
 end
 module CreusotContracts_Std1_Slice_Impl15_ShallowModel
   type t
@@ -1584,11 +1584,11 @@ module CreusotContracts_Std1_Slice_Impl15_ShallowModel
     axiom .
   function shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
   val shallow_model (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : borrowed (slice t)
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 398 14 398 50] Seq.length (ShallowModel0.shallow_model ( ^ result)) = Seq.length (ShallowModel0.shallow_model ( * result)) }
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 399 4 399 50] Inv0.inv result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 402 14 402 50] Seq.length (ShallowModel0.shallow_model ( ^ result)) = Seq.length (ShallowModel0.shallow_model ( * result)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 403 4 403 50] Inv0.inv result }
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 4 399 50] Inv0.inv (shallow_model self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 14 398 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self)))
+  axiom shallow_model_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 403 4 403 50] Inv0.inv (shallow_model self)) && ([#"../../../../../creusot-contracts/src/std/slice.rs" 402 14 402 50] Seq.length (ShallowModel0.shallow_model ( ^ shallow_model self)) = Seq.length (ShallowModel0.shallow_model ( * shallow_model self)))
 end
 module CreusotContracts_Std1_Slice_Impl4_ToMutSeq_Stub
   type t
@@ -1726,7 +1726,7 @@ module CreusotContracts_Std1_Slice_Impl16_Produces
   predicate produces (self : Core_Slice_Iter_IterMut_Type.t_itermut t) (visited : Seq.seq (borrowed t)) (tl : Core_Slice_Iter_IterMut_Type.t_itermut t)
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 424 12 424 66] ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 428 12 428 66] ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToMutSeq0.to_mut_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_IterMut_Type.t_itermut t) (visited : Seq.seq (borrowed t)) (tl : Core_Slice_Iter_IterMut_Type.t_itermut t) : bool
     ensures { result = produces self visited tl }
     
@@ -1801,7 +1801,7 @@ module CreusotContracts_Std1_Slice_Impl17_Resolve
     predicate Inv2.inv = Inv2.inv,
     axiom .
   predicate resolve (self : Core_Slice_Iter_IterMut_Type.t_itermut t) =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 409 20 409 36]  * ShallowModel0.shallow_model self =  ^ ShallowModel0.shallow_model self
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 413 20 413 36]  * ShallowModel0.shallow_model self =  ^ ShallowModel0.shallow_model self
   val resolve (self : Core_Slice_Iter_IterMut_Type.t_itermut t) : bool
     ensures { result = resolve self }
     
@@ -1881,7 +1881,7 @@ module Core_Slice_Impl0_IterMut_Interface
     axiom .
   val iter_mut (self : borrowed (slice t)) : Core_Slice_Iter_IterMut_Type.t_itermut t
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] ShallowModel0.shallow_model result = self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] ShallowModel0.shallow_model result = self }
     
 end
 module CreusotContracts_Std1_Slice_Impl16_Completed_Stub
@@ -1923,7 +1923,7 @@ module CreusotContracts_Std1_Slice_Impl16_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_IterMut_Type.t_itermut t
   predicate completed (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut t)) =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 417 20 417 61] Resolve0.resolve self /\ ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 421 20 421 61] Resolve0.resolve self /\ ShallowModel1.shallow_model ( * ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut t)) : bool
     ensures { result = completed self }
     
@@ -1966,10 +1966,10 @@ module CreusotContracts_Std1_Slice_Impl16_ProducesRefl_Interface
     type t = t
   function produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
   val produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 430 14 430 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 434 14 434 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 430 14 430 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 434 14 434 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl16_ProducesRefl
   type t
@@ -1978,12 +1978,12 @@ module CreusotContracts_Std1_Slice_Impl16_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl16_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : () =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 428 4 428 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 432 4 432 10] ()
   val produces_refl (a : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 430 14 430 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 434 14 434 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 430 14 430 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t . [#"../../../../../creusot-contracts/src/std/slice.rs" 434 14 434 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl16_ProducesTrans_Stub
   type t
@@ -2011,14 +2011,14 @@ module CreusotContracts_Std1_Slice_Impl16_ProducesTrans_Interface
   function produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
     
   val produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 435 15 435 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 436 15 436 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 438 31 438 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 438 61 438 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 437 14 437 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 439 15 439 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 440 15 440 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 442 31 442 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 442 61 442 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 435 15 435 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 436 15 436 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 438 31 438 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 438 61 438 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 437 14 437 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 439 15 439 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 440 15 440 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 442 31 442 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 442 61 442 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl16_ProducesTrans
   type t
@@ -2033,16 +2033,16 @@ module CreusotContracts_Std1_Slice_Impl16_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 433 4 433 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 437 4 437 10] ()
   val produces_trans (a : Core_Slice_Iter_IterMut_Type.t_itermut t) (ab : Seq.seq (borrowed t)) (b : Core_Slice_Iter_IterMut_Type.t_itermut t) (bc : Seq.seq (borrowed t)) (c : Core_Slice_Iter_IterMut_Type.t_itermut t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 435 15 435 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 436 15 436 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 438 31 438 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 438 61 438 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 437 14 437 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 439 15 439 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 440 15 440 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 442 31 442 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 442 61 442 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 435 15 435 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 436 15 436 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 438 31 438 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 438 61 438 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 437 14 437 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut t, ab : Seq.seq (borrowed t), b : Core_Slice_Iter_IterMut_Type.t_itermut t, bc : Seq.seq (borrowed t), c : Core_Slice_Iter_IterMut_Type.t_itermut t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 439 15 439 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 440 15 440 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 442 31 442 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 442 61 442 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C03StdIterators_AllZero_Interface
   use prelude.Borrow
@@ -6180,7 +6180,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t
   val len (self : slice t) : usize
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module Core_Iter_Traits_Iterator_Iterator_Zip_Interface
@@ -6272,10 +6272,10 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 236 19 236 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 237 19 237 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 240 19 240 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 241 19 241 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 238 8 238 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 242 8 242 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Iter_Zip_Impl1_ProducesRefl_Stub

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -1185,10 +1185,10 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 236 19 236 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 237 19 237 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 240 19 240 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../creusot-contracts/src/std/slice.rs" 241 19 241 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 238 8 238 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 242 8 242 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub

--- a/creusot/tests/should_succeed/slices/01.mlcfg
+++ b/creusot/tests/should_succeed/slices/01.mlcfg
@@ -432,7 +432,7 @@ module Core_Slice_Impl0_Len_Interface
     type t = slice t
   val len (self : slice t) : usize
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] Seq.length (ShallowModel0.shallow_model self) = UIntSize.to_int result }
     
 end
 module C01_SliceFirst_Interface

--- a/creusot/tests/should_succeed/slices/02_std.mlcfg
+++ b/creusot/tests/should_succeed/slices/02_std.mlcfg
@@ -530,13 +530,13 @@ module Core_Slice_Impl0_BinarySearch_Interface
     type t = slice t,
     type DeepModelTy0.deepModelTy = Seq.seq DeepModelTy0.deepModelTy
   val binary_search (self : slice t) (x : t) : Core_Result_Result_Type.t_result usize usize
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 323 1] Sorted0.sorted (DeepModel0.deep_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 231 0 327 1] Sorted0.sorted (DeepModel0.deep_model self)}
     requires {Inv0.inv self}
     requires {Inv1.inv x}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 293 8 293 118] forall i : usize . result = Core_Result_Result_Type.C_Ok i -> UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self) /\ Seq.get (DeepModel1.deep_model self) (UIntSize.to_int i) = DeepModel2.deep_model x }
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 294 8 295 96] forall i : usize . result = Core_Result_Result_Type.C_Err i -> UIntSize.to_int i <= Seq.length (ShallowModel0.shallow_model self) /\ (forall j : int . 0 <= j /\ j < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (DeepModel0.deep_model self) j <> DeepModel2.deep_model x) }
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 296 8 297 78] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . j < i -> LtLog0.lt_log (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j)) (DeepModel2.deep_model x)) }
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 298 8 299 99] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . i <= j /\ UIntSize.to_int j < Seq.length (ShallowModel0.shallow_model self) -> LtLog0.lt_log (DeepModel2.deep_model x) (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j))) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 297 8 297 118] forall i : usize . result = Core_Result_Result_Type.C_Ok i -> UIntSize.to_int i < Seq.length (ShallowModel0.shallow_model self) /\ Seq.get (DeepModel1.deep_model self) (UIntSize.to_int i) = DeepModel2.deep_model x }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 298 8 299 96] forall i : usize . result = Core_Result_Result_Type.C_Err i -> UIntSize.to_int i <= Seq.length (ShallowModel0.shallow_model self) /\ (forall j : int . 0 <= j /\ j < Seq.length (ShallowModel0.shallow_model self) -> Seq.get (DeepModel0.deep_model self) j <> DeepModel2.deep_model x) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 300 8 301 78] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . j < i -> LtLog0.lt_log (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j)) (DeepModel2.deep_model x)) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 302 8 303 99] forall i : usize . result = Core_Result_Result_Type.C_Err i -> (forall j : usize . i <= j /\ UIntSize.to_int j < Seq.length (ShallowModel0.shallow_model self) -> LtLog0.lt_log (DeepModel2.deep_model x) (Seq.get (DeepModel0.deep_model self) (UIntSize.to_int j))) }
     
 end
 module Core_Result_Impl0_Unwrap_Interface

--- a/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
+++ b/creusot/tests/should_succeed/syntax/13_vec_macro.mlcfg
@@ -373,7 +373,7 @@ module Alloc_Slice_Impl0_IntoVec_Interface
     type t = slice t
   val into_vec (self : slice t) : Alloc_Vec_Vec_Type.t_vec t a
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 303 18 303 35] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 307 18 307 35] ShallowModel0.shallow_model result = ShallowModel1.shallow_model self }
     ensures { Inv1.inv result }
     
 end

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -330,7 +330,7 @@ module Core_Slice_Impl0_SplitFirstMut_Interface
     type t = borrowed (slice t)
   val split_first_mut (self : borrowed (slice t)) : Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t))
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 256 18 264 9] match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/slice.rs" 260 18 268 9] match (result) with
       | Core_Option_Option_Type.C_Some (first, tail) ->  * first = IndexLogic0.index_logic ( * self) 0 /\  ^ first = IndexLogic0.index_logic ( ^ self) 0 /\ Seq.length (ShallowModel0.shallow_model ( * self)) > 0 /\ Seq.length (ShallowModel0.shallow_model ( ^ self)) > 0 /\ ShallowModel0.shallow_model ( * tail) = Tail0.tail (ShallowModel0.shallow_model ( * self)) /\ ShallowModel0.shallow_model ( ^ tail) = Tail0.tail (ShallowModel0.shallow_model ( ^ self))
       | Core_Option_Option_Type.C_None -> Seq.length (ShallowModel1.shallow_model self) = 0 /\  ^ self =  * self /\ ShallowModel1.shallow_model self = Seq.empty 
       end }

--- a/creusot/tests/should_succeed/vecdeque.mlcfg
+++ b/creusot/tests/should_succeed/vecdeque.mlcfg
@@ -104,12 +104,12 @@ module CreusotContracts_Std1_Deque_Impl0_ShallowModel_Interface
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a
   function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
   val shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
-    requires {[#"../../../../creusot-contracts/src/std/deque.rs" 11 21 11 25] Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 10 14 10 41] Seq.length result <= UIntSize.to_int Max0.mAX' }
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 11 4 11 36] Inv1.inv result }
+    requires {[#"../../../../creusot-contracts/src/std/deque.rs" 12 21 12 25] Inv0.inv self}
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 11 14 11 41] Seq.length result <= UIntSize.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 12 4 12 36] Inv1.inv result }
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . ([#"../../../../creusot-contracts/src/std/deque.rs" 11 21 11 25] Inv0.inv self) -> ([#"../../../../creusot-contracts/src/std/deque.rs" 11 4 11 36] Inv1.inv (shallow_model self)) && ([#"../../../../creusot-contracts/src/std/deque.rs" 10 14 10 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . ([#"../../../../creusot-contracts/src/std/deque.rs" 12 21 12 25] Inv0.inv self) -> ([#"../../../../creusot-contracts/src/std/deque.rs" 12 4 12 36] Inv1.inv (shallow_model self)) && ([#"../../../../creusot-contracts/src/std/deque.rs" 11 14 11 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module CreusotContracts_Std1_Deque_Impl0_ShallowModel
   type t
@@ -126,12 +126,12 @@ module CreusotContracts_Std1_Deque_Impl0_ShallowModel
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a
   function shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
   val shallow_model (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : Seq.seq t
-    requires {[#"../../../../creusot-contracts/src/std/deque.rs" 11 21 11 25] Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 10 14 10 41] Seq.length result <= UIntSize.to_int Max0.mAX' }
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 11 4 11 36] Inv1.inv result }
+    requires {[#"../../../../creusot-contracts/src/std/deque.rs" 12 21 12 25] Inv0.inv self}
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 11 14 11 41] Seq.length result <= UIntSize.to_int Max0.mAX' }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 12 4 12 36] Inv1.inv result }
     ensures { result = shallow_model self }
     
-  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . ([#"../../../../creusot-contracts/src/std/deque.rs" 11 21 11 25] Inv0.inv self) -> ([#"../../../../creusot-contracts/src/std/deque.rs" 11 4 11 36] Inv1.inv (shallow_model self)) && ([#"../../../../creusot-contracts/src/std/deque.rs" 10 14 10 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
+  axiom shallow_model_spec : forall self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a . ([#"../../../../creusot-contracts/src/std/deque.rs" 12 21 12 25] Inv0.inv self) -> ([#"../../../../creusot-contracts/src/std/deque.rs" 12 4 12 36] Inv1.inv (shallow_model self)) && ([#"../../../../creusot-contracts/src/std/deque.rs" 11 14 11 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
 module Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface
   type t
@@ -154,7 +154,7 @@ module Alloc_Collections_VecDeque_Impl4_WithCapacity_Interface
     predicate Inv1.inv = Inv1.inv,
     axiom .
   val with_capacity (capacity : usize) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 59 26 59 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 60 26 60 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_ShallowModel_ShallowModelTy_Type
@@ -230,7 +230,7 @@ module Alloc_Collections_VecDeque_Impl5_IsEmpty_Interface
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a
   val is_empty (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : bool
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 67 26 67 54] result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 68 26 68 54] result = (Seq.length (ShallowModel0.shallow_model self) = 0) }
     
 end
 module Alloc_Collections_VecDeque_Impl5_Len_Interface
@@ -249,7 +249,7 @@ module Alloc_Collections_VecDeque_Impl5_Len_Interface
     type t = Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a
   val len (self : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a) : usize
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 64 26 64 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 65 26 65 48] UIntSize.to_int result = Seq.length (ShallowModel0.shallow_model self) }
     
 end
 module Alloc_Collections_VecDeque_Impl4_New_Interface
@@ -271,7 +271,7 @@ module Alloc_Collections_VecDeque_Impl4_New_Interface
     predicate Inv1.inv = Inv1.inv,
     axiom .
   val new (_1 : ()) : Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t (Alloc_Alloc_Global_Type.t_global)
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 56 26 56 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 57 26 57 44] Seq.length (ShallowModel0.shallow_model result) = 0 }
     
 end
 module CreusotContracts_Model_Impl7_ShallowModel_Stub
@@ -335,7 +335,7 @@ module Alloc_Collections_VecDeque_Impl5_PopFront_Interface
     type t = borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)
   val pop_front (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 73 26 78 17] match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 74 26 79 17] match (result) with
       | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 1 (Seq.length (ShallowModel1.shallow_model self)) /\ ShallowModel1.shallow_model self = Seq.(++) (Seq.singleton t) (ShallowModel0.shallow_model ( ^ self))
       | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
       end }
@@ -449,7 +449,7 @@ module Alloc_Collections_VecDeque_Impl5_PopBack_Interface
     type t = borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)
   val pop_back (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : Core_Option_Option_Type.t_option t
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 81 26 86 17] match (result) with
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 82 26 87 17] match (result) with
       | Core_Option_Option_Type.C_Some t -> ShallowModel0.shallow_model ( ^ self) = SeqExt.subsequence (ShallowModel1.shallow_model self) 0 (Seq.length (ShallowModel1.shallow_model self) - 1) /\ ShallowModel1.shallow_model self = Seq.snoc (ShallowModel0.shallow_model ( ^ self)) t
       | Core_Option_Option_Type.C_None ->  * self =  ^ self /\ Seq.length (ShallowModel1.shallow_model self) = 0
       end }
@@ -486,8 +486,8 @@ module Alloc_Collections_VecDeque_Impl5_PushFront_Interface
   val push_front (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
     requires {Inv0.inv self}
     requires {Inv1.inv value}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 89 26 89 59] Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 90 26 90 73] ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 90 26 90 59] Seq.length (ShallowModel0.shallow_model ( ^ self)) = Seq.length (ShallowModel1.shallow_model self) + 1 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 91 26 91 73] ShallowModel0.shallow_model ( ^ self) = Seq.(++) (Seq.singleton value) (ShallowModel1.shallow_model self) }
     
 end
 module Alloc_Collections_VecDeque_Impl5_PushBack_Interface
@@ -519,7 +519,7 @@ module Alloc_Collections_VecDeque_Impl5_PushBack_Interface
   val push_back (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) (value : t) : ()
     requires {Inv0.inv self}
     requires {Inv1.inv value}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 93 26 93 55] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 94 26 94 55] ShallowModel0.shallow_model ( ^ self) = Seq.snoc (ShallowModel1.shallow_model self) value }
     
 end
 module Alloc_Collections_VecDeque_Impl5_Clear_Interface
@@ -545,7 +545,7 @@ module Alloc_Collections_VecDeque_Impl5_Clear_Interface
     type t = borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)
   val clear (self : borrowed (Alloc_Collections_VecDeque_VecDeque_Type.t_vecdeque t a)) : ()
     requires {Inv0.inv self}
-    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 70 26 70 45] Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
+    ensures { [#"../../../../creusot-contracts/src/std/deque.rs" 71 26 71 45] Seq.length (ShallowModel0.shallow_model ( ^ self)) = 0 }
     
 end
 module TyInv_Trivial

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -937,10 +937,10 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 236 19 236 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 237 19 237 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 240 19 240 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 241 19 241 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 238 8 238 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 242 8 242 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Slice_Impl5_InBounds_Stub

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -700,10 +700,10 @@ module Core_Slice_Impl0_Swap_Interface
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t
   val swap (self : borrowed (slice t)) (a : usize) (b : usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 236 19 236 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 237 19 237 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 240 19 240 35] UIntSize.to_int a < Seq.length (ShallowModel0.shallow_model self)}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 241 19 241 35] UIntSize.to_int b < Seq.length (ShallowModel0.shallow_model self)}
     requires {Inv0.inv self}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 238 8 238 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 242 8 242 52] Permut.exchange (ShallowModel1.shallow_model ( ^ self)) (ShallowModel0.shallow_model self) (UIntSize.to_int a) (UIntSize.to_int b) }
     
 end
 module CreusotContracts_Std1_Iter_Impl0_IntoIterPre_Stub

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -3895,7 +3895,7 @@ module CreusotContracts_Std1_Slice_Impl14_Produces
   predicate produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t)
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 375 12 375 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 379 12 379 66] ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model self) = Seq.(++) visited (ToRefSeq0.to_ref_seq (ShallowModel0.shallow_model tl))
   val produces (self : Core_Slice_Iter_Iter_Type.t_iter t) (visited : Seq.seq t) (tl : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = produces self visited tl }
     
@@ -4029,7 +4029,7 @@ module CreusotContracts_Std1_Slice_Impl14_Completed
   clone CreusotContracts_Resolve_Impl1_Resolve_Stub as Resolve0 with
     type t = Core_Slice_Iter_Iter_Type.t_iter t
   predicate completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 368 20 368 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 372 20 372 61] Resolve0.resolve self /\ ShallowModel1.shallow_model (ShallowModel0.shallow_model self) = Seq.empty 
   val completed (self : borrowed (Core_Slice_Iter_Iter_Type.t_iter t)) : bool
     ensures { result = completed self }
     
@@ -4072,10 +4072,10 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl_Interface
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   type t
@@ -4084,12 +4084,12 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesRefl
   clone CreusotContracts_Std1_Slice_Impl14_Produces_Stub as Produces0 with
     type t = t
   function produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 379 4 379 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 383 4 383 10] ()
   val produces_refl (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a }
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a }
     ensures { result = produces_refl a }
     
-  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 381 14 381 39] Produces0.produces a (Seq.empty ) a
+  axiom produces_refl_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 385 14 385 39] Produces0.produces a (Seq.empty ) a
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Stub
   type t
@@ -4117,14 +4117,14 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans_Interface
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   type t
@@ -4139,16 +4139,16 @@ module CreusotContracts_Std1_Slice_Impl14_ProducesTrans
   function produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
     
    =
-    [#"../../../../../creusot-contracts/src/std/slice.rs" 384 4 384 10] ()
+    [#"../../../../../creusot-contracts/src/std/slice.rs" 388 4 388 10] ()
   val produces_trans (a : Core_Slice_Iter_Iter_Type.t_iter t) (ab : Seq.seq t) (b : Core_Slice_Iter_Iter_Type.t_iter t) (bc : Seq.seq t) (c : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab}
-    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc}
-    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c }
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab}
+    requires {[#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc}
+    ensures { [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c }
     ensures { result = produces_trans a ab b bc c }
     
-  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 386 15 386 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 387 15 387 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 31 389 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 389 61 389 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 388 14 388 42] Produces0.produces a (Seq.(++) ab bc) c)
+  axiom produces_trans_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 390 15 390 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 391 15 391 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 31 393 33] Inv0.inv ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 393 61 393 63] Inv0.inv bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
 module C06KnightsTour_Min_Interface
   use prelude.Borrow


### PR DESCRIPTION
Specification for iterators from `VecDeque` and `copy_from_slice`. 

Also fixes `Index` to not require that `Self` be sized (like for `[T]`).
