### PR TITLE
Improve inference of Ghost when erased

### DIFF
--- a/creusot-contracts-dummy/src/lib.rs
+++ b/creusot-contracts-dummy/src/lib.rs
@@ -29,7 +29,7 @@ pub fn proof_assert(_: TS1) -> TS1 {
 
 #[proc_macro]
 pub fn gh(_: TS1) -> TS1 {
-    quote::quote! { creusot_contracts::ghost::Ghost::dummy() }.into()
+    quote::quote! { creusot_contracts::ghost::Ghost::from_fn(|| std::process::abort()) }.into()
 }
 
 #[proc_macro_attribute]

--- a/creusot-contracts/src/lib.rs
+++ b/creusot-contracts/src/lib.rs
@@ -187,14 +187,14 @@ pub mod ghost {
         T: ?Sized;
 
     impl<T: ?Sized> Ghost<T> {
-        pub fn dummy() -> Ghost<T> {
+        pub fn from_fn(_: fn() -> T) -> Self {
             Ghost(std::marker::PhantomData)
         }
     }
 
     impl<T: ?Sized> Clone for Ghost<T> {
         fn clone(&self) -> Self {
-            Self::dummy()
+            Ghost(std::marker::PhantomData)
         }
     }
 


### PR DESCRIPTION
See: https://github.com/verus-lang/verus/pull/875

This improves the type inference of `gh!` when dealing with erased code.
Previously, it was required to *always* annotate `gh` bindings if you wanted the erased code to work. This was because when the `gh` code is erased, type inference is missing information to determine a concrete type and `rustc` will reject the code as ambiguous.

For example, the following failed to compile with `rustc` previously:

```rust
let x = gh! { 5 };
```

This PR fixes it by exploiting the coercion from `!` to any type in Rust, so that when erased, we will 'default' to `Ghost<!>` while remaining capable to unify with any possible type annotation that was provided in a binding. 

this was found in collaboration with @utaal 

