### PR TITLE
Added MIR optimization to avoid unnecessary re-borrows

### DIFF
--- a/creusot/src/callbacks.rs
+++ b/creusot/src/callbacks.rs
@@ -6,7 +6,7 @@ use rustc_middle::ty::TyCtxt;
 
 use std::{cell::RefCell, collections::HashMap, thread_local};
 
-use crate::{cleanup_spec_closures::*, options::Options};
+use crate::{cleanup_spec_closures::*, options::Options, remove_mir_reborrows::*};
 
 pub struct ToWhy {
     opts: Options,
@@ -32,6 +32,7 @@ impl Callbacks for ToWhy {
                 let mir = (rustc_interface::DEFAULT_QUERY_PROVIDERS.mir_built)(tcx, def_id);
                 let mut mir = mir.steal();
                 cleanup_spec_closures(tcx, def_id.to_def_id(), &mut mir);
+                remove_mir_reborrows(tcx, &mut mir);
                 tcx.alloc_steal_mir(mir)
             };
 

--- a/creusot/src/lib.rs
+++ b/creusot/src/lib.rs
@@ -48,5 +48,6 @@ use translation::*;
 mod error;
 pub(crate) mod lints;
 pub(crate) mod metadata;
+mod remove_mir_reborrows;
 mod translated_item;
 mod validate;

--- a/creusot/src/remove_mir_reborrows.rs
+++ b/creusot/src/remove_mir_reborrows.rs
@@ -1,0 +1,59 @@
+use rustc_ast::Mutability;
+use rustc_middle::{
+    mir::{
+        Body, BorrowKind, Location, Operand, Place, PlaceElem, Rvalue, Statement, StatementKind,
+    },
+    ty::{List, TyCtxt},
+};
+use rustc_mir_dataflow::{
+    impls::MaybeLiveLocals, Analysis, AnalysisDomain, Results, ResultsVisitor,
+};
+
+struct Visitor<'mir, 'tcx> {
+    patch: Vec<(Location, Statement<'tcx>)>,
+    mir: &'mir Body<'tcx>,
+}
+
+impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, MaybeLiveLocals>>
+    for Visitor<'mir, 'tcx>
+{
+    type FlowState = <MaybeLiveLocals as AnalysisDomain<'tcx>>::Domain;
+    fn visit_statement_before_primary_effect(
+        &mut self,
+        _: &Results<'tcx, MaybeLiveLocals>,
+        state: &Self::FlowState,
+        statement: &'mir Statement<'tcx>,
+        location: Location,
+    ) {
+        match &statement.kind {
+            StatementKind::Assign(box (place, Rvalue::Ref(_, BorrowKind::Mut { .. }, rplace)))
+                if rplace.projection.iter().eq([PlaceElem::Deref])
+                    && !state.contains(rplace.local)
+                    && self.mir.local_decls[rplace.local].ty.ref_mutability() // don't convert raw-pointers
+                        == Some(Mutability::Mut) =>
+            {
+                // place = &mut * local => place = move local
+                let new_rplace = Place { local: rplace.local, projection: List::empty() };
+                let new_rplace = Rvalue::Use(Operand::Move(new_rplace));
+                let kind = StatementKind::Assign(Box::new((*place, new_rplace)));
+                let source_info = statement.source_info.clone();
+                self.patch.push((location, Statement { kind, source_info }))
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Cleans up unnecessary reborrows
+/// x = &mut * y => x = move y
+/// when y is dead afterwards
+pub(crate) fn remove_mir_reborrows<'tcx>(tcx: TyCtxt<'tcx>, mir: &mut Body<'tcx>) {
+    let mut vistor = Visitor { patch: Vec::new(), mir };
+    MaybeLiveLocals
+        .into_engine(tcx, mir)
+        .iterate_to_fixpoint()
+        .visit_reachable_with(mir, &mut vistor);
+    for (loc, statement) in vistor.patch {
+        mir.basic_blocks.as_mut()[loc.block].statements[loc.statement_index] = statement;
+    }
+}

--- a/creusot/tests/should_fail/bug/492.mlcfg
+++ b/creusot/tests/should_fail/bug/492.mlcfg
@@ -18,28 +18,6 @@ module CreusotContracts_Invariant_Inv
     ensures { result = inv _x }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module TyInv_Trivial
   type t
   clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
@@ -66,46 +44,32 @@ module C492_ReborrowTuple
   use prelude.Int
   use prelude.UInt32
   use prelude.Borrow
-  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = (borrowed t, uint32)
-  clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = (borrowed t, uint32),
-    predicate Inv0.inv = Inv2.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = borrowed t
+    type t = (borrowed t, uint32)
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = borrowed t,
+    type t = (borrowed t, uint32),
     predicate Inv0.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = t
+    type t = borrowed t
   clone TyInv_Trivial as TyInv_Trivial0 with
-    type t = t,
+    type t = borrowed t,
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = t
   let rec cfg reborrow_tuple [#"../492.rs" 5 0 5 52] [@cfg:stackify] [@cfg:subregion_analysis] (x : borrowed t) : (borrowed t, uint32)
-    requires {[#"../492.rs" 5 25 5 26] Inv1.inv x}
+    requires {[#"../492.rs" 5 25 5 26] Inv0.inv x}
     ensures { [#"../492.rs" 4 10 4 27]  * (let (a, _) = result in a) =  * x }
-    ensures { [#"../492.rs" 5 39 5 52] Inv2.inv result }
+    ensures { [#"../492.rs" 5 39 5 52] Inv1.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : (borrowed t, uint32);
   var x : borrowed t = x;
-  var _3 : borrowed t;
   {
     goto BB0
   }
   BB0 {
-    _3 <- Borrow.borrow_mut ( * x);
-    x <- { x with current = ( ^ _3) };
-    assume { Inv0.inv ( ^ _3) };
-    _0 <- (_3, [#"../492.rs" 6 8 6 10] (32 : uint32));
-    _3 <- any borrowed t;
-    assert { [@expl:type invariant] Inv1.inv x };
-    assume { Resolve0.resolve x };
+    _0 <- (x, [#"../492.rs" 6 8 6 10] (32 : uint32));
+    x <- any borrowed t;
     return _0
   }
   
@@ -151,6 +115,28 @@ module CreusotContracts_Resolve_Impl0_Resolve
   predicate resolve (self : (t1, t2)) =
     [#"../../../../../creusot-contracts/src/resolve.rs" 16 8 16 60] Resolve0.resolve (let (a, _) = self in a) /\ Resolve1.resolve (let (_, a) = self in a)
   val resolve (self : (t1, t2)) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
 end
@@ -216,7 +202,6 @@ module C492_Test
   var x : int32;
   var res : borrowed int32;
   var _4 : (borrowed int32, uint32);
-  var _5 : borrowed int32;
   var _6 : borrowed int32;
   {
     goto BB0
@@ -225,17 +210,14 @@ module C492_Test
     x <- ([#"../492.rs" 11 16 11 17] (5 : int32));
     _6 <- Borrow.borrow_mut x;
     x <-  ^ _6;
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    _4 <- ([#"../492.rs" 12 19 12 41] ReborrowTuple0.reborrow_tuple _5);
-    _5 <- any borrowed int32;
+    _4 <- ([#"../492.rs" 12 19 12 41] ReborrowTuple0.reborrow_tuple _6);
+    _6 <- any borrowed int32;
     goto BB1
   }
   BB1 {
     res <- (let (a, _) = _4 in a);
     _4 <- (let (a, b) = _4 in (any borrowed int32, b));
     assume { Resolve0.resolve _4 };
-    assume { Resolve1.resolve _6 };
     assert { [@expl:assertion] [#"../492.rs" 13 18 13 30]  ^ res = (5 : int32) };
     res <- { res with current = ([#"../492.rs" 14 11 14 13] (10 : int32)) };
     assume { Resolve1.resolve res };

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -197,6 +197,22 @@ module CreusotContracts_Std1_Vec_Impl0_ShallowModel
     
   axiom shallow_model_spec : forall self : Alloc_Vec_Vec_Type.t_vec t a . ([#"../../../../creusot-contracts/src/std/vec.rs" 19 21 19 25] Inv0.inv self) -> ([#"../../../../creusot-contracts/src/std/vec.rs" 19 4 19 36] Inv1.inv (shallow_model self)) && ([#"../../../../creusot-contracts/src/std/vec.rs" 18 14 18 41] Seq.length (shallow_model self) <= UIntSize.to_int Max0.mAX')
 end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_None -> any 't
+      | C_Some a -> a
+      end
+end
+module Alloc_Alloc_Global_Type
+  type t_global  =
+    | C_Global
+    
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -217,22 +233,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
     [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
-    
-end
-module Core_Option_Option_Type
-  type t_option 't =
-    | C_None
-    | C_Some 't
-    
-  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
-    match (self) with
-      | C_None -> any 't
-      | C_Some a -> a
-      end
-end
-module Alloc_Alloc_Global_Type
-  type t_global  =
-    | C_Global
     
 end
 module CreusotContracts_Logic_Ops_Impl0_IndexLogic_Stub
@@ -1162,6 +1162,8 @@ module C100doors_F
     predicate Inv0.inv = Inv5.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial4 with
@@ -1186,7 +1188,7 @@ module C100doors_F
     type t = bool,
     predicate Inv0.inv = Inv1.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
     type t = bool
   clone CreusotContracts_Std1_Slice_Impl5_ResolveElswhere as ResolveElswhere0 with
     type t = bool
@@ -1212,11 +1214,9 @@ module C100doors_F
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve3.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = Core_Ops_Range_Range_Type.t_range usize
@@ -1249,15 +1249,15 @@ module C100doors_F
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv3.inv
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve2 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve1 with
     type t = bool,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv3.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = bool
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = bool,
@@ -1314,7 +1314,6 @@ module C100doors_F
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _11 : ();
   var _12 : Core_Option_Option_Type.t_option usize;
-  var _13 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _14 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _17 : Ghost.ghost_ty (Seq.seq usize);
@@ -1357,21 +1356,18 @@ module C100doors_F
   BB7 {
     _14 <- Borrow.borrow_mut iter;
     iter <-  ^ _14;
-    _13 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _13) };
-    _12 <- ([#"../100doors.rs" 20 4 20 41] Next0.next _13);
-    _13 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _12 <- ([#"../100doors.rs" 20 4 20 41] Next0.next _14);
+    _14 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve0.resolve _14 };
     switch (_12)
       | Core_Option_Option_Type.C_None -> goto BB9
       | Core_Option_Option_Type.C_Some _ -> goto BB10
       end
   }
   BB9 {
-    assume { Resolve2.resolve door_open };
+    assume { Resolve1.resolve door_open };
     _0 <- ();
     goto BB21
   }
@@ -1379,7 +1375,7 @@ module C100doors_F
     goto BB12
   }
   BB11 {
-    assume { Resolve2.resolve door_open };
+    assume { Resolve1.resolve door_open };
     absurd
   }
   BB12 {
@@ -1421,7 +1417,7 @@ module C100doors_F
   }
   BB19 {
     _30 <- { _30 with current = (not _26) };
-    assume { Resolve1.resolve _30 };
+    assume { Resolve0.resolve _30 };
     door <- ([#"../100doors.rs" 27 12 27 24] door + pass);
     _11 <- ();
     goto BB15

--- a/creusot/tests/should_succeed/bdd.mlcfg
+++ b/creusot/tests/should_succeed/bdd.mlcfg
@@ -3097,9 +3097,6 @@ module Bdd_Impl11_Node
   use prelude.UInt64
   use map.Map
   use Bdd_Bdd_Type as Bdd_Bdd_Type
-  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
-  use Bdd_Node_Type as Bdd_Node_Type
-  clone Bdd_Impl3_DeepModel as DeepModel1
   use Bdd_Hashmap_MyHashMap_Type as Bdd_Hashmap_MyHashMap_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone Bdd_Hashmap_Impl0_ShallowModel_Interface as ShallowModel8 with
@@ -3110,11 +3107,9 @@ module Bdd_Impl11_Node
     type k = Bdd_Bdd_Type.t_bdd,
     type v = Bdd_Bdd_Type.t_bdd,
     type DeepModelTy0.deepModelTy = uint64
-  clone Bdd_Impl5_DeepModel as DeepModel0
-  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel6
-  clone Bdd_Impl4_ShallowModel as ShallowModel5 with
-    function DeepModel0.deep_model = DeepModel1.deep_model
+  use Bdd_Node_Type as Bdd_Node_Type
   use prelude.Int
+  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel6
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel3 with
     type t = uint64,
     type ShallowModelTy0.shallowModelTy = int,
@@ -3124,6 +3119,10 @@ module Bdd_Impl11_Node
     val Max0.mAX' = Max0.mAX',
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   clone Bdd_Impl8_Interp as Interp0
+  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
+  clone Bdd_Impl3_DeepModel as DeepModel1
+  clone Bdd_Impl4_ShallowModel as ShallowModel5 with
+    function DeepModel0.deep_model = DeepModel1.deep_model
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel2 with
     type t = Bdd_Node_Type.t_node,
     type ShallowModelTy0.shallowModelTy = Bdd_NodeLog_Type.t_nodelog,
@@ -3148,20 +3147,21 @@ module Bdd_Impl11_Node
     function Leastvar0.leastvar = Leastvar0.leastvar,
     function ShallowModel2.shallow_model = ShallowModel7.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel8.shallow_model
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Bdd_Context_Type.t_context
+  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone Bdd_Impl5_DeepModel as DeepModel0
   clone Bdd_Impl6_ShallowModel as ShallowModel4 with
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Bdd_Context_Type.t_context
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = borrowed (Bdd_Context_Type.t_context)
   clone TyInv_Borrow as TyInv_Borrow0 with
     type t = Bdd_Context_Type.t_context,
-    predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
-    axiom .
-  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
     predicate Inv0.inv = Inv0.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel0 with
     type t = Bdd_Bdd_Type.t_bdd,
@@ -3173,7 +3173,7 @@ module Bdd_Impl11_Node
     type t = Bdd_Context_Type.t_context
   clone Bdd_Impl11_Hashcons_Interface as Hashcons0 with
     predicate IsValidNode0.is_valid_node = IsValidNode0.is_valid_node,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     predicate Grows0.grows = Grows0.grows,
     predicate IsValidBdd0.is_valid_bdd = IsValidBdd0.is_valid_bdd
   clone Bdd_Impl7_Eq_Interface as Eq0 with
@@ -3182,7 +3182,7 @@ module Bdd_Impl11_Node
     requires {[#"../bdd.rs" 458 15 458 40] IsValidBdd0.is_valid_bdd ( * self) childt}
     requires {[#"../bdd.rs" 459 15 459 40] IsValidBdd0.is_valid_bdd ( * self) childf}
     requires {[#"../bdd.rs" 460 15 460 63] UInt64.to_int x < Leastvar0.leastvar childt /\ UInt64.to_int x < Leastvar0.leastvar childf}
-    requires {[#"../bdd.rs" 465 17 465 21] Inv1.inv self}
+    requires {[#"../bdd.rs" 465 17 465 21] Inv0.inv self}
     ensures { [#"../bdd.rs" 461 14 461 26] Grows0.grows self }
     ensures { [#"../bdd.rs" 462 14 462 42] IsValidBdd0.is_valid_bdd ( ^ self) result }
     ensures { [#"../bdd.rs" 463 4 463 106] forall v : Map.map uint64 bool . Interp0.interp result v = (if Map.get v x then
@@ -3199,7 +3199,6 @@ module Bdd_Impl11_Node
   var childt : Bdd_Bdd_Type.t_bdd = childt;
   var childf : Bdd_Bdd_Type.t_bdd = childf;
   var _13 : bool;
-  var _17 : borrowed (Bdd_Context_Type.t_context);
   {
     goto BB0
   }
@@ -3214,22 +3213,17 @@ module Bdd_Impl11_Node
       end
   }
   BB2 {
-    assert { [@expl:type invariant] Inv1.inv self };
+    assert { [@expl:type invariant] Inv0.inv self };
     assume { Resolve0.resolve self };
     _0 <- childt;
     goto BB5
   }
   BB3 {
-    _17 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _17) };
-    assume { Inv0.inv ( ^ _17) };
-    _0 <- ([#"../bdd.rs" 469 8 469 50] Hashcons0.hashcons _17 (Bdd_Node_Type.C_If x childt childf));
-    _17 <- any borrowed (Bdd_Context_Type.t_context);
+    _0 <- ([#"../bdd.rs" 469 8 469 50] Hashcons0.hashcons self (Bdd_Node_Type.C_If x childt childf));
+    self <- any borrowed (Bdd_Context_Type.t_context);
     goto BB4
   }
   BB4 {
-    assert { [@expl:type invariant] Inv1.inv self };
-    assume { Resolve0.resolve self };
     goto BB5
   }
   BB5 {
@@ -3265,9 +3259,6 @@ module Bdd_Impl11_True
   use prelude.Int
   use prelude.UInt64
   use Bdd_Bdd_Type as Bdd_Bdd_Type
-  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
-  use Bdd_Node_Type as Bdd_Node_Type
-  clone Bdd_Impl3_DeepModel as DeepModel0
   use Bdd_Hashmap_MyHashMap_Type as Bdd_Hashmap_MyHashMap_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone Bdd_Hashmap_Impl0_ShallowModel_Interface as ShallowModel6 with
@@ -3278,10 +3269,9 @@ module Bdd_Impl11_True
     type k = Bdd_Bdd_Type.t_bdd,
     type v = Bdd_Bdd_Type.t_bdd,
     type DeepModelTy0.deepModelTy = uint64
-  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel4
-  clone Bdd_Impl4_ShallowModel as ShallowModel3 with
-    function DeepModel0.deep_model = DeepModel0.deep_model
+  use Bdd_Node_Type as Bdd_Node_Type
   use prelude.Int
+  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel4
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel2 with
     type t = uint64,
     type ShallowModelTy0.shallowModelTy = int,
@@ -3291,6 +3281,10 @@ module Bdd_Impl11_True
     val Max0.mAX' = Max0.mAX',
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
   clone Bdd_Impl8_Interp as Interp0
+  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
+  clone Bdd_Impl3_DeepModel as DeepModel0
+  clone Bdd_Impl4_ShallowModel as ShallowModel3 with
+    function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel1 with
     type t = Bdd_Node_Type.t_node,
     type ShallowModelTy0.shallowModelTy = Bdd_NodeLog_Type.t_nodelog,
@@ -3315,30 +3309,28 @@ module Bdd_Impl11_True
     function Leastvar0.leastvar = Leastvar0.leastvar,
     function ShallowModel2.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel6.shallow_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Bdd_Context_Type.t_context
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Bdd_Context_Type.t_context
+  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed (Bdd_Context_Type.t_context)
   clone TyInv_Borrow as TyInv_Borrow0 with
     type t = Bdd_Context_Type.t_context,
-    predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
-    axiom .
-  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
     predicate Inv0.inv = Inv0.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   clone Bdd_Impl10_Grows as Grows0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Bdd_Context_Type.t_context
   clone Bdd_Impl11_Hashcons_Interface as Hashcons0 with
     predicate IsValidNode0.is_valid_node = IsValidNode0.is_valid_node,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     predicate Grows0.grows = Grows0.grows,
     predicate IsValidBdd0.is_valid_bdd = IsValidBdd0.is_valid_bdd
   let rec cfg true_ [#"../bdd.rs" 476 4 476 42] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Bdd_Context_Type.t_context)) : Bdd_Bdd_Type.t_bdd
-    requires {[#"../bdd.rs" 476 22 476 26] Inv1.inv self}
+    requires {[#"../bdd.rs" 476 22 476 26] Inv0.inv self}
     ensures { [#"../bdd.rs" 472 14 472 26] Grows0.grows self }
     ensures { [#"../bdd.rs" 473 14 473 42] IsValidBdd0.is_valid_bdd ( ^ self) result }
     ensures { [#"../bdd.rs" 474 4 474 44] forall v : Map.map uint64 bool . Interp0.interp result v }
@@ -3347,21 +3339,15 @@ module Bdd_Impl11_True
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Bdd_Bdd_Type.t_bdd;
   var self : borrowed (Bdd_Context_Type.t_context) = self;
-  var _6 : borrowed (Bdd_Context_Type.t_context);
   {
     goto BB0
   }
   BB0 {
-    _6 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _6) };
-    assume { Inv0.inv ( ^ _6) };
-    _0 <- ([#"../bdd.rs" 477 8 477 27] Hashcons0.hashcons _6 (Bdd_Node_Type.C_True));
-    _6 <- any borrowed (Bdd_Context_Type.t_context);
+    _0 <- ([#"../bdd.rs" 477 8 477 27] Hashcons0.hashcons self (Bdd_Node_Type.C_True));
+    self <- any borrowed (Bdd_Context_Type.t_context);
     goto BB1
   }
   BB1 {
-    assert { [@expl:type invariant] Inv1.inv self };
-    assume { Resolve0.resolve self };
     return _0
   }
   
@@ -3394,9 +3380,6 @@ module Bdd_Impl11_False
   use prelude.Int
   use prelude.UInt64
   use Bdd_Bdd_Type as Bdd_Bdd_Type
-  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
-  use Bdd_Node_Type as Bdd_Node_Type
-  clone Bdd_Impl3_DeepModel as DeepModel0
   use Bdd_Hashmap_MyHashMap_Type as Bdd_Hashmap_MyHashMap_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone Bdd_Hashmap_Impl0_ShallowModel_Interface as ShallowModel6 with
@@ -3407,10 +3390,9 @@ module Bdd_Impl11_False
     type k = Bdd_Bdd_Type.t_bdd,
     type v = Bdd_Bdd_Type.t_bdd,
     type DeepModelTy0.deepModelTy = uint64
-  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel4
-  clone Bdd_Impl4_ShallowModel as ShallowModel3 with
-    function DeepModel0.deep_model = DeepModel0.deep_model
+  use Bdd_Node_Type as Bdd_Node_Type
   use prelude.Int
+  clone CreusotContracts_Std1_Num_Impl9_ShallowModel as ShallowModel4
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel2 with
     type t = uint64,
     type ShallowModelTy0.shallowModelTy = int,
@@ -3420,6 +3402,10 @@ module Bdd_Impl11_False
     val Max0.mAX' = Max0.mAX',
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
   clone Bdd_Impl8_Interp as Interp0
+  use Bdd_NodeLog_Type as Bdd_NodeLog_Type
+  clone Bdd_Impl3_DeepModel as DeepModel0
+  clone Bdd_Impl4_ShallowModel as ShallowModel3 with
+    function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel1 with
     type t = Bdd_Node_Type.t_node,
     type ShallowModelTy0.shallowModelTy = Bdd_NodeLog_Type.t_nodelog,
@@ -3444,30 +3430,28 @@ module Bdd_Impl11_False
     function Leastvar0.leastvar = Leastvar0.leastvar,
     function ShallowModel2.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel6.shallow_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Bdd_Context_Type.t_context
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Bdd_Context_Type.t_context
+  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed (Bdd_Context_Type.t_context)
   clone TyInv_Borrow as TyInv_Borrow0 with
     type t = Bdd_Context_Type.t_context,
-    predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
-    axiom .
-  clone Bdd_Context_Type_Inv as Bdd_Context_Type_Inv0 with
     predicate Inv0.inv = Inv0.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   clone Bdd_Impl10_Grows as Grows0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Bdd_Context_Type.t_context
   clone Bdd_Impl11_Hashcons_Interface as Hashcons0 with
     predicate IsValidNode0.is_valid_node = IsValidNode0.is_valid_node,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     predicate Grows0.grows = Grows0.grows,
     predicate IsValidBdd0.is_valid_bdd = IsValidBdd0.is_valid_bdd
   let rec cfg false_ [#"../bdd.rs" 484 4 484 43] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Bdd_Context_Type.t_context)) : Bdd_Bdd_Type.t_bdd
-    requires {[#"../bdd.rs" 484 23 484 27] Inv1.inv self}
+    requires {[#"../bdd.rs" 484 23 484 27] Inv0.inv self}
     ensures { [#"../bdd.rs" 480 14 480 26] Grows0.grows self }
     ensures { [#"../bdd.rs" 481 14 481 42] IsValidBdd0.is_valid_bdd ( ^ self) result }
     ensures { [#"../bdd.rs" 482 4 482 45] forall v : Map.map uint64 bool . not Interp0.interp result v }
@@ -3476,21 +3460,15 @@ module Bdd_Impl11_False
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Bdd_Bdd_Type.t_bdd;
   var self : borrowed (Bdd_Context_Type.t_context) = self;
-  var _6 : borrowed (Bdd_Context_Type.t_context);
   {
     goto BB0
   }
   BB0 {
-    _6 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _6) };
-    assume { Inv0.inv ( ^ _6) };
-    _0 <- ([#"../bdd.rs" 485 8 485 28] Hashcons0.hashcons _6 (Bdd_Node_Type.C_False));
-    _6 <- any borrowed (Bdd_Context_Type.t_context);
+    _0 <- ([#"../bdd.rs" 485 8 485 28] Hashcons0.hashcons self (Bdd_Node_Type.C_False));
+    self <- any borrowed (Bdd_Context_Type.t_context);
     goto BB1
   }
   BB1 {
-    assert { [@expl:type invariant] Inv1.inv self };
-    assume { Resolve0.resolve self };
     return _0
   }
   
@@ -3585,8 +3563,6 @@ module Bdd_Impl11_V
     axiom .
   clone Bdd_Impl10_Grows as Grows0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Bdd_Context_Type.t_context
   clone Bdd_Impl11_Node_Interface as Node0 with
     predicate IsValidBdd0.is_valid_bdd = IsValidBdd0.is_valid_bdd,
     function Leastvar0.leastvar = Leastvar0.leastvar,
@@ -3621,7 +3597,6 @@ module Bdd_Impl11_V
   var _7 : borrowed (Bdd_Context_Type.t_context);
   var f : Bdd_Bdd_Type.t_bdd;
   var _9 : borrowed (Bdd_Context_Type.t_context);
-  var _10 : borrowed (Bdd_Context_Type.t_context);
   {
     goto BB0
   }
@@ -3642,16 +3617,11 @@ module Bdd_Impl11_V
     goto BB2
   }
   BB2 {
-    _10 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _10) };
-    assume { Inv0.inv ( ^ _10) };
-    _0 <- ([#"../bdd.rs" 494 8 494 26] Node0.node _10 x t f);
-    _10 <- any borrowed (Bdd_Context_Type.t_context);
+    _0 <- ([#"../bdd.rs" 494 8 494 26] Node0.node self x t f);
+    self <- any borrowed (Bdd_Context_Type.t_context);
     goto BB3
   }
   BB3 {
-    assert { [@expl:type invariant] Inv1.inv self };
-    assume { Resolve0.resolve self };
     return _0
   }
   

--- a/creusot/tests/should_succeed/bug/682.mlcfg
+++ b/creusot/tests/should_succeed/bug/682.mlcfg
@@ -82,8 +82,6 @@ module C682_Foo
   use prelude.Int
   use prelude.UInt64
   clone Core_Num_Impl9_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = uint64
   clone C682_AddSome_Interface as AddSome0 with
     val Max0.mAX' = Max0.mAX'
   let rec cfg foo [#"../682.rs" 12 0 12 23] [@cfg:stackify] [@cfg:subregion_analysis] (a : borrowed uint64) : ()
@@ -95,7 +93,6 @@ module C682_Foo
   var a : borrowed uint64 = a;
   var a_p : Ghost.ghost_ty uint64;
   var _6 : ();
-  var _7 : borrowed uint64;
   {
     goto BB0
   }
@@ -104,14 +101,11 @@ module C682_Foo
     goto BB1
   }
   BB1 {
-    _7 <- Borrow.borrow_mut ( * a);
-    a <- { a with current = ( ^ _7) };
-    _6 <- ([#"../682.rs" 14 4 14 15] AddSome0.add_some _7);
-    _7 <- any borrowed uint64;
+    _6 <- ([#"../682.rs" 14 4 14 15] AddSome0.add_some a);
+    a <- any borrowed uint64;
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve a };
     assert { [@expl:assertion] [#"../682.rs" 15 18 15 27]  * a > Ghost.inner a_p };
     _0 <- ();
     return _0

--- a/creusot/tests/should_succeed/bug/766.mlcfg
+++ b/creusot/tests/should_succeed/bug/766.mlcfg
@@ -18,34 +18,6 @@ module CreusotContracts_Invariant_Inv
     ensures { result = inv _x }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module TyInv_Trivial
-  type t
-  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
-    type t = t
-  axiom inv_trivial : forall self : t . Inv0.inv self = true
-end
 module CreusotContracts_Model_DeepModel_DeepModelTy_Type
   type self
   type deepModelTy
@@ -128,6 +100,12 @@ module C766_Trait_F_Interface
     ensures { [#"../766.rs" 7 14 7 52] DeepModel0.deep_model self = DeepModel0.deep_model self }
     
 end
+module TyInv_Trivial
+  type t
+  clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
+    type t = t
+  axiom inv_trivial : forall self : t . Inv0.inv self = true
+end
 module C766_Trait_Goo_Interface
   type self
   type t
@@ -152,53 +130,39 @@ module C766_Trait_Goo
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel1 with
     type self = self,
     type DeepModelTy0.deepModelTy = CreusotContracts_Logic_Fmap_FMap_Type.t_fmap DeepModelTy0.deepModelTy DeepModelTy1.deepModelTy
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed self
-  clone TyInv_Trivial as TyInv_Trivial1 with
+  clone TyInv_Trivial as TyInv_Trivial0 with
     type t = borrowed self,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     axiom .
   clone CreusotContracts_Model_Impl6_DeepModel as DeepModel0 with
     type t = self,
     type DeepModelTy0.deepModelTy = CreusotContracts_Logic_Fmap_FMap_Type.t_fmap DeepModelTy0.deepModelTy DeepModelTy1.deepModelTy,
     function DeepModel0.deep_model = DeepModel1.deep_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = self
-  clone TyInv_Trivial as TyInv_Trivial0 with
-    type t = self,
-    predicate Inv0.inv = Inv0.inv,
-    axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = self
   clone C766_Trait_F_Interface as F0 with
     type self = self,
     type t = t,
     type u = u,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     type DeepModelTy1.deepModelTy = DeepModelTy1.deepModelTy
   let rec cfg goo [#"../766.rs" 10 4 10 21] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed self) : ()
-    requires {[#"../766.rs" 10 16 10 20] Inv1.inv self}
+    requires {[#"../766.rs" 10 16 10 20] Inv0.inv self}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var self : borrowed self = self;
-  var _2 : borrowed self;
   {
     goto BB0
   }
   BB0 {
-    _2 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _2) };
-    assume { Inv0.inv ( ^ _2) };
-    _0 <- ([#"../766.rs" 11 8 11 16] F0.f _2);
-    _2 <- any borrowed self;
+    _0 <- ([#"../766.rs" 11 8 11 16] F0.f self);
+    self <- any borrowed self;
     goto BB1
   }
   BB1 {
-    assert { [@expl:type invariant] Inv1.inv self };
-    assume { Resolve0.resolve self };
     return _0
   }
   

--- a/creusot/tests/should_succeed/closures/01_basic.mlcfg
+++ b/creusot/tests/should_succeed/closures/01_basic.mlcfg
@@ -498,7 +498,6 @@ module C01Basic_MoveMut_Closure0
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var _1 : borrowed c01basic_movemut_closure0 = _1;
-  var _2 : borrowed uint32;
   var _3 : borrowed uint32;
   {
     goto BB0
@@ -508,13 +507,10 @@ module C01Basic_MoveMut_Closure0
     goto BB1
   }
   BB1 {
-    _2 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _2) };
-    _1 <- { _1 with current = (let C01Basic_MoveMut_Closure0 a =  * _1 in C01Basic_MoveMut_Closure0 _2) };
-    _2 <- any borrowed uint32;
+    _1 <- { _1 with current = (let C01Basic_MoveMut_Closure0 a =  * _1 in C01Basic_MoveMut_Closure0 _3) };
+    _3 <- any borrowed uint32;
     assume { Resolve0.resolve (field_0 ( * _1)) };
     assume { Resolve1.resolve _1 };
-    assume { Resolve0.resolve _3 };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/drop_pair.mlcfg
+++ b/creusot/tests/should_succeed/drop_pair.mlcfg
@@ -157,19 +157,15 @@ module DropPair_Drop
   var _0 : ();
   var _x : borrowed uint32 = _x;
   var y : borrowed uint32 = y;
-  var _3 : borrowed uint32;
   {
     goto BB0
   }
   BB0 {
     assume { Resolve0.resolve _x };
-    _3 <- Borrow.borrow_mut ( * y);
-    y <- { y with current = ( ^ _3) };
-    _x <- _3;
-    _3 <- any borrowed uint32;
+    _x <- y;
+    y <- any borrowed uint32;
     assume { Resolve0.resolve _x };
     _0 <- ();
-    assume { Resolve0.resolve y };
     return _0
   }
   

--- a/creusot/tests/should_succeed/hashmap.mlcfg
+++ b/creusot/tests/should_succeed/hashmap.mlcfg
@@ -1541,58 +1541,58 @@ module Hashmap_Impl5_Add
     predicate Inv0.inv = Inv11.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = borrowed v
+    type t = borrowed (Hashmap_List_Type.t_list (k, v))
   clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = borrowed v,
+    type t = borrowed (Hashmap_List_Type.t_list (k, v)),
     predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = borrowed k
+    type t = Hashmap_List_Type.t_list (k, v)
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = borrowed k,
+    type t = Hashmap_List_Type.t_list (k, v),
     predicate Inv0.inv = Inv9.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = Hashmap_List_Type.t_list (k, v)
+    type t = borrowed v
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = Hashmap_List_Type.t_list (k, v),
+    type t = borrowed v,
     predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = v
+    type t = borrowed k
   clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = v,
+    type t = borrowed k,
     predicate Inv0.inv = Inv7.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = k
+    type t = Hashmap_List_Type.t_list (k, v)
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = k,
+    type t = Hashmap_List_Type.t_list (k, v),
     predicate Inv0.inv = Inv6.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = DeepModelTy0.deepModelTy
+    type t = v
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = DeepModelTy0.deepModelTy,
+    type t = v,
     predicate Inv0.inv = Inv5.inv,
     axiom .
-  use prelude.Ghost
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v)))
+    type t = k
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v))),
+    type t = k,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed (Hashmap_List_Type.t_list (k, v))
+    type t = DeepModelTy0.deepModelTy
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed (Hashmap_List_Type.t_list (k, v)),
+    type t = DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv3.inv,
     axiom .
+  use prelude.Ghost
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = Hashmap_List_Type.t_list (k, v)
+    type t = Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v)))
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = Hashmap_List_Type.t_list (k, v),
+    type t = Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v))),
     predicate Inv0.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Std1_Slice_Impl5_ResolveElswhere as ResolveElswhere0 with
@@ -1653,8 +1653,8 @@ module Hashmap_Impl5_Add
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv5.inv,
+    predicate Inv0.inv = Inv5.inv,
+    predicate Inv1.inv = Inv3.inv,
     function Get0.get = Get0.get,
     function BucketIx0.bucket_ix = BucketIx0.bucket_ix
   clone Hashmap_Impl5_HashmapInv as HashmapInv0 with
@@ -1676,8 +1676,10 @@ module Hashmap_Impl5_Add
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
     type t = Hashmap_List_Type.t_list (k, v)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = v
+    type t = Hashmap_List_Type.t_list (k, v)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    type t = v
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = k
   clone Core_Cmp_PartialEq_Eq_Interface as Eq0 with
     type self = k,
@@ -1687,10 +1689,8 @@ module Hashmap_Impl5_Add
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function DeepModel1.deep_model = DeepModel1.deep_model,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v)))
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Hashmap_List_Type.t_list (k, v)
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = Hashmap_List_Type.t_list (k, v),
     type i = usize,
@@ -1703,7 +1703,7 @@ module Hashmap_Impl5_Add
     predicate HasValue0.has_value = HasValue0.has_value,
     function ShallowModel1.shallow_model = ShallowModel4.shallow_model,
     predicate ResolveElswhere0.resolve_elswhere = ResolveElswhere0.resolve_elswhere,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv2.inv = Inv10.inv,
     predicate Inv3.inv = Inv1.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv4.inv = Inv17.inv
@@ -1723,10 +1723,10 @@ module Hashmap_Impl5_Add
   let rec cfg add [#"../hashmap.rs" 106 4 106 41] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)) (key : k) (val' : v) : ()
     requires {[#"../hashmap.rs" 103 15 103 36] HashmapInv0.hashmap_inv ( * self)}
     requires {[#"../hashmap.rs" 106 20 106 24] Inv12.inv self}
-    requires {[#"../hashmap.rs" 106 26 106 29] Inv6.inv key}
-    requires {[#"../hashmap.rs" 106 34 106 37] Inv7.inv val'}
+    requires {[#"../hashmap.rs" 106 26 106 29] Inv4.inv key}
+    requires {[#"../hashmap.rs" 106 34 106 37] Inv5.inv val'}
     ensures { [#"../hashmap.rs" 104 14 104 35] HashmapInv0.hashmap_inv ( ^ self) }
-    ensures { [#"../hashmap.rs" 105 4 105 124] forall i : DeepModelTy0.deepModelTy . Inv5.inv i -> Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
+    ensures { [#"../hashmap.rs" 105 4 105 124] forall i : DeepModelTy0.deepModelTy . Inv3.inv i -> Map.get (ShallowModel0.shallow_model ( ^ self)) i = (if i = DeepModel0.deep_model key then
       Core_Option_Option_Type.C_Some val'
     else
       Map.get (ShallowModel1.shallow_model self) i
@@ -1744,7 +1744,6 @@ module Hashmap_Impl5_Add
   var _15 : usize;
   var _16 : bool;
   var l : borrowed (Hashmap_List_Type.t_list (k, v));
-  var _18 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _19 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _20 : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global));
   var old_l : Ghost.ghost_ty (borrowed (Hashmap_List_Type.t_list (k, v)));
@@ -1753,7 +1752,6 @@ module Hashmap_Impl5_Add
   var tl : borrowed (Hashmap_List_Type.t_list (k, v));
   var tl1 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _38 : bool;
-  var _45 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _46 : borrowed (Hashmap_List_Type.t_list (k, v));
   {
     goto BB0
@@ -1790,29 +1788,23 @@ module Hashmap_Impl5_Add
     goto BB5
   }
   BB5 {
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    assume { Inv2.inv ( ^ _18) };
-    l <- Borrow.borrow_mut ( * _18);
-    _18 <- { _18 with current = ( ^ l) };
-    assume { Inv2.inv ( ^ l) };
-    assert { [@expl:type invariant] Inv3.inv _18 };
-    assume { Resolve1.resolve _18 };
+    l <- _19;
+    _19 <- any borrowed (Hashmap_List_Type.t_list (k, v));
     old_l <- ([#"../hashmap.rs" 112 20 112 29] Ghost.new l);
     goto BB6
   }
   BB6 {
-    assert { [@expl:type invariant] Inv4.inv old_l };
-    assume { Resolve2.resolve old_l };
+    assert { [@expl:type invariant] Inv2.inv old_l };
+    assume { Resolve1.resolve old_l };
     goto BB7
   }
   BB7 {
     invariant { [#"../hashmap.rs" 114 20 114 52] GoodBucket0.good_bucket ( * Ghost.inner old_self) ( * l) (UIntSize.to_int index) };
     invariant { [#"../hashmap.rs" 114 8 114 54] GoodBucket0.good_bucket ( * Ghost.inner old_self) ( ^ l) (UIntSize.to_int index) -> GoodBucket0.good_bucket ( * Ghost.inner old_self) ( ^ Ghost.inner old_l) (UIntSize.to_int index) };
     invariant { [#"../hashmap.rs" 114 8 114 54] Get0.get ( ^ l) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_Some val' -> Get0.get ( ^ Ghost.inner old_l) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_Some val' };
-    invariant { [#"../hashmap.rs" 114 8 114 54] forall i : DeepModelTy0.deepModelTy . Inv5.inv i -> Get0.get ( ^ l) i = Get0.get ( * l) i -> Get0.get ( ^ Ghost.inner old_l) i = Get0.get ( * Ghost.inner old_l) i };
+    invariant { [#"../hashmap.rs" 114 8 114 54] forall i : DeepModelTy0.deepModelTy . Inv3.inv i -> Get0.get ( ^ l) i = Get0.get ( * l) i -> Get0.get ( ^ Ghost.inner old_l) i = Get0.get ( * Ghost.inner old_l) i };
     invariant { [#"../hashmap.rs" 118 20 118 44] NoDoubleBinding0.no_double_binding ( * l) };
-    invariant { [#"../hashmap.rs" 114 8 114 54] (forall i : DeepModelTy0.deepModelTy . Inv5.inv i -> Get0.get ( * l) i = Get0.get ( ^ l) i \/ i = DeepModel0.deep_model key) /\ NoDoubleBinding0.no_double_binding ( ^ l) -> NoDoubleBinding0.no_double_binding ( ^ Ghost.inner old_l) };
+    invariant { [#"../hashmap.rs" 114 8 114 54] (forall i : DeepModelTy0.deepModelTy . Inv3.inv i -> Get0.get ( * l) i = Get0.get ( ^ l) i \/ i = DeepModel0.deep_model key) /\ NoDoubleBinding0.no_double_binding ( ^ l) -> NoDoubleBinding0.no_double_binding ( ^ Ghost.inner old_l) };
     goto BB8
   }
   BB8 {
@@ -1827,21 +1819,21 @@ module Hashmap_Impl5_Add
   BB10 {
     k <- Borrow.borrow_mut (let (a, _) = Hashmap_List_Type.cons_0 ( * l) in a);
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons (let (a, b) = Hashmap_List_Type.cons_0 ( * l) in ( ^ k, b)) b) };
-    assume { Inv6.inv ( ^ k) };
+    assume { Inv4.inv ( ^ k) };
     v <- Borrow.borrow_mut (let (_, a) = Hashmap_List_Type.cons_0 ( * l) in a);
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons (let (a, b) = Hashmap_List_Type.cons_0 ( * l) in (a,  ^ v)) b) };
-    assume { Inv7.inv ( ^ v) };
+    assume { Inv5.inv ( ^ v) };
     tl <- Borrow.borrow_mut (Hashmap_List_Type.cons_1 ( * l));
     l <- { l with current = (let Hashmap_List_Type.C_Cons a b =  * l in Hashmap_List_Type.C_Cons a ( ^ tl)) };
-    assume { Inv8.inv ( ^ tl) };
+    assume { Inv6.inv ( ^ tl) };
     tl1 <- tl;
     tl <- any borrowed (Hashmap_List_Type.t_list (k, v));
     _38 <- ([#"../hashmap.rs" 123 15 123 24] Eq0.eq ( * k) key);
     goto BB11
   }
   BB11 {
-    assert { [@expl:type invariant] Inv9.inv k };
-    assume { Resolve3.resolve k };
+    assert { [@expl:type invariant] Inv7.inv k };
+    assume { Resolve2.resolve k };
     switch (_38)
       | False -> goto BB13
       | True -> goto BB12
@@ -1850,19 +1842,17 @@ module Hashmap_Impl5_Add
   BB12 {
     assert { [@expl:type invariant] Inv11.inv tl1 };
     assume { Resolve5.resolve tl1 };
-    assert { [@expl:type invariant] Inv6.inv key };
+    assert { [@expl:type invariant] Inv4.inv key };
     assume { Resolve6.resolve key };
-    assert { [@expl:type invariant] Inv7.inv val' };
+    assert { [@expl:type invariant] Inv5.inv val' };
     assume { Resolve7.resolve val' };
     v <- { v with current = val' };
-    assert { [@expl:type invariant] Inv7.inv ( * v) };
+    assert { [@expl:type invariant] Inv5.inv ( * v) };
     assume { Resolve7.resolve ( * v) };
-    assert { [@expl:type invariant] Inv10.inv v };
-    assume { Resolve4.resolve v };
-    assert { [@expl:type invariant] Inv3.inv _19 };
-    assume { Resolve1.resolve _19 };
-    assert { [@expl:type invariant] Inv3.inv l };
-    assume { Resolve1.resolve l };
+    assert { [@expl:type invariant] Inv8.inv v };
+    assume { Resolve3.resolve v };
+    assert { [@expl:type invariant] Inv10.inv l };
+    assume { Resolve4.resolve l };
     assert { [@expl:type invariant] Inv12.inv self };
     assume { Resolve8.resolve self };
     assert { [@expl:assertion] [#"../hashmap.rs" 125 32 125 52] HashmapInv0.hashmap_inv ( * self) };
@@ -1870,28 +1860,23 @@ module Hashmap_Impl5_Add
     goto BB20
   }
   BB13 {
-    assert { [@expl:type invariant] Inv10.inv v };
-    assume { Resolve4.resolve v };
+    assert { [@expl:type invariant] Inv8.inv v };
+    assume { Resolve3.resolve v };
     _46 <- Borrow.borrow_mut ( * tl1);
     tl1 <- { tl1 with current = ( ^ _46) };
-    assume { Inv2.inv ( ^ _46) };
-    _45 <- Borrow.borrow_mut ( * _46);
-    _46 <- { _46 with current = ( ^ _45) };
-    assume { Inv2.inv ( ^ _45) };
-    assert { [@expl:type invariant] Inv3.inv l };
-    assume { Resolve1.resolve l };
-    l <- _45;
-    _45 <- any borrowed (Hashmap_List_Type.t_list (k, v));
-    assert { [@expl:type invariant] Inv3.inv _46 };
-    assume { Resolve1.resolve _46 };
+    assume { Inv9.inv ( ^ _46) };
+    assert { [@expl:type invariant] Inv10.inv l };
+    assume { Resolve4.resolve l };
+    l <- _46;
+    _46 <- any borrowed (Hashmap_List_Type.t_list (k, v));
     assert { [@expl:type invariant] Inv11.inv tl1 };
     assume { Resolve5.resolve tl1 };
     goto BB7
   }
   BB14 {
-    assert { [@expl:type invariant] Inv6.inv key };
+    assert { [@expl:type invariant] Inv4.inv key };
     assume { Resolve6.resolve key };
-    assert { [@expl:type invariant] Inv7.inv val' };
+    assert { [@expl:type invariant] Inv5.inv val' };
     assume { Resolve7.resolve val' };
     goto BB15
   }
@@ -1903,15 +1888,13 @@ module Hashmap_Impl5_Add
   }
   BB17 {
     l <- { l with current = Hashmap_List_Type.C_Cons (key, val') (Hashmap_List_Type.C_Nil) };
-    assert { [@expl:type invariant] Inv2.inv ( * l) };
+    assert { [@expl:type invariant] Inv9.inv ( * l) };
     assume { Resolve9.resolve ( * l) };
-    assert { [@expl:type invariant] Inv3.inv l };
-    assume { Resolve1.resolve l };
+    assert { [@expl:type invariant] Inv10.inv l };
+    assume { Resolve4.resolve l };
     goto BB19
   }
   BB19 {
-    assert { [@expl:type invariant] Inv3.inv _19 };
-    assume { Resolve1.resolve _19 };
     assert { [@expl:type invariant] Inv12.inv self };
     assume { Resolve8.resolve self };
     assert { [@expl:assertion] [#"../hashmap.rs" 133 24 133 44] HashmapInv0.hashmap_inv ( * self) };
@@ -2447,61 +2430,56 @@ module Hashmap_Impl5_Resize
   use prelude.Borrow
   use map.Map
   use seq.Seq
+  use Hashmap_List_Type as Hashmap_List_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv13 with
-    type t = usize
+    type t = borrowed (Hashmap_List_Type.t_list (k, v))
   clone TyInv_Trivial as TyInv_Trivial13 with
-    type t = usize,
+    type t = borrowed (Hashmap_List_Type.t_list (k, v)),
     predicate Inv0.inv = Inv13.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
-  use Hashmap_List_Type as Hashmap_List_Type
-  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))
+    type t = usize
   clone TyInv_Trivial as TyInv_Trivial12 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)),
+    type t = usize,
     predicate Inv0.inv = Inv12.inv,
     axiom .
-  use seq.Seq
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
-    type t = Seq.seq (Hashmap_List_Type.t_list (k, v))
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial11 with
-    type t = Seq.seq (Hashmap_List_Type.t_list (k, v)),
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv11.inv,
     axiom .
+  use seq.Seq
   clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)
+    type t = Seq.seq (Hashmap_List_Type.t_list (k, v))
   clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global),
+    type t = Seq.seq (Hashmap_List_Type.t_list (k, v)),
     predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = Hashmap_List_Type.t_list (k, v)
+    type t = Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global)
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = Hashmap_List_Type.t_list (k, v),
+    type t = Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv9.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = v
+    type t = Hashmap_List_Type.t_list (k, v)
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = v,
+    type t = Hashmap_List_Type.t_list (k, v),
     predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = k
+    type t = v
   clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = k,
+    type t = v,
     predicate Inv0.inv = Inv7.inv,
     axiom .
-  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
-    type self = k
-  clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel0 with
-    type self = k,
-    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = borrowed (Hashmap_List_Type.t_list (k, v))
+    type t = k
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = borrowed (Hashmap_List_Type.t_list (k, v)),
+    type t = k,
     predicate Inv0.inv = Inv6.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
@@ -2510,6 +2488,11 @@ module Hashmap_Impl5_Resize
     type t = Hashmap_List_Type.t_list (k, v),
     predicate Inv0.inv = Inv5.inv,
     axiom .
+  clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
+    type self = k
+  clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel0 with
+    type self = k,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   clone CreusotContracts_Std1_Slice_Impl5_ResolveElswhere as ResolveElswhere0 with
     type t = Hashmap_List_Type.t_list (k, v)
   clone CreusotContracts_Std1_Slice_Impl5_HasValue as HasValue0 with
@@ -2524,7 +2507,7 @@ module Hashmap_Impl5_Resize
     type a = Alloc_Alloc_Global_Type.t_global,
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv11.inv,
+    predicate Inv1.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel6 with
     type t = Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global),
@@ -2553,7 +2536,7 @@ module Hashmap_Impl5_Resize
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv11.inv
+    predicate Inv1.inv = Inv10.inv
   clone Hashmap_Hash_HashLog_Interface as HashLog0 with
     type self = k,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
@@ -2565,7 +2548,7 @@ module Hashmap_Impl5_Resize
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv11.inv
+    predicate Inv1.inv = Inv10.inv
   clone Hashmap_Impl4_Bucket as Bucket0 with
     type k = k,
     type v = v,
@@ -2610,7 +2593,7 @@ module Hashmap_Impl5_Resize
     type t = Ghost.ghost_ty (borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v)),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve7 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
     type self = Hashmap_List_Type.t_list (k, v)
   clone Hashmap_Impl1_NoDoubleBinding as NoDoubleBinding0 with
     type k = k,
@@ -2622,7 +2605,7 @@ module Hashmap_Impl5_Resize
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv7.inv,
     predicate Inv1.inv = Inv1.inv,
     function Get0.get = Get0.get,
     function BucketIx0.bucket_ix = BucketIx0.bucket_ix
@@ -2635,30 +2618,28 @@ module Hashmap_Impl5_Resize
     predicate NoDoubleBinding0.no_double_binding = NoDoubleBinding0.no_double_binding,
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv11.inv
+    predicate Inv1.inv = Inv10.inv
   clone Hashmap_Impl5_Add_Interface as Add0 with
     type k = k,
     type v = v,
     predicate HashmapInv0.hashmap_inv = HashmapInv0.hashmap_inv,
     predicate Inv0.inv = Inv3.inv,
-    predicate Inv1.inv = Inv7.inv,
-    predicate Inv2.inv = Inv8.inv,
+    predicate Inv1.inv = Inv6.inv,
+    predicate Inv2.inv = Inv7.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     predicate Inv3.inv = Inv1.inv,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function ShallowModel1.shallow_model = ShallowModel3.shallow_model
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
-    type self = v
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
-    type self = k
+    type self = v
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+    type self = k
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Hashmap_List_Type.t_list (k, v)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = Hashmap_List_Type.t_list (k, v)
   clone Core_Mem_Replace_Interface as Replace0 with
     type t = Hashmap_List_Type.t_list (k, v),
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv13.inv,
     predicate Inv1.inv = Inv5.inv
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = Hashmap_List_Type.t_list (k, v),
@@ -2667,15 +2648,15 @@ module Hashmap_Impl5_Resize
     type Output0.output = Hashmap_List_Type.t_list (k, v),
     function ShallowModel0.shallow_model = ShallowModel6.shallow_model,
     predicate InBounds0.in_bounds = InBounds0.in_bounds,
-    predicate Inv0.inv = Inv12.inv,
-    predicate Inv1.inv = Inv13.inv,
+    predicate Inv0.inv = Inv11.inv,
+    predicate Inv1.inv = Inv12.inv,
     predicate HasValue0.has_value = HasValue0.has_value,
     function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
     predicate ResolveElswhere0.resolve_elswhere = ResolveElswhere0.resolve_elswhere,
-    predicate Inv2.inv = Inv6.inv,
+    predicate Inv2.inv = Inv13.inv,
     predicate Inv3.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv4.inv = Inv11.inv
+    predicate Inv4.inv = Inv10.inv
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = Hashmap_MyHashMap_Type.t_myhashmap k v
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
@@ -2695,7 +2676,7 @@ module Hashmap_Impl5_Resize
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with
     type t = Hashmap_List_Type.t_list (k, v),
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv9.inv,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v))
@@ -2716,8 +2697,6 @@ module Hashmap_Impl5_Resize
   var _21 : ();
   var _24 : usize;
   var l : Hashmap_List_Type.t_list (k, v);
-  var _27 : borrowed (Hashmap_List_Type.t_list (k, v));
-  var _28 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _29 : borrowed (Hashmap_List_Type.t_list (k, v));
   var _30 : borrowed (Alloc_Vec_Vec_Type.t_vec (Hashmap_List_Type.t_list (k, v)) (Alloc_Alloc_Global_Type.t_global));
   var k : k;
@@ -2782,21 +2761,11 @@ module Hashmap_Impl5_Resize
     goto BB10
   }
   BB10 {
-    _28 <- Borrow.borrow_mut ( * _29);
-    _29 <- { _29 with current = ( ^ _28) };
-    assume { Inv5.inv ( ^ _28) };
-    _27 <- Borrow.borrow_mut ( * _28);
-    _28 <- { _28 with current = ( ^ _27) };
-    assume { Inv5.inv ( ^ _27) };
-    l <- ([#"../hashmap.rs" 177 33 177 83] Replace0.replace _27 (Hashmap_List_Type.C_Nil));
-    _27 <- any borrowed (Hashmap_List_Type.t_list (k, v));
+    l <- ([#"../hashmap.rs" 177 33 177 83] Replace0.replace _29 (Hashmap_List_Type.C_Nil));
+    _29 <- any borrowed (Hashmap_List_Type.t_list (k, v));
     goto BB11
   }
   BB11 {
-    assert { [@expl:type invariant] Inv6.inv _29 };
-    assume { Resolve3.resolve _29 };
-    assert { [@expl:type invariant] Inv6.inv _28 };
-    assume { Resolve3.resolve _28 };
     goto BB12
   }
   BB12 {
@@ -2841,21 +2810,21 @@ module Hashmap_Impl5_Resize
     tl <- Hashmap_List_Type.cons_1 l;
     l <- (let Hashmap_List_Type.C_Cons a b = l in Hashmap_List_Type.C_Cons a (any Hashmap_List_Type.t_list (k, v)));
     assert { [@expl:type invariant] Inv5.inv l };
-    assume { Resolve4.resolve l };
+    assume { Resolve3.resolve l };
     _45 <- Borrow.borrow_mut new;
     new <-  ^ _45;
     assume { Inv2.inv ( ^ _45) };
-    assert { [@expl:type invariant] Inv7.inv k };
-    assume { Resolve5.resolve k };
-    assert { [@expl:type invariant] Inv8.inv v };
-    assume { Resolve6.resolve v };
+    assert { [@expl:type invariant] Inv6.inv k };
+    assume { Resolve4.resolve k };
+    assert { [@expl:type invariant] Inv7.inv v };
+    assume { Resolve5.resolve v };
     _44 <- ([#"../hashmap.rs" 189 16 189 29] Add0.add _45 k v);
     _45 <- any borrowed (Hashmap_MyHashMap_Type.t_myhashmap k v);
     goto BB21
   }
   BB21 {
-    assert { [@expl:type invariant] Inv9.inv tl };
-    assume { Resolve7.resolve tl };
+    assert { [@expl:type invariant] Inv8.inv tl };
+    assume { Resolve6.resolve tl };
     goto BB22
   }
   BB22 {
@@ -2869,7 +2838,7 @@ module Hashmap_Impl5_Resize
   }
   BB25 {
     assert { [@expl:type invariant] Inv5.inv l };
-    assume { Resolve4.resolve l };
+    assume { Resolve3.resolve l };
     assert { [@expl:assertion] [#"../hashmap.rs" 192 12 192 121] forall k : DeepModelTy0.deepModelTy . Inv1.inv k -> BucketIx0.bucket_ix ( * Ghost.inner old_self) k = UIntSize.to_int i -> Map.get (ShallowModel0.shallow_model old_self) k = Map.get (ShallowModel1.shallow_model new) k };
     goto BB27
   }

--- a/creusot/tests/should_succeed/heapsort_generic.mlcfg
+++ b/creusot/tests/should_succeed/heapsort_generic.mlcfg
@@ -1712,18 +1712,30 @@ module HeapsortGeneric_SiftDown
     predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = usize
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = usize,
+    type t = slice t,
     predicate Inv0.inv = Inv9.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+    type t = borrowed (slice t)
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = borrowed (slice t),
+    predicate Inv0.inv = Inv8.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+    type t = usize
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = usize,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial8 with
+  clone TyInv_Trivial as TyInv_Trivial6 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with
     type self = DeepModelTy0.deepModelTy
@@ -1732,39 +1744,27 @@ module HeapsortGeneric_SiftDown
   use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with
     type self = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq t
-  clone TyInv_Trivial as TyInv_Trivial7 with
+  clone TyInv_Trivial as TyInv_Trivial5 with
     type t = Seq.seq t,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel3 with
     type self = t,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (slice t)
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (slice t),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = slice t
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = slice t,
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel6 with
     type t = t,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv9.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel5 with
     type t = slice t,
@@ -1797,7 +1797,7 @@ module HeapsortGeneric_SiftDown
     type a = Alloc_Alloc_Global_Type.t_global,
     predicate Inv0.inv = Inv3.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel4 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
@@ -1881,7 +1881,7 @@ module HeapsortGeneric_SiftDown
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     predicate Inv0.inv = Inv3.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface as DeepModel1 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
@@ -1892,37 +1892,35 @@ module HeapsortGeneric_SiftDown
     predicate Inv1.inv = Inv10.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv2.inv = Inv7.inv,
+    predicate Inv2.inv = Inv5.inv,
     axiom .
   clone HeapsortGeneric_Parent as Parent0
   clone HeapsortGeneric_HeapFrag as HeapFrag0 with
     type t = DeepModelTy0.deepModelTy,
     function Parent0.parent = Parent0.parent,
     function LeLog0.le_log = LeLog0.le_log
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = slice t
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv8.inv,
     function ShallowModel1.shallow_model = ShallowModel6.shallow_model,
-    predicate Inv1.inv = Inv4.inv,
+    predicate Inv1.inv = Inv9.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv2.inv = Inv7.inv
+    predicate Inv2.inv = Inv5.inv
   clone Alloc_Vec_Impl9_DerefMut_Interface as DerefMut0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel2.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv1.inv = Inv5.inv,
-    predicate Inv2.inv = Inv4.inv,
+    predicate Inv1.inv = Inv8.inv,
+    predicate Inv2.inv = Inv9.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv3.inv = Inv7.inv,
+    predicate Inv3.inv = Inv5.inv,
     predicate Inv4.inv = Inv3.inv
   clone Core_Cmp_PartialOrd_Le_Interface as Le0 with
     type self = t,
@@ -1950,8 +1948,8 @@ module HeapsortGeneric_SiftDown
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model,
     predicate InBounds0.in_bounds = InBounds0.in_bounds,
-    predicate Inv0.inv = Inv8.inv,
-    predicate Inv1.inv = Inv9.inv,
+    predicate Inv0.inv = Inv6.inv,
+    predicate Inv1.inv = Inv7.inv,
     predicate HasValue0.has_value = HasValue0.has_value,
     predicate Inv2.inv = Inv2.inv,
     type Output0.output = t
@@ -1971,7 +1969,7 @@ module HeapsortGeneric_SiftDown
     requires {[#"../heapsort_generic.rs" 31 11 31 54] HeapFrag0.heap_frag (DeepModel0.deep_model v) (UIntSize.to_int start + 1) (UIntSize.to_int end')}
     requires {[#"../heapsort_generic.rs" 32 11 32 24] UIntSize.to_int start < UIntSize.to_int end'}
     requires {[#"../heapsort_generic.rs" 33 11 33 27] UIntSize.to_int end' <= Seq.length (ShallowModel0.shallow_model v)}
-    requires {[#"../heapsort_generic.rs" 41 33 41 34] Inv6.inv v}
+    requires {[#"../heapsort_generic.rs" 41 33 41 34] Inv4.inv v}
     ensures { [#"../heapsort_generic.rs" 34 10 34 52] HeapFrag0.heap_frag (DeepModel1.deep_model ( ^ v)) (UIntSize.to_int start) (UIntSize.to_int end') }
     ensures { [#"../heapsort_generic.rs" 35 0 35 36] PermutationOf0.permutation_of (ShallowModel2.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
     ensures { [#"../heapsort_generic.rs" 36 0 37 43] forall i : int . 0 <= i /\ i < UIntSize.to_int start \/ UIntSize.to_int end' <= i /\ i < Seq.length (ShallowModel0.shallow_model v) -> IndexLogic0.index_logic ( * v) i = IndexLogic0.index_logic ( ^ v) i }
@@ -1995,7 +1993,6 @@ module HeapsortGeneric_SiftDown
   var _52 : t;
   var _56 : t;
   var _60 : ();
-  var _61 : borrowed (slice t);
   var _62 : borrowed (slice t);
   var _63 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
@@ -2033,8 +2030,8 @@ module HeapsortGeneric_SiftDown
       end
   }
   BB5 {
-    assert { [@expl:type invariant] Inv6.inv v };
-    assume { Resolve3.resolve v };
+    assert { [@expl:type invariant] Inv4.inv v };
+    assume { Resolve2.resolve v };
     _0 <- ();
     goto BB23
   }
@@ -2108,8 +2105,8 @@ module HeapsortGeneric_SiftDown
       end
   }
   BB19 {
-    assert { [@expl:type invariant] Inv6.inv v };
-    assume { Resolve3.resolve v };
+    assert { [@expl:type invariant] Inv4.inv v };
+    assume { Resolve2.resolve v };
     _0 <- ();
     goto BB23
   }
@@ -2122,16 +2119,11 @@ module HeapsortGeneric_SiftDown
     goto BB21
   }
   BB21 {
-    _61 <- Borrow.borrow_mut ( * _62);
-    _62 <- { _62 with current = ( ^ _61) };
-    assume { Inv4.inv ( ^ _61) };
-    _60 <- ([#"../heapsort_generic.rs" 71 8 71 24] Swap0.swap _61 i child);
-    _61 <- any borrowed (slice t);
+    _60 <- ([#"../heapsort_generic.rs" 71 8 71 24] Swap0.swap _62 i child);
+    _62 <- any borrowed (slice t);
     goto BB22
   }
   BB22 {
-    assert { [@expl:type invariant] Inv5.inv _62 };
-    assume { Resolve2.resolve _62 };
     i <- child;
     goto BB2
   }
@@ -2310,6 +2302,18 @@ module HeapsortGeneric_HeapSort
     type t = Seq.seq t,
     predicate Inv0.inv = Inv6.inv,
     axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = slice t
+  clone TyInv_Trivial as TyInv_Trivial5 with
+    type t = slice t,
+    predicate Inv0.inv = Inv5.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
+    type t = borrowed (slice t)
+  clone TyInv_Trivial as TyInv_Trivial4 with
+    type t = borrowed (slice t),
+    predicate Inv0.inv = Inv4.inv,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with
@@ -2321,11 +2325,11 @@ module HeapsortGeneric_HeapSort
     type self = DeepModelTy0.deepModelTy
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial5 with
+  clone TyInv_Trivial as TyInv_Trivial3 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel2 with
     type self = t,
@@ -2347,21 +2351,9 @@ module HeapsortGeneric_HeapSort
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv6.inv
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (slice t)
-  clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (slice t),
-    predicate Inv0.inv = Inv4.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = slice t
-  clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = slice t,
-    predicate Inv0.inv = Inv3.inv,
-    axiom .
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel6 with
     type t = t,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv5.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv6.inv,
     axiom .
@@ -2504,14 +2496,12 @@ module HeapsortGeneric_HeapSort
     function LeLog0.le_log = LeLog0.le_log,
     function Parent0.parent = Parent0.parent,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = slice t
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     predicate Inv0.inv = Inv4.inv,
     function ShallowModel1.shallow_model = ShallowModel6.shallow_model,
-    predicate Inv1.inv = Inv3.inv,
+    predicate Inv1.inv = Inv5.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv2.inv = Inv6.inv
   clone Alloc_Vec_Impl9_DerefMut_Interface as DerefMut0 with
@@ -2523,7 +2513,7 @@ module HeapsortGeneric_HeapSort
     function ShallowModel2.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel2.shallow_model,
     predicate Inv1.inv = Inv4.inv,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv2.inv = Inv5.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv3.inv = Inv6.inv,
     predicate Inv4.inv = Inv2.inv
@@ -2536,7 +2526,7 @@ module HeapsortGeneric_HeapSort
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv3.inv,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)))
@@ -2559,7 +2549,6 @@ module HeapsortGeneric_HeapSort
   var _21 : usize;
   var end' : usize;
   var _35 : ();
-  var _36 : borrowed (slice t);
   var _37 : borrowed (slice t);
   var _38 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   var _42 : ();
@@ -2648,16 +2637,11 @@ module HeapsortGeneric_HeapSort
     goto BB14
   }
   BB14 {
-    _36 <- Borrow.borrow_mut ( * _37);
-    _37 <- { _37 with current = ( ^ _36) };
-    assume { Inv3.inv ( ^ _36) };
-    _35 <- ([#"../heapsort_generic.rs" 117 8 117 22] Swap0.swap _36 ([#"../heapsort_generic.rs" 117 15 117 16] (0 : usize)) end');
-    _36 <- any borrowed (slice t);
+    _35 <- ([#"../heapsort_generic.rs" 117 8 117 22] Swap0.swap _37 ([#"../heapsort_generic.rs" 117 15 117 16] (0 : usize)) end');
+    _37 <- any borrowed (slice t);
     goto BB15
   }
   BB15 {
-    assert { [@expl:type invariant] Inv4.inv _37 };
-    assume { Resolve2.resolve _37 };
     assert { [@expl:assertion] [#"../heapsort_generic.rs" 119 12 119 59] let _ = HeapFragMax0.heap_frag_max (DeepModel0.deep_model v) 0 (UIntSize.to_int end') in forall j : int . forall i : int . 0 <= i /\ i < UIntSize.to_int end' /\ UIntSize.to_int end' <= j /\ j < Seq.length (ShallowModel0.shallow_model v) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v) i) (Seq.get (DeepModel0.deep_model v) j) };
     _43 <- Borrow.borrow_mut ( * v);
     v <- { v with current = ( ^ _43) };

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -1943,6 +1943,14 @@ module Hillel_InsertUnique
     type t = Seq.seq t,
     predicate Inv0.inv = Inv13.inv,
     axiom .
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
+  clone TyInv_Trivial as TyInv_Trivial12 with
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
+    predicate Inv0.inv = Inv12.inv,
+    axiom .
   use Core_Slice_Iter_Iter_Type as Core_Slice_Iter_Iter_Type
   clone CreusotContracts_Std1_Slice_Impl13_ShallowModel_Interface as ShallowModel2 with
     type t = t
@@ -1950,11 +1958,13 @@ module Hillel_InsertUnique
     type t = Core_Slice_Iter_Iter_Type.t_iter t,
     type ShallowModelTy0.shallowModelTy = slice t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve10 with
+    type t = Core_Slice_Iter_Iter_Type.t_iter t
+  clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
     type t = Seq.seq t
-  clone TyInv_Trivial as TyInv_Trivial12 with
+  clone TyInv_Trivial as TyInv_Trivial11 with
     type t = Seq.seq t,
-    predicate Inv0.inv = Inv12.inv,
+    predicate Inv0.inv = Inv11.inv,
     axiom .
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel5 with
@@ -1963,34 +1973,30 @@ module Hillel_InsertUnique
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv13.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
-  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial11 with
+  clone TyInv_Trivial as TyInv_Trivial10 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv11.inv,
+    predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
     type self = t
-  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = DeepModelTy0.deepModelTy
-  clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = Seq.seq DeepModelTy0.deepModelTy
+    type t = DeepModelTy0.deepModelTy
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = Seq.seq DeepModelTy0.deepModelTy,
+    type t = DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv9.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
+    type t = Seq.seq DeepModelTy0.deepModelTy
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = Seq.seq DeepModelTy0.deepModelTy,
+    predicate Inv0.inv = Inv8.inv,
+    axiom .
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel3 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv12.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv13.inv,
     axiom .
@@ -1998,10 +2004,6 @@ module Hillel_InsertUnique
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
-  clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv8.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial7 with
@@ -2038,11 +2040,9 @@ module Hillel_InsertUnique
     type t = Core_Option_Option_Type.t_option t,
     predicate Inv0.inv = Inv4.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
-    type t = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Std1_Slice_Impl14_Completed as Completed0 with
     type t = t,
-    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Resolve0.resolve = Resolve10.resolve,
     function ShallowModel0.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel5.shallow_model,
     predicate Inv0.inv = Inv15.inv,
@@ -2065,7 +2065,7 @@ module Hillel_InsertUnique
     predicate Inv0.inv = Inv1.inv,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic2.index_logic,
-    predicate Inv1.inv = Inv12.inv,
+    predicate Inv1.inv = Inv11.inv,
     axiom .
   clone CreusotContracts_Std1_Slice_Impl14_Produces as Produces0 with
     type t = t,
@@ -2074,11 +2074,11 @@ module Hillel_InsertUnique
     predicate Inv0.inv = Inv1.inv,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic2.index_logic,
-    predicate Inv1.inv = Inv12.inv
+    predicate Inv1.inv = Inv11.inv
   clone CreusotContracts_Std1_Slice_Impl14_ProducesTrans as ProducesTrans0 with
     type t = t,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv0.inv = Inv12.inv,
+    predicate Inv0.inv = Inv11.inv,
     axiom .
   clone CreusotContracts_Std1_Slice_Impl14_ProducesRefl as ProducesRefl0 with
     type t = t,
@@ -2119,17 +2119,17 @@ module Hillel_InsertUnique
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv12.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv13.inv
   clone CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface as DeepModel3 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv12.inv,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
     function IndexLogic0.index_logic = IndexLogic1.index_logic,
     function DeepModel0.deep_model = DeepModel1.deep_model,
-    predicate Inv1.inv = Inv9.inv,
+    predicate Inv1.inv = Inv8.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv13.inv,
@@ -2141,18 +2141,18 @@ module Hillel_InsertUnique
     predicate Inv1.inv = Inv6.inv,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel4.shallow_model,
-    predicate Inv2.inv = Inv8.inv,
+    predicate Inv2.inv = Inv12.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv3.inv = Inv13.inv
   clone Hillel_IsUnique as IsUnique0 with
     type t = DeepModelTy0.deepModelTy
   clone Hillel_Contains as Contains0 with
     type t = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve10 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve9 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve9 with
-    type self = t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve8 with
+    type self = t
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve7 with
     type self = Core_Slice_Iter_Iter_Type.t_iter t
   clone Core_Cmp_Impls_Impl9_Eq_Interface as Eq0 with
     type a = t,
@@ -2162,9 +2162,9 @@ module Hillel_InsertUnique
     function DeepModel0.deep_model = DeepModel4.deep_model,
     function DeepModel1.deep_model = DeepModel4.deep_model,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve7 with
-    type self = t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
+    type self = t
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
     type self = Core_Option_Option_Type.t_option t
   clone Core_Slice_Iter_Impl181_Next_Interface as Next0 with
     type t = t,
@@ -2191,7 +2191,7 @@ module Hillel_InsertUnique
   clone Alloc_Vec_Impl8_Deref_Interface as Deref0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv11.inv,
+    predicate Inv0.inv = Inv10.inv,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel1.shallow_model,
     predicate Inv1.inv = Inv1.inv
@@ -2208,8 +2208,8 @@ module Hillel_InsertUnique
     type self = Ghost.ghost_ty ()
   clone Hillel_SubsetPush as SubsetPush0 with
     type t = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv9.inv,
-    predicate Inv1.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
+    predicate Inv1.inv = Inv9.inv,
     predicate IsSubset0.is_subset = IsSubset0.is_subset,
     axiom .
   let rec cfg insert_unique [#"../hillel.rs" 79 0 79 62] [@cfg:stackify] [@cfg:subregion_analysis] (vec : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (elem : t) : ()
@@ -2233,7 +2233,6 @@ module Hillel_InsertUnique
   var iter_old : Ghost.ghost_ty (Core_Slice_Iter_Iter_Type.t_iter t);
   var produced : Ghost.ghost_ty (Seq.seq t);
   var _28 : Core_Option_Option_Type.t_option t;
-  var _29 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _30 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var __creusot_proc_iter_elem : t;
   var _33 : Ghost.ghost_ty (Seq.seq t);
@@ -2241,7 +2240,6 @@ module Hillel_InsertUnique
   var _38 : bool;
   var _41 : t;
   var _48 : ();
-  var _49 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
     goto BB0
   }
@@ -2307,14 +2305,11 @@ module Hillel_InsertUnique
   BB13 {
     _30 <- Borrow.borrow_mut iter;
     iter <-  ^ _30;
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
-    _28 <- ([#"../hillel.rs" 84 4 84 111] Next0.next _29);
-    _29 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
+    _28 <- ([#"../hillel.rs" 84 4 84 111] Next0.next _30);
+    _30 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
     goto BB14
   }
   BB14 {
-    assume { Resolve5.resolve _30 };
     switch (_28)
       | Core_Option_Option_Type.C_None -> goto BB15
       | Core_Option_Option_Type.C_Some _ -> goto BB16
@@ -2322,8 +2317,8 @@ module Hillel_InsertUnique
   }
   BB15 {
     assert { [@expl:type invariant] Inv4.inv _28 };
-    assume { Resolve6.resolve _28 };
-    assume { Resolve8.resolve iter };
+    assume { Resolve5.resolve _28 };
+    assume { Resolve7.resolve iter };
     assert { [@expl:assertion] [#"../hillel.rs" 93 20 93 71] IsUnique0.is_unique (Seq.snoc (DeepModel0.deep_model vec) (DeepModel1.deep_model elem)) };
     goto BB24
   }
@@ -2332,18 +2327,18 @@ module Hillel_InsertUnique
   }
   BB17 {
     assert { [@expl:type invariant] Inv4.inv _28 };
-    assume { Resolve6.resolve _28 };
-    assume { Resolve8.resolve iter };
+    assume { Resolve5.resolve _28 };
+    assume { Resolve7.resolve iter };
     assert { [@expl:type invariant] Inv6.inv elem };
-    assume { Resolve9.resolve elem };
+    assume { Resolve8.resolve elem };
     assert { [@expl:type invariant] Inv7.inv vec };
-    assume { Resolve10.resolve vec };
+    assume { Resolve9.resolve vec };
     absurd
   }
   BB18 {
     __creusot_proc_iter_elem <- Core_Option_Option_Type.some_0 _28;
     assert { [@expl:type invariant] Inv4.inv _28 };
-    assume { Resolve6.resolve _28 };
+    assume { Resolve5.resolve _28 };
     _33 <- ([#"../hillel.rs" 84 4 84 111] Ghost.new (Seq.(++) (Ghost.inner produced) (Seq.singleton __creusot_proc_iter_elem)));
     goto BB19
   }
@@ -2354,7 +2349,7 @@ module Hillel_InsertUnique
     assume { Resolve4.resolve produced };
     e <- __creusot_proc_iter_elem;
     assert { [@expl:type invariant] Inv5.inv __creusot_proc_iter_elem };
-    assume { Resolve7.resolve __creusot_proc_iter_elem };
+    assume { Resolve6.resolve __creusot_proc_iter_elem };
     assert { [@expl:assertion] [#"../hillel.rs" 86 24 86 57] e = IndexLogic1.index_logic (Ghost.inner ghost_vec) (Seq.length (Ghost.inner produced) - 1) };
     _41 <- elem;
     _38 <- ([#"../hillel.rs" 87 11 87 21] Eq0.eq e _41);
@@ -2362,20 +2357,20 @@ module Hillel_InsertUnique
   }
   BB20 {
     assert { [@expl:type invariant] Inv5.inv _41 };
-    assume { Resolve7.resolve _41 };
+    assume { Resolve6.resolve _41 };
     assert { [@expl:type invariant] Inv5.inv e };
-    assume { Resolve7.resolve e };
+    assume { Resolve6.resolve e };
     switch (_38)
       | False -> goto BB23
       | True -> goto BB21
       end
   }
   BB21 {
-    assume { Resolve8.resolve iter };
+    assume { Resolve7.resolve iter };
     assert { [@expl:type invariant] Inv6.inv elem };
-    assume { Resolve9.resolve elem };
+    assume { Resolve8.resolve elem };
     assert { [@expl:type invariant] Inv7.inv vec };
-    assume { Resolve10.resolve vec };
+    assume { Resolve9.resolve vec };
     assert { [@expl:assertion] [#"../hillel.rs" 88 28 88 73] Contains0.contains (DeepModel0.deep_model vec) (DeepModel1.deep_model elem) };
     goto BB22
   }
@@ -2387,17 +2382,12 @@ module Hillel_InsertUnique
     goto BB12
   }
   BB24 {
-    _49 <- Borrow.borrow_mut ( * vec);
-    vec <- { vec with current = ( ^ _49) };
-    assume { Inv8.inv ( ^ _49) };
-    _48 <- ([#"../hillel.rs" 94 4 94 18] Push0.push _49 elem);
-    _49 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
+    _48 <- ([#"../hillel.rs" 94 4 94 18] Push0.push vec elem);
+    vec <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     elem <- any t;
     goto BB25
   }
   BB25 {
-    assert { [@expl:type invariant] Inv7.inv vec };
-    assume { Resolve10.resolve vec };
     _0 <- ();
     goto BB26
   }
@@ -2961,59 +2951,61 @@ module Hillel_Unique
     type t = Seq.seq usize,
     predicate Inv0.inv = Inv10.inv,
     axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = Core_Option_Option_Type.t_option usize
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = Core_Option_Option_Type.t_option usize,
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv9.inv,
     axiom .
-  use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
+    type t = Core_Option_Option_Type.t_option usize
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize),
+    type t = Core_Option_Option_Type.t_option usize,
     predicate Inv0.inv = Inv8.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize),
+    predicate Inv0.inv = Inv7.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq t
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = t,
     predicate Inv0.inv = Inv11.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Logic_Ops_Impl2_IndexLogic as IndexLogic1 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     predicate Inv0.inv = Inv11.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Model_DeepModel_DeepModelTy_Type as DeepModelTy0 with
     type self = t
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = Seq.seq DeepModelTy0.deepModelTy
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = Seq.seq DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = Seq.seq t,
+    type t = Seq.seq DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv6.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = slice t,
+    type t = Seq.seq t,
     predicate Inv0.inv = Inv5.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
-  use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
+    type t = slice t,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel3 with
@@ -3026,7 +3018,7 @@ module Hillel_Unique
     type a = Alloc_Alloc_Global_Type.t_global,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Logic_Ops_Impl0_IndexLogic as IndexLogic0 with
     type t = t,
@@ -3034,7 +3026,7 @@ module Hillel_Unique
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Std1_Vec_Impl1_DeepModel_Interface as DeepModel0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
@@ -3042,10 +3034,10 @@ module Hillel_Unique
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
     function DeepModel0.deep_model = DeepModel3.deep_model,
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv6.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv2.inv = Inv6.inv,
+    predicate Inv2.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_Impl6_DeepModel as DeepModel5 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
@@ -3063,11 +3055,9 @@ module Hillel_Unique
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel2
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     function DeepModel0.deep_model = DeepModel2.deep_model
   clone Hillel_Contains as Contains0 with
     type t = DeepModelTy0.deepModelTy
@@ -3077,10 +3067,10 @@ module Hillel_Unique
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     function IndexLogic0.index_logic = IndexLogic1.index_logic,
     function DeepModel0.deep_model = DeepModel3.deep_model,
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv6.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv2.inv = Inv6.inv,
+    predicate Inv2.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = Core_Ops_Range_Range_Type.t_range usize
@@ -3113,24 +3103,22 @@ module Hillel_Unique
     type t = Ghost.ghost_ty (Seq.seq t),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = t
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve5 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve3 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve0.resolve = Resolve1.resolve,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel0 with
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = slice t
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone Hillel_IsSubset as IsSubset0 with
     type t = DeepModelTy0.deepModelTy,
     predicate Contains0.contains = Contains0.contains
@@ -3140,7 +3128,7 @@ module Hillel_Unique
     type t = t,
     function DeepModel0.deep_model = DeepModel5.deep_model,
     predicate IsUnique0.is_unique = IsUnique0.is_unique,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv9.inv,
     predicate Inv1.inv = Inv3.inv,
     function DeepModel1.deep_model = DeepModel0.deep_model,
     predicate IsSubset0.is_subset = IsSubset0.is_subset,
@@ -3150,15 +3138,15 @@ module Hillel_Unique
     predicate Inv2.inv = Inv2.inv,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Inv3.inv = Inv7.inv,
+    predicate Inv3.inv = Inv6.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv4.inv = Inv6.inv
+    predicate Inv4.inv = Inv5.inv
   clone Core_Iter_Range_Impl3_Next_Interface as Next0 with
     type a = usize,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv7.inv,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv1.inv = Inv9.inv
+    predicate Inv1.inv = Inv8.inv
   clone CreusotContracts_Model_Impl4_DeepModel as DeepModel1 with
     type t = slice t,
     type DeepModelTy0.deepModelTy = Seq.seq DeepModelTy0.deepModelTy,
@@ -3170,7 +3158,7 @@ module Hillel_Unique
     predicate IntoIterPost0.into_iter_post = IntoIterPost0.into_iter_post
   clone Core_Slice_Impl0_Len_Interface as Len0 with
     type t = t,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv4.inv,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (Seq.seq t)
@@ -3179,9 +3167,9 @@ module Hillel_Unique
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   let rec cfg unique [#"../hillel.rs" 100 0 100 56] [@cfg:stackify] [@cfg:subregion_analysis] (str : slice t) : Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-    requires {[#"../hillel.rs" 100 36 100 39] Inv5.inv str}
+    requires {[#"../hillel.rs" 100 36 100 39] Inv4.inv str}
     ensures { [#"../hillel.rs" 97 10 97 40] IsUnique0.is_unique (DeepModel0.deep_model result) }
     ensures { [#"../hillel.rs" 98 10 98 58] IsSubset0.is_subset (DeepModel0.deep_model result) (DeepModel1.deep_model str) }
     ensures { [#"../hillel.rs" 99 10 99 58] IsSubset0.is_subset (DeepModel1.deep_model str) (DeepModel0.deep_model result) }
@@ -3197,7 +3185,6 @@ module Hillel_Unique
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _23 : Core_Option_Option_Type.t_option usize;
-  var _24 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _25 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _28 : Ghost.ghost_ty (Seq.seq usize);
@@ -3206,7 +3193,6 @@ module Hillel_Unique
   var _32 : usize;
   var _34 : bool;
   var _35 : ();
-  var _36 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   var _37 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   var _39 : Ghost.ghost_ty (Seq.seq t);
   {
@@ -3262,22 +3248,19 @@ module Hillel_Unique
   BB11 {
     _25 <- Borrow.borrow_mut iter;
     iter <-  ^ _25;
-    _24 <- Borrow.borrow_mut ( * _25);
-    _25 <- { _25 with current = ( ^ _24) };
-    _23 <- ([#"../hillel.rs" 104 4 104 48] Next0.next _24);
-    _24 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _23 <- ([#"../hillel.rs" 104 4 104 48] Next0.next _25);
+    _25 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB12
   }
   BB12 {
-    assume { Resolve1.resolve _25 };
     switch (_23)
       | Core_Option_Option_Type.C_None -> goto BB13
       | Core_Option_Option_Type.C_Some _ -> goto BB14
       end
   }
   BB13 {
-    assert { [@expl:type invariant] Inv5.inv str };
-    assume { Resolve4.resolve str };
+    assert { [@expl:type invariant] Inv4.inv str };
+    assume { Resolve2.resolve str };
     assert { [@expl:assertion] [#"../hillel.rs" 113 20 113 95] IsSubset0.is_subset (SeqExt.subsequence (DeepModel1.deep_model str) 0 (Seq.length (ShallowModel0.shallow_model str))) (DeepModel0.deep_model unique) };
     goto BB21
   }
@@ -3286,9 +3269,9 @@ module Hillel_Unique
   }
   BB15 {
     assert { [@expl:type invariant] Inv2.inv unique };
-    assume { Resolve5.resolve unique };
-    assert { [@expl:type invariant] Inv5.inv str };
-    assume { Resolve4.resolve str };
+    assume { Resolve3.resolve unique };
+    assert { [@expl:type invariant] Inv4.inv str };
+    assume { Resolve2.resolve str };
     absurd
   }
   BB16 {
@@ -3310,18 +3293,13 @@ module Hillel_Unique
     _37 <- Borrow.borrow_mut unique;
     unique <-  ^ _37;
     assume { Inv2.inv ( ^ _37) };
-    _36 <- Borrow.borrow_mut ( * _37);
-    _37 <- { _37 with current = ( ^ _36) };
-    assume { Inv2.inv ( ^ _36) };
     assert { [@expl:type invariant] Inv3.inv elem };
-    assume { Resolve2.resolve elem };
-    _35 <- ([#"../hillel.rs" 109 8 109 40] InsertUnique0.insert_unique _36 elem);
-    _36 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
+    assume { Resolve1.resolve elem };
+    _35 <- ([#"../hillel.rs" 109 8 109 40] InsertUnique0.insert_unique _37 elem);
+    _37 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB19
   }
   BB19 {
-    assert { [@expl:type invariant] Inv4.inv _37 };
-    assume { Resolve3.resolve _37 };
     _39 <- ([#"../hillel.rs" 110 18 110 44] Ghost.new (Seq.snoc (Ghost.inner sub_str) elem));
     goto BB20
   }
@@ -3667,6 +3645,8 @@ module Hillel_Fulcrum
     predicate Inv0.inv = Inv6.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial5 with
@@ -3686,6 +3666,8 @@ module Hillel_Fulcrum
     type t = Core_Slice_Iter_Iter_Type.t_iter uint32,
     type ShallowModelTy0.shallowModelTy = slice uint32,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = Core_Slice_Iter_Iter_Type.t_iter uint32
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = Seq.seq uint32
   clone TyInv_Trivial as TyInv_Trivial3 with
@@ -3701,8 +3683,6 @@ module Hillel_Fulcrum
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed1 with
     type idx = usize,
     predicate Resolve0.resolve = Resolve1.resolve,
@@ -3743,8 +3723,6 @@ module Hillel_Fulcrum
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv8.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Slice_Iter_Iter_Type.t_iter uint32
   clone CreusotContracts_Std1_Slice_Impl14_Completed as Completed0 with
     type t = uint32,
     predicate Resolve0.resolve = Resolve0.resolve,
@@ -3845,7 +3823,6 @@ module Hillel_Fulcrum
   var produced : Ghost.ghost_ty (Seq.seq uint32);
   var _18 : ();
   var _19 : Core_Option_Option_Type.t_option uint32;
-  var _20 : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
   var _21 : borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
   var __creusot_proc_iter_elem : uint32;
   var _24 : Ghost.ghost_ty (Seq.seq uint32);
@@ -3858,7 +3835,6 @@ module Hillel_Fulcrum
   var iter_old1 : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced1 : Ghost.ghost_ty (Seq.seq usize);
   var _50 : Core_Option_Option_Type.t_option usize;
-  var _51 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _52 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem1 : usize;
   var _55 : Ghost.ghost_ty (Seq.seq usize);
@@ -3896,14 +3872,11 @@ module Hillel_Fulcrum
   BB5 {
     _21 <- Borrow.borrow_mut iter;
     iter <-  ^ _21;
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
-    _19 <- ([#"../hillel.rs" 159 4 159 60] Next0.next _20);
-    _20 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
+    _19 <- ([#"../hillel.rs" 159 4 159 60] Next0.next _21);
+    _21 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter uint32);
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _21 };
     switch (_19)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8
@@ -3965,14 +3938,11 @@ module Hillel_Fulcrum
   BB17 {
     _52 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _52;
-    _51 <- Borrow.borrow_mut ( * _52);
-    _52 <- { _52 with current = ( ^ _51) };
-    _50 <- ([#"../hillel.rs" 171 4 171 58] Next1.next _51);
-    _51 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _50 <- ([#"../hillel.rs" 171 4 171 58] Next1.next _52);
+    _52 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB18
   }
   BB18 {
-    assume { Resolve1.resolve _52 };
     switch (_50)
       | Core_Option_Option_Type.C_None -> goto BB19
       | Core_Option_Option_Type.C_Some _ -> goto BB20

--- a/creusot/tests/should_succeed/index_range.mlcfg
+++ b/creusot/tests/should_succeed/index_range.mlcfg
@@ -1662,8 +1662,8 @@ module IndexRange_TestRange
     goto BB54
   }
   BB54 {
-    s2 <- Borrow.borrow_mut ( * _105);
-    _105 <- { _105 with current = ( ^ s2) };
+    s2 <- _105;
+    _105 <- any borrowed (slice int32);
     _111 <- ([#"../index_range.rs" 60 12 60 19] Len0.len ( * s2));
     goto BB55
   }
@@ -1675,7 +1675,6 @@ module IndexRange_TestRange
   }
   BB56 {
     assume { Resolve0.resolve s2 };
-    assume { Resolve0.resolve _105 };
     assume { Resolve1.resolve arr };
     absurd
   }
@@ -1701,7 +1700,6 @@ module IndexRange_TestRange
   }
   BB60 {
     assume { Resolve0.resolve s2 };
-    assume { Resolve0.resolve _105 };
     switch (not ([#"../index_range.rs" 67 12 67 21] Slice.get ( * s2) _124 = ([#"../index_range.rs" 67 20 67 21] (3 : int32))))
       | False -> goto BB62
       | True -> goto BB61
@@ -2290,8 +2288,8 @@ module IndexRange_TestRangeTo
     goto BB23
   }
   BB23 {
-    s1 <- Borrow.borrow_mut ( * _44);
-    _44 <- { _44 with current = ( ^ s1) };
+    s1 <- _44;
+    _44 <- any borrowed (slice int32);
     _50 <- ([#"../index_range.rs" 100 12 100 19] Len0.len ( * s1));
     goto BB24
   }
@@ -2303,7 +2301,6 @@ module IndexRange_TestRangeTo
   }
   BB25 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _44 };
     assume { Resolve1.resolve arr };
     absurd
   }
@@ -2329,7 +2326,6 @@ module IndexRange_TestRangeTo
   }
   BB29 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _44 };
     switch (not ([#"../index_range.rs" 104 12 104 21] Slice.get ( * s1) _63 = ([#"../index_range.rs" 104 20 104 21] (1 : int32))))
       | False -> goto BB31
       | True -> goto BB30
@@ -2948,8 +2944,8 @@ module IndexRange_TestRangeFrom
     goto BB28
   }
   BB28 {
-    s1 <- Borrow.borrow_mut ( * _54);
-    _54 <- { _54 with current = ( ^ s1) };
+    s1 <- _54;
+    _54 <- any borrowed (slice int32);
     _60 <- ([#"../index_range.rs" 139 12 139 19] Len0.len ( * s1));
     goto BB29
   }
@@ -2961,7 +2957,6 @@ module IndexRange_TestRangeFrom
   }
   BB30 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _54 };
     assume { Resolve1.resolve arr };
     absurd
   }
@@ -2987,7 +2982,6 @@ module IndexRange_TestRangeFrom
   }
   BB34 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _54 };
     switch (not ([#"../index_range.rs" 143 12 143 21] Slice.get ( * s1) _73 = ([#"../index_range.rs" 143 20 143 21] (4 : int32))))
       | False -> goto BB36
       | True -> goto BB35
@@ -3542,8 +3536,8 @@ module IndexRange_TestRangeFull
     goto BB26
   }
   BB26 {
-    s1 <- Borrow.borrow_mut ( * _43);
-    _43 <- { _43 with current = ( ^ s1) };
+    s1 <- _43;
+    _43 <- any borrowed (slice int32);
     _49 <- ([#"../index_range.rs" 166 12 166 19] Len0.len ( * s1));
     goto BB27
   }
@@ -3555,7 +3549,6 @@ module IndexRange_TestRangeFull
   }
   BB28 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _43 };
     assume { Resolve1.resolve arr };
     absurd
   }
@@ -3575,7 +3568,6 @@ module IndexRange_TestRangeFull
   BB31 {
     s1 <- { s1 with current = Slice.set ( * s1) _55 ([#"../index_range.rs" 168 11 168 13] (-1 : int32)) };
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _43 };
     _61 <- ([#"../index_range.rs" 170 12 170 21] Len1.len arr);
     goto BB32
   }
@@ -4143,8 +4135,8 @@ module IndexRange_TestRangeToInclusive
     goto BB19
   }
   BB19 {
-    s1 <- Borrow.borrow_mut ( * _35);
-    _35 <- { _35 with current = ( ^ s1) };
+    s1 <- _35;
+    _35 <- any borrowed (slice int32);
     _41 <- ([#"../index_range.rs" 196 12 196 19] Len0.len ( * s1));
     goto BB20
   }
@@ -4156,7 +4148,6 @@ module IndexRange_TestRangeToInclusive
   }
   BB21 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _35 };
     assume { Resolve1.resolve arr };
     absurd
   }
@@ -4182,7 +4173,6 @@ module IndexRange_TestRangeToInclusive
   }
   BB25 {
     assume { Resolve0.resolve s1 };
-    assume { Resolve0.resolve _35 };
     switch (not ([#"../index_range.rs" 200 12 200 21] Slice.get ( * s1) _54 = ([#"../index_range.rs" 200 20 200 21] (1 : int32))))
       | False -> goto BB27
       | True -> goto BB26

--- a/creusot/tests/should_succeed/invariant_moves.mlcfg
+++ b/creusot/tests/should_succeed/invariant_moves.mlcfg
@@ -38,28 +38,6 @@ module Alloc_Alloc_Global_Type
     | C_Global
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module CreusotContracts_Invariant_Inv_Stub
   type t
   predicate inv (_x : t)
@@ -423,7 +401,7 @@ module InvariantMoves_TestInvariantMove
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve1 with
     type t = uint32
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel0 with
@@ -444,16 +422,14 @@ module InvariantMoves_TestInvariantMove
     type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve1 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve0 with
     type t = uint32,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve0.resolve = Resolve1.resolve,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv3.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
   clone Alloc_Vec_Impl1_Pop_Interface as Pop0 with
     type t = uint32,
     type a = Alloc_Alloc_Global_Type.t_global,
@@ -470,7 +446,6 @@ module InvariantMoves_TestInvariantMove
   var _0 : ();
   var x : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global) = x;
   var _4 : Core_Option_Option_Type.t_option uint32;
-  var _5 : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
   var _6 : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
   {
     goto BB0
@@ -488,14 +463,11 @@ module InvariantMoves_TestInvariantMove
   BB3 {
     _6 <- Borrow.borrow_mut x;
     x <-  ^ _6;
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    _4 <- ([#"../invariant_moves.rs" 7 26 7 40] Pop0.pop _5);
-    _5 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
+    _4 <- ([#"../invariant_moves.rs" 7 26 7 40] Pop0.pop _6);
+    _6 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
     goto BB4
   }
   BB4 {
-    assume { Resolve0.resolve _6 };
     switch (_4)
       | Core_Option_Option_Type.C_Some _ -> goto BB5
       | _ -> goto BB7
@@ -508,7 +480,7 @@ module InvariantMoves_TestInvariantMove
     goto BB2
   }
   BB7 {
-    assume { Resolve1.resolve x };
+    assume { Resolve0.resolve x };
     _0 <- ();
     goto BB8
   }

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -1461,83 +1461,83 @@ module C02IterMut_IterMut
     predicate Inv0.inv = Inv7.inv,
     axiom .
   use seq.Seq
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq t
   clone Core_Num_Impl11_Max as Max0
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = slice t
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = t,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv6.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   use C02IterMut_IterMut_Type as C02IterMut_IterMut_Type
   clone C02IterMut_Impl0_Invariant as Invariant0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv6.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = Seq.seq t,
+    type t = slice t,
     predicate Inv0.inv = Inv6.inv,
     axiom .
-  use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = Core_Ops_Range_RangeFull_Type.t_rangefull
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = Core_Ops_Range_RangeFull_Type.t_rangefull,
+    type t = Seq.seq t,
     predicate Inv0.inv = Inv5.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = C02IterMut_IterMut_Type.t_itermut t
-  clone C02IterMut_IterMut_Type_Inv as C02IterMut_IterMut_Type_Inv0 with
-    type t = t,
-    predicate Inv0.inv = Inv4.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
-    predicate Inv1.inv = Inv7.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
-    predicate Inv0.inv = Inv3.inv,
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
+    predicate Inv0.inv = Inv4.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = borrowed (slice t)
   clone TyInv_Trivial as TyInv_Trivial2 with
     type t = borrowed (slice t),
+    predicate Inv0.inv = Inv3.inv,
+    axiom .
+  use Core_Ops_Range_RangeFull_Type as Core_Ops_Range_RangeFull_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
+    type t = Core_Ops_Range_RangeFull_Type.t_rangefull
+  clone TyInv_Trivial as TyInv_Trivial1 with
+    type t = Core_Ops_Range_RangeFull_Type.t_rangefull,
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = slice t,
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = C02IterMut_IterMut_Type.t_itermut t
+  clone C02IterMut_IterMut_Type_Inv as C02IterMut_IterMut_Type_Inv0 with
+    type t = t,
     predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    predicate Inv1.inv = Inv7.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
+  clone TyInv_Trivial as TyInv_Trivial0 with
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
+    predicate Inv0.inv = Inv0.inv,
     axiom .
   clone CreusotContracts_Std1_Slice_Impl9_ResolveElswhere as ResolveElswhere0 with
     type t = t
   clone CreusotContracts_Std1_Slice_Impl9_HasValue as HasValue0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv6.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Std1_Slice_Impl9_InBounds as InBounds0 with
     type t = t
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv0.inv,
-    axiom .
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel3 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv0.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel1 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
@@ -1547,66 +1547,44 @@ module C02IterMut_IterMut
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = slice t
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = t,
     type i = Core_Ops_Range_RangeFull_Type.t_rangefull,
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     predicate InBounds0.in_bounds = InBounds0.in_bounds,
-    predicate Inv0.inv = Inv3.inv,
-    predicate Inv1.inv = Inv5.inv,
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv2.inv,
     predicate HasValue0.has_value = HasValue0.has_value,
     function ShallowModel1.shallow_model = ShallowModel3.shallow_model,
     predicate ResolveElswhere0.resolve_elswhere = ResolveElswhere0.resolve_elswhere,
-    predicate Inv2.inv = Inv2.inv,
+    predicate Inv2.inv = Inv3.inv,
     type Output0.output = slice t,
-    predicate Inv3.inv = Inv0.inv,
+    predicate Inv3.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv4.inv = Inv6.inv
+    predicate Inv4.inv = Inv5.inv
   let rec cfg iter_mut [#"../02_iter_mut.rs" 72 0 72 55] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : C02IterMut_IterMut_Type.t_itermut t
-    requires {[#"../02_iter_mut.rs" 72 19 72 20] Inv3.inv v}
+    requires {[#"../02_iter_mut.rs" 72 19 72 20] Inv0.inv v}
     ensures { [#"../02_iter_mut.rs" 69 10 69 29] ShallowModel0.shallow_model (C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel1.shallow_model v }
     ensures { [#"../02_iter_mut.rs" 70 10 70 35] ShallowModel2.shallow_model ( ^ C02IterMut_IterMut_Type.itermut_inner result) = ShallowModel3.shallow_model ( ^ v) }
     ensures { [#"../02_iter_mut.rs" 71 10 71 33] Seq.length (ShallowModel3.shallow_model ( ^ v)) = Seq.length (ShallowModel1.shallow_model v) }
-    ensures { [#"../02_iter_mut.rs" 72 41 72 55] Inv4.inv result }
+    ensures { [#"../02_iter_mut.rs" 72 41 72 55] Inv1.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : C02IterMut_IterMut_Type.t_itermut t;
   var v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) = v;
-  var _5 : borrowed (slice t);
-  var _6 : borrowed (slice t);
   var _7 : borrowed (slice t);
-  var _8 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
     goto BB0
   }
   BB0 {
-    _8 <- Borrow.borrow_mut ( * v);
-    v <- { v with current = ( ^ _8) };
-    assume { Inv0.inv ( ^ _8) };
-    _7 <- ([#"../02_iter_mut.rs" 73 26 73 31] IndexMut0.index_mut _8 (Core_Ops_Range_RangeFull_Type.C_RangeFull));
-    _8 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
+    _7 <- ([#"../02_iter_mut.rs" 73 26 73 31] IndexMut0.index_mut v (Core_Ops_Range_RangeFull_Type.C_RangeFull));
+    v <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
-    assume { Inv1.inv ( ^ _6) };
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    assume { Inv1.inv ( ^ _5) };
-    _0 <- C02IterMut_IterMut_Type.C_IterMut _5;
-    _5 <- any borrowed (slice t);
-    assert { [@expl:type invariant] Inv2.inv _7 };
-    assume { Resolve0.resolve _7 };
-    assert { [@expl:type invariant] Inv2.inv _6 };
-    assume { Resolve0.resolve _6 };
-    assert { [@expl:type invariant] Inv3.inv v };
-    assume { Resolve1.resolve v };
+    _0 <- C02IterMut_IterMut_Type.C_IterMut _7;
+    _7 <- any borrowed (slice t);
     return _0
   }
   
@@ -1733,7 +1711,7 @@ module C02IterMut_AllZero
     predicate Inv0.inv = Inv8.inv,
     axiom .
   use C02IterMut_IterMut_Type as C02IterMut_IterMut_Type
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = C02IterMut_IterMut_Type.t_itermut usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = C02IterMut_IterMut_Type.t_itermut usize
@@ -1802,7 +1780,7 @@ module C02IterMut_AllZero
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   clone C02IterMut_Impl1_Completed as Completed0 with
     type t = usize,
-    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve0.resolve = Resolve1.resolve,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
   clone CreusotContracts_Logic_Ops_Impl2_IndexLogic as IndexLogic2 with
     type t = usize,
@@ -1859,8 +1837,6 @@ module C02IterMut_AllZero
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq usize,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = usize
   clone C02IterMut_Impl1_Next_Interface as Next0 with
@@ -1895,7 +1871,6 @@ module C02IterMut_AllZero
   var v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) = v;
   var it : C02IterMut_IterMut_Type.t_itermut usize;
   var _5 : C02IterMut_IterMut_Type.t_itermut usize;
-  var _6 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var iter_old : Ghost.ghost_ty (C02IterMut_IterMut_Type.t_itermut usize);
   var produced : Ghost.ghost_ty (Seq.seq (borrowed usize));
   var _15 : Core_Option_Option_Type.t_option (borrowed usize);
@@ -1906,10 +1881,8 @@ module C02IterMut_AllZero
     goto BB0
   }
   BB0 {
-    _6 <- Borrow.borrow_mut ( * v);
-    v <- { v with current = ( ^ _6) };
-    _5 <- ([#"../02_iter_mut.rs" 79 17 79 28] IterMut0.iter_mut _6);
-    _6 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
+    _5 <- ([#"../02_iter_mut.rs" 79 17 79 28] IterMut0.iter_mut v);
+    v <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
@@ -1950,14 +1923,12 @@ module C02IterMut_AllZero
   }
   BB8 {
     _0 <- ();
-    assume { Resolve1.resolve v };
     return _0
   }
   BB9 {
     goto BB11
   }
   BB10 {
-    assume { Resolve1.resolve v };
     absurd
   }
   BB11 {

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -371,28 +371,6 @@ module CreusotContracts_Std1_Slice_Impl14_Produces
     ensures { result = produces self visited tl }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module Core_Option_Option_Type
   type t_option 't =
     | C_None
@@ -485,6 +463,28 @@ module Core_Iter_Traits_Collect_Impl0_IntoIter_Interface
     requires {Inv0.inv self}
     ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 89 0 166 1] IntoIterPost0.into_iter_post self result }
     ensures { Inv0.inv result }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
     
 end
 module CreusotContracts_Model_Impl7_ShallowModel_Stub
@@ -761,6 +761,8 @@ module C03StdIterators_SliceIter
     type t = Core_Slice_Iter_Iter_Type.t_iter t,
     type ShallowModelTy0.shallowModelTy = slice t,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+    type t = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq t
   clone TyInv_Trivial as TyInv_Trivial5 with
@@ -787,11 +789,9 @@ module C03StdIterators_SliceIter
     type t = Core_Option_Option_Type.t_option t,
     predicate Inv0.inv = Inv3.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Std1_Slice_Impl14_Completed as Completed0 with
     type t = t,
-    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve0.resolve = Resolve6.resolve,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel2.shallow_model,
     predicate Inv0.inv = Inv6.inv,
@@ -854,11 +854,11 @@ module C03StdIterators_SliceIter
     type t = slice t,
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
-    type self = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
-    type self = t
+    type self = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+    type self = t
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Core_Option_Option_Type.t_option t
   clone Core_Slice_Iter_Impl181_Next_Interface as Next0 with
     type t = t,
@@ -894,7 +894,6 @@ module C03StdIterators_SliceIter
   var iter_old : Ghost.ghost_ty (Core_Slice_Iter_Iter_Type.t_iter t);
   var produced : Ghost.ghost_ty (Seq.seq t);
   var _17 : Core_Option_Option_Type.t_option t;
-  var _18 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _19 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var __creusot_proc_iter_elem : t;
   var _22 : Ghost.ghost_ty (Seq.seq t);
@@ -936,14 +935,11 @@ module C03StdIterators_SliceIter
   BB6 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../03_std_iterators.rs" 8 4 8 38] Next0.next _18);
-    _18 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
+    _17 <- ([#"../03_std_iterators.rs" 8 4 8 38] Next0.next _19);
+    _19 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
     goto BB7
   }
   BB7 {
-    assume { Resolve3.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB8
       | Core_Option_Option_Type.C_Some _ -> goto BB9
@@ -951,8 +947,8 @@ module C03StdIterators_SliceIter
   }
   BB8 {
     assert { [@expl:type invariant] Inv3.inv _17 };
-    assume { Resolve4.resolve _17 };
-    assume { Resolve6.resolve iter };
+    assume { Resolve3.resolve _17 };
+    assume { Resolve5.resolve iter };
     _0 <- i;
     return _0
   }
@@ -961,14 +957,14 @@ module C03StdIterators_SliceIter
   }
   BB10 {
     assert { [@expl:type invariant] Inv3.inv _17 };
-    assume { Resolve4.resolve _17 };
-    assume { Resolve6.resolve iter };
+    assume { Resolve3.resolve _17 };
+    assume { Resolve5.resolve iter };
     absurd
   }
   BB11 {
     __creusot_proc_iter_elem <- Core_Option_Option_Type.some_0 _17;
     assert { [@expl:type invariant] Inv3.inv _17 };
-    assume { Resolve4.resolve _17 };
+    assume { Resolve3.resolve _17 };
     _22 <- ([#"../03_std_iterators.rs" 8 4 8 38] Ghost.new (Seq.(++) (Ghost.inner produced) (Seq.singleton __creusot_proc_iter_elem)));
     goto BB12
   }
@@ -978,7 +974,7 @@ module C03StdIterators_SliceIter
     assert { [@expl:type invariant] Inv1.inv produced };
     assume { Resolve2.resolve produced };
     assert { [@expl:type invariant] Inv4.inv __creusot_proc_iter_elem };
-    assume { Resolve5.resolve __creusot_proc_iter_elem };
+    assume { Resolve4.resolve __creusot_proc_iter_elem };
     i <- ([#"../03_std_iterators.rs" 10 8 10 14] i + ([#"../03_std_iterators.rs" 10 13 10 14] (1 : usize)));
     goto BB5
   }
@@ -1217,6 +1213,8 @@ module C03StdIterators_VecIter
     type t = Core_Slice_Iter_Iter_Type.t_iter t,
     type ShallowModelTy0.shallowModelTy = slice t,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+    type t = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = Seq.seq t
   clone TyInv_Trivial as TyInv_Trivial6 with
@@ -1256,11 +1254,9 @@ module C03StdIterators_VecIter
     type t = Core_Option_Option_Type.t_option t,
     predicate Inv0.inv = Inv3.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Std1_Slice_Impl14_Completed as Completed0 with
     type t = t,
-    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve0.resolve = Resolve6.resolve,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel4.shallow_model,
     predicate Inv0.inv = Inv7.inv,
@@ -1332,11 +1328,11 @@ module C03StdIterators_VecIter
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
-    type self = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
-    type self = t
+    type self = Core_Slice_Iter_Iter_Type.t_iter t
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+    type self = t
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Core_Option_Option_Type.t_option t
   clone Core_Slice_Iter_Impl181_Next_Interface as Next0 with
     type t = t,
@@ -1368,7 +1364,6 @@ module C03StdIterators_VecIter
   var iter_old : Ghost.ghost_ty (Core_Slice_Iter_Iter_Type.t_iter t);
   var produced : Ghost.ghost_ty (Seq.seq t);
   var _16 : Core_Option_Option_Type.t_option t;
-  var _17 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var _18 : borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
   var __creusot_proc_iter_elem : t;
   var _21 : Ghost.ghost_ty (Seq.seq t);
@@ -1405,14 +1400,11 @@ module C03StdIterators_VecIter
   BB5 {
     _18 <- Borrow.borrow_mut iter;
     iter <-  ^ _18;
-    _17 <- Borrow.borrow_mut ( * _18);
-    _18 <- { _18 with current = ( ^ _17) };
-    _16 <- ([#"../03_std_iterators.rs" 19 4 19 38] Next0.next _17);
-    _17 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
+    _16 <- ([#"../03_std_iterators.rs" 19 4 19 38] Next0.next _18);
+    _18 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter t);
     goto BB6
   }
   BB6 {
-    assume { Resolve3.resolve _18 };
     switch (_16)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8
@@ -1420,8 +1412,8 @@ module C03StdIterators_VecIter
   }
   BB7 {
     assert { [@expl:type invariant] Inv3.inv _16 };
-    assume { Resolve4.resolve _16 };
-    assume { Resolve6.resolve iter };
+    assume { Resolve3.resolve _16 };
+    assume { Resolve5.resolve iter };
     _0 <- i;
     return _0
   }
@@ -1430,14 +1422,14 @@ module C03StdIterators_VecIter
   }
   BB9 {
     assert { [@expl:type invariant] Inv3.inv _16 };
-    assume { Resolve4.resolve _16 };
-    assume { Resolve6.resolve iter };
+    assume { Resolve3.resolve _16 };
+    assume { Resolve5.resolve iter };
     absurd
   }
   BB10 {
     __creusot_proc_iter_elem <- Core_Option_Option_Type.some_0 _16;
     assert { [@expl:type invariant] Inv3.inv _16 };
-    assume { Resolve4.resolve _16 };
+    assume { Resolve3.resolve _16 };
     _21 <- ([#"../03_std_iterators.rs" 19 4 19 38] Ghost.new (Seq.(++) (Ghost.inner produced) (Seq.singleton __creusot_proc_iter_elem)));
     goto BB11
   }
@@ -1447,7 +1439,7 @@ module C03StdIterators_VecIter
     assert { [@expl:type invariant] Inv1.inv produced };
     assume { Resolve2.resolve produced };
     assert { [@expl:type invariant] Inv4.inv __creusot_proc_iter_elem };
-    assume { Resolve5.resolve __creusot_proc_iter_elem };
+    assume { Resolve4.resolve __creusot_proc_iter_elem };
     i <- ([#"../03_std_iterators.rs" 21 8 21 14] i + ([#"../03_std_iterators.rs" 21 13 21 14] (1 : usize)));
     goto BB4
   }
@@ -2106,6 +2098,8 @@ module C03StdIterators_AllZero
     type t = Core_Slice_Iter_IterMut_Type.t_itermut usize,
     type ShallowModelTy0.shallowModelTy = borrowed (slice usize),
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+    type t = Core_Slice_Iter_IterMut_Type.t_itermut usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = Seq.seq (borrowed usize)
   clone TyInv_Trivial as TyInv_Trivial6 with
@@ -2138,11 +2132,9 @@ module C03StdIterators_AllZero
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv1.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Slice_Iter_IterMut_Type.t_itermut usize
   clone CreusotContracts_Std1_Slice_Impl16_Completed as Completed0 with
     type t = usize,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel3.shallow_model,
     predicate Inv0.inv = Inv3.inv,
@@ -2214,9 +2206,7 @@ module C03StdIterators_AllZero
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq usize,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Std1_Slice_Impl17_Resolve as Resolve3 with
+  clone CreusotContracts_Std1_Slice_Impl17_Resolve as Resolve1 with
     type t = usize,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel3.shallow_model,
@@ -2224,7 +2214,7 @@ module C03StdIterators_AllZero
     predicate Inv1.inv = Inv3.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv4.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = usize
   clone Core_Slice_Iter_Impl189_Next_Interface as Next0 with
     type t = usize,
@@ -2233,8 +2223,6 @@ module C03StdIterators_AllZero
     predicate Inv0.inv = Inv7.inv
   clone CreusotContracts_Logic_Ops_Impl6_IndexLogic as IndexLogic0 with
     type t = borrowed usize
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = slice usize
   clone Core_Iter_Traits_Collect_Impl0_IntoIter_Interface as IntoIter0 with
     type i = Core_Slice_Iter_IterMut_Type.t_itermut usize,
     predicate IntoIterPre0.into_iter_pre = IntoIterPre0.into_iter_pre,
@@ -2270,13 +2258,10 @@ module C03StdIterators_AllZero
   var v : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) = v;
   var iter : Core_Slice_Iter_IterMut_Type.t_itermut usize;
   var _5 : Core_Slice_Iter_IterMut_Type.t_itermut usize;
-  var _6 : borrowed (slice usize);
   var _7 : borrowed (slice usize);
-  var _8 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var iter_old : Ghost.ghost_ty (Core_Slice_Iter_IterMut_Type.t_itermut usize);
   var produced : Ghost.ghost_ty (Seq.seq (borrowed usize));
   var _17 : Core_Option_Option_Type.t_option (borrowed usize);
-  var _18 : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
   var _19 : borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
   var __creusot_proc_iter_elem : borrowed usize;
   var _22 : Ghost.ghost_ty (Seq.seq (borrowed usize));
@@ -2285,17 +2270,13 @@ module C03StdIterators_AllZero
     goto BB0
   }
   BB0 {
-    _8 <- Borrow.borrow_mut ( * v);
-    v <- { v with current = ( ^ _8) };
-    _7 <- ([#"../03_std_iterators.rs" 30 13 30 25] DerefMut0.deref_mut _8);
-    _8 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
+    _7 <- ([#"../03_std_iterators.rs" 30 13 30 25] DerefMut0.deref_mut v);
+    v <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
-    _5 <- ([#"../03_std_iterators.rs" 30 13 30 25] IterMut0.iter_mut _6);
-    _6 <- any borrowed (slice usize);
+    _5 <- ([#"../03_std_iterators.rs" 30 13 30 25] IterMut0.iter_mut _7);
+    _7 <- any borrowed (slice usize);
     goto BB2
   }
   BB2 {
@@ -2304,7 +2285,6 @@ module C03StdIterators_AllZero
     goto BB3
   }
   BB3 {
-    assume { Resolve0.resolve _7 };
     iter_old <- ([#"../03_std_iterators.rs" 29 4 29 87] Ghost.new iter);
     goto BB4
   }
@@ -2324,31 +2304,26 @@ module C03StdIterators_AllZero
   BB7 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../03_std_iterators.rs" 29 4 29 87] Next0.next _18);
-    _18 <- any borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
+    _17 <- ([#"../03_std_iterators.rs" 29 4 29 87] Next0.next _19);
+    _19 <- any borrowed (Core_Slice_Iter_IterMut_Type.t_itermut usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB9
       | Core_Option_Option_Type.C_Some _ -> goto BB10
       end
   }
   BB9 {
-    assume { Resolve3.resolve iter };
+    assume { Resolve1.resolve iter };
     _0 <- ();
-    assume { Resolve4.resolve v };
     return _0
   }
   BB10 {
     goto BB12
   }
   BB11 {
-    assume { Resolve3.resolve iter };
-    assume { Resolve4.resolve v };
+    assume { Resolve1.resolve iter };
     absurd
   }
   BB12 {
@@ -2363,7 +2338,7 @@ module C03StdIterators_AllZero
     x <- __creusot_proc_iter_elem;
     __creusot_proc_iter_elem <- any borrowed usize;
     x <- { x with current = ([#"../03_std_iterators.rs" 31 13 31 14] (0 : usize)) };
-    assume { Resolve2.resolve x };
+    assume { Resolve0.resolve x };
     goto BB6
   }
   
@@ -5175,6 +5150,8 @@ module C03StdIterators_SumRange
     predicate Inv0.inv = Inv2.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = Core_Ops_Range_Range_Type.t_range isize
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range isize)
   clone TyInv_Trivial as TyInv_Trivial1 with
@@ -5183,8 +5160,6 @@ module C03StdIterators_SumRange
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl34_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range isize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = isize,
     predicate Resolve0.resolve = Resolve0.resolve,
@@ -5236,7 +5211,6 @@ module C03StdIterators_SumRange
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range isize);
   var produced : Ghost.ghost_ty (Seq.seq isize);
   var _17 : Core_Option_Option_Type.t_option isize;
-  var _18 : borrowed (Core_Ops_Range_Range_Type.t_range isize);
   var _19 : borrowed (Core_Ops_Range_Range_Type.t_range isize);
   var __creusot_proc_iter_elem : isize;
   var _22 : Ghost.ghost_ty (Seq.seq isize);
@@ -5268,14 +5242,11 @@ module C03StdIterators_SumRange
   BB5 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../03_std_iterators.rs" 65 4 65 48] Next0.next _18);
-    _18 <- any borrowed (Core_Ops_Range_Range_Type.t_range isize);
+    _17 <- ([#"../03_std_iterators.rs" 65 4 65 48] Next0.next _19);
+    _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range isize);
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8
@@ -5715,7 +5686,7 @@ module C03StdIterators_EnumerateRange
   use seq.Seq
   use prelude.Borrow
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
     type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
@@ -5741,11 +5712,21 @@ module C03StdIterators_EnumerateRange
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed1 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
+  use Core_Iter_Adapters_Enumerate_Enumerate_Type as Core_Iter_Adapters_Enumerate_Enumerate_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
+    type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = Seq.seq usize
+    type t = borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize))
+  clone TyInv_Borrow as TyInv_Borrow0 with
+    type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize),
+    predicate Inv0.inv = Inv3.inv,
+    predicate Inv1.inv = Inv0.inv,
+    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
+    type t = Seq.seq usize
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Produces as Produces1 with
     type idx = usize,
@@ -5753,36 +5734,26 @@ module C03StdIterators_EnumerateRange
   clone CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans_Interface as ProducesTrans1 with
     type idx = usize,
     predicate Produces0.produces = Produces1.produces,
-    predicate Inv0.inv = Inv2.inv,
-    predicate Inv1.inv = Inv3.inv,
+    predicate Inv0.inv = Inv1.inv,
+    predicate Inv1.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Std1_Iter_Range_Impl0_ProducesRefl_Interface as ProducesRefl1 with
     type idx = usize,
-    predicate Inv0.inv = Inv2.inv,
+    predicate Inv0.inv = Inv1.inv,
     predicate Produces0.produces = Produces1.produces,
     axiom .
   clone TyInv_Trivial as TyInv_Trivial1 with
     type t = Seq.seq usize,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv2.inv,
     axiom .
   clone TyInv_Trivial as TyInv_Trivial0 with
     type t = Core_Ops_Range_Range_Type.t_range usize,
-    predicate Inv0.inv = Inv2.inv,
-    axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve4 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
-    type t = usize
-  use Core_Iter_Adapters_Enumerate_Enumerate_Type as Core_Iter_Adapters_Enumerate_Enumerate_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize))
-  clone TyInv_Borrow as TyInv_Borrow0 with
-    type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize),
     predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
     axiom .
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
+    type t = usize
   clone CreusotContracts_Std1_Iter_Enumerate_Impl0_Iter_Interface as Iter0 with
     type i = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Enumerate_Impl2_Completed as Completed0 with
@@ -5796,7 +5767,7 @@ module C03StdIterators_EnumerateRange
     type i = Core_Ops_Range_Range_Type.t_range usize,
     type Item0.item = usize,
     function N0.n = N0.n,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv2.inv,
     function Iter0.iter = Iter0.iter,
     predicate Produces0.produces = Produces1.produces
   clone CreusotContracts_Std1_Iter_Enumerate_Impl2_ProducesTrans_Interface as ProducesTrans0 with
@@ -5815,26 +5786,24 @@ module C03StdIterators_EnumerateRange
   clone Core_Iter_Adapters_Enumerate_Enumerate_Type_Inv as Core_Iter_Adapters_Enumerate_Enumerate_Type_Inv0 with
     type i = Core_Ops_Range_Range_Type.t_range usize,
     predicate Inv0.inv = Inv0.inv,
-    predicate Inv1.inv = Inv2.inv,
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Std1_Iter_Impl0_IntoIterPost as IntoIterPost0 with
     type i = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)
   clone CreusotContracts_Std1_Iter_Impl0_IntoIterPre as IntoIterPre0 with
     type i = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)
-  clone CreusotContracts_Std1_Iter_Enumerate_Impl3_Resolve as Resolve2 with
+  clone CreusotContracts_Std1_Iter_Enumerate_Impl3_Resolve as Resolve1 with
     type i = Core_Ops_Range_Range_Type.t_range usize,
     function Iter0.iter = Iter0.iter,
-    predicate Resolve0.resolve = Resolve4.resolve
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
+    predicate Resolve0.resolve = Resolve3.resolve
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = usize,
     type t2 = usize,
-    predicate Resolve0.resolve = Resolve3.resolve,
-    predicate Resolve1.resolve = Resolve3.resolve
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)
+    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve1.resolve = Resolve2.resolve
   clone Core_Iter_Adapters_Enumerate_Impl1_Next_Interface as Next0 with
     type i = Core_Ops_Range_Range_Type.t_range usize,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv3.inv,
     type Item0.item = usize,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
@@ -5848,7 +5817,7 @@ module C03StdIterators_EnumerateRange
     predicate IntoIterPost0.into_iter_post = IntoIterPost0.into_iter_post
   clone Core_Iter_Traits_Iterator_Iterator_Enumerate_Interface as Enumerate0 with
     type self = Core_Ops_Range_Range_Type.t_range usize,
-    predicate Inv0.inv = Inv2.inv,
+    predicate Inv0.inv = Inv1.inv,
     function Iter0.iter = Iter0.iter,
     function N0.n = N0.n,
     predicate Inv1.inv = Inv0.inv
@@ -5861,7 +5830,6 @@ module C03StdIterators_EnumerateRange
   var iter_old : Ghost.ghost_ty (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize));
   var produced : Ghost.ghost_ty (Seq.seq (usize, usize));
   var _12 : Core_Option_Option_Type.t_option (usize, usize);
-  var _13 : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize));
   var _14 : borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize));
   var __creusot_proc_iter_elem : (usize, usize);
   var _17 : Ghost.ghost_ty (Seq.seq (usize, usize));
@@ -5901,16 +5869,11 @@ module C03StdIterators_EnumerateRange
     _14 <- Borrow.borrow_mut iter;
     iter <-  ^ _14;
     assume { Inv0.inv ( ^ _14) };
-    _13 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _13) };
-    assume { Inv0.inv ( ^ _13) };
-    _12 <- ([#"../03_std_iterators.rs" 73 4 73 96] Next0.next _13);
-    _13 <- any borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize));
+    _12 <- ([#"../03_std_iterators.rs" 73 4 73 96] Next0.next _14);
+    _14 <- any borrowed (Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize));
     goto BB7
   }
   BB7 {
-    assert { [@expl:type invariant] Inv1.inv _14 };
-    assume { Resolve0.resolve _14 };
     switch (_12)
       | Core_Option_Option_Type.C_None -> goto BB8
       | Core_Option_Option_Type.C_Some _ -> goto BB9
@@ -5918,7 +5881,7 @@ module C03StdIterators_EnumerateRange
   }
   BB8 {
     assert { [@expl:type invariant] Inv0.inv iter };
-    assume { Resolve2.resolve iter };
+    assume { Resolve1.resolve iter };
     _0 <- ();
     return _0
   }
@@ -5927,7 +5890,7 @@ module C03StdIterators_EnumerateRange
   }
   BB10 {
     assert { [@expl:type invariant] Inv0.inv iter };
-    assume { Resolve2.resolve iter };
+    assume { Resolve1.resolve iter };
     absurd
   }
   BB11 {
@@ -5940,9 +5903,9 @@ module C03StdIterators_EnumerateRange
     _17 <- any Ghost.ghost_ty (Seq.seq (usize, usize));
     ix <- (let (a, _) = __creusot_proc_iter_elem in a);
     x <- (let (_, a) = __creusot_proc_iter_elem in a);
-    assume { Resolve1.resolve __creusot_proc_iter_elem };
+    assume { Resolve0.resolve __creusot_proc_iter_elem };
     _21 <- (ix, x);
-    assume { Resolve1.resolve _21 };
+    assume { Resolve0.resolve _21 };
     goto BB5
   }
   
@@ -6543,13 +6506,13 @@ module C03StdIterators_MyReverse
     type t = Core_Option_Option_Type.t_option (usize, usize),
     predicate Inv0.inv = Inv8.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
     type t = Core_Ops_Range_Range_Type.t_range usize
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed1 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   use Core_Iter_Adapters_Zip_Zip_Type as Core_Iter_Adapters_Zip_Zip_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
@@ -6603,7 +6566,7 @@ module C03StdIterators_MyReverse
     type t = slice t,
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve4 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
     type t = usize
   clone CreusotContracts_Std1_Iter_Zip_Impl0_Iterb_Interface as Iterb0 with
     type a = Core_Ops_Range_Range_Type.t_range usize,
@@ -6620,11 +6583,11 @@ module C03StdIterators_MyReverse
     function Iterb0.iterb = Iterb0.iterb,
     predicate Completed0.completed = Completed1.completed,
     predicate Completed1.completed = Completed1.completed,
-    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     type Item0.item = usize,
     predicate Inv2.inv = Inv12.inv,
     predicate Produces0.produces = Produces1.produces,
-    predicate Resolve1.resolve = Resolve4.resolve
+    predicate Resolve1.resolve = Resolve3.resolve
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = t,
     predicate Inv0.inv = Inv2.inv,
@@ -6692,7 +6655,7 @@ module C03StdIterators_MyReverse
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = slice t
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
@@ -6702,13 +6665,11 @@ module C03StdIterators_MyReverse
     predicate Inv1.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv9.inv
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
     type t1 = usize,
     type t2 = usize,
-    predicate Resolve0.resolve = Resolve4.resolve,
-    predicate Resolve1.resolve = Resolve4.resolve
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)
+    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve1.resolve = Resolve3.resolve
   clone Core_Iter_Adapters_Zip_Impl1_Next_Interface as Next0 with
     type a = Core_Ops_Range_Range_Type.t_range usize,
     type b = Core_Ops_Range_Range_Type.t_range usize,
@@ -6764,7 +6725,6 @@ module C03StdIterators_MyReverse
   var iter_old : Ghost.ghost_ty (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize));
   var produced : Ghost.ghost_ty (Seq.seq (usize, usize));
   var _28 : Core_Option_Option_Type.t_option (usize, usize);
-  var _29 : borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize));
   var _30 : borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize));
   var __creusot_proc_iter_elem : (usize, usize);
   var _33 : Ghost.ghost_ty (Seq.seq (usize, usize));
@@ -6827,14 +6787,11 @@ module C03StdIterators_MyReverse
   BB10 {
     _30 <- Borrow.borrow_mut iter;
     iter <-  ^ _30;
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
-    _28 <- ([#"../03_std_iterators.rs" 97 4 97 36] Next0.next _29);
-    _29 <- any borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize));
+    _28 <- ([#"../03_std_iterators.rs" 97 4 97 36] Next0.next _30);
+    _30 <- any borrowed (Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize));
     goto BB11
   }
   BB11 {
-    assume { Resolve1.resolve _30 };
     switch (_28)
       | Core_Option_Option_Type.C_None -> goto BB12
       | Core_Option_Option_Type.C_Some _ -> goto BB13
@@ -6842,7 +6799,7 @@ module C03StdIterators_MyReverse
   }
   BB12 {
     assert { [@expl:type invariant] Inv3.inv slice };
-    assume { Resolve3.resolve slice };
+    assume { Resolve2.resolve slice };
     _0 <- ();
     return _0
   }
@@ -6851,7 +6808,7 @@ module C03StdIterators_MyReverse
   }
   BB14 {
     assert { [@expl:type invariant] Inv3.inv slice };
-    assume { Resolve3.resolve slice };
+    assume { Resolve2.resolve slice };
     absurd
   }
   BB15 {
@@ -6864,7 +6821,7 @@ module C03StdIterators_MyReverse
     _33 <- any Ghost.ghost_ty (Seq.seq (usize, usize));
     i <- (let (a, _) = __creusot_proc_iter_elem in a);
     j <- (let (_, a) = __creusot_proc_iter_elem in a);
-    assume { Resolve2.resolve __creusot_proc_iter_elem };
+    assume { Resolve1.resolve __creusot_proc_iter_elem };
     _38 <- Borrow.borrow_mut ( * slice);
     slice <- { slice with current = ( ^ _38) };
     assume { Inv2.inv ( ^ _38) };

--- a/creusot/tests/should_succeed/iterators/04_skip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/04_skip.mlcfg
@@ -574,28 +574,6 @@ module Core_Option_Option_Type
       | C_Some a -> a
       end
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module CreusotContracts_Logic_Ops_Impl6_IndexLogic_Stub
   type t
   use prelude.Ghost
@@ -622,6 +600,28 @@ module CreusotContracts_Logic_Ops_Impl6_IndexLogic
     [#"../../../../../creusot-contracts/src/logic/ops.rs" 85 8 85 33] Seq.get (Ghost.inner self) ix
   val index_logic [@inline:trivial] (self : Ghost.ghost_ty (Seq.seq t)) (ix : int) : t
     ensures { result = index_logic self ix }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
     
 end
 module CreusotContracts_Std1_Default_Default_IsDefault_Stub
@@ -823,25 +823,25 @@ module C04Skip_Impl0_Next
     type t = Ghost.ghost_ty (borrowed (C04Skip_Skip_Type.t_skip i)),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = Item0.item
   clone C04Skip_Impl0_Produces as Produces1 with
     type i = i,
     type Item0.item = Item0.item,
     predicate Inv0.inv = Inv9.inv,
     predicate Produces0.produces = Produces0.produces,
-    predicate Resolve0.resolve = Resolve3.resolve
+    predicate Resolve0.resolve = Resolve2.resolve
   clone C04Skip_Impl0_Completed as Completed0 with
     type i = i,
     type Item0.item = Item0.item,
     predicate Inv0.inv = Inv8.inv,
     predicate Inv1.inv = Inv9.inv,
     predicate Produces0.produces = Produces0.produces,
-    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     predicate Completed0.completed = Completed1.completed
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
     type t = C04Skip_Skip_Type.t_skip i
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Core_Option_Option_Type.t_option Item0.item
   clone C04Skip_Common_Iterator_Next_Interface as Next0 with
     type self = i,
@@ -852,10 +852,8 @@ module C04Skip_Impl0_Next
     predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Logic_Ops_Impl6_IndexLogic as IndexLogic0 with
     type t = Item0.item
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = Ghost.ghost_ty (Seq.seq Item0.item)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = usize
   clone Core_Mem_Take_Interface as Take0 with
     type t = usize,
     predicate Inv0.inv = Inv6.inv,
@@ -876,7 +874,6 @@ module C04Skip_Impl0_Next
   var self : borrowed (C04Skip_Skip_Type.t_skip i) = self;
   var old_self : Ghost.ghost_ty (borrowed (C04Skip_Skip_Type.t_skip i));
   var n : usize;
-  var _6 : borrowed usize;
   var _7 : borrowed usize;
   var skipped : Ghost.ghost_ty (Seq.seq Item0.item);
   var r : Core_Option_Option_Type.t_option Item0.item;
@@ -895,26 +892,23 @@ module C04Skip_Impl0_Next
     assume { Resolve0.resolve old_self };
     _7 <- Borrow.borrow_mut (C04Skip_Skip_Type.skip_n ( * self));
     self <- { self with current = (let C04Skip_Skip_Type.C_Skip a b =  * self in C04Skip_Skip_Type.C_Skip a ( ^ _7)) };
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
-    n <- ([#"../04_skip.rs" 65 20 65 47] Take0.take _6);
-    _6 <- any borrowed usize;
+    n <- ([#"../04_skip.rs" 65 20 65 47] Take0.take _7);
+    _7 <- any borrowed usize;
     goto BB2
   }
   BB2 {
-    assume { Resolve1.resolve _7 };
     skipped <- ([#"../04_skip.rs" 66 26 66 44] Ghost.new (Seq.empty ));
     goto BB3
   }
   BB3 {
     assert { [@expl:type invariant] Inv1.inv skipped };
-    assume { Resolve2.resolve skipped };
+    assume { Resolve1.resolve skipped };
     goto BB4
   }
   BB4 {
     invariant { [#"../04_skip.rs" 67 20 67 53] Seq.length (Ghost.inner skipped) + UIntSize.to_int n = UIntSize.to_int (C04Skip_Skip_Type.skip_n ( * Ghost.inner old_self)) };
     invariant { [#"../04_skip.rs" 67 8 67 55] Produces0.produces (C04Skip_Skip_Type.skip_iter ( * Ghost.inner old_self)) (Ghost.inner skipped) (C04Skip_Skip_Type.skip_iter ( * self)) };
-    invariant { [#"../04_skip.rs" 67 8 67 55] forall i : int . 0 <= i /\ i < Seq.length (Ghost.inner skipped) -> Resolve3.resolve (IndexLogic0.index_logic skipped i) };
+    invariant { [#"../04_skip.rs" 67 8 67 55] forall i : int . 0 <= i /\ i < Seq.length (Ghost.inner skipped) -> Resolve2.resolve (IndexLogic0.index_logic skipped i) };
     invariant { [#"../04_skip.rs" 70 20 70 35] UIntSize.to_int (C04Skip_Skip_Type.skip_n ( * self)) = 0 };
     invariant { [#"../04_skip.rs" 71 20 71 29] Inv2.inv self };
     goto BB5
@@ -935,7 +929,7 @@ module C04Skip_Impl0_Next
   }
   BB7 {
     assert { [@expl:type invariant] Inv2.inv self };
-    assume { Resolve5.resolve self };
+    assume { Resolve4.resolve self };
     _0 <- r;
     r <- any Core_Option_Option_Type.t_option Item0.item;
     goto BB15
@@ -948,7 +942,7 @@ module C04Skip_Impl0_Next
   }
   BB9 {
     assert { [@expl:type invariant] Inv2.inv self };
-    assume { Resolve5.resolve self };
+    assume { Resolve4.resolve self };
     _0 <- r;
     r <- any Core_Option_Option_Type.t_option Item0.item;
     goto BB15
@@ -960,9 +954,9 @@ module C04Skip_Impl0_Next
     x <- Core_Option_Option_Type.some_0 r;
     r <- (let Core_Option_Option_Type.C_Some a = r in Core_Option_Option_Type.C_Some (any Item0.item));
     assert { [@expl:type invariant] Inv4.inv x };
-    assume { Resolve3.resolve x };
+    assume { Resolve2.resolve x };
     assert { [@expl:type invariant] Inv5.inv r };
-    assume { Resolve4.resolve r };
+    assume { Resolve3.resolve r };
     _25 <- ([#"../04_skip.rs" 78 26 78 67] Ghost.new (Seq.(++) (Ghost.inner skipped) (Seq.singleton x)));
     goto BB12
   }
@@ -970,7 +964,7 @@ module C04Skip_Impl0_Next
     skipped <- _25;
     _25 <- any Ghost.ghost_ty (Seq.seq Item0.item);
     assert { [@expl:type invariant] Inv1.inv skipped };
-    assume { Resolve2.resolve skipped };
+    assume { Resolve1.resolve skipped };
     n <- ([#"../04_skip.rs" 79 16 79 22] n - ([#"../04_skip.rs" 79 21 79 22] (1 : usize)));
     goto BB13
   }

--- a/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
+++ b/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
@@ -396,17 +396,17 @@ module C07Fuse_Impl0_Next
     type t = Seq.seq Item0.item,
     predicate Inv0.inv = Inv6.inv,
     axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = Core_Option_Option_Type.t_option Item0.item
+    type t = borrowed i
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = Core_Option_Option_Type.t_option Item0.item,
+    type t = borrowed i,
     predicate Inv0.inv = Inv5.inv,
     axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed i
+    type t = Core_Option_Option_Type.t_option Item0.item
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed i,
+    type t = Core_Option_Option_Type.t_option Item0.item,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone C07Fuse_Common_Iterator_Produces_Interface as Produces1 with
@@ -458,21 +458,19 @@ module C07Fuse_Impl0_Next
     predicate Produces0.produces = Produces1.produces
   clone C07Fuse_Impl0_Completed as Completed0 with
     type i = i,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv5.inv,
     predicate Completed0.completed = Completed1.completed
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
-    type self = Core_Option_Option_Type.t_option i
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
+    type self = Core_Option_Option_Type.t_option i
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = Core_Option_Option_Type.t_option Item0.item
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = i
   clone C07Fuse_Common_Iterator_Next_Interface as Next0 with
     type self = i,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv5.inv,
     type Item0.item = Item0.item,
     predicate Completed0.completed = Completed1.completed,
     predicate Produces0.produces = Produces1.produces,
-    predicate Inv1.inv = Inv5.inv
+    predicate Inv1.inv = Inv4.inv
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = C07Fuse_Fuse_Type.t_fuse i
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
@@ -483,7 +481,7 @@ module C07Fuse_Impl0_Next
       | Core_Option_Option_Type.C_None -> Completed0.completed self
       | Core_Option_Option_Type.C_Some v -> Produces0.produces ( * self) (Seq.singleton v) ( ^ self)
       end }
-    ensures { [#"../07_fuse.rs" 39 26 39 44] Inv5.inv result }
+    ensures { [#"../07_fuse.rs" 39 26 39 44] Inv4.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.t_option Item0.item;
@@ -491,7 +489,6 @@ module C07Fuse_Impl0_Next
   var _3 : borrowed (Core_Option_Option_Type.t_option i);
   var iter : borrowed i;
   var _6 : Core_Option_Option_Type.t_option Item0.item;
-  var _7 : borrowed i;
   var x : Core_Option_Option_Type.t_option Item0.item;
   {
     goto BB0
@@ -512,11 +509,8 @@ module C07Fuse_Impl0_Next
     iter <- Borrow.borrow_mut (Core_Option_Option_Type.some_0 ( * _3));
     _3 <- { _3 with current = (let Core_Option_Option_Type.C_Some a =  * _3 in Core_Option_Option_Type.C_Some ( ^ iter)) };
     assume { Inv3.inv ( ^ iter) };
-    _7 <- Borrow.borrow_mut ( * iter);
-    iter <- { iter with current = ( ^ _7) };
-    assume { Inv3.inv ( ^ _7) };
-    _6 <- ([#"../07_fuse.rs" 42 32 42 43] Next0.next _7);
-    _7 <- any borrowed i;
+    _6 <- ([#"../07_fuse.rs" 42 32 42 43] Next0.next iter);
+    iter <- any borrowed i;
     goto BB5
   }
   BB3 {
@@ -535,8 +529,6 @@ module C07Fuse_Impl0_Next
     goto BB15
   }
   BB5 {
-    assert { [@expl:type invariant] Inv4.inv iter };
-    assume { Resolve2.resolve iter };
     assert { [@expl:type invariant] Inv1.inv _3 };
     assume { Resolve0.resolve _3 };
     switch (_6)
@@ -557,14 +549,14 @@ module C07Fuse_Impl0_Next
     goto BB12
   }
   BB8 {
-    assert { [@expl:type invariant] Inv5.inv _6 };
-    assume { Resolve3.resolve _6 };
+    assert { [@expl:type invariant] Inv4.inv _6 };
+    assume { Resolve2.resolve _6 };
     goto BB9
   }
   BB9 {
     self <- { self with current = (let C07Fuse_Fuse_Type.C_Fuse a =  * self in C07Fuse_Fuse_Type.C_Fuse (Core_Option_Option_Type.C_None)) };
     assert { [@expl:type invariant] Inv0.inv (C07Fuse_Fuse_Type.fuse_iter ( * self)) };
-    assume { Resolve4.resolve (C07Fuse_Fuse_Type.fuse_iter ( * self)) };
+    assume { Resolve3.resolve (C07Fuse_Fuse_Type.fuse_iter ( * self)) };
     assert { [@expl:type invariant] Inv2.inv self };
     assume { Resolve1.resolve self };
     goto BB11

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -318,6 +318,17 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     ensures { result = shallow_model self }
     
 end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_None -> any 't
+      | C_Some a -> a
+      end
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -339,17 +350,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
-end
-module Core_Option_Option_Type
-  type t_option 't =
-    | C_None
-    | C_Some 't
-    
-  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
-    match (self) with
-      | C_None -> any 't
-      | C_Some a -> a
-      end
 end
 module TyInv_Trivial
   type t
@@ -684,47 +684,47 @@ module C08CollectExtend_Extend
     type t = t,
     predicate Inv0.inv = Inv9.inv,
     axiom .
-  use seq.Seq
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = Seq.seq t
+    type t = borrowed i
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = Seq.seq t,
+    type t = borrowed i,
     predicate Inv0.inv = Inv8.inv,
+    axiom .
+  use seq.Seq
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+    type t = Seq.seq t
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = Seq.seq t,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
-  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv6.inv,
     axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = Core_Option_Option_Type.t_option t
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = Core_Option_Option_Type.t_option t,
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv5.inv,
     axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed i
+    type t = Core_Option_Option_Type.t_option t
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed i,
+    type t = Core_Option_Option_Type.t_option t,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv5.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv8.inv,
+    predicate Inv1.inv = Inv7.inv,
     axiom .
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
@@ -743,7 +743,7 @@ module C08CollectExtend_Extend
     type self = i,
     predicate Produces0.produces = Produces0.produces,
     predicate Inv0.inv = Inv3.inv,
-    predicate Inv1.inv = Inv8.inv,
+    predicate Inv1.inv = Inv7.inv,
     type Item0.item = t,
     axiom .
   clone CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface as ProducesRefl0 with
@@ -781,31 +781,29 @@ module C08CollectExtend_Extend
     axiom .
   clone CreusotContracts_Std1_Iter_Iterator_Completed_Interface as Completed0 with
     type self = i
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
     type self = i
   clone Alloc_Vec_Impl1_Push_Interface as Push0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv6.inv,
     predicate Inv1.inv = Inv9.inv,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv2.inv = Inv6.inv,
+    predicate Inv2.inv = Inv5.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv3.inv = Inv8.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+    predicate Inv3.inv = Inv7.inv
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Core_Option_Option_Type.t_option t
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = i
   clone Core_Iter_Traits_Iterator_Iterator_Next_Interface as Next0 with
     type self = i,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv8.inv,
     type Item0.item = t,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv1.inv = Inv5.inv
+    predicate Inv1.inv = Inv4.inv
   clone CreusotContracts_Ghost_Impl1_ShallowModel as ShallowModel1 with
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
@@ -822,9 +820,9 @@ module C08CollectExtend_Extend
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)))
   let rec cfg extend [#"../08_collect_extend.rs" 25 0 25 66] [@cfg:stackify] [@cfg:subregion_analysis] (vec : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (iter : i) : ()
-    requires {[#"../08_collect_extend.rs" 25 40 25 43] Inv7.inv vec}
+    requires {[#"../08_collect_extend.rs" 25 40 25 43] Inv6.inv vec}
     requires {[#"../08_collect_extend.rs" 25 58 25 62] Inv3.inv iter}
-    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq t . exists done_ : borrowed i . Inv8.inv prod /\ Inv4.inv done_ /\ Completed0.completed done_ /\ Produces0.produces iter prod ( * done_) /\ ShallowModel2.shallow_model ( ^ vec) = Seq.(++) (ShallowModel0.shallow_model vec) prod }
+    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq t . exists done_ : borrowed i . Inv7.inv prod /\ Inv8.inv done_ /\ Completed0.completed done_ /\ Produces0.produces iter prod ( * done_) /\ ShallowModel2.shallow_model ( ^ vec) = Seq.(++) (ShallowModel0.shallow_model vec) prod }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -835,7 +833,6 @@ module C08CollectExtend_Extend
   var iter_old : Ghost.ghost_ty i;
   var produced : Ghost.ghost_ty (Seq.seq t);
   var _17 : Core_Option_Option_Type.t_option t;
-  var _18 : borrowed i;
   var _19 : borrowed i;
   var __creusot_proc_iter_elem : t;
   var _22 : Ghost.ghost_ty (Seq.seq t);
@@ -891,28 +888,23 @@ module C08CollectExtend_Extend
     _19 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _19;
     assume { Inv3.inv ( ^ _19) };
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    assume { Inv3.inv ( ^ _18) };
-    _17 <- ([#"../08_collect_extend.rs" 27 4 27 35] Next0.next _18);
-    _18 <- any borrowed i;
+    _17 <- ([#"../08_collect_extend.rs" 27 4 27 35] Next0.next _19);
+    _19 <- any borrowed i;
     goto BB10
   }
   BB10 {
-    assert { [@expl:type invariant] Inv4.inv _19 };
-    assume { Resolve3.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB11
       | Core_Option_Option_Type.C_Some _ -> goto BB12
       end
   }
   BB11 {
-    assert { [@expl:type invariant] Inv5.inv _17 };
-    assume { Resolve4.resolve _17 };
+    assert { [@expl:type invariant] Inv4.inv _17 };
+    assume { Resolve3.resolve _17 };
     assert { [@expl:type invariant] Inv3.inv iter1 };
-    assume { Resolve5.resolve iter1 };
-    assert { [@expl:type invariant] Inv7.inv vec };
-    assume { Resolve6.resolve vec };
+    assume { Resolve4.resolve iter1 };
+    assert { [@expl:type invariant] Inv6.inv vec };
+    assume { Resolve5.resolve vec };
     _0 <- ();
     goto BB20
   }
@@ -920,19 +912,19 @@ module C08CollectExtend_Extend
     goto BB14
   }
   BB13 {
-    assert { [@expl:type invariant] Inv5.inv _17 };
-    assume { Resolve4.resolve _17 };
+    assert { [@expl:type invariant] Inv4.inv _17 };
+    assume { Resolve3.resolve _17 };
     assert { [@expl:type invariant] Inv3.inv iter1 };
-    assume { Resolve5.resolve iter1 };
-    assert { [@expl:type invariant] Inv7.inv vec };
-    assume { Resolve6.resolve vec };
+    assume { Resolve4.resolve iter1 };
+    assert { [@expl:type invariant] Inv6.inv vec };
+    assume { Resolve5.resolve vec };
     absurd
   }
   BB14 {
     __creusot_proc_iter_elem <- Core_Option_Option_Type.some_0 _17;
     _17 <- (let Core_Option_Option_Type.C_Some a = _17 in Core_Option_Option_Type.C_Some (any t));
-    assert { [@expl:type invariant] Inv5.inv _17 };
-    assume { Resolve4.resolve _17 };
+    assert { [@expl:type invariant] Inv4.inv _17 };
+    assume { Resolve3.resolve _17 };
     _22 <- ([#"../08_collect_extend.rs" 27 4 27 35] Ghost.new (Seq.(++) (Ghost.inner produced) (Seq.singleton __creusot_proc_iter_elem)));
     goto BB15
   }
@@ -945,7 +937,7 @@ module C08CollectExtend_Extend
     __creusot_proc_iter_elem <- any t;
     _26 <- Borrow.borrow_mut ( * vec);
     vec <- { vec with current = ( ^ _26) };
-    assume { Inv6.inv ( ^ _26) };
+    assume { Inv5.inv ( ^ _26) };
     _25 <- ([#"../08_collect_extend.rs" 30 8 30 19] Push0.push _26 x);
     _26 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     x <- any t;
@@ -1141,51 +1133,51 @@ module C08CollectExtend_Collect
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv7.inv,
     axiom .
-  use seq.Seq
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = Seq.seq Item0.item
+    type t = borrowed i
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = Seq.seq Item0.item,
+    type t = borrowed i,
     predicate Inv0.inv = Inv6.inv,
     axiom .
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
+  use seq.Seq
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = Seq.seq Item0.item
+  clone TyInv_Trivial as TyInv_Trivial5 with
+    type t = Seq.seq Item0.item,
+    predicate Inv0.inv = Inv5.inv,
+    axiom .
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
     type self = Item0.item
   clone Core_Num_Impl11_Max as Max0
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel0 with
     type t = Item0.item,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Logic_Ops_Impl0_IndexLogic as IndexLogic0 with
     type t = Item0.item,
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel1 with
     type t = Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq Item0.item,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = Core_Option_Option_Type.t_option Item0.item
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = Core_Option_Option_Type.t_option Item0.item,
+    type t = Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv4.inv,
     axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed i
+    type t = Core_Option_Option_Type.t_option Item0.item
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed i,
+    type t = Core_Option_Option_Type.t_option Item0.item,
     predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
@@ -1197,7 +1189,7 @@ module C08CollectExtend_Collect
     type self = i,
     predicate Produces0.produces = Produces0.produces,
     predicate Inv0.inv = Inv2.inv,
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv1.inv = Inv5.inv,
     type Item0.item = Item0.item,
     axiom .
   clone CreusotContracts_Std1_Iter_Iterator_ProducesRefl_Interface as ProducesRefl0 with
@@ -1229,15 +1221,15 @@ module C08CollectExtend_Collect
     type i = i
   clone CreusotContracts_Std1_Iter_Iterator_Completed_Interface as Completed0 with
     type self = i
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve5 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve4 with
     type t = Item0.item,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve6.resolve,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+    predicate Inv1.inv = Inv5.inv
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = i
   clone Alloc_Vec_Impl1_Push_Interface as Push0 with
     type t = Item0.item,
@@ -1246,20 +1238,18 @@ module C08CollectExtend_Collect
     predicate Inv1.inv = Inv8.inv,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel1.shallow_model,
-    predicate Inv2.inv = Inv5.inv,
+    predicate Inv2.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv3.inv = Inv6.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
+    predicate Inv3.inv = Inv5.inv
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = Core_Option_Option_Type.t_option Item0.item
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = i
   clone Core_Iter_Traits_Iterator_Iterator_Next_Interface as Next0 with
     type self = i,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv6.inv,
     type Item0.item = Item0.item,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv1.inv = Inv4.inv
+    predicate Inv1.inv = Inv3.inv
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = Ghost.ghost_ty (Seq.seq Item0.item)
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
@@ -1272,13 +1262,13 @@ module C08CollectExtend_Collect
   clone Alloc_Vec_Impl0_New_Interface as New0 with
     type t = Item0.item,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv1.inv = Inv5.inv
   let rec cfg collect [#"../08_collect_extend.rs" 42 0 42 52] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) : Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global)
     requires {[#"../08_collect_extend.rs" 42 28 42 32] Inv2.inv iter}
-    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq Item0.item . exists done_ : borrowed i . Inv6.inv prod /\ Inv3.inv done_ /\ Completed0.completed done_ /\ Produces0.produces iter prod ( * done_) /\ ShallowModel0.shallow_model result = prod }
-    ensures { [#"../08_collect_extend.rs" 42 40 42 52] Inv5.inv result }
+    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq Item0.item . exists done_ : borrowed i . Inv5.inv prod /\ Inv6.inv done_ /\ Completed0.completed done_ /\ Produces0.produces iter prod ( * done_) /\ ShallowModel0.shallow_model result = prod }
+    ensures { [#"../08_collect_extend.rs" 42 40 42 52] Inv4.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global);
@@ -1288,7 +1278,6 @@ module C08CollectExtend_Collect
   var iter_old : Ghost.ghost_ty i;
   var produced : Ghost.ghost_ty (Seq.seq Item0.item);
   var _15 : Core_Option_Option_Type.t_option Item0.item;
-  var _16 : borrowed i;
   var _17 : borrowed i;
   var __creusot_proc_iter_elem : Item0.item;
   var _20 : Ghost.ghost_ty (Seq.seq Item0.item);
@@ -1344,45 +1333,40 @@ module C08CollectExtend_Collect
     _17 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _17;
     assume { Inv2.inv ( ^ _17) };
-    _16 <- Borrow.borrow_mut ( * _17);
-    _17 <- { _17 with current = ( ^ _16) };
-    assume { Inv2.inv ( ^ _16) };
-    _15 <- ([#"../08_collect_extend.rs" 45 4 45 40] Next0.next _16);
-    _16 <- any borrowed i;
+    _15 <- ([#"../08_collect_extend.rs" 45 4 45 40] Next0.next _17);
+    _17 <- any borrowed i;
     goto BB11
   }
   BB11 {
-    assert { [@expl:type invariant] Inv3.inv _17 };
-    assume { Resolve2.resolve _17 };
     switch (_15)
       | Core_Option_Option_Type.C_None -> goto BB12
       | Core_Option_Option_Type.C_Some _ -> goto BB13
       end
   }
   BB12 {
-    assert { [@expl:type invariant] Inv4.inv _15 };
-    assume { Resolve3.resolve _15 };
+    assert { [@expl:type invariant] Inv3.inv _15 };
+    assume { Resolve2.resolve _15 };
     assert { [@expl:type invariant] Inv2.inv iter1 };
-    assume { Resolve4.resolve iter1 };
+    assume { Resolve3.resolve iter1 };
     goto BB21
   }
   BB13 {
     goto BB15
   }
   BB14 {
-    assert { [@expl:type invariant] Inv4.inv _15 };
-    assume { Resolve3.resolve _15 };
+    assert { [@expl:type invariant] Inv3.inv _15 };
+    assume { Resolve2.resolve _15 };
     assert { [@expl:type invariant] Inv2.inv iter1 };
-    assume { Resolve4.resolve iter1 };
-    assert { [@expl:type invariant] Inv5.inv res };
-    assume { Resolve5.resolve res };
+    assume { Resolve3.resolve iter1 };
+    assert { [@expl:type invariant] Inv4.inv res };
+    assume { Resolve4.resolve res };
     absurd
   }
   BB15 {
     __creusot_proc_iter_elem <- Core_Option_Option_Type.some_0 _15;
     _15 <- (let Core_Option_Option_Type.C_Some a = _15 in Core_Option_Option_Type.C_Some (any Item0.item));
-    assert { [@expl:type invariant] Inv4.inv _15 };
-    assume { Resolve3.resolve _15 };
+    assert { [@expl:type invariant] Inv3.inv _15 };
+    assume { Resolve2.resolve _15 };
     _20 <- ([#"../08_collect_extend.rs" 45 4 45 40] Ghost.new (Seq.(++) (Ghost.inner produced) (Seq.singleton __creusot_proc_iter_elem)));
     goto BB16
   }
@@ -1395,7 +1379,7 @@ module C08CollectExtend_Collect
     __creusot_proc_iter_elem <- any Item0.item;
     _24 <- Borrow.borrow_mut res;
     res <-  ^ _24;
-    assume { Inv5.inv ( ^ _24) };
+    assume { Inv4.inv ( ^ _24) };
     _23 <- ([#"../08_collect_extend.rs" 47 8 47 19] Push0.push _24 x);
     _24 <- any borrowed (Alloc_Vec_Vec_Type.t_vec Item0.item (Alloc_Alloc_Global_Type.t_global));
     x <- any Item0.item;
@@ -1890,7 +1874,7 @@ module C08CollectExtend_ExtendIndex
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel6.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq uint32
@@ -1959,7 +1943,7 @@ module C08CollectExtend_ExtendIndex
     type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve1 with
     type t = uint32
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel0 with
     type t = uint32,
@@ -1982,7 +1966,7 @@ module C08CollectExtend_ExtendIndex
   clone CreusotContracts_Std1_Vec_Impl8_Completed as Completed0 with
     type t = uint32,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     function ShallowModel0.shallow_model = ShallowModel7.shallow_model
   clone CreusotContracts_Std1_Vec_Impl4_IntoIterPost as IntoIterPost0 with
     type t = uint32,
@@ -2007,16 +1991,14 @@ module C08CollectExtend_ExtendIndex
     type t = slice uint32,
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve1 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve0 with
     type t = uint32,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve0.resolve = Resolve1.resolve,
     predicate Inv0.inv = Inv2.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv5.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
   clone C08CollectExtend_Extend_Interface as Extend0 with
     type t = uint32,
     type i = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global),
@@ -2053,7 +2035,6 @@ module C08CollectExtend_ExtendIndex
   var oldv1 : Ghost.ghost_ty (slice uint32);
   var oldv2 : Ghost.ghost_ty (slice uint32);
   var _7 : ();
-  var _8 : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
   var _9 : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
   var _10 : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global);
   {
@@ -2070,21 +2051,18 @@ module C08CollectExtend_ExtendIndex
   BB2 {
     _9 <- Borrow.borrow_mut v1;
     v1 <-  ^ _9;
-    _8 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _8) };
     _10 <- ([#"../08_collect_extend.rs" 55 20 55 34] IntoIter0.into_iter v2);
     v2 <- any Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global);
     goto BB3
   }
   BB3 {
-    _7 <- ([#"../08_collect_extend.rs" 55 4 55 35] Extend0.extend _8 _10);
-    _8 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
+    _7 <- ([#"../08_collect_extend.rs" 55 4 55 35] Extend0.extend _9 _10);
+    _9 <- any borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global));
     _10 <- any Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global);
     goto BB4
   }
   BB4 {
-    assume { Resolve0.resolve _9 };
-    assume { Resolve1.resolve v1 };
+    assume { Resolve0.resolve v1 };
     assert { [@expl:assertion] [#"../08_collect_extend.rs" 57 4 57 55] Seq.(==) (ShallowModel0.shallow_model v1) (Seq.(++) (ShallowModel1.shallow_model oldv1) (ShallowModel1.shallow_model oldv2)) };
     goto BB5
   }

--- a/creusot/tests/should_succeed/knapsack.mlcfg
+++ b/creusot/tests/should_succeed/knapsack.mlcfg
@@ -986,7 +986,7 @@ module Knapsack_Knapsack01Dyn
     type t = Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv10.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve6 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve5 with
     type t = usize
   use seq.Seq
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
@@ -1114,11 +1114,11 @@ module Knapsack_Knapsack01Dyn
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv5.inv
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve5 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve4 with
     type t = usize,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     function IndexLogic0.index_logic = IndexLogic2.index_logic,
-    predicate Resolve0.resolve = Resolve6.resolve,
+    predicate Resolve0.resolve = Resolve5.resolve,
     predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv5.inv
@@ -1136,8 +1136,6 @@ module Knapsack_Knapsack01Dyn
     predicate Inv0.inv = Inv17.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv8.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
     type t = usize
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut1 with
@@ -1235,7 +1233,7 @@ module Knapsack_Knapsack01Dyn
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global),
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve5.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     predicate Inv0.inv = Inv6.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv7.inv
@@ -1298,7 +1296,6 @@ module Knapsack_Knapsack01Dyn
   var _57 : usize;
   var _59 : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global);
   var _66 : borrowed usize;
-  var _67 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _68 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _69 : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
   var result : Alloc_Vec_Vec_Type.t_vec (Knapsack_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global);
@@ -1452,17 +1449,14 @@ module Knapsack_Knapsack01Dyn
     goto BB31
   }
   BB31 {
-    _67 <- Borrow.borrow_mut ( * _68);
-    _68 <- { _68 with current = ( ^ _67) };
-    _66 <- ([#"../knapsack.rs" 77 12 77 32] IndexMut1.index_mut _67 w);
-    _67 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
+    _66 <- ([#"../knapsack.rs" 77 12 77 32] IndexMut1.index_mut _68 w);
+    _68 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB32
   }
   BB32 {
     _66 <- { _66 with current = _38 };
     _38 <- any usize;
     assume { Resolve3.resolve _66 };
-    assume { Resolve4.resolve _68 };
     w <- ([#"../knapsack.rs" 82 12 82 18] w + ([#"../knapsack.rs" 82 17 82 18] (1 : usize)));
     _19 <- ();
     goto BB18

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -711,28 +711,6 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
     ensures { result = produces self visited o }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module Core_Option_Option_Type
   type t_option 't =
     | C_None
@@ -1097,6 +1075,28 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
     [#"../../../../creusot-contracts/src/std/iter/range.rs" 65 8 71 9] Seq.length visited = RangeInclusiveLen0.range_inclusive_len self - RangeInclusiveLen0.range_inclusive_len o /\ (IsEmptyLog0.is_empty_log self -> IsEmptyLog0.is_empty_log o) /\ (IsEmptyLog0.is_empty_log o \/ EndLog0.end_log self = EndLog0.end_log o) /\ (forall i : int . 0 <= i /\ i < Seq.length visited -> DeepModel0.deep_model (Seq.get visited i) = DeepModel0.deep_model (StartLog0.start_log self) + i)
   val produces (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) (visited : Seq.seq idx) (o : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive idx) : bool
     ensures { result = produces self visited o }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
     
 end
 module CreusotContracts_Std1_Vec_Impl10_Resolve_Stub
@@ -2386,7 +2386,7 @@ module KnapsackFull_Knapsack01Dyn
     type t = borrowed (Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv21.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve8 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve6 with
     type t = usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv20 with
     type t = borrowed usize
@@ -2448,6 +2448,8 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv0.inv = Inv13.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial12 with
@@ -2531,11 +2533,11 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv0.inv = Inv7.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv8.inv
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve7 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve4 with
     type t = usize,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model,
     function IndexLogic0.index_logic = IndexLogic3.index_logic,
-    predicate Resolve0.resolve = Resolve8.resolve,
+    predicate Resolve0.resolve = Resolve6.resolve,
     predicate Inv0.inv = Inv7.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv8.inv
@@ -2651,11 +2653,9 @@ module KnapsackFull_Knapsack01Dyn
     type t = KnapsackFull_Item_Type.t_item name
   clone CreusotContracts_Std1_Slice_Impl5_InBounds as InBounds0 with
     type t = KnapsackFull_Item_Type.t_item name
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve5.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel4 with
     type t = KnapsackFull_Item_Type.t_item name,
@@ -2705,7 +2705,7 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv2.inv = Inv5.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv3.inv = Inv3.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve6 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Logic_Ops_Impl0_IndexLogic as IndexLogic0 with
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global),
@@ -2714,11 +2714,11 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv0.inv = Inv9.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv10.inv
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve5 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve2 with
     type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global),
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve7.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     predicate Inv0.inv = Inv9.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv10.inv
@@ -2745,9 +2745,7 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv0.inv = Inv5.inv,
     val Max0.mAX' = Max1.mAX',
     predicate Inv1.inv = Inv3.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = usize
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut1 with
     type t = usize,
@@ -2804,8 +2802,6 @@ module KnapsackFull_Knapsack01Dyn
     predicate Inv1.inv = Inv6.inv,
     predicate HasValue0.has_value = HasValue1.has_value,
     predicate Inv2.inv = Inv16.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize
   clone Core_Iter_Range_Impl12_Next_Interface as Next1 with
     type a = usize,
     predicate Inv0.inv = Inv14.inv,
@@ -2827,7 +2823,7 @@ module KnapsackFull_Knapsack01Dyn
     function IsEmptyLog0.is_empty_log = IsEmptyLog0.is_empty_log,
     predicate Inv1.inv = Inv2.inv,
     type DeepModelTy0.deepModelTy = int
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = KnapsackFull_Item_Type.t_item name
   clone CreusotContracts_Model_Impl5_ShallowModel as ShallowModel0 with
     type t = Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global),
@@ -2907,7 +2903,6 @@ module KnapsackFull_Knapsack01Dyn
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _31 : ();
   var _32 : Core_Option_Option_Type.t_option usize;
-  var _33 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _34 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _37 : Ghost.ghost_ty (Seq.seq usize);
@@ -2919,7 +2914,6 @@ module KnapsackFull_Knapsack01Dyn
   var iter_old1 : Ghost.ghost_ty (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var produced1 : Ghost.ghost_ty (Seq.seq usize);
   var _58 : Core_Option_Option_Type.t_option usize;
-  var _59 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _60 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var __creusot_proc_iter_elem1 : usize;
   var _63 : Ghost.ghost_ty (Seq.seq usize);
@@ -2932,7 +2926,6 @@ module KnapsackFull_Knapsack01Dyn
   var _85 : usize;
   var _87 : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global);
   var _94 : borrowed usize;
-  var _95 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _96 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _97 : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
   var result : Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global);
@@ -3008,14 +3001,11 @@ module KnapsackFull_Knapsack01Dyn
   BB13 {
     _34 <- Borrow.borrow_mut iter;
     iter <-  ^ _34;
-    _33 <- Borrow.borrow_mut ( * _34);
-    _34 <- { _34 with current = ( ^ _33) };
-    _32 <- ([#"../knapsack_full.rs" 88 4 88 55] Next0.next _33);
-    _33 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _32 <- ([#"../knapsack_full.rs" 88 4 88 55] Next0.next _34);
+    _34 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB14
   }
   BB14 {
-    assume { Resolve0.resolve _34 };
     switch (_32)
       | Core_Option_Option_Type.C_None -> goto BB15
       | Core_Option_Option_Type.C_Some _ -> goto BB16
@@ -3046,7 +3036,7 @@ module KnapsackFull_Knapsack01Dyn
   BB20 {
     it <- _41;
     assert { [@expl:type invariant] Inv1.inv _41 };
-    assume { Resolve1.resolve _41 };
+    assume { Resolve0.resolve _41 };
     _45 <- ([#"../knapsack_full.rs" 110 17 110 31] New0.new ([#"../knapsack_full.rs" 110 17 110 18] (0 : usize)) max_weight);
     goto BB21
   }
@@ -3094,14 +3084,11 @@ module KnapsackFull_Knapsack01Dyn
   BB31 {
     _60 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _60;
-    _59 <- Borrow.borrow_mut ( * _60);
-    _60 <- { _60 with current = ( ^ _59) };
-    _58 <- ([#"../knapsack_full.rs" 98 8 98 59] Next1.next _59);
-    _59 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
+    _58 <- ([#"../knapsack_full.rs" 98 8 98 59] Next1.next _60);
+    _60 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
     goto BB32
   }
   BB32 {
-    assume { Resolve2.resolve _60 };
     switch (_58)
       | Core_Option_Option_Type.C_None -> goto BB33
       | Core_Option_Option_Type.C_Some _ -> goto BB34
@@ -3109,7 +3096,7 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB33 {
     assert { [@expl:type invariant] Inv1.inv it };
-    assume { Resolve1.resolve it };
+    assume { Resolve0.resolve it };
     _31 <- ();
     goto BB12
   }
@@ -3173,17 +3160,14 @@ module KnapsackFull_Knapsack01Dyn
     goto BB47
   }
   BB47 {
-    _95 <- Borrow.borrow_mut ( * _96);
-    _96 <- { _96 with current = ( ^ _95) };
-    _94 <- ([#"../knapsack_full.rs" 111 12 111 32] IndexMut1.index_mut _95 w);
-    _95 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
+    _94 <- ([#"../knapsack_full.rs" 111 12 111 32] IndexMut1.index_mut _96 w);
+    _96 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB48
   }
   BB48 {
     _94 <- { _94 with current = _66 };
     _66 <- any usize;
-    assume { Resolve3.resolve _94 };
-    assume { Resolve4.resolve _96 };
+    assume { Resolve1.resolve _94 };
     _31 <- ();
     goto BB30
   }
@@ -3231,7 +3215,7 @@ module KnapsackFull_Knapsack01Dyn
   BB58 {
     it1 <- _118;
     assert { [@expl:type invariant] Inv1.inv _118 };
-    assume { Resolve1.resolve _118 };
+    assume { Resolve0.resolve _118 };
     _125 <- ([#"../knapsack_full.rs" 143 11 143 28] Index1.index best_value ([#"../knapsack_full.rs" 143 22 143 27] j + ([#"../knapsack_full.rs" 143 26 143 27] (1 : usize))));
     goto BB59
   }
@@ -3263,14 +3247,14 @@ module KnapsackFull_Knapsack01Dyn
   }
   BB64 {
     assert { [@expl:type invariant] Inv1.inv it1 };
-    assume { Resolve1.resolve it1 };
+    assume { Resolve0.resolve it1 };
     left_weight <- ([#"../knapsack_full.rs" 145 12 145 36] left_weight - KnapsackFull_Item_Type.item_weight it1);
     _31 <- ();
     goto BB66
   }
   BB65 {
     assert { [@expl:type invariant] Inv1.inv it1 };
-    assume { Resolve1.resolve it1 };
+    assume { Resolve0.resolve it1 };
     _31 <- ();
     goto BB66
   }
@@ -3278,9 +3262,9 @@ module KnapsackFull_Knapsack01Dyn
     goto BB55
   }
   BB67 {
-    assume { Resolve5.resolve best_value };
+    assume { Resolve2.resolve best_value };
     assert { [@expl:type invariant] Inv4.inv items };
-    assume { Resolve6.resolve items };
+    assume { Resolve3.resolve items };
     _0 <- result;
     result <- any Alloc_Vec_Vec_Type.t_vec (KnapsackFull_Item_Type.t_item name) (Alloc_Alloc_Global_Type.t_global);
     goto BB68
@@ -3292,17 +3276,17 @@ module KnapsackFull_Knapsack01Dyn
     return _0
   }
   BB74 {
-    assume { Resolve5.resolve best_value };
+    assume { Resolve2.resolve best_value };
     assert { [@expl:type invariant] Inv4.inv items };
-    assume { Resolve6.resolve items };
+    assume { Resolve3.resolve items };
     goto BB17
   }
   BB75 {
     assert { [@expl:type invariant] Inv1.inv it };
-    assume { Resolve1.resolve it };
-    assume { Resolve5.resolve best_value };
+    assume { Resolve0.resolve it };
+    assume { Resolve2.resolve best_value };
     assert { [@expl:type invariant] Inv4.inv items };
-    assume { Resolve6.resolve items };
+    assume { Resolve3.resolve items };
     goto BB17
   }
   

--- a/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
+++ b/creusot/tests/should_succeed/lang/branch_borrow_2.mlcfg
@@ -41,8 +41,6 @@ module BranchBorrow2_F
   var z : borrowed int32;
   var w : borrowed int32;
   var _8 : ();
-  var _11 : borrowed int32;
-  var _12 : borrowed int32;
   {
     goto BB0
   }
@@ -72,10 +70,8 @@ module BranchBorrow2_F
   }
   BB3 {
     z <- { z with current = ([#"../branch_borrow_2.rs" 23 17 23 18] (8 : int32)) };
-    _12 <- Borrow.borrow_mut ( * z);
-    z <- { z with current = ( ^ _12) };
-    w <- _12;
-    _12 <- any borrowed int32;
+    w <- z;
+    z <- any borrowed int32;
     _8 <- ();
     goto BB6
   }
@@ -91,18 +87,14 @@ module BranchBorrow2_F
   BB5 {
     assume { Resolve0.resolve z };
     y <- { y with current = ([#"../branch_borrow_2.rs" 19 17 19 18] (7 : int32)) };
-    _11 <- Borrow.borrow_mut ( * y);
-    y <- { y with current = ( ^ _11) };
-    w <- _11;
-    _11 <- any borrowed int32;
+    w <- y;
+    y <- any borrowed int32;
     _8 <- ();
     goto BB6
   }
   BB6 {
     w <- { w with current = ([#"../branch_borrow_2.rs" 28 9 28 10] (5 : int32)) };
     assume { Resolve0.resolve w };
-    assume { Resolve0.resolve z };
-    assume { Resolve0.resolve y };
     switch (not ([#"../branch_borrow_2.rs" 30 12 30 18] c = ([#"../branch_borrow_2.rs" 30 17 30 18] (5 : int32))))
       | False -> goto BB8
       | True -> goto BB7
@@ -268,7 +260,6 @@ module BranchBorrow2_H
   var y : borrowed int32;
   var w : borrowed int32;
   var _6 : ();
-  var _9 : borrowed int32;
   {
     goto BB0
   }
@@ -295,17 +286,14 @@ module BranchBorrow2_H
   BB2 {
     assume { Resolve0.resolve x };
     y <- { y with current = ([#"../branch_borrow_2.rs" 56 13 56 14] (6 : int32)) };
-    _9 <- Borrow.borrow_mut ( * y);
-    y <- { y with current = ( ^ _9) };
-    w <- _9;
-    _9 <- any borrowed int32;
+    w <- y;
+    y <- any borrowed int32;
     _6 <- ();
     goto BB3
   }
   BB3 {
     assume { Resolve0.resolve w };
     _0 <- ();
-    assume { Resolve0.resolve y };
     return _0
   }
   

--- a/creusot/tests/should_succeed/list_index_mut.mlcfg
+++ b/creusot/tests/should_succeed/list_index_mut.mlcfg
@@ -325,7 +325,7 @@ module ListIndexMut_IndexMut
     type t = usize,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = ListIndexMut_List_Type.t_list
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = borrowed (ListIndexMut_List_Type.t_list),
@@ -336,10 +336,8 @@ module ListIndexMut_IndexMut
     predicate Inv0.inv = Inv0.inv,
     predicate Inv1.inv = Inv1.inv,
     predicate Inv2.inv = Inv2.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = ListIndexMut_List_Type.t_list
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = uint32
+    type t = ListIndexMut_List_Type.t_list
   clone CreusotContracts_Ghost_Impl1_ShallowModel as ShallowModel0 with
     type t = usize,
     type ShallowModelTy0.shallowModelTy = int,
@@ -357,7 +355,6 @@ module ListIndexMut_IndexMut
   var _0 : borrowed uint32;
   var l : borrowed (ListIndexMut_List_Type.t_list) = l;
   var ix : usize = ix;
-  var _3 : borrowed uint32;
   var old_l : Ghost.ghost_ty (borrowed (ListIndexMut_List_Type.t_list));
   var old_ix : Ghost.ghost_ty usize;
   var _22 : borrowed (ListIndexMut_List_Type.t_list);
@@ -408,23 +405,19 @@ module ListIndexMut_IndexMut
   BB7 {
     _22 <- Borrow.borrow_mut ( * _23);
     _23 <- { _23 with current = ( ^ _22) };
-    assume { Resolve1.resolve l };
+    assume { Resolve0.resolve l };
     l <- _22;
     _22 <- any borrowed (ListIndexMut_List_Type.t_list);
-    assume { Resolve2.resolve _23 };
+    assume { Resolve1.resolve _23 };
     ix <- ([#"../list_index_mut.rs" 52 8 52 15] ix - ([#"../list_index_mut.rs" 52 14 52 15] (1 : usize)));
     goto BB3
   }
   BB8 {
     _29 <- Borrow.borrow_mut (ListIndexMut_List_Type.list_0 ( * l));
     l <- { l with current = (let ListIndexMut_List_Type.C_List a b =  * l in ListIndexMut_List_Type.C_List ( ^ _29) b) };
-    _3 <- Borrow.borrow_mut ( * _29);
-    _29 <- { _29 with current = ( ^ _3) };
-    _0 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve0.resolve _29 };
-    assume { Resolve0.resolve _3 };
-    assume { Resolve1.resolve l };
+    _0 <- _29;
+    _29 <- any borrowed uint32;
+    assume { Resolve0.resolve l };
     return _0
   }
   
@@ -454,8 +447,6 @@ module ListIndexMut_Write
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone ListIndexMut_Impl0_Get as Get0
   clone ListIndexMut_Impl0_Len as Len0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = ListIndexMut_List_Type.t_list
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = uint32
   clone ListIndexMut_IndexMut_Interface as IndexMut0 with
@@ -473,21 +464,17 @@ module ListIndexMut_Write
   var ix : usize = ix;
   var v : uint32 = v;
   var _9 : borrowed uint32;
-  var _10 : borrowed (ListIndexMut_List_Type.t_list);
   {
     goto BB0
   }
   BB0 {
-    _10 <- Borrow.borrow_mut ( * l);
-    l <- { l with current = ( ^ _10) };
-    _9 <- ([#"../list_index_mut.rs" 64 5 64 21] IndexMut0.index_mut _10 ix);
-    _10 <- any borrowed (ListIndexMut_List_Type.t_list);
+    _9 <- ([#"../list_index_mut.rs" 64 5 64 21] IndexMut0.index_mut l ix);
+    l <- any borrowed (ListIndexMut_List_Type.t_list);
     goto BB1
   }
   BB1 {
     _9 <- { _9 with current = v };
     assume { Resolve0.resolve _9 };
-    assume { Resolve1.resolve l };
     _0 <- ();
     return _0
   }
@@ -505,8 +492,6 @@ module ListIndexMut_F
   use Core_Option_Option_Type as Core_Option_Option_Type
   clone ListIndexMut_Impl0_Get as Get0
   clone ListIndexMut_Impl0_Len as Len0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = ListIndexMut_List_Type.t_list
   clone ListIndexMut_Write_Interface as Write0 with
     function Len0.len = Len0.len,
     function Get0.get = Get0.get
@@ -515,7 +500,6 @@ module ListIndexMut_F
   var _0 : ();
   var l : ListIndexMut_List_Type.t_list;
   var _6 : ();
-  var _7 : borrowed (ListIndexMut_List_Type.t_list);
   var _8 : borrowed (ListIndexMut_List_Type.t_list);
   {
     goto BB0
@@ -536,14 +520,11 @@ module ListIndexMut_F
   BB4 {
     _8 <- Borrow.borrow_mut l;
     l <-  ^ _8;
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    _6 <- ([#"../list_index_mut.rs" 69 4 69 23] Write0.write _7 ([#"../list_index_mut.rs" 69 18 69 19] (0 : usize)) ([#"../list_index_mut.rs" 69 21 69 22] (2 : uint32)));
-    _7 <- any borrowed (ListIndexMut_List_Type.t_list);
+    _6 <- ([#"../list_index_mut.rs" 69 4 69 23] Write0.write _8 ([#"../list_index_mut.rs" 69 18 69 19] (0 : usize)) ([#"../list_index_mut.rs" 69 21 69 22] (2 : uint32)));
+    _8 <- any borrowed (ListIndexMut_List_Type.t_list);
     goto BB5
   }
   BB5 {
-    assume { Resolve0.resolve _8 };
     _0 <- ();
     goto BB6
   }

--- a/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
+++ b/creusot/tests/should_succeed/list_reversal_lasso.mlcfg
@@ -889,10 +889,8 @@ module ListReversalLasso_Impl2_IndexMut
     val Max0.mAX' = Max0.mAX',
     predicate Inv0.inv = Inv3.inv,
     predicate Inv1.inv = Inv4.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = ListReversalLasso_Memory_Type.t_memory
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = usize
+    type t = ListReversalLasso_Memory_Type.t_memory
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = usize,
     type i = usize,
@@ -920,8 +918,6 @@ module ListReversalLasso_Impl2_IndexMut
   var _0 : borrowed usize;
   var self : borrowed (ListReversalLasso_Memory_Type.t_memory) = self;
   var i : usize = i;
-  var _3 : borrowed usize;
-  var _9 : borrowed usize;
   var _10 : borrowed usize;
   var _11 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   {
@@ -935,16 +931,9 @@ module ListReversalLasso_Impl2_IndexMut
     goto BB1
   }
   BB1 {
-    _9 <- Borrow.borrow_mut ( * _10);
-    _10 <- { _10 with current = ( ^ _9) };
-    _3 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _3) };
-    _0 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve0.resolve _10 };
-    assume { Resolve0.resolve _9 };
-    assume { Resolve0.resolve _3 };
-    assume { Resolve1.resolve self };
+    _0 <- _10;
+    _10 <- any borrowed usize;
+    assume { Resolve0.resolve self };
     return _0
   }
   
@@ -1276,8 +1265,6 @@ module ListReversalLasso_Impl4_ListReversalList
   clone ListReversalLasso_Impl4_List as List0 with
     val Null0.nULL' = Null0.nULL',
     predicate ListSeg0.list_seg = ListSeg0.list_seg
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = usize
   clone Core_Mem_Replace_Interface as Replace0 with
     type t = usize,
     predicate Inv0.inv = Inv2.inv,
@@ -1303,12 +1290,9 @@ module ListReversalLasso_Impl4_ListReversalList
   var r : usize;
   var n : Ghost.ghost_ty int;
   var _17 : usize;
-  var _18 : borrowed usize;
-  var _19 : borrowed usize;
   var _20 : borrowed usize;
   var _21 : borrowed (ListReversalLasso_Memory_Type.t_memory);
   var _23 : usize;
-  var _24 : borrowed usize;
   var _25 : borrowed usize;
   var _27 : Ghost.ghost_ty int;
   {
@@ -1342,28 +1326,19 @@ module ListReversalLasso_Impl4_ListReversalList
     goto BB5
   }
   BB5 {
-    _19 <- Borrow.borrow_mut ( * _20);
-    _20 <- { _20 with current = ( ^ _19) };
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
     _25 <- Borrow.borrow_mut r;
     r <-  ^ _25;
-    _24 <- Borrow.borrow_mut ( * _25);
-    _25 <- { _25 with current = ( ^ _24) };
-    _23 <- ([#"../list_reversal_lasso.rs" 108 48 108 76] Replace0.replace _24 l);
-    _24 <- any borrowed usize;
+    _23 <- ([#"../list_reversal_lasso.rs" 108 48 108 76] Replace0.replace _25 l);
+    _25 <- any borrowed usize;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _25 };
-    _17 <- ([#"../list_reversal_lasso.rs" 108 16 108 77] Replace0.replace _18 _23);
-    _18 <- any borrowed usize;
+    _17 <- ([#"../list_reversal_lasso.rs" 108 16 108 77] Replace0.replace _20 _23);
+    _20 <- any borrowed usize;
     _23 <- any usize;
     goto BB7
   }
   BB7 {
-    assume { Resolve1.resolve _20 };
-    assume { Resolve1.resolve _19 };
     l <- _17;
     _17 <- any usize;
     _27 <- ([#"../list_reversal_lasso.rs" 109 16 109 30] Ghost.new (Ghost.inner n + 1));
@@ -1523,8 +1498,6 @@ module ListReversalLasso_Impl4_ListReversalLoop
     function IndexLogic0.index_logic = IndexLogic1.index_logic
   clone ListReversalLasso_Impl4_Loop as Loop0 with
     predicate ListSeg0.list_seg = ListSeg0.list_seg
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = usize
   clone Core_Mem_Replace_Interface as Replace0 with
     type t = usize,
     predicate Inv0.inv = Inv2.inv,
@@ -1554,12 +1527,9 @@ module ListReversalLasso_Impl4_ListReversalLoop
   var r : usize;
   var n : Ghost.ghost_ty int;
   var _21 : usize;
-  var _22 : borrowed usize;
-  var _23 : borrowed usize;
   var _24 : borrowed usize;
   var _25 : borrowed (ListReversalLasso_Memory_Type.t_memory);
   var _27 : usize;
-  var _28 : borrowed usize;
   var _29 : borrowed usize;
   var _31 : Ghost.ghost_ty int;
   {
@@ -1595,28 +1565,19 @@ module ListReversalLasso_Impl4_ListReversalLoop
     goto BB5
   }
   BB5 {
-    _23 <- Borrow.borrow_mut ( * _24);
-    _24 <- { _24 with current = ( ^ _23) };
-    _22 <- Borrow.borrow_mut ( * _23);
-    _23 <- { _23 with current = ( ^ _22) };
     _29 <- Borrow.borrow_mut r;
     r <-  ^ _29;
-    _28 <- Borrow.borrow_mut ( * _29);
-    _29 <- { _29 with current = ( ^ _28) };
-    _27 <- ([#"../list_reversal_lasso.rs" 139 48 139 76] Replace0.replace _28 l);
-    _28 <- any borrowed usize;
+    _27 <- ([#"../list_reversal_lasso.rs" 139 48 139 76] Replace0.replace _29 l);
+    _29 <- any borrowed usize;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _29 };
-    _21 <- ([#"../list_reversal_lasso.rs" 139 16 139 77] Replace0.replace _22 _27);
-    _22 <- any borrowed usize;
+    _21 <- ([#"../list_reversal_lasso.rs" 139 16 139 77] Replace0.replace _24 _27);
+    _24 <- any borrowed usize;
     _27 <- any usize;
     goto BB7
   }
   BB7 {
-    assume { Resolve1.resolve _24 };
-    assume { Resolve1.resolve _23 };
     l <- _21;
     _21 <- any usize;
     _31 <- ([#"../list_reversal_lasso.rs" 140 16 140 30] Ghost.new (Ghost.inner n + 1));
@@ -1752,8 +1713,6 @@ module ListReversalLasso_Impl4_ListReversalLasso
     function IndexLogic0.index_logic = IndexLogic1.index_logic
   clone ListReversalLasso_Impl4_Lasso as Lasso0 with
     predicate ListSeg0.list_seg = ListSeg0.list_seg
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = usize
   clone Core_Mem_Replace_Interface as Replace0 with
     type t = usize,
     predicate Inv0.inv = Inv2.inv,
@@ -1783,12 +1742,9 @@ module ListReversalLasso_Impl4_ListReversalLasso
   var r : usize;
   var n : Ghost.ghost_ty int;
   var _19 : usize;
-  var _20 : borrowed usize;
-  var _21 : borrowed usize;
   var _22 : borrowed usize;
   var _23 : borrowed (ListReversalLasso_Memory_Type.t_memory);
   var _25 : usize;
-  var _26 : borrowed usize;
   var _27 : borrowed usize;
   var _29 : Ghost.ghost_ty int;
   {
@@ -1831,28 +1787,19 @@ module ListReversalLasso_Impl4_ListReversalLasso
     goto BB5
   }
   BB5 {
-    _21 <- Borrow.borrow_mut ( * _22);
-    _22 <- { _22 with current = ( ^ _21) };
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
     _27 <- Borrow.borrow_mut r;
     r <-  ^ _27;
-    _26 <- Borrow.borrow_mut ( * _27);
-    _27 <- { _27 with current = ( ^ _26) };
-    _25 <- ([#"../list_reversal_lasso.rs" 191 48 191 76] Replace0.replace _26 l);
-    _26 <- any borrowed usize;
+    _25 <- ([#"../list_reversal_lasso.rs" 191 48 191 76] Replace0.replace _27 l);
+    _27 <- any borrowed usize;
     goto BB6
   }
   BB6 {
-    assume { Resolve1.resolve _27 };
-    _19 <- ([#"../list_reversal_lasso.rs" 191 16 191 77] Replace0.replace _20 _25);
-    _20 <- any borrowed usize;
+    _19 <- ([#"../list_reversal_lasso.rs" 191 16 191 77] Replace0.replace _22 _25);
+    _22 <- any borrowed usize;
     _25 <- any usize;
     goto BB7
   }
   BB7 {
-    assume { Resolve1.resolve _22 };
-    assume { Resolve1.resolve _21 };
     l <- _19;
     _19 <- any usize;
     _29 <- ([#"../list_reversal_lasso.rs" 192 16 192 30] Ghost.new (Ghost.inner n + 1));

--- a/creusot/tests/should_succeed/mapping_test.mlcfg
+++ b/creusot/tests/should_succeed/mapping_test.mlcfg
@@ -286,8 +286,6 @@ module MappingTest_F
     type t = MappingTest_T_Type.t_t,
     type ShallowModelTy0.shallowModelTy = Map.map int int,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = MappingTest_T_Type.t_t
   clone MappingTest_Incr_Interface as Incr0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel1.shallow_model
@@ -296,7 +294,6 @@ module MappingTest_F
   var _0 : ();
   var x : MappingTest_T_Type.t_t;
   var _6 : ();
-  var _7 : borrowed (MappingTest_T_Type.t_t);
   var _8 : borrowed (MappingTest_T_Type.t_t);
   {
     goto BB0
@@ -307,14 +304,11 @@ module MappingTest_F
     assert { [@expl:assertion] [#"../mapping_test.rs" 41 19 41 34] Map.get (ShallowModel0.shallow_model x) 42 = 0 };
     _8 <- Borrow.borrow_mut x;
     x <-  ^ _8;
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    _6 <- ([#"../mapping_test.rs" 42 4 42 16] Incr0.incr _7);
-    _7 <- any borrowed (MappingTest_T_Type.t_t);
+    _6 <- ([#"../mapping_test.rs" 42 4 42 16] Incr0.incr _8);
+    _8 <- any borrowed (MappingTest_T_Type.t_t);
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _8 };
     assert { [@expl:assertion] [#"../mapping_test.rs" 43 19 43 34] Map.get (ShallowModel0.shallow_model x) 13 = 1 };
     assert { [@expl:assertion] [#"../mapping_test.rs" 44 19 44 34] Map.get (ShallowModel0.shallow_model x) 42 = 1 };
     _0 <- ();

--- a/creusot/tests/should_succeed/projection_toggle.mlcfg
+++ b/creusot/tests/should_succeed/projection_toggle.mlcfg
@@ -65,12 +65,6 @@ end
 module ProjectionToggle_ProjToggle
   type t
   use prelude.Borrow
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = t
-  clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = t,
-    predicate Inv0.inv = Inv1.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed t
   clone TyInv_Trivial as TyInv_Trivial0 with
@@ -94,9 +88,7 @@ module ProjectionToggle_ProjToggle
   var toggle : bool = toggle;
   var a : borrowed t = a;
   var b : borrowed t = b;
-  var _4 : borrowed t;
   var _6 : borrowed t;
-  var _8 : borrowed t;
   {
     goto BB0
   }
@@ -109,39 +101,20 @@ module ProjectionToggle_ProjToggle
   BB1 {
     assert { [@expl:type invariant] Inv0.inv b };
     assume { Resolve0.resolve b };
-    _8 <- Borrow.borrow_mut ( * a);
-    a <- { a with current = ( ^ _8) };
-    assume { Inv1.inv ( ^ _8) };
-    _6 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _6) };
-    assume { Inv1.inv ( ^ _6) };
-    assert { [@expl:type invariant] Inv0.inv _8 };
-    assume { Resolve0.resolve _8 };
+    _6 <- a;
+    a <- any borrowed t;
     goto BB3
   }
   BB2 {
     assert { [@expl:type invariant] Inv0.inv a };
     assume { Resolve0.resolve a };
-    _6 <- Borrow.borrow_mut ( * b);
-    b <- { b with current = ( ^ _6) };
-    assume { Inv1.inv ( ^ _6) };
+    _6 <- b;
+    b <- any borrowed t;
     goto BB3
   }
   BB3 {
-    _4 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _4) };
-    assume { Inv1.inv ( ^ _4) };
-    _0 <- Borrow.borrow_mut ( * _4);
-    _4 <- { _4 with current = ( ^ _0) };
-    assume { Inv1.inv ( ^ _0) };
-    assert { [@expl:type invariant] Inv0.inv _6 };
-    assume { Resolve0.resolve _6 };
-    assert { [@expl:type invariant] Inv0.inv _4 };
-    assume { Resolve0.resolve _4 };
-    assert { [@expl:type invariant] Inv0.inv b };
-    assume { Resolve0.resolve b };
-    assert { [@expl:type invariant] Inv0.inv a };
-    assume { Resolve0.resolve a };
+    _0 <- _6;
+    _6 <- any borrowed t;
     return _0
   }
   
@@ -170,9 +143,7 @@ module ProjectionToggle_F
   var a : int32;
   var b : int32;
   var x : borrowed int32;
-  var _4 : borrowed int32;
   var _5 : borrowed int32;
-  var _6 : borrowed int32;
   var _7 : borrowed int32;
   {
     goto BB0
@@ -182,20 +153,14 @@ module ProjectionToggle_F
     b <- ([#"../projection_toggle.rs" 15 16 15 17] (5 : int32));
     _5 <- Borrow.borrow_mut a;
     a <-  ^ _5;
-    _4 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _4) };
     _7 <- Borrow.borrow_mut b;
     b <-  ^ _7;
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
-    x <- ([#"../projection_toggle.rs" 17 12 17 45] ProjToggle0.proj_toggle ([#"../projection_toggle.rs" 17 24 17 28] true) _4 _6);
-    _4 <- any borrowed int32;
-    _6 <- any borrowed int32;
+    x <- ([#"../projection_toggle.rs" 17 12 17 45] ProjToggle0.proj_toggle ([#"../projection_toggle.rs" 17 24 17 28] true) _5 _7);
+    _5 <- any borrowed int32;
+    _7 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _7 };
-    assume { Resolve0.resolve _5 };
     x <- { x with current = ([#"../projection_toggle.rs" 19 4 19 11]  * x + ([#"../projection_toggle.rs" 19 10 19 11] (5 : int32))) };
     assume { Resolve0.resolve x };
     switch (not ([#"../projection_toggle.rs" 20 12 20 19] a = ([#"../projection_toggle.rs" 20 17 20 19] (15 : int32))))

--- a/creusot/tests/should_succeed/red_black_tree.mlcfg
+++ b/creusot/tests/should_succeed/red_black_tree.mlcfg
@@ -3190,7 +3190,7 @@ module RedBlackTree_Impl14_RotateRight
     predicate Inv0.inv = Inv10.inv,
     axiom .
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   use RedBlackTree_Color_Type as RedBlackTree_Color_Type
   use RedBlackTree_Node_Type as RedBlackTree_Node_Type
@@ -3198,13 +3198,13 @@ module RedBlackTree_Impl14_RotateRight
   clone RedBlackTree_Impl9_Height as Height1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv2.inv,
     axiom .
   clone RedBlackTree_Impl10_HeightInvariantHere as HeightInvariantHere0 with
     type k = k,
     type v = v,
     function Height0.height = Height1.height,
-    predicate Inv0.inv = Inv3.inv
+    predicate Inv0.inv = Inv2.inv
   clone RedBlackTree_Impl9_HeightInvariant as HeightInvariant1 with
     type k = k,
     type v = v,
@@ -3239,6 +3239,18 @@ module RedBlackTree_Impl14_RotateRight
     predicate Inv0.inv = Inv9.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
+    predicate Inv0.inv = Inv8.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    predicate Inv0.inv = Inv7.inv,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv11.inv,
@@ -3288,17 +3300,17 @@ module RedBlackTree_Impl14_RotateRight
     function LeLog0.le_log = LeLog0.le_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl1_HasMapping as HasMapping1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv3.inv,
     predicate Inv1.inv = Inv11.inv,
     predicate Inv2.inv = Inv10.inv,
-    predicate Inv3.inv = Inv6.inv,
+    predicate Inv3.inv = Inv4.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model,
@@ -3313,40 +3325,28 @@ module RedBlackTree_Impl14_RotateRight
     type v = v,
     predicate BstInvariantHere0.bst_invariant_here = BstInvariantHere0.bst_invariant_here,
     predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv8.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv6.inv,
     axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv5.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv3.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    type t = RedBlackTree_Tree_Type.t_tree k v,
     predicate Inv0.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
@@ -3367,10 +3367,10 @@ module RedBlackTree_Impl14_RotateRight
   clone RedBlackTree_Impl10_Height as Height0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv0.inv = Inv3.inv,
+    predicate Inv1.inv = Inv4.inv,
     function Height0.height = Height1.height,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv2.inv = Inv2.inv,
     axiom .
   clone RedBlackTree_Impl1_SameMappings as SameMappings0 with
     type k = k,
@@ -3379,8 +3379,8 @@ module RedBlackTree_Impl14_RotateRight
     predicate Inv0.inv = Inv10.inv,
     predicate Inv1.inv = Inv11.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
-    predicate Inv2.inv = Inv5.inv,
-    predicate Inv3.inv = Inv6.inv,
+    predicate Inv2.inv = Inv3.inv,
+    predicate Inv3.inv = Inv4.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
   clone RedBlackTree_Impl7_Color as Color0 with
     type k = k,
@@ -3390,34 +3390,28 @@ module RedBlackTree_Impl14_RotateRight
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant0.height_invariant
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = RedBlackTree_Tree_Type.t_tree k v
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = RedBlackTree_Color_Type.t_color
   clone Core_Mem_Swap_Interface as Swap2 with
     type t = RedBlackTree_Color_Type.t_color,
     predicate Inv0.inv = Inv9.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone Core_Mem_Swap_Interface as Swap1 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv8.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = RedBlackTree_Tree_Type.t_tree k v
+    predicate Inv0.inv = Inv6.inv
   clone Core_Mem_Swap_Interface as Swap0 with
     type t = RedBlackTree_Tree_Type.t_tree k v,
-    predicate Inv0.inv = Inv4.inv
+    predicate Inv0.inv = Inv8.inv
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv6.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
+    predicate Inv1.inv = Inv4.inv
   clone Core_Mem_Take_Interface as Take0 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv2.inv,
+    predicate Inv0.inv = Inv7.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv1.inv
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
@@ -3425,14 +3419,14 @@ module RedBlackTree_Impl14_RotateRight
   let rec cfg rotate_right [#"../red_black_tree.rs" 412 4 412 30] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : ()
     requires {[#"../red_black_tree.rs" 400 15 400 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 401 15 401 42] Color0.color (RedBlackTree_Node_Type.node_left ( * self)) = RedBlackTree_Color_Type.C_Red}
-    requires {[#"../red_black_tree.rs" 412 25 412 29] Inv8.inv self}
+    requires {[#"../red_black_tree.rs" 412 25 412 29] Inv6.inv self}
     ensures { [#"../red_black_tree.rs" 402 14 402 42] SameMappings0.same_mappings ( * self) ( ^ self) }
     ensures { [#"../red_black_tree.rs" 403 14 403 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 404 14 404 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 405 14 405 65] LtLog0.lt_log (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( ^ self))) (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( * self))) }
     ensures { [#"../red_black_tree.rs" 406 14 406 42] Color0.color (RedBlackTree_Node_Type.node_right ( ^ self)) = RedBlackTree_Color_Type.C_Red }
     ensures { [#"../red_black_tree.rs" 407 14 407 44] RedBlackTree_Node_Type.node_color ( ^ self) = RedBlackTree_Node_Type.node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 408 4 411 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . Inv6.inv r /\ Inv6.inv l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)) = Core_Option_Option_Type.C_Some l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( ^ self)) = Core_Option_Option_Type.C_Some r /\ (RedBlackTree_Node_Type.node_left ( ^ self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) = (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( * self)) /\ RedBlackTree_Node_Type.node_key r = RedBlackTree_Node_Type.node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 408 4 411 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . Inv4.inv r /\ Inv4.inv l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)) = Core_Option_Option_Type.C_Some l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( ^ self)) = Core_Option_Option_Type.C_Some r /\ (RedBlackTree_Node_Type.node_left ( ^ self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) = (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( * self)) /\ RedBlackTree_Node_Type.node_key r = RedBlackTree_Node_Type.node_key ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -3440,21 +3434,16 @@ module RedBlackTree_Impl14_RotateRight
   var old_self : Ghost.ghost_ty (borrowed (RedBlackTree_Node_Type.t_node k v));
   var x : RedBlackTree_Node_Type.t_node k v;
   var _14 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _15 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _16 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _17 : ();
-  var _18 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _19 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
-  var _20 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _21 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _22 : ();
   var _23 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _24 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _25 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _26 : ();
-  var _27 : borrowed (RedBlackTree_Color_Type.t_color);
   var _28 : borrowed (RedBlackTree_Color_Type.t_color);
-  var _29 : borrowed (RedBlackTree_Color_Type.t_color);
   var _30 : borrowed (RedBlackTree_Color_Type.t_color);
   {
     goto BB0
@@ -3469,16 +3458,11 @@ module RedBlackTree_Impl14_RotateRight
     _16 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_left ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _16)) b c d e) };
     assume { Inv1.inv ( ^ _16) };
-    _15 <- Borrow.borrow_mut ( * _16);
-    _16 <- { _16 with current = ( ^ _15) };
-    assume { Inv1.inv ( ^ _15) };
-    _14 <- ([#"../red_black_tree.rs" 421 20 421 55] Take0.take _15);
-    _15 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
+    _14 <- ([#"../red_black_tree.rs" 421 20 421 55] Take0.take _16);
+    _16 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
     goto BB2
   }
   BB2 {
-    assert { [@expl:type invariant] Inv2.inv _16 };
-    assume { Resolve1.resolve _16 };
     x <- ([#"../red_black_tree.rs" 421 20 421 64] Unwrap0.unwrap _14);
     _14 <- any Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
     goto BB3
@@ -3486,59 +3470,43 @@ module RedBlackTree_Impl14_RotateRight
   BB3 {
     _19 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node ( ^ _19) b c d e) };
-    assume { Inv3.inv ( ^ _19) };
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    assume { Inv3.inv ( ^ _18) };
+    assume { Inv2.inv ( ^ _19) };
     _21 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a b c d ( ^ _21));
-    assume { Inv3.inv ( ^ _21) };
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
-    assume { Inv3.inv ( ^ _20) };
-    _17 <- ([#"../red_black_tree.rs" 428 8 428 52] Swap0.swap _18 _20);
-    _18 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
-    _20 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    assume { Inv2.inv ( ^ _21) };
+    _17 <- ([#"../red_black_tree.rs" 428 8 428 52] Swap0.swap _19 _21);
+    _19 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    _21 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB4
   }
   BB4 {
-    assert { [@expl:type invariant] Inv4.inv _21 };
-    assume { Resolve2.resolve _21 };
-    assert { [@expl:type invariant] Inv4.inv _19 };
-    assume { Resolve2.resolve _19 };
     _23 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _23) };
-    assume { Inv5.inv ( ^ _23) };
+    assume { Inv3.inv ( ^ _23) };
     _25 <- Borrow.borrow_mut x;
     x <-  ^ _25;
-    assume { Inv6.inv ( ^ _25) };
+    assume { Inv4.inv ( ^ _25) };
     _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
-    assume { Inv5.inv ( ^ _24) };
+    assume { Inv3.inv ( ^ _24) };
     _22 <- ([#"../red_black_tree.rs" 434 8 434 36] Swap1.swap _23 _24);
     _23 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _24 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB5
   }
   BB5 {
-    assert { [@expl:type invariant] Inv7.inv _25 };
-    assume { Resolve3.resolve _25 };
+    assert { [@expl:type invariant] Inv5.inv _25 };
+    assume { Resolve1.resolve _25 };
     _28 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _28) c d e) };
-    _27 <- Borrow.borrow_mut ( * _28);
-    _28 <- { _28 with current = ( ^ _27) };
     _30 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a ( ^ _30) c d e);
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
-    _26 <- ([#"../red_black_tree.rs" 435 8 435 53] Swap2.swap _27 _29);
-    _27 <- any borrowed (RedBlackTree_Color_Type.t_color);
-    _29 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _26 <- ([#"../red_black_tree.rs" 435 8 435 53] Swap2.swap _28 _30);
+    _28 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _30 <- any borrowed (RedBlackTree_Color_Type.t_color);
     goto BB6
   }
   BB6 {
-    assume { Resolve4.resolve _30 };
-    assume { Resolve4.resolve _28 };
     assert { [@expl:assertion] [#"../red_black_tree.rs" 441 8 441 90] HasMapping0.has_mapping (RedBlackTree_Node_Type.node_left ( * Ghost.inner old_self)) (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( * self))) (RedBlackTree_Node_Type.node_val ( * self)) };
     goto BB7
   }
@@ -3551,10 +3519,10 @@ module RedBlackTree_Impl14_RotateRight
   BB9 {
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (RedBlackTree_Tree_Type.C_Tree (Core_Option_Option_Type.C_Some x))) };
     x <- any RedBlackTree_Node_Type.t_node k v;
-    assert { [@expl:type invariant] Inv3.inv (RedBlackTree_Node_Type.node_right ( * self)) };
-    assume { Resolve5.resolve (RedBlackTree_Node_Type.node_right ( * self)) };
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve6.resolve self };
+    assert { [@expl:type invariant] Inv2.inv (RedBlackTree_Node_Type.node_right ( * self)) };
+    assume { Resolve2.resolve (RedBlackTree_Node_Type.node_right ( * self)) };
+    assert { [@expl:type invariant] Inv6.inv self };
+    assume { Resolve3.resolve self };
     goto BB11
   }
   BB11 {
@@ -3653,7 +3621,7 @@ module RedBlackTree_Impl14_RotateLeft
     predicate Inv0.inv = Inv10.inv,
     axiom .
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   use RedBlackTree_Color_Type as RedBlackTree_Color_Type
   use RedBlackTree_Node_Type as RedBlackTree_Node_Type
@@ -3661,13 +3629,13 @@ module RedBlackTree_Impl14_RotateLeft
   clone RedBlackTree_Impl9_Height as Height1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv2.inv,
     axiom .
   clone RedBlackTree_Impl10_HeightInvariantHere as HeightInvariantHere0 with
     type k = k,
     type v = v,
     function Height0.height = Height1.height,
-    predicate Inv0.inv = Inv3.inv
+    predicate Inv0.inv = Inv2.inv
   clone RedBlackTree_Impl9_HeightInvariant as HeightInvariant1 with
     type k = k,
     type v = v,
@@ -3702,6 +3670,18 @@ module RedBlackTree_Impl14_RotateLeft
     predicate Inv0.inv = Inv9.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
+    predicate Inv0.inv = Inv8.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    predicate Inv0.inv = Inv7.inv,
+    axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv11.inv,
@@ -3751,17 +3731,17 @@ module RedBlackTree_Impl14_RotateLeft
     function LeLog0.le_log = LeLog0.le_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl1_HasMapping as HasMapping1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv3.inv,
     predicate Inv1.inv = Inv11.inv,
     predicate Inv2.inv = Inv10.inv,
-    predicate Inv3.inv = Inv6.inv,
+    predicate Inv3.inv = Inv4.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model,
@@ -3776,40 +3756,28 @@ module RedBlackTree_Impl14_RotateLeft
     type v = v,
     predicate BstInvariantHere0.bst_invariant_here = BstInvariantHere0.bst_invariant_here,
     predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv8.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
   clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv6.inv,
     axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv5.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv3.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    type t = RedBlackTree_Tree_Type.t_tree k v,
     predicate Inv0.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
@@ -3830,10 +3798,10 @@ module RedBlackTree_Impl14_RotateLeft
   clone RedBlackTree_Impl10_Height as Height0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
-    predicate Inv1.inv = Inv6.inv,
+    predicate Inv0.inv = Inv3.inv,
+    predicate Inv1.inv = Inv4.inv,
     function Height0.height = Height1.height,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv2.inv = Inv2.inv,
     axiom .
   clone RedBlackTree_Impl1_SameMappings as SameMappings0 with
     type k = k,
@@ -3842,8 +3810,8 @@ module RedBlackTree_Impl14_RotateLeft
     predicate Inv0.inv = Inv10.inv,
     predicate Inv1.inv = Inv11.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
-    predicate Inv2.inv = Inv5.inv,
-    predicate Inv3.inv = Inv6.inv,
+    predicate Inv2.inv = Inv3.inv,
+    predicate Inv3.inv = Inv4.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
   clone RedBlackTree_Impl7_Color as Color0 with
     type k = k,
@@ -3853,34 +3821,28 @@ module RedBlackTree_Impl14_RotateLeft
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant0.height_invariant
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = RedBlackTree_Tree_Type.t_tree k v
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = RedBlackTree_Color_Type.t_color
   clone Core_Mem_Swap_Interface as Swap2 with
     type t = RedBlackTree_Color_Type.t_color,
     predicate Inv0.inv = Inv9.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone Core_Mem_Swap_Interface as Swap1 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv8.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = RedBlackTree_Tree_Type.t_tree k v
+    predicate Inv0.inv = Inv6.inv
   clone Core_Mem_Swap_Interface as Swap0 with
     type t = RedBlackTree_Tree_Type.t_tree k v,
-    predicate Inv0.inv = Inv4.inv
+    predicate Inv0.inv = Inv8.inv
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv6.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
+    predicate Inv1.inv = Inv4.inv
   clone Core_Mem_Take_Interface as Take0 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv2.inv,
+    predicate Inv0.inv = Inv7.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv1.inv
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
@@ -3888,14 +3850,14 @@ module RedBlackTree_Impl14_RotateLeft
   let rec cfg rotate_left [#"../red_black_tree.rs" 462 4 462 29] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Node_Type.t_node k v)) : ()
     requires {[#"../red_black_tree.rs" 450 15 450 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 451 15 451 43] Color0.color (RedBlackTree_Node_Type.node_right ( * self)) = RedBlackTree_Color_Type.C_Red}
-    requires {[#"../red_black_tree.rs" 462 24 462 28] Inv8.inv self}
+    requires {[#"../red_black_tree.rs" 462 24 462 28] Inv6.inv self}
     ensures { [#"../red_black_tree.rs" 452 14 452 42] SameMappings0.same_mappings ( * self) ( ^ self) }
     ensures { [#"../red_black_tree.rs" 453 14 453 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 454 14 454 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 455 14 455 65] LtLog0.lt_log (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( * self))) (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( ^ self))) }
     ensures { [#"../red_black_tree.rs" 456 14 456 41] Color0.color (RedBlackTree_Node_Type.node_left ( ^ self)) = RedBlackTree_Color_Type.C_Red }
     ensures { [#"../red_black_tree.rs" 457 14 457 44] RedBlackTree_Node_Type.node_color ( ^ self) = RedBlackTree_Node_Type.node_color ( * self) }
-    ensures { [#"../red_black_tree.rs" 458 4 461 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . Inv6.inv r /\ Inv6.inv l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)) = Core_Option_Option_Type.C_Some r /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( ^ self)) = Core_Option_Option_Type.C_Some l /\ (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( ^ self)) = (RedBlackTree_Node_Type.node_left ( * self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) /\ RedBlackTree_Node_Type.node_key l = RedBlackTree_Node_Type.node_key ( * self) }
+    ensures { [#"../red_black_tree.rs" 458 4 461 36] exists r : RedBlackTree_Node_Type.t_node k v . exists l : RedBlackTree_Node_Type.t_node k v . Inv4.inv r /\ Inv4.inv l /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)) = Core_Option_Option_Type.C_Some r /\ RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( ^ self)) = Core_Option_Option_Type.C_Some l /\ (RedBlackTree_Node_Type.node_left l, RedBlackTree_Node_Type.node_right l, RedBlackTree_Node_Type.node_right ( ^ self)) = (RedBlackTree_Node_Type.node_left ( * self), RedBlackTree_Node_Type.node_left r, RedBlackTree_Node_Type.node_right r) /\ RedBlackTree_Node_Type.node_key l = RedBlackTree_Node_Type.node_key ( * self) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -3903,21 +3865,16 @@ module RedBlackTree_Impl14_RotateLeft
   var old_self : Ghost.ghost_ty (borrowed (RedBlackTree_Node_Type.t_node k v));
   var x : RedBlackTree_Node_Type.t_node k v;
   var _14 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _15 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _16 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _17 : ();
-  var _18 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _19 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
-  var _20 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _21 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _22 : ();
   var _23 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _24 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _25 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _26 : ();
-  var _27 : borrowed (RedBlackTree_Color_Type.t_color);
   var _28 : borrowed (RedBlackTree_Color_Type.t_color);
-  var _29 : borrowed (RedBlackTree_Color_Type.t_color);
   var _30 : borrowed (RedBlackTree_Color_Type.t_color);
   {
     goto BB0
@@ -3932,16 +3889,11 @@ module RedBlackTree_Impl14_RotateLeft
     _16 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _16))) };
     assume { Inv1.inv ( ^ _16) };
-    _15 <- Borrow.borrow_mut ( * _16);
-    _16 <- { _16 with current = ( ^ _15) };
-    assume { Inv1.inv ( ^ _15) };
-    _14 <- ([#"../red_black_tree.rs" 464 20 464 56] Take0.take _15);
-    _15 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
+    _14 <- ([#"../red_black_tree.rs" 464 20 464 56] Take0.take _16);
+    _16 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
     goto BB2
   }
   BB2 {
-    assert { [@expl:type invariant] Inv2.inv _16 };
-    assume { Resolve1.resolve _16 };
     x <- ([#"../red_black_tree.rs" 464 20 464 65] Unwrap0.unwrap _14);
     _14 <- any Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
     goto BB3
@@ -3949,59 +3901,43 @@ module RedBlackTree_Impl14_RotateLeft
   BB3 {
     _19 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d ( ^ _19)) };
-    assume { Inv3.inv ( ^ _19) };
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    assume { Inv3.inv ( ^ _18) };
+    assume { Inv2.inv ( ^ _19) };
     _21 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node ( ^ _21) b c d e);
-    assume { Inv3.inv ( ^ _21) };
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
-    assume { Inv3.inv ( ^ _20) };
-    _17 <- ([#"../red_black_tree.rs" 465 8 465 52] Swap0.swap _18 _20);
-    _18 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
-    _20 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    assume { Inv2.inv ( ^ _21) };
+    _17 <- ([#"../red_black_tree.rs" 465 8 465 52] Swap0.swap _19 _21);
+    _19 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    _21 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB4
   }
   BB4 {
-    assert { [@expl:type invariant] Inv4.inv _21 };
-    assume { Resolve2.resolve _21 };
-    assert { [@expl:type invariant] Inv4.inv _19 };
-    assume { Resolve2.resolve _19 };
     _23 <- Borrow.borrow_mut ( * self);
     self <- { self with current = ( ^ _23) };
-    assume { Inv5.inv ( ^ _23) };
+    assume { Inv3.inv ( ^ _23) };
     _25 <- Borrow.borrow_mut x;
     x <-  ^ _25;
-    assume { Inv6.inv ( ^ _25) };
+    assume { Inv4.inv ( ^ _25) };
     _24 <- Borrow.borrow_mut ( * _25);
     _25 <- { _25 with current = ( ^ _24) };
-    assume { Inv5.inv ( ^ _24) };
+    assume { Inv3.inv ( ^ _24) };
     _22 <- ([#"../red_black_tree.rs" 466 8 466 36] Swap1.swap _23 _24);
     _23 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _24 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB5
   }
   BB5 {
-    assert { [@expl:type invariant] Inv7.inv _25 };
-    assume { Resolve3.resolve _25 };
+    assert { [@expl:type invariant] Inv5.inv _25 };
+    assume { Resolve1.resolve _25 };
     _28 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _28) c d e) };
-    _27 <- Borrow.borrow_mut ( * _28);
-    _28 <- { _28 with current = ( ^ _27) };
     _30 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color x);
     x <- (let RedBlackTree_Node_Type.C_Node a b c d e = x in RedBlackTree_Node_Type.C_Node a ( ^ _30) c d e);
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
-    _26 <- ([#"../red_black_tree.rs" 467 8 467 53] Swap2.swap _27 _29);
-    _27 <- any borrowed (RedBlackTree_Color_Type.t_color);
-    _29 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _26 <- ([#"../red_black_tree.rs" 467 8 467 53] Swap2.swap _28 _30);
+    _28 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _30 <- any borrowed (RedBlackTree_Color_Type.t_color);
     goto BB6
   }
   BB6 {
-    assume { Resolve4.resolve _30 };
-    assume { Resolve4.resolve _28 };
     assert { [@expl:assertion] [#"../red_black_tree.rs" 468 8 468 91] HasMapping0.has_mapping (RedBlackTree_Node_Type.node_right ( * Ghost.inner old_self)) (DeepModel0.deep_model (RedBlackTree_Node_Type.node_key ( * self))) (RedBlackTree_Node_Type.node_val ( * self)) };
     goto BB7
   }
@@ -4014,10 +3950,10 @@ module RedBlackTree_Impl14_RotateLeft
   BB9 {
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node (RedBlackTree_Tree_Type.C_Tree (Core_Option_Option_Type.C_Some x)) b c d e) };
     x <- any RedBlackTree_Node_Type.t_node k v;
-    assert { [@expl:type invariant] Inv3.inv (RedBlackTree_Node_Type.node_left ( * self)) };
-    assume { Resolve5.resolve (RedBlackTree_Node_Type.node_left ( * self)) };
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve6.resolve self };
+    assert { [@expl:type invariant] Inv2.inv (RedBlackTree_Node_Type.node_left ( * self)) };
+    assume { Resolve2.resolve (RedBlackTree_Node_Type.node_left ( * self)) };
+    assert { [@expl:type invariant] Inv6.inv self };
+    assume { Resolve3.resolve self };
     goto BB11
   }
   BB11 {
@@ -4317,10 +4253,8 @@ module RedBlackTree_Impl14_FlipColors
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant0.height_invariant
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = RedBlackTree_Node_Type.t_node k v
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = RedBlackTree_Color_Type.t_color
+    type t = RedBlackTree_Node_Type.t_node k v
   clone Core_Mem_Swap_Interface as Swap0 with
     type t = RedBlackTree_Color_Type.t_color,
     predicate Inv0.inv = Inv6.inv
@@ -4355,9 +4289,7 @@ module RedBlackTree_Impl14_FlipColors
   var _14 : Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v));
   var _15 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _16 : ();
-  var _17 : borrowed (RedBlackTree_Color_Type.t_color);
   var _18 : borrowed (RedBlackTree_Color_Type.t_color);
-  var _19 : borrowed (RedBlackTree_Color_Type.t_color);
   var _20 : borrowed (RedBlackTree_Color_Type.t_color);
   var _21 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _22 : Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v));
@@ -4384,8 +4316,6 @@ module RedBlackTree_Impl14_FlipColors
     assume { Resolve0.resolve _13 };
     _18 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * self));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a ( ^ _18) c d e) };
-    _17 <- Borrow.borrow_mut ( * _18);
-    _18 <- { _18 with current = ( ^ _17) };
     _23 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_right ( * self)));
     self <- { self with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * self in RedBlackTree_Node_Type.C_Node a b c d (let RedBlackTree_Tree_Type.C_Tree a = RedBlackTree_Node_Type.node_right ( * self) in RedBlackTree_Tree_Type.C_Tree ( ^ _23))) };
     assume { Inv0.inv ( ^ _23) };
@@ -4401,20 +4331,16 @@ module RedBlackTree_Impl14_FlipColors
   BB4 {
     _20 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_color ( * _21));
     _21 <- { _21 with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * _21 in RedBlackTree_Node_Type.C_Node a ( ^ _20) c d e) };
-    _19 <- Borrow.borrow_mut ( * _20);
-    _20 <- { _20 with current = ( ^ _19) };
-    _16 <- ([#"../red_black_tree.rs" 488 8 488 85] Swap0.swap _17 _19);
-    _17 <- any borrowed (RedBlackTree_Color_Type.t_color);
-    _19 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _16 <- ([#"../red_black_tree.rs" 488 8 488 85] Swap0.swap _18 _20);
+    _18 <- any borrowed (RedBlackTree_Color_Type.t_color);
+    _20 <- any borrowed (RedBlackTree_Color_Type.t_color);
     goto BB5
   }
   BB5 {
     assert { [@expl:type invariant] Inv1.inv _21 };
     assume { Resolve0.resolve _21 };
-    assume { Resolve1.resolve _20 };
-    assume { Resolve1.resolve _18 };
     assert { [@expl:type invariant] Inv2.inv self };
-    assume { Resolve2.resolve self };
+    assume { Resolve1.resolve self };
     _0 <- ();
     return _0
   }
@@ -4834,7 +4760,6 @@ module RedBlackTree_Impl14_Balance
   var _35 : bool;
   var _37 : bool;
   var _39 : ();
-  var _40 : borrowed (RedBlackTree_Node_Type.t_node k v);
   {
     goto BB0
   }
@@ -4969,16 +4894,11 @@ module RedBlackTree_Impl14_Balance
     goto BB23
   }
   BB26 {
-    _40 <- Borrow.borrow_mut ( * self);
-    self <- { self with current = ( ^ _40) };
-    assume { Inv0.inv ( ^ _40) };
-    _39 <- ([#"../red_black_tree.rs" 520 12 520 30] FlipColors0.flip_colors _40);
-    _40 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _39 <- ([#"../red_black_tree.rs" 520 12 520 30] FlipColors0.flip_colors self);
+    self <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB27
   }
   BB27 {
-    assert { [@expl:type invariant] Inv2.inv self };
-    assume { Resolve1.resolve self };
     _0 <- ();
     goto BB29
   }
@@ -7345,7 +7265,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with
     type self = DeepModelTy0.deepModelTy
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   use RedBlackTree_Color_Type as RedBlackTree_Color_Type
   use RedBlackTree_Node_Type as RedBlackTree_Node_Type
@@ -7353,13 +7273,13 @@ module RedBlackTree_Impl15_DeleteMaxRec
   clone RedBlackTree_Impl9_Height as Height0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
   clone RedBlackTree_Impl10_HeightInvariantHere as HeightInvariantHere0 with
     type k = k,
     type v = v,
     function Height0.height = Height0.height,
-    predicate Inv0.inv = Inv8.inv
+    predicate Inv0.inv = Inv6.inv
   clone CreusotContracts_Logic_Ord_OrdLogic_LtLog_Interface as LtLog0 with
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel0 with
@@ -7370,16 +7290,16 @@ module RedBlackTree_Impl15_DeleteMaxRec
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
     type t = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
     type t = v
   clone RedBlackTree_Impl4_BstInvariantHere as BstInvariantHere0 with
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv9.inv,
-    predicate Inv1.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
+    predicate Inv1.inv = Inv8.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log
@@ -7426,10 +7346,22 @@ module RedBlackTree_Impl15_DeleteMaxRec
     predicate Inv0.inv = Inv12.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
-    type t = (k, v)
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial11 with
-    type t = (k, v),
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv11.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+  clone TyInv_Trivial as TyInv_Trivial10 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    predicate Inv0.inv = Inv10.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+    type t = (k, v)
+  clone TyInv_Trivial as TyInv_Trivial9 with
+    type t = (k, v),
+    predicate Inv0.inv = Inv9.inv,
     axiom .
   clone RedBlackTree_Impl7_Color as Color0 with
     type k = k,
@@ -7440,44 +7372,44 @@ module RedBlackTree_Impl15_DeleteMaxRec
     function Color0.color = Color0.color
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface as Antisym20 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface as Antisym10 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface as Trans0 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface as Refl0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface as CmpGtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function GtLog0.gt_log = GtLog0.gt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface as CmpGeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function GeLog0.ge_log = GeLog0.ge_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface as CmpLtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function LtLog0.lt_log = LtLog0.lt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
@@ -7485,21 +7417,21 @@ module RedBlackTree_Impl15_DeleteMaxRec
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface as CmpLeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv8.inv,
     function LeLog0.le_log = LeLog0.le_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
-    axiom .
-  clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = v,
-    predicate Inv0.inv = Inv9.inv,
-    axiom .
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
+    type t = DeepModelTy0.deepModelTy,
     predicate Inv0.inv = Inv8.inv,
+    axiom .
+  clone TyInv_Trivial as TyInv_Trivial7 with
+    type t = v,
+    predicate Inv0.inv = Inv7.inv,
+    axiom .
+  clone TyInv_Trivial as TyInv_Trivial6 with
+    type t = RedBlackTree_Tree_Type.t_tree k v,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
   clone RedBlackTree_Impl7_ColorInvariant as ColorInvariant0 with
     type k = k,
@@ -7510,17 +7442,17 @@ module RedBlackTree_Impl15_DeleteMaxRec
     type v = v,
     predicate ColorInvariantHere0.color_invariant_here = ColorInvariantHere0.color_invariant_here,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl1_HasMapping as HasMapping1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv3.inv,
-    predicate Inv1.inv = Inv10.inv,
-    predicate Inv2.inv = Inv9.inv,
-    predicate Inv3.inv = Inv1.inv,
+    predicate Inv0.inv = Inv1.inv,
+    predicate Inv1.inv = Inv8.inv,
+    predicate Inv2.inv = Inv7.inv,
+    predicate Inv3.inv = Inv4.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model,
@@ -7531,72 +7463,60 @@ module RedBlackTree_Impl15_DeleteMaxRec
     type v = v,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv1.inv
+    predicate Inv0.inv = Inv4.inv
   clone RedBlackTree_Impl6_MatchN as MatchN0 with
     type k = k,
     type v = v,
     predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant,
     predicate MatchT0.match_t = MatchT0.match_t
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = RedBlackTree_Node_Type.t_node k v
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+    type t = RedBlackTree_Node_Type.t_node k v
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv5.inv,
+    axiom .
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone TyInv_Trivial as TyInv_Trivial4 with
+    type t = RedBlackTree_Node_Type.t_node k v,
+    predicate Inv0.inv = Inv4.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
+  clone TyInv_Trivial as TyInv_Trivial3 with
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
+    predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv4.inv,
-    axiom .
-  clone RedBlackTree_Impl10_Height as Height1 with
-    type k = k,
-    type v = v,
-    predicate Inv0.inv = Inv3.inv,
-    predicate Inv1.inv = Inv1.inv,
-    function Height0.height = Height0.height,
-    predicate Inv2.inv = Inv8.inv,
-    axiom .
-  clone RedBlackTree_Impl1_SameMappings as SameMappings0 with
-    type k = k,
-    type v = v,
-    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv9.inv,
-    predicate Inv1.inv = Inv10.inv,
-    predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
-    predicate Inv2.inv = Inv3.inv,
-    predicate Inv3.inv = Inv1.inv,
-    predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone RedBlackTree_Impl12_InternalInvariant as InternalInvariant1 with
-    type k = k,
-    type v = v,
-    predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant,
-    predicate HeightInvariant0.height_invariant = HeightInvariant1.height_invariant
-  clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv3.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial2 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone RedBlackTree_Impl10_Height as Height1 with
+    type k = k,
+    type v = v,
+    predicate Inv0.inv = Inv1.inv,
+    predicate Inv1.inv = Inv4.inv,
+    function Height0.height = Height0.height,
+    predicate Inv2.inv = Inv6.inv,
+    axiom .
+  clone RedBlackTree_Impl1_SameMappings as SameMappings0 with
+    type k = k,
+    type v = v,
+    type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
+    predicate Inv0.inv = Inv7.inv,
+    predicate Inv1.inv = Inv8.inv,
+    predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
+    predicate Inv2.inv = Inv1.inv,
+    predicate Inv3.inv = Inv4.inv,
+    predicate HasMapping1.has_mapping = HasMapping0.has_mapping
+  clone RedBlackTree_Impl12_InternalInvariant as InternalInvariant1 with
+    type k = k,
+    type v = v,
+    predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant,
+    predicate HeightInvariant0.height_invariant = HeightInvariant1.height_invariant
   clone TyInv_Trivial as TyInv_Trivial1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv1.inv,
@@ -7619,118 +7539,113 @@ module RedBlackTree_Impl15_DeleteMaxRec
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv2.inv,
     predicate SameMappings0.same_mappings = SameMappings0.same_mappings,
     function Height0.height = Height1.height,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv1.inv = Inv3.inv,
-    predicate Inv2.inv = Inv1.inv,
+    predicate Inv1.inv = Inv1.inv,
+    predicate Inv2.inv = Inv4.inv,
     function Height1.height = Height0.height,
-    predicate Inv3.inv = Inv8.inv
+    predicate Inv3.inv = Inv6.inv
   clone RedBlackTree_Impl14_MoveRedRight_Interface as MoveRedRight0 with
     type k = k,
     type v = v,
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv2.inv,
     function Height0.height = Height1.height,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv1.inv = Inv9.inv,
-    predicate Inv2.inv = Inv10.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv8.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function LeLog0.le_log = LeLog0.le_log,
     predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant,
     function Color0.color = Color0.color,
-    predicate Inv3.inv = Inv3.inv,
-    predicate Inv4.inv = Inv1.inv,
+    predicate Inv3.inv = Inv1.inv,
+    predicate Inv4.inv = Inv4.inv,
     function Height1.height = Height0.height,
-    predicate Inv5.inv = Inv8.inv,
+    predicate Inv5.inv = Inv6.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap2 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv15.inv,
-    predicate Inv1.inv = Inv7.inv
+    predicate Inv1.inv = Inv5.inv
   clone Core_Option_Impl0_AsRef_Interface as AsRef0 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv14.inv,
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv5.inv,
     predicate Inv2.inv = Inv15.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv0.inv,
-    predicate Inv1.inv = Inv1.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    predicate Inv1.inv = Inv4.inv
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = RedBlackTree_Tree_Type.t_tree k v
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone Core_Mem_Take_Interface as Take0 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv10.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv0.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl14_RotateRight_Interface as RotateRight0 with
     type k = k,
     type v = v,
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Color0.color = Color0.color,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv2.inv,
     predicate SameMappings0.same_mappings = SameMappings0.same_mappings,
     function Height0.height = Height1.height,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log,
-    predicate Inv1.inv = Inv1.inv,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv1.inv = Inv4.inv,
+    predicate Inv2.inv = Inv1.inv,
     function Height1.height = Height0.height,
-    predicate Inv3.inv = Inv8.inv,
+    predicate Inv3.inv = Inv6.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
   clone RedBlackTree_Impl13_IsRed_Interface as IsRed0 with
     type k = k,
     type v = v,
     predicate Inv0.inv = Inv13.inv,
     function Color0.color = Color0.color
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = RedBlackTree_Node_Type.t_node k v
   clone Alloc_Boxed_Impl57_AsMut_Interface as AsMut1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv2.inv,
-    predicate Inv1.inv = Inv4.inv
+    predicate Inv0.inv = Inv11.inv,
+    predicate Inv1.inv = Inv2.inv
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv12.inv,
-    predicate Inv1.inv = Inv2.inv
+    predicate Inv1.inv = Inv11.inv
   clone Core_Option_Impl0_AsMut_Interface as AsMut0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv5.inv,
-    predicate Inv1.inv = Inv2.inv,
+    predicate Inv0.inv = Inv10.inv,
+    predicate Inv1.inv = Inv11.inv,
     predicate Inv2.inv = Inv12.inv
   let rec cfg delete_max_rec [#"../red_black_tree.rs" 643 4 643 42] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : (k, v)
     requires {[#"../red_black_tree.rs" 632 15 632 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 633 15 634 62] MatchT0.match_t (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) ( * self) \/ MatchT0.match_t (Cpn0.cpn (RedBlackTree_Color_Type.C_Black) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Black))) ( * self)}
-    requires {[#"../red_black_tree.rs" 643 27 643 31] Inv6.inv self}
+    requires {[#"../red_black_tree.rs" 643 27 643 31] Inv3.inv self}
     ensures { [#"../red_black_tree.rs" 635 14 635 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 636 14 636 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 637 14 637 66] HasMapping0.has_mapping ( * self) (DeepModel0.deep_model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 638 4 638 104] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv9.inv v -> Inv10.inv k -> HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (DeepModel0.deep_model (let (a, _) = result in a)) }
-    ensures { [#"../red_black_tree.rs" 639 4 640 73] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv9.inv v -> Inv10.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 638 4 638 104] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv7.inv v -> Inv8.inv k -> HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log k (DeepModel0.deep_model (let (a, _) = result in a)) }
+    ensures { [#"../red_black_tree.rs" 639 4 640 73] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv7.inv v -> Inv8.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 641 14 641 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 642 4 642 69] Color0.color ( * self) = RedBlackTree_Color_Type.C_Black -> Color0.color ( ^ self) = RedBlackTree_Color_Type.C_Black }
-    ensures { [#"../red_black_tree.rs" 643 36 643 42] Inv11.inv result }
+    ensures { [#"../red_black_tree.rs" 643 36 643 42] Inv9.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : (k, v);
   var self : borrowed (RedBlackTree_Tree_Type.t_tree k v) = self;
   var node : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _12 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _13 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _14 : Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v));
   var _15 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
@@ -7739,7 +7654,6 @@ module RedBlackTree_Impl15_DeleteMaxRec
   var _19 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var node1 : RedBlackTree_Node_Type.t_node k v;
   var _24 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _25 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _26 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _29 : ();
   var _30 : bool;
@@ -7747,13 +7661,10 @@ module RedBlackTree_Impl15_DeleteMaxRec
   var _35 : bool;
   var _37 : RedBlackTree_Node_Type.t_node k v;
   var _38 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _40 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _41 : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _42 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var r : (k, v);
   var _44 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _45 : ();
-  var _46 : borrowed (RedBlackTree_Node_Type.t_node k v);
   {
     goto BB0
   }
@@ -7771,16 +7682,11 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB2
   }
   BB2 {
-    _12 <- Borrow.borrow_mut ( * _13);
-    _13 <- { _13 with current = ( ^ _12) };
-    assume { Inv1.inv ( ^ _12) };
-    node <- ([#"../red_black_tree.rs" 644 23 644 59] AsMut1.as_mut _12);
-    _12 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    node <- ([#"../red_black_tree.rs" 644 23 644 59] AsMut1.as_mut _13);
+    _13 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB3
   }
   BB3 {
-    assert { [@expl:type invariant] Inv2.inv _13 };
-    assume { Resolve0.resolve _13 };
     _17 <- ([#"../red_black_tree.rs" 645 11 645 29] IsRed0.is_red (RedBlackTree_Node_Type.node_left ( * node)));
     goto BB4
   }
@@ -7793,7 +7699,7 @@ module RedBlackTree_Impl15_DeleteMaxRec
   BB5 {
     _19 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _19) };
-    assume { Inv3.inv ( ^ _19) };
+    assume { Inv1.inv ( ^ _19) };
     _16 <- ([#"../red_black_tree.rs" 646 12 646 31] RotateRight0.rotate_right _19);
     _19 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB6
@@ -7815,30 +7721,25 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB10
   }
   BB10 {
-    assert { [@expl:type invariant] Inv4.inv node };
-    assume { Resolve1.resolve node };
+    assert { [@expl:type invariant] Inv2.inv node };
+    assume { Resolve0.resolve node };
     _26 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _26)) };
     assume { Inv0.inv ( ^ _26) };
-    _25 <- Borrow.borrow_mut ( * _26);
-    _26 <- { _26 with current = ( ^ _25) };
-    assume { Inv0.inv ( ^ _25) };
-    _24 <- ([#"../red_black_tree.rs" 649 23 649 53] Take0.take _25);
-    _25 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
+    _24 <- ([#"../red_black_tree.rs" 649 23 649 53] Take0.take _26);
+    _26 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
     goto BB11
   }
   BB11 {
-    assert { [@expl:type invariant] Inv5.inv _26 };
-    assume { Resolve2.resolve _26 };
-    assert { [@expl:type invariant] Inv6.inv self };
-    assume { Resolve3.resolve self };
+    assert { [@expl:type invariant] Inv3.inv self };
+    assume { Resolve1.resolve self };
     node1 <- ([#"../red_black_tree.rs" 649 23 649 62] Unwrap1.unwrap _24);
     _24 <- any Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
     goto BB12
   }
   BB12 {
-    assert { [@expl:type invariant] Inv1.inv node1 };
-    assume { Resolve4.resolve node1 };
+    assert { [@expl:type invariant] Inv4.inv node1 };
+    assume { Resolve2.resolve node1 };
     _0 <- (RedBlackTree_Node_Type.node_key node1, RedBlackTree_Node_Type.node_val node1);
     node1 <- (let RedBlackTree_Node_Type.C_Node a b c d e = node1 in RedBlackTree_Node_Type.C_Node a b (any k) d e);
     node1 <- (let RedBlackTree_Node_Type.C_Node a b c d e = node1 in RedBlackTree_Node_Type.C_Node a b c (any v) e);
@@ -7880,8 +7781,8 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB21
   }
   BB21 {
-    assert { [@expl:type invariant] Inv7.inv _37 };
-    assume { Resolve5.resolve _37 };
+    assert { [@expl:type invariant] Inv5.inv _37 };
+    assume { Resolve3.resolve _37 };
     _35 <- ([#"../red_black_tree.rs" 652 36 652 83] IsRed0.is_red (RedBlackTree_Node_Type.node_left _37));
     goto BB22
   }
@@ -7891,23 +7792,13 @@ module RedBlackTree_Impl15_DeleteMaxRec
     goto BB18
   }
   BB23 {
-    _42 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _42) };
-    assume { Inv3.inv ( ^ _42) };
-    _41 <- ([#"../red_black_tree.rs" 653 19 653 40] MoveRedRight0.move_red_right _42);
-    _42 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _41 <- ([#"../red_black_tree.rs" 653 19 653 40] MoveRedRight0.move_red_right node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB24
   }
   BB24 {
-    _40 <- Borrow.borrow_mut ( * _41);
-    _41 <- { _41 with current = ( ^ _40) };
-    assume { Inv3.inv ( ^ _40) };
-    assert { [@expl:type invariant] Inv4.inv node };
-    assume { Resolve1.resolve node };
-    node <- _40;
-    _40 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
-    assert { [@expl:type invariant] Inv4.inv _41 };
-    assume { Resolve1.resolve _41 };
+    node <- _41;
+    _41 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _29 <- ();
     goto BB26
   }
@@ -7918,24 +7809,19 @@ module RedBlackTree_Impl15_DeleteMaxRec
   BB26 {
     _44 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _44)) };
-    assume { Inv8.inv ( ^ _44) };
+    assume { Inv6.inv ( ^ _44) };
     r <- ([#"../red_black_tree.rs" 655 16 655 43] delete_max_rec _44);
     _44 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB27
   }
   BB27 {
-    _46 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _46) };
-    assume { Inv3.inv ( ^ _46) };
-    _45 <- ([#"../red_black_tree.rs" 656 8 656 22] Balance0.balance _46);
-    _46 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _45 <- ([#"../red_black_tree.rs" 656 8 656 22] Balance0.balance node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB28
   }
   BB28 {
-    assert { [@expl:type invariant] Inv4.inv node };
-    assume { Resolve1.resolve node };
-    assert { [@expl:type invariant] Inv6.inv self };
-    assume { Resolve3.resolve self };
+    assert { [@expl:type invariant] Inv3.inv self };
+    assume { Resolve1.resolve self };
     _0 <- r;
     r <- any (k, v);
     goto BB29
@@ -8552,7 +8438,7 @@ module RedBlackTree_Impl15_DeleteMinRec
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with
     type self = DeepModelTy0.deepModelTy
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   use RedBlackTree_Color_Type as RedBlackTree_Color_Type
   use RedBlackTree_Node_Type as RedBlackTree_Node_Type
@@ -8560,13 +8446,13 @@ module RedBlackTree_Impl15_DeleteMinRec
   clone RedBlackTree_Impl9_Height as Height0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   clone RedBlackTree_Impl10_HeightInvariantHere as HeightInvariantHere0 with
     type k = k,
     type v = v,
     function Height0.height = Height0.height,
-    predicate Inv0.inv = Inv8.inv
+    predicate Inv0.inv = Inv5.inv
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel0 with
     type self = k,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
@@ -8575,19 +8461,25 @@ module RedBlackTree_Impl15_DeleteMinRec
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
     type t = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = v
   clone RedBlackTree_Impl4_BstInvariantHere as BstInvariantHere0 with
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv9.inv,
-    predicate Inv1.inv = Inv10.inv,
+    predicate Inv0.inv = Inv6.inv,
+    predicate Inv1.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log
+  clone CreusotContracts_Invariant_Inv_Interface as Inv15 with
+    type t = RedBlackTree_Node_Type.t_node k v
+  clone TyInv_Trivial as TyInv_Trivial15 with
+    type t = RedBlackTree_Node_Type.t_node k v,
+    predicate Inv0.inv = Inv15.inv,
+    axiom .
   clone RedBlackTree_Impl9_HeightInvariant as HeightInvariant0 with
     type k = k,
     type v = v,
@@ -8606,12 +8498,6 @@ module RedBlackTree_Impl15_DeleteMinRec
     type v = v,
     predicate BstInvariantHere0.bst_invariant_here = BstInvariantHere0.bst_invariant_here,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv15 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial15 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv15.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv14 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial14 with
@@ -8619,22 +8505,40 @@ module RedBlackTree_Impl15_DeleteMinRec
     predicate Inv0.inv = Inv14.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv13 with
-    type t = RedBlackTree_Tree_Type.t_tree k v
+    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial13 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
+    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv13.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
-    type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v))
+    type t = RedBlackTree_Tree_Type.t_tree k v
   clone TyInv_Trivial as TyInv_Trivial12 with
-    type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v)),
+    type t = RedBlackTree_Tree_Type.t_tree k v,
     predicate Inv0.inv = Inv12.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
-    type t = (k, v)
+    type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v))
   clone TyInv_Trivial as TyInv_Trivial11 with
-    type t = (k, v),
+    type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v)),
     predicate Inv0.inv = Inv11.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+  clone TyInv_Trivial as TyInv_Trivial10 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    predicate Inv0.inv = Inv10.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+  clone TyInv_Trivial as TyInv_Trivial9 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    predicate Inv0.inv = Inv9.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+    type t = (k, v)
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = (k, v),
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone RedBlackTree_Impl7_Color as Color0 with
     type k = k,
@@ -8645,44 +8549,44 @@ module RedBlackTree_Impl15_DeleteMinRec
     function Color0.color = Color0.color
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface as Antisym20 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface as Antisym10 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface as Trans0 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface as Refl0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface as CmpGtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function GtLog0.gt_log = GtLog0.gt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface as CmpGeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function GeLog0.ge_log = GeLog0.ge_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface as CmpLtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function LtLog0.lt_log = LtLog0.lt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
@@ -8690,29 +8594,27 @@ module RedBlackTree_Impl15_DeleteMinRec
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface as CmpLeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     function LeLog0.le_log = LeLog0.le_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone TyInv_Trivial as TyInv_Trivial10 with
+  clone TyInv_Trivial as TyInv_Trivial7 with
     type t = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv10.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
-  clone TyInv_Trivial as TyInv_Trivial9 with
+  clone TyInv_Trivial as TyInv_Trivial6 with
     type t = v,
-    predicate Inv0.inv = Inv9.inv,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl1_HasMapping as HasMapping1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv10.inv,
-    predicate Inv2.inv = Inv9.inv,
-    predicate Inv3.inv = Inv1.inv,
+    predicate Inv0.inv = Inv15.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv6.inv,
+    predicate Inv3.inv = Inv3.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel0.deep_model,
@@ -8721,15 +8623,15 @@ module RedBlackTree_Impl15_DeleteMinRec
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv9.inv,
-    predicate Inv1.inv = Inv10.inv,
+    predicate Inv0.inv = Inv6.inv,
+    predicate Inv1.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
-    predicate Inv2.inv = Inv7.inv,
-    predicate Inv3.inv = Inv1.inv,
+    predicate Inv2.inv = Inv15.inv,
+    predicate Inv3.inv = Inv3.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone TyInv_Trivial as TyInv_Trivial8 with
+  clone TyInv_Trivial as TyInv_Trivial5 with
     type t = RedBlackTree_Tree_Type.t_tree k v,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   clone RedBlackTree_Impl7_ColorInvariant as ColorInvariant0 with
     type k = k,
@@ -8743,10 +8645,10 @@ module RedBlackTree_Impl15_DeleteMinRec
   clone RedBlackTree_Impl10_Height as Height1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv1.inv,
+    predicate Inv0.inv = Inv15.inv,
+    predicate Inv1.inv = Inv3.inv,
     function Height0.height = Height0.height,
-    predicate Inv2.inv = Inv8.inv,
+    predicate Inv2.inv = Inv5.inv,
     axiom .
   use RedBlackTree_Cp_Type as RedBlackTree_Cp_Type
   clone RedBlackTree_Impl6_MatchT as MatchT0 with
@@ -8754,7 +8656,7 @@ module RedBlackTree_Impl15_DeleteMinRec
     type v = v,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv1.inv
+    predicate Inv0.inv = Inv3.inv
   clone RedBlackTree_Impl6_MatchN as MatchN0 with
     type k = k,
     type v = v,
@@ -8765,45 +8667,29 @@ module RedBlackTree_Impl15_DeleteMinRec
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant1.height_invariant
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = RedBlackTree_Node_Type.t_node k v
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+    type t = RedBlackTree_Node_Type.t_node k v
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv4.inv,
     axiom .
-  clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
-    type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
+    type t = RedBlackTree_Node_Type.t_node k v
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
@@ -8824,109 +8710,103 @@ module RedBlackTree_Impl15_DeleteMinRec
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv1.inv,
     predicate SameMappings0.same_mappings = SameMappings0.same_mappings,
     function Height0.height = Height1.height,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv1.inv = Inv7.inv,
-    predicate Inv2.inv = Inv1.inv,
+    predicate Inv1.inv = Inv15.inv,
+    predicate Inv2.inv = Inv3.inv,
     function Height1.height = Height0.height,
-    predicate Inv3.inv = Inv8.inv
+    predicate Inv3.inv = Inv5.inv
   clone RedBlackTree_Impl14_MoveRedLeft_Interface as MoveRedLeft0 with
     type k = k,
     type v = v,
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv1.inv,
     function Height0.height = Height1.height,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv1.inv = Inv9.inv,
-    predicate Inv2.inv = Inv10.inv,
+    predicate Inv1.inv = Inv6.inv,
+    predicate Inv2.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
     function DeepModel0.deep_model = DeepModel0.deep_model,
     function LeLog0.le_log = LeLog0.le_log,
     predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant,
     function Color0.color = Color0.color,
-    predicate Inv3.inv = Inv7.inv,
-    predicate Inv4.inv = Inv1.inv,
+    predicate Inv3.inv = Inv15.inv,
+    predicate Inv4.inv = Inv3.inv,
     function Height1.height = Height0.height,
-    predicate Inv5.inv = Inv8.inv,
+    predicate Inv5.inv = Inv5.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve3 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap2 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv15.inv,
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv0.inv = Inv14.inv,
+    predicate Inv1.inv = Inv4.inv
   clone Core_Option_Impl0_AsRef_Interface as AsRef0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv14.inv,
-    predicate Inv1.inv = Inv6.inv,
-    predicate Inv2.inv = Inv15.inv
+    predicate Inv0.inv = Inv13.inv,
+    predicate Inv1.inv = Inv4.inv,
+    predicate Inv2.inv = Inv14.inv
   clone RedBlackTree_Impl13_IsRed_Interface as IsRed0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv13.inv,
+    predicate Inv0.inv = Inv12.inv,
     function Color0.color = Color0.color
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv0.inv,
-    predicate Inv1.inv = Inv1.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    predicate Inv1.inv = Inv3.inv
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = RedBlackTree_Tree_Type.t_tree k v
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone Core_Mem_Take_Interface as Take0 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv9.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv0.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = RedBlackTree_Node_Type.t_node k v
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone Alloc_Boxed_Impl57_AsMut_Interface as AsMut1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv2.inv,
-    predicate Inv1.inv = Inv3.inv
+    predicate Inv0.inv = Inv10.inv,
+    predicate Inv1.inv = Inv1.inv
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv12.inv,
-    predicate Inv1.inv = Inv2.inv
+    predicate Inv0.inv = Inv11.inv,
+    predicate Inv1.inv = Inv10.inv
   clone Core_Option_Impl0_AsMut_Interface as AsMut0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv4.inv,
-    predicate Inv1.inv = Inv2.inv,
-    predicate Inv2.inv = Inv12.inv
+    predicate Inv0.inv = Inv9.inv,
+    predicate Inv1.inv = Inv10.inv,
+    predicate Inv2.inv = Inv11.inv
   let rec cfg delete_min_rec [#"../red_black_tree.rs" 696 4 696 42] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) : (k, v)
     requires {[#"../red_black_tree.rs" 685 15 685 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 686 15 687 62] MatchT0.match_t (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) ( * self) \/ MatchT0.match_t (Cpn0.cpn (RedBlackTree_Color_Type.C_Black) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Black))) ( * self)}
-    requires {[#"../red_black_tree.rs" 696 27 696 31] Inv5.inv self}
+    requires {[#"../red_black_tree.rs" 696 27 696 31] Inv2.inv self}
     ensures { [#"../red_black_tree.rs" 688 14 688 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 689 14 689 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 690 14 690 66] HasMapping0.has_mapping ( * self) (DeepModel0.deep_model (let (a, _) = result in a)) (let (_, a) = result in a) }
-    ensures { [#"../red_black_tree.rs" 691 4 691 104] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv9.inv v -> Inv10.inv k -> HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (DeepModel0.deep_model (let (a, _) = result in a)) k }
-    ensures { [#"../red_black_tree.rs" 692 4 693 73] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv9.inv v -> Inv10.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 691 4 691 104] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv6.inv v -> Inv7.inv k -> HasMapping0.has_mapping ( * self) k v -> LeLog0.le_log (DeepModel0.deep_model (let (a, _) = result in a)) k }
+    ensures { [#"../red_black_tree.rs" 692 4 693 73] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv6.inv v -> Inv7.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model (let (a, _) = result in a) <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 694 14 694 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 695 4 695 69] Color0.color ( * self) = RedBlackTree_Color_Type.C_Black -> Color0.color ( ^ self) = RedBlackTree_Color_Type.C_Black }
-    ensures { [#"../red_black_tree.rs" 696 36 696 42] Inv11.inv result }
+    ensures { [#"../red_black_tree.rs" 696 36 696 42] Inv8.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : (k, v);
   var self : borrowed (RedBlackTree_Tree_Type.t_tree k v) = self;
   var node : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _12 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _13 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _14 : Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v));
   var _15 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var node1 : RedBlackTree_Node_Type.t_node k v;
   var _20 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _21 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _22 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _25 : ();
   var _26 : bool;
@@ -8934,13 +8814,10 @@ module RedBlackTree_Impl15_DeleteMinRec
   var _31 : bool;
   var _33 : RedBlackTree_Node_Type.t_node k v;
   var _34 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _36 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _37 : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _38 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var r : (k, v);
   var _40 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _41 : ();
-  var _42 : borrowed (RedBlackTree_Node_Type.t_node k v);
   {
     goto BB0
   }
@@ -8958,16 +8835,11 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB2
   }
   BB2 {
-    _12 <- Borrow.borrow_mut ( * _13);
-    _13 <- { _13 with current = ( ^ _12) };
-    assume { Inv1.inv ( ^ _12) };
-    node <- ([#"../red_black_tree.rs" 697 23 697 59] AsMut1.as_mut _12);
-    _12 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    node <- ([#"../red_black_tree.rs" 697 23 697 59] AsMut1.as_mut _13);
+    _13 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB3
   }
   BB3 {
-    assert { [@expl:type invariant] Inv2.inv _13 };
-    assume { Resolve0.resolve _13 };
     switch (RedBlackTree_Tree_Type.tree_node (RedBlackTree_Node_Type.node_left ( * node)))
       | Core_Option_Option_Type.C_None -> goto BB4
       | _ -> goto BB10
@@ -8977,30 +8849,25 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB5
   }
   BB5 {
-    assert { [@expl:type invariant] Inv3.inv node };
-    assume { Resolve1.resolve node };
+    assert { [@expl:type invariant] Inv1.inv node };
+    assume { Resolve0.resolve node };
     _22 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _22)) };
     assume { Inv0.inv ( ^ _22) };
-    _21 <- Borrow.borrow_mut ( * _22);
-    _22 <- { _22 with current = ( ^ _21) };
-    assume { Inv0.inv ( ^ _21) };
-    _20 <- ([#"../red_black_tree.rs" 699 23 699 53] Take0.take _21);
-    _21 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
+    _20 <- ([#"../red_black_tree.rs" 699 23 699 53] Take0.take _22);
+    _22 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
     goto BB6
   }
   BB6 {
-    assert { [@expl:type invariant] Inv4.inv _22 };
-    assume { Resolve2.resolve _22 };
-    assert { [@expl:type invariant] Inv5.inv self };
-    assume { Resolve3.resolve self };
+    assert { [@expl:type invariant] Inv2.inv self };
+    assume { Resolve1.resolve self };
     node1 <- ([#"../red_black_tree.rs" 699 23 699 62] Unwrap1.unwrap _20);
     _20 <- any Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
     goto BB7
   }
   BB7 {
-    assert { [@expl:type invariant] Inv1.inv node1 };
-    assume { Resolve4.resolve node1 };
+    assert { [@expl:type invariant] Inv3.inv node1 };
+    assume { Resolve2.resolve node1 };
     _0 <- (RedBlackTree_Node_Type.node_key node1, RedBlackTree_Node_Type.node_val node1);
     node1 <- (let RedBlackTree_Node_Type.C_Node a b c d e = node1 in RedBlackTree_Node_Type.C_Node a b (any k) d e);
     node1 <- (let RedBlackTree_Node_Type.C_Node a b c d e = node1 in RedBlackTree_Node_Type.C_Node a b c (any v) e);
@@ -9042,8 +8909,8 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB16
   }
   BB16 {
-    assert { [@expl:type invariant] Inv6.inv _33 };
-    assume { Resolve5.resolve _33 };
+    assert { [@expl:type invariant] Inv4.inv _33 };
+    assume { Resolve3.resolve _33 };
     _31 <- ([#"../red_black_tree.rs" 702 35 702 81] IsRed0.is_red (RedBlackTree_Node_Type.node_left _33));
     goto BB17
   }
@@ -9053,23 +8920,13 @@ module RedBlackTree_Impl15_DeleteMinRec
     goto BB13
   }
   BB18 {
-    _38 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _38) };
-    assume { Inv7.inv ( ^ _38) };
-    _37 <- ([#"../red_black_tree.rs" 703 19 703 39] MoveRedLeft0.move_red_left _38);
-    _38 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _37 <- ([#"../red_black_tree.rs" 703 19 703 39] MoveRedLeft0.move_red_left node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB19
   }
   BB19 {
-    _36 <- Borrow.borrow_mut ( * _37);
-    _37 <- { _37 with current = ( ^ _36) };
-    assume { Inv7.inv ( ^ _36) };
-    assert { [@expl:type invariant] Inv3.inv node };
-    assume { Resolve1.resolve node };
-    node <- _36;
-    _36 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
-    assert { [@expl:type invariant] Inv3.inv _37 };
-    assume { Resolve1.resolve _37 };
+    node <- _37;
+    _37 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _25 <- ();
     goto BB21
   }
@@ -9080,24 +8937,19 @@ module RedBlackTree_Impl15_DeleteMinRec
   BB21 {
     _40 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _40) b c d e) };
-    assume { Inv8.inv ( ^ _40) };
+    assume { Inv5.inv ( ^ _40) };
     r <- ([#"../red_black_tree.rs" 705 16 705 42] delete_min_rec _40);
     _40 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB22
   }
   BB22 {
-    _42 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _42) };
-    assume { Inv7.inv ( ^ _42) };
-    _41 <- ([#"../red_black_tree.rs" 706 8 706 22] Balance0.balance _42);
-    _42 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _41 <- ([#"../red_black_tree.rs" 706 8 706 22] Balance0.balance node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB23
   }
   BB23 {
-    assert { [@expl:type invariant] Inv3.inv node };
-    assume { Resolve1.resolve node };
-    assert { [@expl:type invariant] Inv5.inv self };
-    assume { Resolve3.resolve self };
+    assert { [@expl:type invariant] Inv2.inv self };
+    assume { Resolve1.resolve self };
     _0 <- r;
     r <- any (k, v);
     goto BB24
@@ -9745,20 +9597,32 @@ module RedBlackTree_Impl15_DeleteRec
   clone CreusotContracts_Logic_Ord_OrdLogic_GeLog_Interface as GeLog0 with
     type self = DeepModelTy0.deepModelTy
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   use RedBlackTree_Color_Type as RedBlackTree_Color_Type
   use RedBlackTree_Node_Type as RedBlackTree_Node_Type
   clone RedBlackTree_Impl9_Height as Height0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv3.inv,
     axiom .
   clone RedBlackTree_Impl10_HeightInvariantHere as HeightInvariantHere0 with
     type k = k,
     type v = v,
     function Height0.height = Height0.height,
-    predicate Inv0.inv = Inv7.inv
+    predicate Inv0.inv = Inv3.inv
+  clone CreusotContracts_Invariant_Inv_Interface as Inv20 with
+    type t = borrowed v
+  clone TyInv_Trivial as TyInv_Trivial20 with
+    type t = borrowed v,
+    predicate Inv0.inv = Inv20.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv19 with
+    type t = borrowed k
+  clone TyInv_Trivial as TyInv_Trivial19 with
+    type t = borrowed k,
+    predicate Inv0.inv = Inv19.inv,
+    axiom .
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel1 with
     type self = k,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
@@ -9772,18 +9636,18 @@ module RedBlackTree_Impl15_DeleteRec
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel1.deep_model
-  clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
     type t = v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv14 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
     type t = DeepModelTy0.deepModelTy
   clone RedBlackTree_Impl0_ModelAccHasMapping as ModelAccHasMapping0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv3.inv,
     predicate Inv1.inv = Inv21.inv,
-    predicate Inv2.inv = Inv14.inv,
+    predicate Inv2.inv = Inv10.inv,
     function ModelAcc0.model_acc = ModelAcc0.model_acc,
-    predicate Inv3.inv = Inv11.inv,
+    predicate Inv3.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel1.deep_model,
@@ -9794,8 +9658,8 @@ module RedBlackTree_Impl15_DeleteRec
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv11.inv,
-    predicate Inv1.inv = Inv14.inv,
+    predicate Inv0.inv = Inv7.inv,
+    predicate Inv1.inv = Inv10.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log
@@ -9807,21 +9671,21 @@ module RedBlackTree_Impl15_DeleteRec
     type k = k,
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv3.inv,
     predicate Inv1.inv = Inv21.inv,
-    predicate Inv2.inv = Inv14.inv,
-    predicate Inv3.inv = Inv11.inv,
+    predicate Inv2.inv = Inv10.inv,
+    predicate Inv3.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     function ModelAcc0.model_acc = ModelAcc0.model_acc,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function ModelAccHasMapping0.model_acc_has_mapping = ModelAccHasMapping0.model_acc_has_mapping,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv20 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv18 with
     type t = (k, v)
-  clone TyInv_Trivial as TyInv_Trivial20 with
+  clone TyInv_Trivial as TyInv_Trivial18 with
     type t = (k, v),
-    predicate Inv0.inv = Inv20.inv,
+    predicate Inv0.inv = Inv18.inv,
     axiom .
   clone RedBlackTree_Impl9_HeightInvariant as HeightInvariant0 with
     type k = k,
@@ -9837,67 +9701,67 @@ module RedBlackTree_Impl15_DeleteRec
     type v = v,
     predicate BstInvariantHere0.bst_invariant_here = BstInvariantHere0.bst_invariant_here,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv19 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial19 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv19.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv18 with
-    type t = RedBlackTree_Tree_Type.t_tree k v
-  clone TyInv_Trivial as TyInv_Trivial18 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
-    predicate Inv0.inv = Inv18.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv17 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial17 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv17.inv,
     axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv16 with
+    type t = RedBlackTree_Tree_Type.t_tree k v
+  clone TyInv_Trivial as TyInv_Trivial16 with
+    type t = RedBlackTree_Tree_Type.t_tree k v,
+    predicate Inv0.inv = Inv16.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv15 with
+    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
+  clone TyInv_Trivial as TyInv_Trivial15 with
+    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
+    predicate Inv0.inv = Inv15.inv,
+    axiom .
   use Core_Cmp_Ordering_Type as Core_Cmp_Ordering_Type
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym2_Interface as Antisym20 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Antisym1_Interface as Antisym10 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Trans_Interface as Trans0 with
     type self = DeepModelTy0.deepModelTy,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_Refl_Interface as Refl0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGtLog_Interface as CmpGtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function GtLog0.gt_log = GtLog0.gt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpGeLog_Interface as CmpGeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function GeLog0.ge_log = GeLog0.ge_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLtLog_Interface as CmpLtLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function LtLog0.lt_log = LtLog0.lt_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
@@ -9905,21 +9769,33 @@ module RedBlackTree_Impl15_DeleteRec
     type self = DeepModelTy0.deepModelTy
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLeLog_Interface as CmpLeLog0 with
     type self = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     function LeLog0.le_log = LeLog0.le_log,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv16 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv14 with
     type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v))
-  clone TyInv_Trivial as TyInv_Trivial16 with
+  clone TyInv_Trivial as TyInv_Trivial14 with
     type t = Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v)),
-    predicate Inv0.inv = Inv16.inv,
+    predicate Inv0.inv = Inv14.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv15 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv13 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+  clone TyInv_Trivial as TyInv_Trivial13 with
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    predicate Inv0.inv = Inv13.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
+  clone TyInv_Trivial as TyInv_Trivial12 with
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
+    predicate Inv0.inv = Inv12.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
     type t = Core_Option_Option_Type.t_option (k, v)
-  clone TyInv_Trivial as TyInv_Trivial15 with
+  clone TyInv_Trivial as TyInv_Trivial11 with
     type t = Core_Option_Option_Type.t_option (k, v),
-    predicate Inv0.inv = Inv15.inv,
+    predicate Inv0.inv = Inv11.inv,
     axiom .
   clone RedBlackTree_Impl7_Color as Color0 with
     type k = k,
@@ -9928,21 +9804,21 @@ module RedBlackTree_Impl15_DeleteRec
     type k = k,
     type v = v,
     function Color0.color = Color0.color
-  clone TyInv_Trivial as TyInv_Trivial14 with
+  clone TyInv_Trivial as TyInv_Trivial10 with
     type t = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv14.inv,
+    predicate Inv0.inv = Inv10.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl1_HasMapping as HasMapping1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
-    predicate Inv1.inv = Inv14.inv,
-    predicate Inv2.inv = Inv11.inv,
-    predicate Inv3.inv = Inv1.inv,
+    predicate Inv0.inv = Inv9.inv,
+    predicate Inv1.inv = Inv10.inv,
+    predicate Inv2.inv = Inv7.inv,
+    predicate Inv3.inv = Inv8.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function DeepModel0.deep_model = DeepModel1.deep_model,
@@ -9951,41 +9827,32 @@ module RedBlackTree_Impl15_DeleteRec
     type k = k,
     type v = v,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv0.inv = Inv11.inv,
-    predicate Inv1.inv = Inv14.inv,
+    predicate Inv0.inv = Inv7.inv,
+    predicate Inv1.inv = Inv10.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
-    predicate Inv2.inv = Inv5.inv,
-    predicate Inv3.inv = Inv1.inv,
+    predicate Inv2.inv = Inv9.inv,
+    predicate Inv3.inv = Inv8.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone CreusotContracts_Invariant_Inv_Interface as Inv13 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
-  clone TyInv_Trivial as TyInv_Trivial13 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
-    predicate Inv0.inv = Inv13.inv,
+  clone TyInv_Trivial as TyInv_Trivial9 with
+    type t = RedBlackTree_Node_Type.t_node k v,
+    predicate Inv0.inv = Inv9.inv,
+    axiom .
+  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = RedBlackTree_Node_Type.t_node k v,
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Std1_Option_Impl1_IsDefault as IsDefault0 with
     type t = RedBlackTree_Node_Type.t_node k v
-  clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
-    type t = borrowed v
-  clone TyInv_Trivial as TyInv_Trivial12 with
-    type t = borrowed v,
-    predicate Inv0.inv = Inv12.inv,
-    axiom .
-  clone TyInv_Trivial as TyInv_Trivial11 with
+  clone TyInv_Trivial as TyInv_Trivial7 with
     type t = v,
-    predicate Inv0.inv = Inv11.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = borrowed k
-  clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = borrowed k,
-    predicate Inv0.inv = Inv10.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = k
-  clone TyInv_Trivial as TyInv_Trivial9 with
+  clone TyInv_Trivial as TyInv_Trivial6 with
     type t = k,
-    predicate Inv0.inv = Inv9.inv,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
   use prelude.Ghost
   clone RedBlackTree_Impl3_ShallowModel as ShallowModel0 with
@@ -9997,9 +9864,9 @@ module RedBlackTree_Impl15_DeleteRec
     type k = k,
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv14.inv,
-    predicate Inv2.inv = Inv11.inv,
+    predicate Inv0.inv = Inv3.inv,
+    predicate Inv1.inv = Inv10.inv,
+    predicate Inv2.inv = Inv7.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
@@ -10008,21 +9875,21 @@ module RedBlackTree_Impl15_DeleteRec
     predicate Inv3.inv = Inv21.inv,
     function ModelAcc0.model_acc = ModelAcc0.model_acc,
     axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = borrowed (RedBlackTree_Tree_Type.t_tree k v)
-  clone TyInv_Trivial as TyInv_Trivial8 with
+  clone TyInv_Trivial as TyInv_Trivial5 with
     type t = borrowed (RedBlackTree_Tree_Type.t_tree k v),
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = RedBlackTree_Tree_Type.t_tree k v,
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v)
-  clone TyInv_Trivial as TyInv_Trivial6 with
+  clone TyInv_Trivial as TyInv_Trivial4 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
+    axiom .
+  clone TyInv_Trivial as TyInv_Trivial3 with
+    type t = RedBlackTree_Tree_Type.t_tree k v,
+    predicate Inv0.inv = Inv3.inv,
     axiom .
   clone RedBlackTree_Impl7_ColorInvariant as ColorInvariant0 with
     type k = k,
@@ -10036,10 +9903,10 @@ module RedBlackTree_Impl15_DeleteRec
   clone RedBlackTree_Impl10_Height as Height1 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv5.inv,
-    predicate Inv1.inv = Inv1.inv,
+    predicate Inv0.inv = Inv9.inv,
+    predicate Inv1.inv = Inv8.inv,
     function Height0.height = Height0.height,
-    predicate Inv2.inv = Inv7.inv,
+    predicate Inv2.inv = Inv3.inv,
     axiom .
   use RedBlackTree_Cp_Type as RedBlackTree_Cp_Type
   clone RedBlackTree_Impl6_MatchT as MatchT0 with
@@ -10047,7 +9914,7 @@ module RedBlackTree_Impl15_DeleteRec
     type v = v,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv1.inv
+    predicate Inv0.inv = Inv8.inv
   clone RedBlackTree_Impl6_MatchN as MatchN0 with
     type k = k,
     type v = v,
@@ -10058,31 +9925,16 @@ module RedBlackTree_Impl15_DeleteRec
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant1.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant1.height_invariant
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = RedBlackTree_Node_Type.t_node k v
-  clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv4.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = k
-  clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = k,
-    predicate Inv0.inv = Inv3.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+    type t = RedBlackTree_Node_Type.t_node k v
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = k
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = RedBlackTree_Node_Type.t_node k v,
+    type t = k,
     predicate Inv0.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
@@ -10107,63 +9959,57 @@ module RedBlackTree_Impl15_DeleteRec
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Color0.color = Color0.color,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     predicate SameMappings0.same_mappings = SameMappings0.same_mappings,
     function Height0.height = Height1.height,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv1.inv = Inv5.inv,
-    predicate Inv2.inv = Inv1.inv,
+    predicate Inv1.inv = Inv9.inv,
+    predicate Inv2.inv = Inv8.inv,
     function Height1.height = Height0.height,
-    predicate Inv3.inv = Inv7.inv
+    predicate Inv3.inv = Inv3.inv
   clone RedBlackTree_Impl14_RotateRight_Interface as RotateRight0 with
     type k = k,
     type v = v,
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Color0.color = Color0.color,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     predicate SameMappings0.same_mappings = SameMappings0.same_mappings,
     function Height0.height = Height1.height,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log,
-    predicate Inv1.inv = Inv1.inv,
-    predicate Inv2.inv = Inv5.inv,
+    predicate Inv1.inv = Inv8.inv,
+    predicate Inv2.inv = Inv9.inv,
     function Height1.height = Height0.height,
-    predicate Inv3.inv = Inv7.inv,
+    predicate Inv3.inv = Inv3.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve9 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap2 with
     type t = RedBlackTree_Node_Type.t_node k v,
     predicate Inv0.inv = Inv0.inv,
-    predicate Inv1.inv = Inv1.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve8 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
+    predicate Inv1.inv = Inv8.inv
   clone Core_Mem_Take_Interface as Take0 with
     type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv13.inv,
+    predicate Inv0.inv = Inv12.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv0.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve7 with
-    type t = v
   clone Core_Mem_Swap_Interface as Swap1 with
     type t = v,
-    predicate Inv0.inv = Inv12.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
-    type t = k
+    predicate Inv0.inv = Inv20.inv
   clone Core_Mem_Swap_Interface as Swap0 with
     type t = k,
-    predicate Inv0.inv = Inv10.inv
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve5 with
+    predicate Inv0.inv = Inv19.inv
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve4 with
     type self = Ghost.ghost_ty ()
   clone RedBlackTree_Impl0_HasMappingInj as HasMappingInj0 with
     type k = k,
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv14.inv,
-    predicate Inv2.inv = Inv11.inv,
+    predicate Inv0.inv = Inv3.inv,
+    predicate Inv1.inv = Inv10.inv,
+    predicate Inv2.inv = Inv7.inv,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function HasMappingModel0.has_mapping_model = HasMappingModel0.has_mapping_model,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
@@ -10174,42 +10020,42 @@ module RedBlackTree_Impl15_DeleteRec
     predicate InternalInvariant0.internal_invariant = InternalInvariant0.internal_invariant,
     predicate MatchT0.match_t = MatchT0.match_t,
     function Cpn0.cpn = Cpn0.cpn,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv5.inv,
     function Height0.height = Height0.height,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv1.inv = Inv11.inv,
-    predicate Inv2.inv = Inv14.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv10.inv,
     function LeLog0.le_log = LeLog0.le_log,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
     function Color0.color = Color0.color,
-    predicate Inv3.inv = Inv20.inv,
-    predicate Inv4.inv = Inv7.inv
+    predicate Inv3.inv = Inv18.inv,
+    predicate Inv4.inv = Inv3.inv
   clone RedBlackTree_Impl14_MoveRedRight_Interface as MoveRedRight0 with
     type k = k,
     type v = v,
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function Height0.height = Height1.height,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv1.inv = Inv11.inv,
-    predicate Inv2.inv = Inv14.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv10.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function LeLog0.le_log = LeLog0.le_log,
     predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant,
     function Color0.color = Color0.color,
-    predicate Inv3.inv = Inv5.inv,
-    predicate Inv4.inv = Inv1.inv,
+    predicate Inv3.inv = Inv9.inv,
+    predicate Inv4.inv = Inv8.inv,
     function Height1.height = Height0.height,
-    predicate Inv5.inv = Inv7.inv,
+    predicate Inv5.inv = Inv3.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = RedBlackTree_Tree_Type.t_tree k v
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    type t = RedBlackTree_Tree_Type.t_tree k v
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = RedBlackTree_Node_Type.t_node k v
   clone RedBlackTree_Impl14_MoveRedLeft_Interface as MoveRedLeft0 with
     type k = k,
@@ -10217,79 +10063,77 @@ module RedBlackTree_Impl15_DeleteRec
     predicate InternalInvariant0.internal_invariant = InternalInvariant1.internal_invariant,
     function Cpn0.cpn = Cpn0.cpn,
     predicate MatchN0.match_n = MatchN0.match_n,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function Height0.height = Height1.height,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
-    predicate Inv1.inv = Inv11.inv,
-    predicate Inv2.inv = Inv14.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv10.inv,
     predicate HasMapping0.has_mapping = HasMapping1.has_mapping,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function LeLog0.le_log = LeLog0.le_log,
     predicate ColorInvariant0.color_invariant = ColorInvariant1.color_invariant,
     function Color0.color = Color0.color,
-    predicate Inv3.inv = Inv5.inv,
-    predicate Inv4.inv = Inv1.inv,
+    predicate Inv3.inv = Inv9.inv,
+    predicate Inv4.inv = Inv8.inv,
     function Height1.height = Height0.height,
-    predicate Inv5.inv = Inv7.inv,
+    predicate Inv5.inv = Inv3.inv,
     predicate HasMapping1.has_mapping = HasMapping0.has_mapping
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = RedBlackTree_Node_Type.t_node k v
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap1 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv19.inv,
-    predicate Inv1.inv = Inv4.inv
+    predicate Inv0.inv = Inv17.inv,
+    predicate Inv1.inv = Inv2.inv
   clone Core_Option_Impl0_AsRef_Interface as AsRef0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv17.inv,
-    predicate Inv1.inv = Inv4.inv,
-    predicate Inv2.inv = Inv19.inv
+    predicate Inv0.inv = Inv15.inv,
+    predicate Inv1.inv = Inv2.inv,
+    predicate Inv2.inv = Inv17.inv
   clone RedBlackTree_Impl13_IsRed_Interface as IsRed0 with
     type k = k,
     type v = v,
-    predicate Inv0.inv = Inv18.inv,
+    predicate Inv0.inv = Inv16.inv,
     function Color0.color = Color0.color
   clone Core_Option_Impl0_IsNone_Interface as IsNone0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv17.inv
+    predicate Inv0.inv = Inv15.inv
   clone Core_Cmp_Ord_Cmp_Interface as Cmp0 with
     type self = k,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv1.inv,
     function DeepModel0.deep_model = DeepModel1.deep_model,
     function CmpLog0.cmp_log = CmpLog0.cmp_log,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = k
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = RedBlackTree_Node_Type.t_node k v
   clone Alloc_Boxed_Impl57_AsMut_Interface as AsMut1 with
     type t = RedBlackTree_Node_Type.t_node k v,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv2.inv,
-    predicate Inv1.inv = Inv6.inv
+    predicate Inv0.inv = Inv13.inv,
+    predicate Inv1.inv = Inv4.inv
   clone Core_Option_Impl0_Unwrap_Interface as Unwrap0 with
     type t = borrowed (RedBlackTree_Node_Type.t_node k v),
-    predicate Inv0.inv = Inv16.inv,
-    predicate Inv1.inv = Inv2.inv
+    predicate Inv0.inv = Inv14.inv,
+    predicate Inv1.inv = Inv13.inv
   clone Core_Option_Impl0_AsMut_Interface as AsMut0 with
     type t = RedBlackTree_Node_Type.t_node k v,
-    predicate Inv0.inv = Inv13.inv,
-    predicate Inv1.inv = Inv2.inv,
-    predicate Inv2.inv = Inv16.inv
+    predicate Inv0.inv = Inv12.inv,
+    predicate Inv1.inv = Inv13.inv,
+    predicate Inv2.inv = Inv14.inv
   let rec cfg delete_rec [#"../red_black_tree.rs" 748 4 748 55] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) (key : k) : Core_Option_Option_Type.t_option (k, v)
     requires {[#"../red_black_tree.rs" 736 15 736 43] InternalInvariant0.internal_invariant ( * self)}
     requires {[#"../red_black_tree.rs" 737 15 738 62] MatchT0.match_t (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) ( * self) \/ MatchT0.match_t (Cpn0.cpn (RedBlackTree_Color_Type.C_Black) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Red)) (RedBlackTree_Cp_Type.C_CPL (RedBlackTree_Color_Type.C_Black))) ( * self)}
-    requires {[#"../red_black_tree.rs" 748 23 748 27] Inv8.inv self}
-    requires {[#"../red_black_tree.rs" 748 29 748 32] Inv3.inv key}
+    requires {[#"../red_black_tree.rs" 748 23 748 27] Inv5.inv self}
+    requires {[#"../red_black_tree.rs" 748 29 748 32] Inv1.inv key}
     ensures { [#"../red_black_tree.rs" 739 14 739 42] InternalInvariant0.internal_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 740 14 740 50] Height0.height ( * self) = Height0.height ( ^ self) }
     ensures { [#"../red_black_tree.rs" 741 14 744 5] match (result) with
-      | Core_Option_Option_Type.C_None -> forall v : v . Inv11.inv v -> not HasMapping0.has_mapping ( * self) (DeepModel0.deep_model key) v
+      | Core_Option_Option_Type.C_None -> forall v : v . Inv7.inv v -> not HasMapping0.has_mapping ( * self) (DeepModel0.deep_model key) v
       | Core_Option_Option_Type.C_Some (k, v) -> DeepModel0.deep_model key = DeepModel1.deep_model k /\ HasMapping0.has_mapping ( * self) (DeepModel1.deep_model k) v
       end }
-    ensures { [#"../red_black_tree.rs" 745 4 745 129] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv11.inv v -> Inv14.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
+    ensures { [#"../red_black_tree.rs" 745 4 745 129] forall v : v . forall k : DeepModelTy0.deepModelTy . Inv7.inv v -> Inv10.inv k -> HasMapping0.has_mapping ( ^ self) k v = (DeepModel0.deep_model key <> k /\ HasMapping0.has_mapping ( * self) k v) }
     ensures { [#"../red_black_tree.rs" 746 14 746 39] ColorInvariant0.color_invariant ( ^ self) }
     ensures { [#"../red_black_tree.rs" 747 4 747 69] Color0.color ( * self) = RedBlackTree_Color_Type.C_Black -> Color0.color ( ^ self) = RedBlackTree_Color_Type.C_Black }
-    ensures { [#"../red_black_tree.rs" 748 41 748 55] Inv15.inv result }
+    ensures { [#"../red_black_tree.rs" 748 41 748 55] Inv11.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.t_option (k, v);
@@ -10297,7 +10141,6 @@ module RedBlackTree_Impl15_DeleteRec
   var key : k = key;
   var r : Core_Option_Option_Type.t_option (k, v);
   var node : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _13 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _14 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _15 : Core_Option_Option_Type.t_option (borrowed (RedBlackTree_Node_Type.t_node k v));
   var _16 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
@@ -10311,9 +10154,7 @@ module RedBlackTree_Impl15_DeleteRec
   var _33 : bool;
   var _35 : RedBlackTree_Node_Type.t_node k v;
   var _36 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _38 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _39 : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _40 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _41 : Core_Option_Option_Type.t_option (k, v);
   var _42 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var ord : Core_Cmp_Ordering_Type.t_ordering;
@@ -10325,32 +10166,24 @@ module RedBlackTree_Impl15_DeleteRec
   var _53 : bool;
   var node1 : RedBlackTree_Node_Type.t_node k v;
   var _60 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _61 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _62 : borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
   var _66 : ();
   var _68 : bool;
   var _70 : RedBlackTree_Node_Type.t_node k v;
   var _71 : Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
-  var _73 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _74 : borrowed (RedBlackTree_Node_Type.t_node k v);
-  var _75 : borrowed (RedBlackTree_Node_Type.t_node k v);
   var kv : (k, v);
   var _78 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _79 : Ghost.ghost_ty ();
   var _81 : ();
-  var _82 : borrowed k;
   var _83 : borrowed k;
-  var _84 : borrowed k;
   var _85 : borrowed k;
   var _86 : ();
-  var _87 : borrowed v;
   var _88 : borrowed v;
-  var _89 : borrowed v;
   var _90 : borrowed v;
   var _93 : Core_Option_Option_Type.t_option (k, v);
   var _94 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _96 : ();
-  var _97 : borrowed (RedBlackTree_Node_Type.t_node k v);
   {
     goto BB0
   }
@@ -10368,19 +10201,14 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB2
   }
   BB2 {
-    _13 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _13) };
-    assume { Inv1.inv ( ^ _13) };
-    node <- ([#"../red_black_tree.rs" 750 23 750 59] AsMut1.as_mut _13);
-    _13 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    node <- ([#"../red_black_tree.rs" 750 23 750 59] AsMut1.as_mut _14);
+    _14 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB3
   }
   BB3 {
-    assert { [@expl:type invariant] Inv2.inv _14 };
-    assume { Resolve0.resolve _14 };
     _21 <- RedBlackTree_Node_Type.node_key ( * node);
-    assert { [@expl:type invariant] Inv3.inv _21 };
-    assume { Resolve1.resolve _21 };
+    assert { [@expl:type invariant] Inv1.inv _21 };
+    assume { Resolve0.resolve _21 };
     _18 <- ([#"../red_black_tree.rs" 751 14 751 32] Cmp0.cmp key _21);
     goto BB4
   }
@@ -10409,13 +10237,13 @@ module RedBlackTree_Impl15_DeleteRec
       end
   }
   BB9 {
-    assert { [@expl:type invariant] Inv6.inv node };
-    assume { Resolve3.resolve node };
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assert { [@expl:type invariant] Inv4.inv node };
+    assume { Resolve2.resolve node };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     _0 <- Core_Option_Option_Type.C_None;
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve4.resolve self };
+    assert { [@expl:type invariant] Inv5.inv self };
+    assume { Resolve3.resolve self };
     goto BB74
   }
   BB10 {
@@ -10448,8 +10276,8 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB16
   }
   BB16 {
-    assert { [@expl:type invariant] Inv4.inv _35 };
-    assume { Resolve2.resolve _35 };
+    assert { [@expl:type invariant] Inv2.inv _35 };
+    assume { Resolve1.resolve _35 };
     _33 <- ([#"../red_black_tree.rs" 756 43 756 89] IsRed0.is_red (RedBlackTree_Node_Type.node_left _35));
     goto BB17
   }
@@ -10459,23 +10287,13 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB13
   }
   BB18 {
-    _40 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _40) };
-    assume { Inv5.inv ( ^ _40) };
-    _39 <- ([#"../red_black_tree.rs" 757 27 757 47] MoveRedLeft0.move_red_left _40);
-    _40 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _39 <- ([#"../red_black_tree.rs" 757 27 757 47] MoveRedLeft0.move_red_left node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB19
   }
   BB19 {
-    _38 <- Borrow.borrow_mut ( * _39);
-    _39 <- { _39 with current = ( ^ _38) };
-    assume { Inv5.inv ( ^ _38) };
-    assert { [@expl:type invariant] Inv6.inv node };
-    assume { Resolve3.resolve node };
-    node <- _38;
-    _38 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
-    assert { [@expl:type invariant] Inv6.inv _39 };
-    assume { Resolve3.resolve _39 };
+    node <- _39;
+    _39 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _27 <- ();
     goto BB21
   }
@@ -10486,9 +10304,9 @@ module RedBlackTree_Impl15_DeleteRec
   BB21 {
     _42 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _42) b c d e) };
-    assume { Inv7.inv ( ^ _42) };
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assume { Inv3.inv ( ^ _42) };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     _41 <- ([#"../red_black_tree.rs" 759 20 759 45] delete_rec _42 key);
     _42 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB22
@@ -10514,7 +10332,7 @@ module RedBlackTree_Impl15_DeleteRec
   BB27 {
     _48 <- Borrow.borrow_mut ( * node);
     node <- { node with current = ( ^ _48) };
-    assume { Inv5.inv ( ^ _48) };
+    assume { Inv9.inv ( ^ _48) };
     _47 <- ([#"../red_black_tree.rs" 763 20 763 39] RotateRight0.rotate_right _48);
     _48 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB28
@@ -10522,9 +10340,9 @@ module RedBlackTree_Impl15_DeleteRec
   BB28 {
     _50 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _50)) };
-    assume { Inv7.inv ( ^ _50) };
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assume { Inv3.inv ( ^ _50) };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     _49 <- ([#"../red_black_tree.rs" 764 24 764 50] delete_rec _50 key);
     _50 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB29
@@ -10552,10 +10370,10 @@ module RedBlackTree_Impl15_DeleteRec
       end
   }
   BB35 {
-    assert { [@expl:type invariant] Inv6.inv node };
-    assume { Resolve3.resolve node };
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assert { [@expl:type invariant] Inv4.inv node };
+    assume { Resolve2.resolve node };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     switch (ord)
       | Core_Cmp_Ordering_Type.C_Greater -> goto BB36
       | _ -> goto BB38
@@ -10565,8 +10383,8 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB37
   }
   BB37 {
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve4.resolve self };
+    assert { [@expl:type invariant] Inv5.inv self };
+    assume { Resolve3.resolve self };
     _0 <- Core_Option_Option_Type.C_None;
     goto BB73
   }
@@ -10574,25 +10392,20 @@ module RedBlackTree_Impl15_DeleteRec
     _62 <- Borrow.borrow_mut (RedBlackTree_Tree_Type.tree_node ( * self));
     self <- { self with current = (let RedBlackTree_Tree_Type.C_Tree a =  * self in RedBlackTree_Tree_Type.C_Tree ( ^ _62)) };
     assume { Inv0.inv ( ^ _62) };
-    _61 <- Borrow.borrow_mut ( * _62);
-    _62 <- { _62 with current = ( ^ _61) };
-    assume { Inv0.inv ( ^ _61) };
-    _60 <- ([#"../red_black_tree.rs" 770 35 770 65] Take0.take _61);
-    _61 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
+    _60 <- ([#"../red_black_tree.rs" 770 35 770 65] Take0.take _62);
+    _62 <- any borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v));
     goto BB39
   }
   BB39 {
-    assert { [@expl:type invariant] Inv13.inv _62 };
-    assume { Resolve8.resolve _62 };
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve4.resolve self };
+    assert { [@expl:type invariant] Inv5.inv self };
+    assume { Resolve3.resolve self };
     node1 <- ([#"../red_black_tree.rs" 770 35 770 74] Unwrap2.unwrap _60);
     _60 <- any Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v);
     goto BB40
   }
   BB40 {
-    assert { [@expl:type invariant] Inv1.inv node1 };
-    assume { Resolve9.resolve node1 };
+    assert { [@expl:type invariant] Inv8.inv node1 };
+    assume { Resolve5.resolve node1 };
     goto BB41
   }
   BB41 {
@@ -10617,8 +10430,8 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB46
   }
   BB46 {
-    assert { [@expl:type invariant] Inv4.inv _70 };
-    assume { Resolve2.resolve _70 };
+    assert { [@expl:type invariant] Inv2.inv _70 };
+    assume { Resolve1.resolve _70 };
     _68 <- ([#"../red_black_tree.rs" 773 24 773 71] IsRed0.is_red (RedBlackTree_Node_Type.node_left _70));
     goto BB47
   }
@@ -10629,23 +10442,13 @@ module RedBlackTree_Impl15_DeleteRec
       end
   }
   BB48 {
-    _75 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _75) };
-    assume { Inv5.inv ( ^ _75) };
-    _74 <- ([#"../red_black_tree.rs" 774 31 774 52] MoveRedRight0.move_red_right _75);
-    _75 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _74 <- ([#"../red_black_tree.rs" 774 31 774 52] MoveRedRight0.move_red_right node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB49
   }
   BB49 {
-    _73 <- Borrow.borrow_mut ( * _74);
-    _74 <- { _74 with current = ( ^ _73) };
-    assume { Inv5.inv ( ^ _73) };
-    assert { [@expl:type invariant] Inv6.inv node };
-    assume { Resolve3.resolve node };
-    node <- _73;
-    _73 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
-    assert { [@expl:type invariant] Inv6.inv _74 };
-    assume { Resolve3.resolve _74 };
+    node <- _74;
+    _74 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     _66 <- ();
     goto BB51
   }
@@ -10663,11 +10466,11 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB53
   }
   BB53 {
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     _78 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _78)) };
-    assume { Inv7.inv ( ^ _78) };
+    assume { Inv3.inv ( ^ _78) };
     kv <- ([#"../red_black_tree.rs" 777 37 777 64] DeleteMinRec0.delete_min_rec _78);
     _78 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB54
@@ -10677,51 +10480,31 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB55
   }
   BB55 {
-    assume { Resolve5.resolve _79 };
+    assume { Resolve4.resolve _79 };
     _83 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_key ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b ( ^ _83) d e) };
-    assume { Inv9.inv ( ^ _83) };
-    _82 <- Borrow.borrow_mut ( * _83);
-    _83 <- { _83 with current = ( ^ _82) };
-    assume { Inv9.inv ( ^ _82) };
+    assume { Inv6.inv ( ^ _83) };
     _85 <- Borrow.borrow_mut (let (a, _) = kv in a);
     kv <- (let (a, b) = kv in ( ^ _85, b));
-    assume { Inv9.inv ( ^ _85) };
-    _84 <- Borrow.borrow_mut ( * _85);
-    _85 <- { _85 with current = ( ^ _84) };
-    assume { Inv9.inv ( ^ _84) };
-    _81 <- ([#"../red_black_tree.rs" 779 24 779 64] Swap0.swap _82 _84);
-    _82 <- any borrowed k;
-    _84 <- any borrowed k;
+    assume { Inv6.inv ( ^ _85) };
+    _81 <- ([#"../red_black_tree.rs" 779 24 779 64] Swap0.swap _83 _85);
+    _83 <- any borrowed k;
+    _85 <- any borrowed k;
     goto BB56
   }
   BB56 {
-    assert { [@expl:type invariant] Inv10.inv _85 };
-    assume { Resolve6.resolve _85 };
-    assert { [@expl:type invariant] Inv10.inv _83 };
-    assume { Resolve6.resolve _83 };
     _88 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c ( ^ _88) e) };
-    assume { Inv11.inv ( ^ _88) };
-    _87 <- Borrow.borrow_mut ( * _88);
-    _88 <- { _88 with current = ( ^ _87) };
-    assume { Inv11.inv ( ^ _87) };
+    assume { Inv7.inv ( ^ _88) };
     _90 <- Borrow.borrow_mut (let (_, a) = kv in a);
     kv <- (let (a, b) = kv in (a,  ^ _90));
-    assume { Inv11.inv ( ^ _90) };
-    _89 <- Borrow.borrow_mut ( * _90);
-    _90 <- { _90 with current = ( ^ _89) };
-    assume { Inv11.inv ( ^ _89) };
-    _86 <- ([#"../red_black_tree.rs" 780 24 780 64] Swap1.swap _87 _89);
-    _87 <- any borrowed v;
-    _89 <- any borrowed v;
+    assume { Inv7.inv ( ^ _90) };
+    _86 <- ([#"../red_black_tree.rs" 780 24 780 64] Swap1.swap _88 _90);
+    _88 <- any borrowed v;
+    _90 <- any borrowed v;
     goto BB57
   }
   BB57 {
-    assert { [@expl:type invariant] Inv12.inv _90 };
-    assume { Resolve7.resolve _90 };
-    assert { [@expl:type invariant] Inv12.inv _88 };
-    assume { Resolve7.resolve _88 };
     goto BB58
   }
   BB58 {
@@ -10742,9 +10525,9 @@ module RedBlackTree_Impl15_DeleteRec
   BB63 {
     _94 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _94)) };
-    assume { Inv7.inv ( ^ _94) };
-    assert { [@expl:type invariant] Inv3.inv key };
-    assume { Resolve1.resolve key };
+    assume { Inv3.inv ( ^ _94) };
+    assert { [@expl:type invariant] Inv1.inv key };
+    assume { Resolve0.resolve key };
     _93 <- ([#"../red_black_tree.rs" 783 28 783 54] delete_rec _94 key);
     _94 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     goto BB64
@@ -10765,18 +10548,13 @@ module RedBlackTree_Impl15_DeleteRec
     goto BB69
   }
   BB69 {
-    _97 <- Borrow.borrow_mut ( * node);
-    node <- { node with current = ( ^ _97) };
-    assume { Inv5.inv ( ^ _97) };
-    _96 <- ([#"../red_black_tree.rs" 788 8 788 22] Balance0.balance _97);
-    _97 <- any borrowed (RedBlackTree_Node_Type.t_node k v);
+    _96 <- ([#"../red_black_tree.rs" 788 8 788 22] Balance0.balance node);
+    node <- any borrowed (RedBlackTree_Node_Type.t_node k v);
     goto BB70
   }
   BB70 {
-    assert { [@expl:type invariant] Inv6.inv node };
-    assume { Resolve3.resolve node };
-    assert { [@expl:type invariant] Inv8.inv self };
-    assume { Resolve4.resolve self };
+    assert { [@expl:type invariant] Inv5.inv self };
+    assume { Resolve3.resolve self };
     _0 <- r;
     r <- any Core_Option_Option_Type.t_option (k, v);
     goto BB71
@@ -11896,17 +11674,17 @@ module RedBlackTree_Impl15_GetMut
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Core_Option_Option_Type as Core_Option_Option_Type
   use map.Map
-  clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
-    type t = Map.map DeepModelTy0.deepModelTy (Core_Option_Option_Type.t_option v)
-  clone TyInv_Trivial as TyInv_Trivial12 with
-    type t = Map.map DeepModelTy0.deepModelTy (Core_Option_Option_Type.t_option v),
-    predicate Inv0.inv = Inv12.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv11 with
-    type t = Core_Option_Option_Type.t_option (borrowed v)
+    type t = Map.map DeepModelTy0.deepModelTy (Core_Option_Option_Type.t_option v)
   clone TyInv_Trivial as TyInv_Trivial11 with
-    type t = Core_Option_Option_Type.t_option (borrowed v),
+    type t = Map.map DeepModelTy0.deepModelTy (Core_Option_Option_Type.t_option v),
     predicate Inv0.inv = Inv11.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
+    type t = Core_Option_Option_Type.t_option (borrowed v)
+  clone TyInv_Trivial as TyInv_Trivial10 with
+    type t = Core_Option_Option_Type.t_option (borrowed v),
+    predicate Inv0.inv = Inv10.inv,
     axiom .
   use RedBlackTree_Tree_Type as RedBlackTree_Tree_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
@@ -11955,22 +11733,16 @@ module RedBlackTree_Impl15_GetMut
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate HeightInvariant0.height_invariant = HeightInvariant0.height_invariant
-  clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
-  clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
-    predicate Inv0.inv = Inv10.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v))
   clone TyInv_Trivial as TyInv_Trivial9 with
-    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
+    type t = borrowed (Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)),
     predicate Inv0.inv = Inv9.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = borrowed v
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v)
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = borrowed v,
+    type t = borrowed (RedBlackTree_Node_Type.t_node k v),
     predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
@@ -12032,7 +11804,7 @@ module RedBlackTree_Impl15_GetMut
     type k = k,
     type v = v,
     predicate Inv0.inv = Inv6.inv,
-    predicate Inv1.inv = Inv12.inv,
+    predicate Inv1.inv = Inv11.inv,
     predicate Inv2.inv = Inv2.inv,
     function ModelAcc0.model_acc = ModelAcc0.model_acc,
     predicate Inv3.inv = Inv1.inv,
@@ -12045,7 +11817,7 @@ module RedBlackTree_Impl15_GetMut
     type v = v,
     predicate BstInvariant0.bst_invariant = BstInvariant0.bst_invariant,
     predicate Inv0.inv = Inv6.inv,
-    predicate Inv1.inv = Inv12.inv,
+    predicate Inv1.inv = Inv11.inv,
     predicate Inv2.inv = Inv2.inv,
     predicate Inv3.inv = Inv1.inv,
     predicate HasMapping0.has_mapping = HasMapping0.has_mapping,
@@ -12073,12 +11845,10 @@ module RedBlackTree_Impl15_GetMut
     predicate InternalInvariant0.internal_invariant = InternalInvariant0.internal_invariant,
     predicate ColorInvariant0.color_invariant = ColorInvariant0.color_invariant,
     function Color0.color = Color0.color
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
-    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
-    type t = RedBlackTree_Node_Type.t_node k v
+    type t = Core_Option_Option_Type.t_option (RedBlackTree_Node_Type.t_node k v)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
-    type t = v
+    type t = RedBlackTree_Node_Type.t_node k v
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
     type t = RedBlackTree_Tree_Type.t_tree k v
   clone Core_Cmp_Ord_Cmp_Interface as Cmp0 with
@@ -12116,7 +11886,7 @@ module RedBlackTree_Impl15_GetMut
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy,
     function ModelAccHasMapping0.model_acc_has_mapping = ModelAccHasMapping0.model_acc_has_mapping,
     function HasMappingModelAcc0.has_mapping_model_acc = HasMappingModelAcc0.has_mapping_model_acc,
-    predicate Inv3.inv = Inv12.inv,
+    predicate Inv3.inv = Inv11.inv,
     function ModelAcc0.model_acc = ModelAcc0.model_acc,
     axiom .
   let rec cfg get_mut [#"../red_black_tree.rs" 844 4 844 56] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (RedBlackTree_Tree_Type.t_tree k v)) (key : k) : Core_Option_Option_Type.t_option (borrowed v)
@@ -12128,7 +11898,7 @@ module RedBlackTree_Impl15_GetMut
       | Core_Option_Option_Type.C_Some v -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_Some ( * v) /\ ShallowModel1.shallow_model ( ^ self) = Map.set (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) (Core_Option_Option_Type.C_Some ( ^ v))
       | Core_Option_Option_Type.C_None -> Map.get (ShallowModel0.shallow_model self) (DeepModel0.deep_model key) = Core_Option_Option_Type.C_None /\ ShallowModel1.shallow_model ( ^ self) = ShallowModel0.shallow_model self
       end }
-    ensures { [#"../red_black_tree.rs" 844 42 844 56] Inv11.inv result }
+    ensures { [#"../red_black_tree.rs" 844 42 844 56] Inv10.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.t_option (borrowed v);
@@ -12142,11 +11912,8 @@ module RedBlackTree_Impl15_GetMut
   var node : borrowed (RedBlackTree_Node_Type.t_node k v);
   var _26 : Core_Cmp_Ordering_Type.t_ordering;
   var _29 : k;
-  var _31 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _32 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
-  var _34 : borrowed v;
   var _35 : borrowed v;
-  var _36 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   var _37 : borrowed (RedBlackTree_Tree_Type.t_tree k v);
   {
     goto BB0
@@ -12218,25 +11985,20 @@ module RedBlackTree_Impl15_GetMut
     _37 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_right ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c d ( ^ _37)) };
     assume { Inv6.inv ( ^ _37) };
-    _36 <- Borrow.borrow_mut ( * _37);
-    _37 <- { _37 with current = ( ^ _36) };
-    assume { Inv6.inv ( ^ _36) };
     assert { [@expl:type invariant] Inv7.inv tree };
     assume { Resolve3.resolve tree };
-    tree <- _36;
-    _36 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    tree <- _37;
+    _37 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     _22 <- ();
-    assert { [@expl:type invariant] Inv7.inv _37 };
-    assume { Resolve3.resolve _37 };
     goto BB14
   }
   BB11 {
-    assert { [@expl:type invariant] Inv9.inv node };
-    assume { Resolve5.resolve node };
+    assert { [@expl:type invariant] Inv8.inv node };
+    assume { Resolve4.resolve node };
     assert { [@expl:type invariant] Inv5.inv key };
     assume { Resolve2.resolve key };
-    assert { [@expl:type invariant] Inv10.inv _23 };
-    assume { Resolve6.resolve _23 };
+    assert { [@expl:type invariant] Inv9.inv _23 };
+    assume { Resolve5.resolve _23 };
     assert { [@expl:type invariant] Inv7.inv tree };
     assume { Resolve3.resolve tree };
     absurd
@@ -12245,16 +12007,11 @@ module RedBlackTree_Impl15_GetMut
     _32 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_left ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node ( ^ _32) b c d e) };
     assume { Inv6.inv ( ^ _32) };
-    _31 <- Borrow.borrow_mut ( * _32);
-    _32 <- { _32 with current = ( ^ _31) };
-    assume { Inv6.inv ( ^ _31) };
     assert { [@expl:type invariant] Inv7.inv tree };
     assume { Resolve3.resolve tree };
-    tree <- _31;
-    _31 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
+    tree <- _32;
+    _32 <- any borrowed (RedBlackTree_Tree_Type.t_tree k v);
     _22 <- ();
-    assert { [@expl:type invariant] Inv7.inv _32 };
-    assume { Resolve3.resolve _32 };
     goto BB14
   }
   BB13 {
@@ -12263,29 +12020,24 @@ module RedBlackTree_Impl15_GetMut
     _35 <- Borrow.borrow_mut (RedBlackTree_Node_Type.node_val ( * node));
     node <- { node with current = (let RedBlackTree_Node_Type.C_Node a b c d e =  * node in RedBlackTree_Node_Type.C_Node a b c ( ^ _35) e) };
     assume { Inv1.inv ( ^ _35) };
-    _34 <- Borrow.borrow_mut ( * _35);
-    _35 <- { _35 with current = ( ^ _34) };
-    assume { Inv1.inv ( ^ _34) };
-    _0 <- Core_Option_Option_Type.C_Some _34;
-    _34 <- any borrowed v;
-    assert { [@expl:type invariant] Inv8.inv _35 };
-    assume { Resolve4.resolve _35 };
-    assert { [@expl:type invariant] Inv9.inv node };
-    assume { Resolve5.resolve node };
-    assert { [@expl:type invariant] Inv10.inv _23 };
-    assume { Resolve6.resolve _23 };
+    _0 <- Core_Option_Option_Type.C_Some _35;
+    _35 <- any borrowed v;
+    assert { [@expl:type invariant] Inv8.inv node };
+    assume { Resolve4.resolve node };
+    assert { [@expl:type invariant] Inv9.inv _23 };
+    assume { Resolve5.resolve _23 };
     goto BB16
   }
   BB14 {
-    assert { [@expl:type invariant] Inv9.inv node };
-    assume { Resolve5.resolve node };
-    assert { [@expl:type invariant] Inv10.inv _23 };
-    assume { Resolve6.resolve _23 };
+    assert { [@expl:type invariant] Inv8.inv node };
+    assume { Resolve4.resolve node };
+    assert { [@expl:type invariant] Inv9.inv _23 };
+    assume { Resolve5.resolve _23 };
     goto BB3
   }
   BB15 {
-    assert { [@expl:type invariant] Inv10.inv _23 };
-    assume { Resolve6.resolve _23 };
+    assert { [@expl:type invariant] Inv9.inv _23 };
+    assume { Resolve5.resolve _23 };
     assert { [@expl:type invariant] Inv5.inv key };
     assume { Resolve2.resolve key };
     _0 <- Core_Option_Option_Type.C_None;

--- a/creusot/tests/should_succeed/resolve_uninit.mlcfg
+++ b/creusot/tests/should_succeed/resolve_uninit.mlcfg
@@ -201,11 +201,7 @@ module ResolveUninit_InitJoin
   var y : borrowed int32;
   var z : borrowed int32;
   var _5 : ();
-  var _7 : borrowed int32;
   var _8 : borrowed int32;
-  var _9 : borrowed int32;
-  var _10 : borrowed int32;
-  var _11 : borrowed int32;
   var _12 : borrowed int32;
   {
     goto BB0
@@ -219,29 +215,18 @@ module ResolveUninit_InitJoin
   BB1 {
     _8 <- Borrow.borrow_mut x;
     x <-  ^ _8;
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    z <- _7;
-    _7 <- any borrowed int32;
-    assume { Resolve0.resolve _8 };
-    _10 <- Borrow.borrow_mut ( * z);
-    z <- { z with current = ( ^ _10) };
-    _9 <- Borrow.borrow_mut ( * _10);
-    _10 <- { _10 with current = ( ^ _9) };
-    y <- _9;
-    _9 <- any borrowed int32;
-    assume { Resolve0.resolve _10 };
+    z <- _8;
+    _8 <- any borrowed int32;
+    y <- z;
+    z <- any borrowed int32;
     _5 <- ();
-    goto BB7
+    goto BB3
   }
   BB2 {
     _12 <- Borrow.borrow_mut x;
     x <-  ^ _12;
-    _11 <- Borrow.borrow_mut ( * _12);
-    _12 <- { _12 with current = ( ^ _11) };
-    y <- _11;
-    _11 <- any borrowed int32;
-    assume { Resolve0.resolve _12 };
+    y <- _12;
+    _12 <- any borrowed int32;
     _5 <- ();
     goto BB3
   }
@@ -259,10 +244,6 @@ module ResolveUninit_InitJoin
   BB5 {
     _0 <- ();
     return _0
-  }
-  BB7 {
-    assume { Resolve0.resolve z };
-    goto BB3
   }
   
 end

--- a/creusot/tests/should_succeed/result/own.mlcfg
+++ b/creusot/tests/should_succeed/result/own.mlcfg
@@ -651,27 +651,27 @@ module Own_Impl0_AsMut
     predicate Inv0.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (Own_OwnResult_Type.t_ownresult t e)
+    type t = borrowed e
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (Own_OwnResult_Type.t_ownresult t e),
+    type t = borrowed e,
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed e
+    type t = borrowed t
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed e,
+    type t = borrowed t,
     predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = e
+    type t = borrowed (Own_OwnResult_Type.t_ownresult t e)
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = e,
+    type t = borrowed (Own_OwnResult_Type.t_ownresult t e),
     predicate Inv0.inv = Inv2.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = borrowed t
+    type t = e
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = borrowed t,
+    type t = e,
     predicate Inv0.inv = Inv1.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
@@ -680,24 +680,18 @@ module Own_Impl0_AsMut
     type t = t,
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Own_OwnResult_Type.t_ownresult t e
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = e
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = t
+    type t = Own_OwnResult_Type.t_ownresult t e
   let rec cfg as_mut [#"../own.rs" 71 4 71 57] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Own_OwnResult_Type.t_ownresult t e)) : Own_OwnResult_Type.t_ownresult (borrowed t) (borrowed e)
-    requires {[#"../own.rs" 71 23 71 27] Inv4.inv self}
-    ensures { [#"../own.rs" 63 4 70 6] exists t : borrowed t . Inv1.inv t /\ ( * self = Own_OwnResult_Type.C_Ok ( * t) /\  ^ self = Own_OwnResult_Type.C_Ok ( ^ t) /\ result = Own_OwnResult_Type.C_Ok t \/ (exists e : borrowed e . Inv3.inv e /\  * self = Own_OwnResult_Type.C_Err ( * e) /\  ^ self = Own_OwnResult_Type.C_Err ( ^ e) /\ result = Own_OwnResult_Type.C_Err e)) }
+    requires {[#"../own.rs" 71 23 71 27] Inv2.inv self}
+    ensures { [#"../own.rs" 63 4 70 6] exists t : borrowed t . Inv3.inv t /\ ( * self = Own_OwnResult_Type.C_Ok ( * t) /\  ^ self = Own_OwnResult_Type.C_Ok ( ^ t) /\ result = Own_OwnResult_Type.C_Ok t \/ (exists e : borrowed e . Inv4.inv e /\  * self = Own_OwnResult_Type.C_Err ( * e) /\  ^ self = Own_OwnResult_Type.C_Err ( ^ e) /\ result = Own_OwnResult_Type.C_Err e)) }
     ensures { [#"../own.rs" 71 32 71 57] Inv5.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Own_OwnResult_Type.t_ownresult (borrowed t) (borrowed e);
   var self : borrowed (Own_OwnResult_Type.t_ownresult t e) = self;
   var x : borrowed t;
-  var _5 : borrowed t;
   var x1 : borrowed e;
-  var _7 : borrowed e;
   {
     goto BB0
   }
@@ -713,37 +707,27 @@ module Own_Impl0_AsMut
   BB2 {
     x1 <- Borrow.borrow_mut (Own_OwnResult_Type.err_0 ( * self));
     self <- { self with current = (let Own_OwnResult_Type.C_Err a =  * self in Own_OwnResult_Type.C_Err ( ^ x1)) };
-    assume { Inv2.inv ( ^ x1) };
-    _7 <- Borrow.borrow_mut ( * x1);
-    x1 <- { x1 with current = ( ^ _7) };
-    assume { Inv2.inv ( ^ _7) };
-    _0 <- Own_OwnResult_Type.C_Err _7;
-    _7 <- any borrowed e;
-    assert { [@expl:type invariant] Inv3.inv x1 };
-    assume { Resolve1.resolve x1 };
+    assume { Inv1.inv ( ^ x1) };
+    _0 <- Own_OwnResult_Type.C_Err x1;
+    x1 <- any borrowed e;
     goto BB5
   }
   BB3 {
-    assert { [@expl:type invariant] Inv4.inv self };
-    assume { Resolve2.resolve self };
+    assert { [@expl:type invariant] Inv2.inv self };
+    assume { Resolve0.resolve self };
     absurd
   }
   BB4 {
     x <- Borrow.borrow_mut (Own_OwnResult_Type.ok_0 ( * self));
     self <- { self with current = (let Own_OwnResult_Type.C_Ok a =  * self in Own_OwnResult_Type.C_Ok ( ^ x)) };
     assume { Inv0.inv ( ^ x) };
-    _5 <- Borrow.borrow_mut ( * x);
-    x <- { x with current = ( ^ _5) };
-    assume { Inv0.inv ( ^ _5) };
-    _0 <- Own_OwnResult_Type.C_Ok _5;
-    _5 <- any borrowed t;
-    assert { [@expl:type invariant] Inv1.inv x };
-    assume { Resolve0.resolve x };
+    _0 <- Own_OwnResult_Type.C_Ok x;
+    x <- any borrowed t;
     goto BB5
   }
   BB5 {
-    assert { [@expl:type invariant] Inv4.inv self };
-    assume { Resolve2.resolve self };
+    assert { [@expl:type invariant] Inv2.inv self };
+    assume { Resolve0.resolve self };
     return _0
   }
   

--- a/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max.mlcfg
@@ -50,9 +50,7 @@ module IncMax_TakeMax
   var _0 : borrowed uint32;
   var ma : borrowed uint32 = ma;
   var mb : borrowed uint32 = mb;
-  var _3 : borrowed uint32;
   var _5 : borrowed uint32;
-  var _9 : borrowed uint32;
   {
     goto BB0
   }
@@ -64,28 +62,19 @@ module IncMax_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _9) };
-    _5 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _5) };
-    assume { Resolve0.resolve _9 };
+    _5 <- ma;
+    ma <- any borrowed uint32;
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- Borrow.borrow_mut ( * mb);
-    mb <- { mb with current = ( ^ _5) };
+    _5 <- mb;
+    mb <- any borrowed uint32;
     goto BB3
   }
   BB3 {
-    _3 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _3) };
-    _0 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _3 };
-    assume { Resolve0.resolve mb };
-    assume { Resolve0.resolve ma };
+    _0 <- _5;
+    _5 <- any borrowed uint32;
     return _0
   }
   
@@ -112,9 +101,7 @@ module IncMax_IncMax
   var a : uint32 = a;
   var b : uint32 = b;
   var mc : borrowed uint32;
-  var _5 : borrowed uint32;
   var _6 : borrowed uint32;
-  var _7 : borrowed uint32;
   var _8 : borrowed uint32;
   {
     goto BB0
@@ -122,20 +109,14 @@ module IncMax_IncMax
   BB0 {
     _6 <- Borrow.borrow_mut a;
     a <-  ^ _6;
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
     _8 <- Borrow.borrow_mut b;
     b <-  ^ _8;
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    mc <- ([#"../inc_max.rs" 16 13 16 37] TakeMax0.take_max _5 _7);
-    _5 <- any borrowed uint32;
-    _7 <- any borrowed uint32;
+    mc <- ([#"../inc_max.rs" 16 13 16 37] TakeMax0.take_max _6 _8);
+    _6 <- any borrowed uint32;
+    _8 <- any borrowed uint32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _8 };
-    assume { Resolve0.resolve _6 };
     mc <- { mc with current = ([#"../inc_max.rs" 17 4 17 12]  * mc + ([#"../inc_max.rs" 17 11 17 12] (1 : uint32))) };
     assume { Resolve0.resolve mc };
     switch (not ([#"../inc_max.rs" 18 12 18 18] a <> b))

--- a/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_3.mlcfg
@@ -42,10 +42,8 @@ module IncMax3_IncMax3
   use prelude.Int
   use prelude.UInt32
   use prelude.Borrow
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = uint32
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = borrowed uint32
+    type t = uint32
   clone IncMax3_Swap_Interface as Swap0
   let rec cfg inc_max_3 [#"../inc_max_3.rs" 12 0 12 79] [@cfg:stackify] [@cfg:subregion_analysis] (ma : borrowed uint32) (mb : borrowed uint32) (mc : borrowed uint32) : ()
     requires {[#"../inc_max_3.rs" 10 11 10 76]  * ma <= (1000000 : uint32) /\  * mb <= (1000000 : uint32) /\  * mc <= (1000000 : uint32)}
@@ -58,21 +56,15 @@ module IncMax3_IncMax3
   var mc : borrowed uint32 = mc;
   var _6 : ();
   var _10 : ();
-  var _11 : borrowed (borrowed uint32);
   var _12 : borrowed (borrowed uint32);
-  var _13 : borrowed (borrowed uint32);
   var _14 : borrowed (borrowed uint32);
   var _15 : ();
   var _19 : ();
-  var _20 : borrowed (borrowed uint32);
   var _21 : borrowed (borrowed uint32);
-  var _22 : borrowed (borrowed uint32);
   var _23 : borrowed (borrowed uint32);
   var _24 : ();
   var _28 : ();
-  var _29 : borrowed (borrowed uint32);
   var _30 : borrowed (borrowed uint32);
-  var _31 : borrowed (borrowed uint32);
   var _32 : borrowed (borrowed uint32);
   {
     goto BB0
@@ -86,20 +78,14 @@ module IncMax3_IncMax3
   BB1 {
     _12 <- Borrow.borrow_mut ma;
     ma <-  ^ _12;
-    _11 <- Borrow.borrow_mut ( * _12);
-    _12 <- { _12 with current = ( ^ _11) };
     _14 <- Borrow.borrow_mut mb;
     mb <-  ^ _14;
-    _13 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _13) };
-    _10 <- ([#"../inc_max_3.rs" 14 8 14 30] Swap0.swap _11 _13);
-    _11 <- any borrowed (borrowed uint32);
-    _13 <- any borrowed (borrowed uint32);
+    _10 <- ([#"../inc_max_3.rs" 14 8 14 30] Swap0.swap _12 _14);
+    _12 <- any borrowed (borrowed uint32);
+    _14 <- any borrowed (borrowed uint32);
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve _14 };
-    assume { Resolve0.resolve _12 };
     _6 <- ();
     goto BB4
   }
@@ -116,26 +102,20 @@ module IncMax3_IncMax3
   BB5 {
     _21 <- Borrow.borrow_mut mb;
     mb <-  ^ _21;
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
     _23 <- Borrow.borrow_mut mc;
     mc <-  ^ _23;
-    _22 <- Borrow.borrow_mut ( * _23);
-    _23 <- { _23 with current = ( ^ _22) };
-    _19 <- ([#"../inc_max_3.rs" 17 8 17 30] Swap0.swap _20 _22);
-    _20 <- any borrowed (borrowed uint32);
-    _22 <- any borrowed (borrowed uint32);
+    _19 <- ([#"../inc_max_3.rs" 17 8 17 30] Swap0.swap _21 _23);
+    _21 <- any borrowed (borrowed uint32);
+    _23 <- any borrowed (borrowed uint32);
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _23 };
-    assume { Resolve0.resolve _21 };
-    assume { Resolve1.resolve mc };
+    assume { Resolve0.resolve mc };
     _15 <- ();
     goto BB8
   }
   BB7 {
-    assume { Resolve1.resolve mc };
+    assume { Resolve0.resolve mc };
     _15 <- ();
     goto BB8
   }
@@ -148,20 +128,14 @@ module IncMax3_IncMax3
   BB9 {
     _30 <- Borrow.borrow_mut ma;
     ma <-  ^ _30;
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
     _32 <- Borrow.borrow_mut mb;
     mb <-  ^ _32;
-    _31 <- Borrow.borrow_mut ( * _32);
-    _32 <- { _32 with current = ( ^ _31) };
-    _28 <- ([#"../inc_max_3.rs" 20 8 20 30] Swap0.swap _29 _31);
-    _29 <- any borrowed (borrowed uint32);
-    _31 <- any borrowed (borrowed uint32);
+    _28 <- ([#"../inc_max_3.rs" 20 8 20 30] Swap0.swap _30 _32);
+    _30 <- any borrowed (borrowed uint32);
+    _32 <- any borrowed (borrowed uint32);
     goto BB10
   }
   BB10 {
-    assume { Resolve0.resolve _32 };
-    assume { Resolve0.resolve _30 };
     _24 <- ();
     goto BB12
   }
@@ -171,9 +145,9 @@ module IncMax3_IncMax3
   }
   BB12 {
     ma <- { ma with current = ([#"../inc_max_3.rs" 22 4 22 12]  * ma + ([#"../inc_max_3.rs" 22 11 22 12] (2 : uint32))) };
-    assume { Resolve1.resolve ma };
+    assume { Resolve0.resolve ma };
     mb <- { mb with current = ([#"../inc_max_3.rs" 23 4 23 12]  * mb + ([#"../inc_max_3.rs" 23 11 23 12] (1 : uint32))) };
-    assume { Resolve1.resolve mb };
+    assume { Resolve0.resolve mb };
     _0 <- ();
     return _0
   }
@@ -190,8 +164,6 @@ module IncMax3_TestIncMax3
   use prelude.Borrow
   use prelude.Int
   use prelude.UInt32
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = uint32
   clone IncMax3_IncMax3_Interface as IncMax30
   let rec cfg test_inc_max_3 [#"../inc_max_3.rs" 27 0 27 57] [@cfg:stackify] [@cfg:subregion_analysis] (a : uint32) (b : uint32) (c : uint32) : ()
     requires {[#"../inc_max_3.rs" 26 11 26 70] a <= (1000000 : uint32) /\ b <= (1000000 : uint32) /\ c <= (1000000 : uint32)}
@@ -202,11 +174,8 @@ module IncMax3_TestIncMax3
   var b : uint32 = b;
   var c : uint32 = c;
   var _5 : ();
-  var _6 : borrowed uint32;
   var _7 : borrowed uint32;
-  var _8 : borrowed uint32;
   var _9 : borrowed uint32;
-  var _10 : borrowed uint32;
   var _11 : borrowed uint32;
   var _14 : bool;
   var _15 : bool;
@@ -216,26 +185,17 @@ module IncMax3_TestIncMax3
   BB0 {
     _7 <- Borrow.borrow_mut a;
     a <-  ^ _7;
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
     _9 <- Borrow.borrow_mut b;
     b <-  ^ _9;
-    _8 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _8) };
     _11 <- Borrow.borrow_mut c;
     c <-  ^ _11;
-    _10 <- Borrow.borrow_mut ( * _11);
-    _11 <- { _11 with current = ( ^ _10) };
-    _5 <- ([#"../inc_max_3.rs" 28 4 28 37] IncMax30.inc_max_3 _6 _8 _10);
-    _6 <- any borrowed uint32;
-    _8 <- any borrowed uint32;
-    _10 <- any borrowed uint32;
+    _5 <- ([#"../inc_max_3.rs" 28 4 28 37] IncMax30.inc_max_3 _7 _9 _11);
+    _7 <- any borrowed uint32;
+    _9 <- any borrowed uint32;
+    _11 <- any borrowed uint32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _11 };
-    assume { Resolve0.resolve _9 };
-    assume { Resolve0.resolve _7 };
     switch ([#"../inc_max_3.rs" 29 12 29 18] a <> b)
       | False -> goto BB5
       | True -> goto BB6

--- a/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_many.mlcfg
@@ -50,9 +50,7 @@ module IncMaxMany_TakeMax
   var _0 : borrowed uint32;
   var ma : borrowed uint32 = ma;
   var mb : borrowed uint32 = mb;
-  var _3 : borrowed uint32;
   var _5 : borrowed uint32;
-  var _9 : borrowed uint32;
   {
     goto BB0
   }
@@ -64,28 +62,19 @@ module IncMaxMany_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _9) };
-    _5 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _5) };
-    assume { Resolve0.resolve _9 };
+    _5 <- ma;
+    ma <- any borrowed uint32;
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- Borrow.borrow_mut ( * mb);
-    mb <- { mb with current = ( ^ _5) };
+    _5 <- mb;
+    mb <- any borrowed uint32;
     goto BB3
   }
   BB3 {
-    _3 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _3) };
-    _0 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _3 };
-    assume { Resolve0.resolve mb };
-    assume { Resolve0.resolve ma };
+    _0 <- _5;
+    _5 <- any borrowed uint32;
     return _0
   }
   
@@ -113,9 +102,7 @@ module IncMaxMany_IncMaxMany
   var b : uint32 = b;
   var k : uint32 = k;
   var mc : borrowed uint32;
-  var _6 : borrowed uint32;
   var _7 : borrowed uint32;
-  var _8 : borrowed uint32;
   var _9 : borrowed uint32;
   var _13 : bool;
   {
@@ -124,20 +111,14 @@ module IncMaxMany_IncMaxMany
   BB0 {
     _7 <- Borrow.borrow_mut a;
     a <-  ^ _7;
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
     _9 <- Borrow.borrow_mut b;
     b <-  ^ _9;
-    _8 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _8) };
-    mc <- ([#"../inc_max_many.rs" 16 13 16 37] TakeMax0.take_max _6 _8);
-    _6 <- any borrowed uint32;
-    _8 <- any borrowed uint32;
+    mc <- ([#"../inc_max_many.rs" 16 13 16 37] TakeMax0.take_max _7 _9);
+    _7 <- any borrowed uint32;
+    _9 <- any borrowed uint32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _9 };
-    assume { Resolve0.resolve _7 };
     mc <- { mc with current = ([#"../inc_max_many.rs" 17 4 17 12]  * mc + k) };
     assume { Resolve0.resolve mc };
     switch ([#"../inc_max_many.rs" 18 12 18 22] a >= ([#"../inc_max_many.rs" 18 17 18 22] b + k))

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -50,9 +50,7 @@ module IncMaxRepeat_TakeMax
   var _0 : borrowed uint32;
   var ma : borrowed uint32 = ma;
   var mb : borrowed uint32 = mb;
-  var _3 : borrowed uint32;
   var _5 : borrowed uint32;
-  var _9 : borrowed uint32;
   {
     goto BB0
   }
@@ -64,28 +62,19 @@ module IncMaxRepeat_TakeMax
   }
   BB1 {
     assume { Resolve0.resolve mb };
-    _9 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _9) };
-    _5 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _5) };
-    assume { Resolve0.resolve _9 };
+    _5 <- ma;
+    ma <- any borrowed uint32;
     goto BB3
   }
   BB2 {
     assume { Resolve0.resolve ma };
-    _5 <- Borrow.borrow_mut ( * mb);
-    mb <- { mb with current = ( ^ _5) };
+    _5 <- mb;
+    mb <- any borrowed uint32;
     goto BB3
   }
   BB3 {
-    _3 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _3) };
-    _0 <- Borrow.borrow_mut ( * _3);
-    _3 <- { _3 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _3 };
-    assume { Resolve0.resolve mb };
-    assume { Resolve0.resolve ma };
+    _0 <- _5;
+    _5 <- any borrowed uint32;
     return _0
   }
   
@@ -571,6 +560,8 @@ module IncMaxRepeat_IncMaxRepeat
     predicate Inv0.inv = Inv2.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+    type t = Core_Ops_Range_Range_Type.t_range uint32
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range uint32)
   clone TyInv_Trivial as TyInv_Trivial1 with
@@ -579,11 +570,9 @@ module IncMaxRepeat_IncMaxRepeat
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl7_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range uint32
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = uint32,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve1.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = Core_Ops_Range_Range_Type.t_range uint32
@@ -609,7 +598,7 @@ module IncMaxRepeat_IncMaxRepeat
     type i = Core_Ops_Range_Range_Type.t_range uint32
   clone CreusotContracts_Std1_Iter_Impl0_IntoIterPre as IntoIterPre0 with
     type i = Core_Ops_Range_Range_Type.t_range uint32
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = uint32
   clone IncMaxRepeat_TakeMax_Interface as TakeMax0
   clone Core_Iter_Range_Impl3_Next_Interface as Next0 with
@@ -635,14 +624,11 @@ module IncMaxRepeat_IncMaxRepeat
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range uint32);
   var produced : Ghost.ghost_ty (Seq.seq uint32);
   var _18 : Core_Option_Option_Type.t_option uint32;
-  var _19 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _20 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var __creusot_proc_iter_elem : uint32;
   var _23 : Ghost.ghost_ty (Seq.seq uint32);
   var mc : borrowed uint32;
-  var _26 : borrowed uint32;
   var _27 : borrowed uint32;
-  var _28 : borrowed uint32;
   var _29 : borrowed uint32;
   var _33 : bool;
   {
@@ -673,14 +659,11 @@ module IncMaxRepeat_IncMaxRepeat
   BB5 {
     _20 <- Borrow.borrow_mut iter;
     iter <-  ^ _20;
-    _19 <- Borrow.borrow_mut ( * _20);
-    _20 <- { _20 with current = ( ^ _19) };
-    _18 <- ([#"../inc_max_repeat.rs" 16 4 16 86] Next0.next _19);
-    _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);
+    _18 <- ([#"../inc_max_repeat.rs" 16 4 16 86] Next0.next _20);
+    _20 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _20 };
     switch (_18)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8
@@ -708,22 +691,16 @@ module IncMaxRepeat_IncMaxRepeat
     _23 <- any Ghost.ghost_ty (Seq.seq uint32);
     _27 <- Borrow.borrow_mut a;
     a <-  ^ _27;
-    _26 <- Borrow.borrow_mut ( * _27);
-    _27 <- { _27 with current = ( ^ _26) };
     _29 <- Borrow.borrow_mut b;
     b <-  ^ _29;
-    _28 <- Borrow.borrow_mut ( * _29);
-    _29 <- { _29 with current = ( ^ _28) };
-    mc <- ([#"../inc_max_repeat.rs" 19 17 19 41] TakeMax0.take_max _26 _28);
-    _26 <- any borrowed uint32;
-    _28 <- any borrowed uint32;
+    mc <- ([#"../inc_max_repeat.rs" 19 17 19 41] TakeMax0.take_max _27 _29);
+    _27 <- any borrowed uint32;
+    _29 <- any borrowed uint32;
     goto BB12
   }
   BB12 {
-    assume { Resolve1.resolve _29 };
-    assume { Resolve1.resolve _27 };
     mc <- { mc with current = ([#"../inc_max_repeat.rs" 20 8 20 16]  * mc + ([#"../inc_max_repeat.rs" 20 15 20 16] (1 : uint32))) };
-    assume { Resolve1.resolve mc };
+    assume { Resolve0.resolve mc };
     goto BB4
   }
   BB13 {

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_list.mlcfg
@@ -312,7 +312,6 @@ module IncSome2List_Impl0_TakeSomeRest
   var ml : borrowed (IncSome2List_List_Type.t_list);
   var _8 : Ghost.ghost_ty ();
   var _10 : bool;
-  var _11 : borrowed uint32;
   var _12 : borrowed (IncSome2List_List_Type.t_list);
   var _13 : borrowed (IncSome2List_List_Type.t_list);
   {
@@ -354,12 +353,10 @@ module IncSome2List_Impl0_TakeSomeRest
       end
   }
   BB7 {
-    _11 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _11) };
     _12 <- Borrow.borrow_mut ( * ml);
     ml <- { ml with current = ( ^ _12) };
-    _0 <- (_11, _12);
-    _11 <- any borrowed uint32;
+    _0 <- (ma, _12);
+    ma <- any borrowed uint32;
     _12 <- any borrowed (IncSome2List_List_Type.t_list);
     goto BB10
   }
@@ -376,7 +373,6 @@ module IncSome2List_Impl0_TakeSomeRest
   }
   BB10 {
     assume { Resolve1.resolve ml };
-    assume { Resolve0.resolve ma };
     assume { Resolve2.resolve self };
     return _0
   }
@@ -446,15 +442,15 @@ module IncSome2List_IncSome2List
   use prelude.Int
   use prelude.UInt32
   clone CreusotContracts_Std1_Num_Impl6_ShallowModel as ShallowModel1
+  use IncSome2List_List_Type as IncSome2List_List_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+    type t = IncSome2List_List_Type.t_list
   use prelude.Int
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = uint32,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
-  use IncSome2List_List_Type as IncSome2List_List_Type
   clone IncSome2List_Impl0_Sum as Sum0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = IncSome2List_List_Type.t_list
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = uint32
   clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
@@ -482,7 +478,6 @@ module IncSome2List_IncSome2List
   var _10 : borrowed (IncSome2List_List_Type.t_list);
   var mb : borrowed uint32;
   var _12 : (borrowed uint32, borrowed (IncSome2List_List_Type.t_list));
-  var _13 : borrowed (IncSome2List_List_Type.t_list);
   var _19 : uint32;
   {
     goto BB0
@@ -507,10 +502,8 @@ module IncSome2List_IncSome2List
     ml <- (let (_, a) = _9 in a);
     _9 <- (let (a, b) = _9 in (a, any borrowed (IncSome2List_List_Type.t_list)));
     assume { Resolve0.resolve _9 };
-    _13 <- Borrow.borrow_mut ( * ml);
-    ml <- { ml with current = ( ^ _13) };
-    _12 <- ([#"../inc_some_2_list.rs" 73 18 73 37] TakeSomeRest0.take_some_rest _13);
-    _13 <- any borrowed (IncSome2List_List_Type.t_list);
+    _12 <- ([#"../inc_some_2_list.rs" 73 18 73 37] TakeSomeRest0.take_some_rest ml);
+    ml <- any borrowed (IncSome2List_List_Type.t_list);
     goto BB4
   }
   BB4 {
@@ -521,7 +514,6 @@ module IncSome2List_IncSome2List
     assume { Resolve1.resolve ma };
     mb <- { mb with current = ([#"../inc_some_2_list.rs" 75 4 75 12]  * mb + k) };
     assume { Resolve1.resolve mb };
-    assume { Resolve2.resolve ml };
     _19 <- ([#"../inc_some_2_list.rs" 76 12 76 21] SumX0.sum_x l);
     goto BB5
   }

--- a/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_2_tree.mlcfg
@@ -328,8 +328,6 @@ module IncSome2Tree_Impl0_TakeSomeRest
   var ma : borrowed uint32;
   var mtr : borrowed (IncSome2Tree_Tree_Type.t_tree);
   var _11 : bool;
-  var _12 : borrowed uint32;
-  var _13 : borrowed (IncSome2Tree_Tree_Type.t_tree);
   var _14 : borrowed (IncSome2Tree_Tree_Type.t_tree);
   var _15 : bool;
   var _16 : borrowed (IncSome2Tree_Tree_Type.t_tree);
@@ -374,8 +372,6 @@ module IncSome2Tree_Impl0_TakeSomeRest
       end
   }
   BB6 {
-    _12 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _12) };
     _15 <- ([#"../inc_some_2_tree.rs" 72 28 72 36] Random0.random ());
     goto BB7
   }
@@ -389,9 +385,8 @@ module IncSome2Tree_Impl0_TakeSomeRest
     assume { Resolve1.resolve mtr };
     _16 <- Borrow.borrow_mut ( * mtl);
     mtl <- { mtl with current = ( ^ _16) };
-    _14 <- Borrow.borrow_mut ( * _16);
-    _16 <- { _16 with current = ( ^ _14) };
-    assume { Resolve2.resolve _16 };
+    _14 <- _16;
+    _16 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
     goto BB10
   }
   BB9 {
@@ -401,12 +396,9 @@ module IncSome2Tree_Impl0_TakeSomeRest
     goto BB10
   }
   BB10 {
-    _13 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _13) };
-    _0 <- (_12, _13);
-    _12 <- any borrowed uint32;
-    _13 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
-    assume { Resolve2.resolve _14 };
+    _0 <- (ma, _14);
+    ma <- any borrowed uint32;
+    _14 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
     goto BB18
   }
   BB11 {
@@ -447,7 +439,6 @@ module IncSome2Tree_Impl0_TakeSomeRest
   }
   BB18 {
     assume { Resolve1.resolve mtr };
-    assume { Resolve0.resolve ma };
     assume { Resolve1.resolve mtl };
     assume { Resolve2.resolve self };
     return _0
@@ -518,15 +509,15 @@ module IncSome2Tree_IncSome2Tree
   use prelude.Int
   use prelude.UInt32
   clone CreusotContracts_Std1_Num_Impl6_ShallowModel as ShallowModel1
+  use IncSome2Tree_Tree_Type as IncSome2Tree_Tree_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+    type t = IncSome2Tree_Tree_Type.t_tree
   use prelude.Int
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = uint32,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
-  use IncSome2Tree_Tree_Type as IncSome2Tree_Tree_Type
   clone IncSome2Tree_Impl0_Sum as Sum0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = IncSome2Tree_Tree_Type.t_tree
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = uint32
   clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
@@ -554,7 +545,6 @@ module IncSome2Tree_IncSome2Tree
   var _10 : borrowed (IncSome2Tree_Tree_Type.t_tree);
   var mb : borrowed uint32;
   var _12 : (borrowed uint32, borrowed (IncSome2Tree_Tree_Type.t_tree));
-  var _13 : borrowed (IncSome2Tree_Tree_Type.t_tree);
   var _19 : uint32;
   {
     goto BB0
@@ -579,10 +569,8 @@ module IncSome2Tree_IncSome2Tree
     mt <- (let (_, a) = _9 in a);
     _9 <- (let (a, b) = _9 in (a, any borrowed (IncSome2Tree_Tree_Type.t_tree)));
     assume { Resolve0.resolve _9 };
-    _13 <- Borrow.borrow_mut ( * mt);
-    mt <- { mt with current = ( ^ _13) };
-    _12 <- ([#"../inc_some_2_tree.rs" 88 18 88 37] TakeSomeRest0.take_some_rest _13);
-    _13 <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
+    _12 <- ([#"../inc_some_2_tree.rs" 88 18 88 37] TakeSomeRest0.take_some_rest mt);
+    mt <- any borrowed (IncSome2Tree_Tree_Type.t_tree);
     goto BB4
   }
   BB4 {
@@ -593,7 +581,6 @@ module IncSome2Tree_IncSome2Tree
     assume { Resolve1.resolve ma };
     mb <- { mb with current = ([#"../inc_some_2_tree.rs" 90 4 90 12]  * mb + k) };
     assume { Resolve1.resolve mb };
-    assume { Resolve2.resolve mt };
     _19 <- ([#"../inc_some_2_tree.rs" 91 12 91 21] SumX0.sum_x t);
     goto BB5
   }

--- a/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_list.mlcfg
@@ -306,15 +306,11 @@ module IncSomeList_Impl0_TakeSome
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : borrowed uint32;
   var self : borrowed (IncSomeList_List_Type.t_list) = self;
-  var _2 : borrowed uint32;
-  var _5 : borrowed uint32;
   var ma : borrowed uint32;
   var ml : borrowed (IncSomeList_List_Type.t_list);
-  var _9 : borrowed uint32;
   var _10 : Ghost.ghost_ty ();
   var _12 : borrowed uint32;
   var _13 : bool;
-  var _14 : borrowed uint32;
   var _15 : borrowed uint32;
   var _16 : borrowed (IncSomeList_List_Type.t_list);
   {
@@ -357,11 +353,8 @@ module IncSomeList_Impl0_TakeSome
   }
   BB7 {
     assume { Resolve1.resolve ml };
-    _14 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _14) };
-    _12 <- Borrow.borrow_mut ( * _14);
-    _14 <- { _14 with current = ( ^ _12) };
-    assume { Resolve0.resolve _14 };
+    _12 <- ma;
+    ma <- any borrowed uint32;
     goto BB10
   }
   BB8 {
@@ -373,26 +366,14 @@ module IncSomeList_Impl0_TakeSome
     goto BB9
   }
   BB9 {
-    _12 <- Borrow.borrow_mut ( * _15);
-    _15 <- { _15 with current = ( ^ _12) };
-    assume { Resolve0.resolve _15 };
+    _12 <- _15;
+    _15 <- any borrowed uint32;
     goto BB10
   }
   BB10 {
-    _9 <- Borrow.borrow_mut ( * _12);
-    _12 <- { _12 with current = ( ^ _9) };
-    _5 <- Borrow.borrow_mut ( * _9);
-    _9 <- { _9 with current = ( ^ _5) };
-    assume { Resolve0.resolve _12 };
-    assume { Resolve0.resolve _9 };
     assume { Resolve1.resolve ml };
-    assume { Resolve0.resolve ma };
-    _2 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _2) };
-    _0 <- Borrow.borrow_mut ( * _2);
-    _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _2 };
+    _0 <- _12;
+    _12 <- any borrowed uint32;
     assume { Resolve2.resolve self };
     return _0
   }

--- a/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_some_tree.mlcfg
@@ -322,17 +322,12 @@ module IncSomeTree_Impl0_TakeSome
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : borrowed uint32;
   var self : borrowed (IncSomeTree_Tree_Type.t_tree) = self;
-  var _2 : borrowed uint32;
-  var _5 : borrowed uint32;
   var mtl : borrowed (IncSomeTree_Tree_Type.t_tree);
   var ma : borrowed uint32;
   var mtr : borrowed (IncSomeTree_Tree_Type.t_tree);
-  var _10 : borrowed uint32;
   var _13 : borrowed uint32;
   var _14 : bool;
-  var _15 : borrowed uint32;
   var _16 : bool;
-  var _17 : borrowed uint32;
   var _18 : borrowed uint32;
   var _19 : borrowed (IncSomeTree_Tree_Type.t_tree);
   var _20 : borrowed uint32;
@@ -377,11 +372,8 @@ module IncSomeTree_Impl0_TakeSome
   BB6 {
     assume { Resolve1.resolve mtr };
     assume { Resolve1.resolve mtl };
-    _15 <- Borrow.borrow_mut ( * ma);
-    ma <- { ma with current = ( ^ _15) };
-    _13 <- Borrow.borrow_mut ( * _15);
-    _15 <- { _15 with current = ( ^ _13) };
-    assume { Resolve0.resolve _15 };
+    _13 <- ma;
+    ma <- any borrowed uint32;
     goto BB14
   }
   BB7 {
@@ -404,12 +396,8 @@ module IncSomeTree_Impl0_TakeSome
     goto BB10
   }
   BB10 {
-    _17 <- Borrow.borrow_mut ( * _18);
-    _18 <- { _18 with current = ( ^ _17) };
-    _13 <- Borrow.borrow_mut ( * _17);
-    _17 <- { _17 with current = ( ^ _13) };
-    assume { Resolve0.resolve _18 };
-    assume { Resolve0.resolve _17 };
+    _13 <- _18;
+    _18 <- any borrowed uint32;
     goto BB13
   }
   BB11 {
@@ -421,30 +409,18 @@ module IncSomeTree_Impl0_TakeSome
     goto BB12
   }
   BB12 {
-    _13 <- Borrow.borrow_mut ( * _20);
-    _20 <- { _20 with current = ( ^ _13) };
-    assume { Resolve0.resolve _20 };
+    _13 <- _20;
+    _20 <- any borrowed uint32;
     goto BB13
   }
   BB13 {
     goto BB14
   }
   BB14 {
-    _10 <- Borrow.borrow_mut ( * _13);
-    _13 <- { _13 with current = ( ^ _10) };
-    _5 <- Borrow.borrow_mut ( * _10);
-    _10 <- { _10 with current = ( ^ _5) };
-    assume { Resolve0.resolve _13 };
-    assume { Resolve0.resolve _10 };
     assume { Resolve1.resolve mtr };
-    assume { Resolve0.resolve ma };
     assume { Resolve1.resolve mtl };
-    _2 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _2) };
-    _0 <- Borrow.borrow_mut ( * _2);
-    _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _2 };
+    _0 <- _13;
+    _13 <- any borrowed uint32;
     assume { Resolve2.resolve self };
     return _0
   }

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -674,6 +674,17 @@ module CreusotContracts_Model_Impl6_DeepModel
     ensures { result = deep_model self }
     
 end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_None -> any 't
+      | C_Some a -> a
+      end
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -695,17 +706,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
-end
-module Core_Option_Option_Type
-  type t_option 't =
-    | C_None
-    | C_Some 't
-    
-  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
-    match (self) with
-      | C_None -> any 't
-      | C_Some a -> a
-      end
 end
 module TyInv_Trivial
   type t
@@ -1985,10 +1985,22 @@ module SelectionSortGeneric_SelectionSort
     predicate Inv0.inv = Inv11.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv10 with
-    type t = usize
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial10 with
-    type t = usize,
+    type t = slice t,
     predicate Inv0.inv = Inv10.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+    type t = borrowed (slice t)
+  clone TyInv_Trivial as TyInv_Trivial9 with
+    type t = borrowed (slice t),
+    predicate Inv0.inv = Inv9.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+    type t = usize
+  clone TyInv_Trivial as TyInv_Trivial8 with
+    type t = usize,
+    predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_GtLog_Interface as GtLog0 with
     type self = DeepModelTy0.deepModelTy
@@ -1998,26 +2010,28 @@ module SelectionSortGeneric_SelectionSort
   clone CreusotContracts_Logic_Ord_OrdLogic_CmpLog_Interface as CmpLog0 with
     type self = DeepModelTy0.deepModelTy
   use Core_Option_Option_Type as Core_Option_Option_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv9 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
     type t = Core_Option_Option_Type.t_option usize
-  clone TyInv_Trivial as TyInv_Trivial9 with
+  clone TyInv_Trivial as TyInv_Trivial7 with
     type t = Core_Option_Option_Type.t_option usize,
-    predicate Inv0.inv = Inv9.inv,
+    predicate Inv0.inv = Inv7.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
-  clone TyInv_Trivial as TyInv_Trivial8 with
+  clone TyInv_Trivial as TyInv_Trivial6 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize),
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv6.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial7 with
+  clone TyInv_Trivial as TyInv_Trivial5 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_DeepModel_DeepModel_Interface as DeepModel4 with
     type self = t,
@@ -2039,27 +2053,15 @@ module SelectionSortGeneric_SelectionSort
     predicate Inv0.inv = Inv3.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv11.inv
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (slice t)
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (slice t),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = slice t
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = slice t,
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel6 with
     type t = t,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv10.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv11.inv,
     axiom .
@@ -2140,11 +2142,9 @@ module SelectionSortGeneric_SelectionSort
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel2
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve3.resolve,
     function DeepModel0.deep_model = DeepModel2.deep_model
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
@@ -2207,28 +2207,26 @@ module SelectionSortGeneric_SelectionSort
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv11.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve4 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = slice t
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv9.inv,
     function ShallowModel1.shallow_model = ShallowModel6.shallow_model,
-    predicate Inv1.inv = Inv4.inv,
+    predicate Inv1.inv = Inv10.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv11.inv
   clone Alloc_Vec_Impl9_DerefMut_Interface as DerefMut0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel2.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv1.inv = Inv5.inv,
-    predicate Inv2.inv = Inv4.inv,
+    predicate Inv1.inv = Inv9.inv,
+    predicate Inv2.inv = Inv10.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv3.inv = Inv11.inv,
     predicate Inv4.inv = Inv3.inv
@@ -2241,7 +2239,7 @@ module SelectionSortGeneric_SelectionSort
     function DeepModel1.deep_model = DeepModel3.deep_model,
     function LtLog0.lt_log = LtLog0.lt_log,
     type DeepModelTy0.deepModelTy = DeepModelTy0.deepModelTy
-  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve2 with
+  clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve1 with
     type self = t
   clone Alloc_Vec_Impl12_Index_Interface as Index0 with
     type t = t,
@@ -2249,17 +2247,17 @@ module SelectionSortGeneric_SelectionSort
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model,
     predicate InBounds0.in_bounds = InBounds0.in_bounds,
-    predicate Inv0.inv = Inv7.inv,
-    predicate Inv1.inv = Inv10.inv,
+    predicate Inv0.inv = Inv5.inv,
+    predicate Inv1.inv = Inv8.inv,
     predicate HasValue0.has_value = HasValue0.has_value,
     predicate Inv2.inv = Inv2.inv,
     type Output0.output = t
   clone Core_Iter_Range_Impl3_Next_Interface as Next0 with
     type a = usize,
-    predicate Inv0.inv = Inv8.inv,
+    predicate Inv0.inv = Inv6.inv,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv1.inv = Inv9.inv
+    predicate Inv1.inv = Inv7.inv
   clone SelectionSortGeneric_Partition as Partition0 with
     type t = DeepModelTy0.deepModelTy,
     function LeLog0.le_log = LeLog0.le_log
@@ -2281,12 +2279,12 @@ module SelectionSortGeneric_SelectionSort
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv5.inv,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)))
   let rec cfg selection_sort [#"../selection_sort_generic.rs" 30 0 32 29] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    requires {[#"../selection_sort_generic.rs" 30 42 30 43] Inv6.inv v}
+    requires {[#"../selection_sort_generic.rs" 30 42 30 43] Inv4.inv v}
     ensures { [#"../selection_sort_generic.rs" 28 10 28 35] Sorted0.sorted (DeepModel1.deep_model ( ^ v)) }
     ensures { [#"../selection_sort_generic.rs" 29 0 29 36] PermutationOf0.permutation_of (ShallowModel2.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
     
@@ -2300,7 +2298,6 @@ module SelectionSortGeneric_SelectionSort
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _19 : ();
   var _20 : Core_Option_Option_Type.t_option usize;
-  var _21 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _22 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _25 : Ghost.ghost_ty (Seq.seq usize);
@@ -2311,7 +2308,6 @@ module SelectionSortGeneric_SelectionSort
   var iter_old1 : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced1 : Ghost.ghost_ty (Seq.seq usize);
   var _44 : Core_Option_Option_Type.t_option usize;
-  var _45 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _46 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem1 : usize;
   var _49 : Ghost.ghost_ty (Seq.seq usize);
@@ -2320,7 +2316,6 @@ module SelectionSortGeneric_SelectionSort
   var _54 : t;
   var _58 : t;
   var _63 : ();
-  var _64 : borrowed (slice t);
   var _65 : borrowed (slice t);
   var _66 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
@@ -2363,22 +2358,19 @@ module SelectionSortGeneric_SelectionSort
   BB7 {
     _22 <- Borrow.borrow_mut iter;
     iter <-  ^ _22;
-    _21 <- Borrow.borrow_mut ( * _22);
-    _22 <- { _22 with current = ( ^ _21) };
-    _20 <- ([#"../selection_sort_generic.rs" 35 4 35 43] Next0.next _21);
-    _21 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _20 <- ([#"../selection_sort_generic.rs" 35 4 35 43] Next0.next _22);
+    _22 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _22 };
     switch (_20)
       | Core_Option_Option_Type.C_None -> goto BB9
       | Core_Option_Option_Type.C_Some _ -> goto BB10
       end
   }
   BB9 {
-    assert { [@expl:type invariant] Inv6.inv v };
-    assume { Resolve4.resolve v };
+    assert { [@expl:type invariant] Inv4.inv v };
+    assume { Resolve2.resolve v };
     _0 <- ();
     return _0
   }
@@ -2427,14 +2419,11 @@ module SelectionSortGeneric_SelectionSort
   BB19 {
     _46 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _46;
-    _45 <- Borrow.borrow_mut ( * _46);
-    _46 <- { _46 with current = ( ^ _45) };
-    _44 <- ([#"../selection_sort_generic.rs" 41 8 41 121] Next0.next _45);
-    _45 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _44 <- ([#"../selection_sort_generic.rs" 41 8 41 121] Next0.next _46);
+    _46 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB20
   }
   BB20 {
-    assume { Resolve1.resolve _46 };
     switch (_44)
       | Core_Option_Option_Type.C_None -> goto BB21
       | Core_Option_Option_Type.C_Some _ -> goto BB22
@@ -2465,13 +2454,13 @@ module SelectionSortGeneric_SelectionSort
   }
   BB25 {
     assert { [@expl:type invariant] Inv2.inv _54 };
-    assume { Resolve2.resolve _54 };
+    assume { Resolve1.resolve _54 };
     _58 <- ([#"../selection_sort_generic.rs" 44 22 44 28] Index0.index ( * v) min);
     goto BB26
   }
   BB26 {
     assert { [@expl:type invariant] Inv2.inv _58 };
-    assume { Resolve2.resolve _58 };
+    assume { Resolve1.resolve _58 };
     _52 <- ([#"../selection_sort_generic.rs" 44 15 44 28] Lt0.lt _54 _58);
     goto BB27
   }
@@ -2494,28 +2483,23 @@ module SelectionSortGeneric_SelectionSort
     goto BB18
   }
   BB31 {
-    _64 <- Borrow.borrow_mut ( * _65);
-    _65 <- { _65 with current = ( ^ _64) };
-    assume { Inv4.inv ( ^ _64) };
-    _63 <- ([#"../selection_sort_generic.rs" 48 8 48 22] Swap0.swap _64 i min);
-    _64 <- any borrowed (slice t);
+    _63 <- ([#"../selection_sort_generic.rs" 48 8 48 22] Swap0.swap _65 i min);
+    _65 <- any borrowed (slice t);
     goto BB32
   }
   BB32 {
-    assert { [@expl:type invariant] Inv5.inv _65 };
-    assume { Resolve3.resolve _65 };
     assert { [@expl:assertion] [#"../selection_sort_generic.rs" 49 8 50 63] let i = Seq.length (Ghost.inner produced) in forall k2 : int . forall k1 : int . 0 <= k1 /\ k1 < i /\ i <= k2 /\ k2 < Seq.length (DeepModel0.deep_model v) -> LeLog0.le_log (Seq.get (DeepModel0.deep_model v) k1) (Seq.get (DeepModel0.deep_model v) k2) };
     _19 <- ();
     goto BB6
   }
   BB34 {
-    assert { [@expl:type invariant] Inv6.inv v };
-    assume { Resolve4.resolve v };
+    assert { [@expl:type invariant] Inv4.inv v };
+    assume { Resolve2.resolve v };
     goto BB11
   }
   BB35 {
-    assert { [@expl:type invariant] Inv6.inv v };
-    assume { Resolve4.resolve v };
+    assert { [@expl:type invariant] Inv4.inv v };
+    assume { Resolve2.resolve v };
     goto BB11
   }
   

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -383,28 +383,6 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
     ensures { result = produces self visited o }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module Core_Option_Option_Type
   type t_option 't =
     | C_None
@@ -1102,8 +1080,6 @@ module Sum_SumFirstN
     type i = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32
   clone CreusotContracts_Std1_Iter_Impl0_IntoIterPre as IntoIterPre0 with
     type i = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32
   clone Core_Iter_Range_Impl12_Next_Interface as Next0 with
     type a = uint32,
     predicate Inv0.inv = Inv2.inv,
@@ -1138,7 +1114,6 @@ module Sum_SumFirstN
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
   var produced : Ghost.ghost_ty (Seq.seq uint32);
   var _17 : Core_Option_Option_Type.t_option uint32;
-  var _18 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
   var _19 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
   var __creusot_proc_iter_elem : uint32;
   var _22 : Ghost.ghost_ty (Seq.seq uint32);
@@ -1176,14 +1151,11 @@ module Sum_SumFirstN
   BB6 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../sum.rs" 8 4 8 67] Next0.next _18);
-    _18 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
+    _17 <- ([#"../sum.rs" 8 4 8 67] Next0.next _19);
+    _19 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32);
     goto BB7
   }
   BB7 {
-    assume { Resolve0.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB8
       | Core_Option_Option_Type.C_Some _ -> goto BB9

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -214,28 +214,6 @@ module CreusotContracts_Std1_Iter_Range_Impl0_Produces
     ensures { result = produces self visited o }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module Core_Option_Option_Type
   type t_option 't =
     | C_None
@@ -563,6 +541,28 @@ module CreusotContracts_Std1_Num_Impl7_DeepModel
     ensures { result = deep_model self }
     
 end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
 module CreusotContracts_Std1_Iter_Range_Impl0_Completed_Stub
   type idx
   use prelude.Borrow
@@ -626,6 +626,8 @@ module SumOfOdds_ComputeSumOfOdd
     predicate Inv0.inv = Inv2.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = Core_Ops_Range_Range_Type.t_range uint32
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range uint32)
   clone TyInv_Trivial as TyInv_Trivial1 with
@@ -635,8 +637,6 @@ module SumOfOdds_ComputeSumOfOdd
   clone SumOfOdds_Sqr as Sqr0
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl7_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range uint32
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = uint32,
     predicate Resolve0.resolve = Resolve0.resolve,
@@ -694,7 +694,6 @@ module SumOfOdds_ComputeSumOfOdd
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range uint32);
   var produced : Ghost.ghost_ty (Seq.seq uint32);
   var _18 : Core_Option_Option_Type.t_option uint32;
-  var _19 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var _20 : borrowed (Core_Ops_Range_Range_Type.t_range uint32);
   var __creusot_proc_iter_elem : uint32;
   var _23 : Ghost.ghost_ty (Seq.seq uint32);
@@ -727,14 +726,11 @@ module SumOfOdds_ComputeSumOfOdd
   BB5 {
     _20 <- Borrow.borrow_mut iter;
     iter <-  ^ _20;
-    _19 <- Borrow.borrow_mut ( * _20);
-    _20 <- { _20 with current = ( ^ _19) };
-    _18 <- ([#"../sum_of_odds.rs" 38 4 38 50] Next0.next _19);
-    _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);
+    _18 <- ([#"../sum_of_odds.rs" 38 4 38 50] Next0.next _20);
+    _20 <- any borrowed (Core_Ops_Range_Range_Type.t_range uint32);
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _20 };
     switch (_18)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8

--- a/creusot/tests/should_succeed/swap_borrows.mlcfg
+++ b/creusot/tests/should_succeed/swap_borrows.mlcfg
@@ -126,6 +126,25 @@ module SwapBorrows_Swap
   }
   
 end
+module CreusotContracts_Resolve_Impl2_Resolve_Stub
+  type t
+  predicate resolve (self : t)
+end
+module CreusotContracts_Resolve_Impl2_Resolve_Interface
+  type t
+  predicate resolve (self : t)
+  val resolve (self : t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl2_Resolve
+  type t
+  predicate resolve (self : t) =
+    [#"../../../../creusot-contracts/src/resolve.rs" 36 8 36 12] true
+  val resolve (self : t) : bool
+    ensures { result = resolve self }
+    
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -148,25 +167,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
     ensures { result = resolve self }
     
 end
-module CreusotContracts_Resolve_Impl2_Resolve_Stub
-  type t
-  predicate resolve (self : t)
-end
-module CreusotContracts_Resolve_Impl2_Resolve_Interface
-  type t
-  predicate resolve (self : t)
-  val resolve (self : t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl2_Resolve
-  type t
-  predicate resolve (self : t) =
-    [#"../../../../creusot-contracts/src/resolve.rs" 36 8 36 12] true
-  val resolve (self : t) : bool
-    ensures { result = resolve self }
-    
-end
 module SwapBorrows_F_Interface
   val f [#"../swap_borrows.rs" 10 0 10 10] (_1 : ()) : ()
 end
@@ -180,23 +180,23 @@ module SwapBorrows_F
     type t = (borrowed uint32, borrowed uint32),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
     type t = uint32
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
     type t = uint32
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
     type t1 = borrowed uint32,
     type t2 = borrowed uint32,
-    predicate Resolve0.resolve = Resolve1.resolve,
-    predicate Resolve1.resolve = Resolve1.resolve
+    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve1.resolve = Resolve3.resolve
   clone SwapBorrows_Swap_Interface as Swap0 with
     type t = borrowed uint32,
     predicate Inv0.inv = Inv0.inv
   clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = uint32,
     type t2 = uint32,
-    predicate Resolve0.resolve = Resolve3.resolve,
-    predicate Resolve1.resolve = Resolve3.resolve
+    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve1.resolve = Resolve2.resolve
   let rec cfg f [#"../swap_borrows.rs" 10 0 10 10] [@cfg:stackify] [@cfg:subregion_analysis] (_1 : ()) : ()
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -205,7 +205,6 @@ module SwapBorrows_F
   var _3 : (uint32, uint32);
   var p : (borrowed uint32, borrowed uint32);
   var _6 : borrowed uint32;
-  var _7 : borrowed uint32;
   var _8 : borrowed uint32;
   {
     goto BB0
@@ -219,17 +218,14 @@ module SwapBorrows_F
     a <-  ^ _6;
     _8 <- Borrow.borrow_mut b;
     b <-  ^ _8;
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    p <- ([#"../swap_borrows.rs" 12 12 12 34] Swap0.swap (_6, _7));
+    p <- ([#"../swap_borrows.rs" 12 12 12 34] Swap0.swap (_6, _8));
     _6 <- any borrowed uint32;
-    _7 <- any borrowed uint32;
+    _8 <- any borrowed uint32;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve _8 };
     p <- (let (a, b) = p in ({ (let (a, _) = p in a) with current = ([#"../swap_borrows.rs" 13 11 13 13] (10 : uint32)) }, b));
-    assume { Resolve2.resolve p };
+    assume { Resolve1.resolve p };
     assert { [@expl:assertion] [#"../swap_borrows.rs" 15 20 15 30] b = (10 : uint32) };
     assert { [@expl:assertion] [#"../swap_borrows.rs" 16 20 16 29] a = (0 : uint32) };
     _0 <- ();

--- a/creusot/tests/should_succeed/take_first_mut.mlcfg
+++ b/creusot/tests/should_succeed/take_first_mut.mlcfg
@@ -421,67 +421,55 @@ module TakeFirstMut_TakeFirstMut
   use seq.Seq
   use prelude.Int
   use seq.Seq
-  clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = Seq.seq t
-  clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = Seq.seq t,
-    predicate Inv0.inv = Inv7.inv,
-    axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = Core_Option_Option_Type.t_option (borrowed t)
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = Core_Option_Option_Type.t_option (borrowed t),
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed t
+    type t = Seq.seq t
   clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed t,
+    type t = Seq.seq t,
     predicate Inv0.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = t
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = t,
+    type t = slice t,
     predicate Inv0.inv = Inv4.inv,
     axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = borrowed (borrowed (slice t))
+    type t = Core_Option_Option_Type.t_option (borrowed t)
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = borrowed (borrowed (slice t)),
+    type t = Core_Option_Option_Type.t_option (borrowed t),
     predicate Inv0.inv = Inv3.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv2 with
-    type t = Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t))
+    type t = borrowed (borrowed (slice t))
   clone TyInv_Trivial as TyInv_Trivial2 with
-    type t = Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t)),
+    type t = borrowed (borrowed (slice t)),
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = slice t
+    type t = Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t))
+  clone TyInv_Trivial as TyInv_Trivial1 with
+    type t = Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t)),
+    predicate Inv0.inv = Inv1.inv,
+    axiom .
+  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel0 with
     type t = t,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv1.inv = Inv5.inv,
     axiom .
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel1 with
     type t = slice t,
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = slice t,
-    predicate Inv0.inv = Inv1.inv,
-    axiom .
   clone CreusotContracts_Std1_Slice_Impl2_IsDefault as IsDefault0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed (slice t)
   clone TyInv_Trivial as TyInv_Trivial0 with
@@ -493,11 +481,9 @@ module TakeFirstMut_TakeFirstMut
   clone CreusotContracts_Logic_Ops_Impl2_IndexLogic as IndexLogic0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv1.inv = Inv7.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = t
+    predicate Inv1.inv = Inv5.inv
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = slice t
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
@@ -511,34 +497,31 @@ module TakeFirstMut_TakeFirstMut
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function Tail0.tail = Tail0.tail,
     function ShallowModel1.shallow_model = ShallowModel1.shallow_model,
-    predicate Inv1.inv = Inv2.inv,
-    predicate Inv2.inv = Inv1.inv,
+    predicate Inv1.inv = Inv1.inv,
+    predicate Inv2.inv = Inv4.inv,
     val Max0.mAX' = Max0.mAX',
-    predicate Inv3.inv = Inv7.inv
+    predicate Inv3.inv = Inv5.inv
   clone Core_Mem_Take_Interface as Take0 with
     type t = borrowed (slice t),
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv2.inv,
     predicate IsDefault0.is_default = IsDefault0.is_default,
     predicate Inv1.inv = Inv0.inv
   let rec cfg take_first_mut [#"../take_first_mut.rs" 14 0 14 74] [@cfg:stackify] [@cfg:subregion_analysis] (self_ : borrowed (borrowed (slice t))) : Core_Option_Option_Type.t_option (borrowed t)
-    requires {[#"../take_first_mut.rs" 14 29 14 34] Inv3.inv self_}
+    requires {[#"../take_first_mut.rs" 14 29 14 34] Inv2.inv self_}
     ensures { [#"../take_first_mut.rs" 6 10 13 1] match (result) with
       | Core_Option_Option_Type.C_Some r ->  * r = IndexLogic0.index_logic ( *  * self_) 0 /\  ^ r = IndexLogic0.index_logic ( ^  * self_) 0 /\ Seq.length (ShallowModel0.shallow_model ( *  * self_)) > 0 /\ Seq.length (ShallowModel0.shallow_model ( ^  * self_)) > 0 /\ ShallowModel0.shallow_model ( *  ^ self_) = Tail0.tail (ShallowModel0.shallow_model ( *  * self_)) /\ ShallowModel0.shallow_model ( ^  ^ self_) = Tail0.tail (ShallowModel0.shallow_model ( ^  * self_))
       | Core_Option_Option_Type.C_None ->  ^ self_ =  * self_ /\ Seq.length (ShallowModel0.shallow_model ( *  * self_)) = 0
       end }
-    ensures { [#"../take_first_mut.rs" 14 57 14 74] Inv6.inv result }
+    ensures { [#"../take_first_mut.rs" 14 57 14 74] Inv3.inv result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : Core_Option_Option_Type.t_option (borrowed t);
   var self_ : borrowed (borrowed (slice t)) = self_;
   var _3 : Core_Option_Option_Type.t_option (borrowed t, borrowed (slice t));
-  var _4 : borrowed (slice t);
   var _5 : borrowed (slice t);
   var _6 : borrowed (borrowed (slice t));
   var first : borrowed t;
   var rem : borrowed (slice t);
-  var _11 : borrowed (slice t);
-  var _12 : borrowed t;
   {
     goto BB0
   }
@@ -551,11 +534,8 @@ module TakeFirstMut_TakeFirstMut
     goto BB1
   }
   BB1 {
-    _4 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _4) };
-    assume { Inv1.inv ( ^ _4) };
-    _3 <- ([#"../take_first_mut.rs" 15 10 15 44] SplitFirstMut0.split_first_mut _4);
-    _4 <- any borrowed (slice t);
+    _3 <- ([#"../take_first_mut.rs" 15 10 15 44] SplitFirstMut0.split_first_mut _5);
+    _5 <- any borrowed (slice t);
     goto BB2
   }
   BB2 {
@@ -572,47 +552,31 @@ module TakeFirstMut_TakeFirstMut
     _3 <- (let Core_Option_Option_Type.C_Some a = _3 in Core_Option_Option_Type.C_Some (let (a, b) = Core_Option_Option_Type.some_0 _3 in (any borrowed t, b)));
     rem <- (let (_, a) = Core_Option_Option_Type.some_0 _3 in a);
     _3 <- (let Core_Option_Option_Type.C_Some a = _3 in Core_Option_Option_Type.C_Some (let (a, b) = Core_Option_Option_Type.some_0 _3 in (a, any borrowed (slice t))));
-    assert { [@expl:type invariant] Inv2.inv _3 };
+    assert { [@expl:type invariant] Inv1.inv _3 };
     assume { Resolve0.resolve _3 };
-    _11 <- Borrow.borrow_mut ( * rem);
-    rem <- { rem with current = ( ^ _11) };
-    assume { Inv1.inv ( ^ _11) };
-    self_ <- { self_ with current = _11 };
-    _11 <- any borrowed (slice t);
+    self_ <- { self_ with current = rem };
+    rem <- any borrowed (slice t);
     assert { [@expl:type invariant] Inv0.inv ( * self_) };
     assume { Resolve2.resolve ( * self_) };
-    assert { [@expl:type invariant] Inv3.inv self_ };
+    assert { [@expl:type invariant] Inv2.inv self_ };
     assume { Resolve1.resolve self_ };
-    _12 <- Borrow.borrow_mut ( * first);
-    first <- { first with current = ( ^ _12) };
-    assume { Inv4.inv ( ^ _12) };
-    _0 <- Core_Option_Option_Type.C_Some _12;
-    _12 <- any borrowed t;
-    assert { [@expl:type invariant] Inv0.inv rem };
-    assume { Resolve2.resolve rem };
-    assert { [@expl:type invariant] Inv5.inv first };
-    assume { Resolve3.resolve first };
-    assert { [@expl:type invariant] Inv0.inv _5 };
-    assume { Resolve2.resolve _5 };
+    _0 <- Core_Option_Option_Type.C_Some first;
+    first <- any borrowed t;
     goto BB7
   }
   BB5 {
-    assert { [@expl:type invariant] Inv2.inv _3 };
+    assert { [@expl:type invariant] Inv1.inv _3 };
     assume { Resolve0.resolve _3 };
-    assert { [@expl:type invariant] Inv3.inv self_ };
+    assert { [@expl:type invariant] Inv2.inv self_ };
     assume { Resolve1.resolve self_ };
-    assert { [@expl:type invariant] Inv0.inv _5 };
-    assume { Resolve2.resolve _5 };
     absurd
   }
   BB6 {
-    assert { [@expl:type invariant] Inv2.inv _3 };
+    assert { [@expl:type invariant] Inv1.inv _3 };
     assume { Resolve0.resolve _3 };
-    assert { [@expl:type invariant] Inv3.inv self_ };
+    assert { [@expl:type invariant] Inv2.inv self_ };
     assume { Resolve1.resolve self_ };
     _0 <- Core_Option_Option_Type.C_None;
-    assert { [@expl:type invariant] Inv0.inv _5 };
-    assume { Resolve2.resolve _5 };
     goto BB7
   }
   BB7 {

--- a/creusot/tests/should_succeed/trusted_unsafe.mlcfg
+++ b/creusot/tests/should_succeed/trusted_unsafe.mlcfg
@@ -1,0 +1,8 @@
+
+module TrustedUnsafe_Test_Interface
+  use prelude.Opaque
+  use prelude.Borrow
+  use prelude.Int
+  use prelude.UInt32
+  val test [#"../trusted_unsafe.rs" 5 0 5 51] (x : opaque_ptr) : borrowed uint32
+end

--- a/creusot/tests/should_succeed/trusted_unsafe.rs
+++ b/creusot/tests/should_succeed/trusted_unsafe.rs
@@ -1,0 +1,7 @@
+extern crate creusot_contracts;
+use creusot_contracts::*;
+
+#[trusted]
+pub unsafe fn test(x: *mut u32) -> &'static mut u32 {
+    &mut *x
+}

--- a/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
+++ b/creusot/tests/should_succeed/type_invariants/borrows.mlcfg
@@ -159,10 +159,8 @@ module Borrows_Impl1_InnerMut
     predicate Inv0.inv = Inv0.inv,
     predicate Inv1.inv = Inv1.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
+    type t = Borrows_NonZero_Type.t_nonzero
   let rec cfg inner_mut [#"../borrows.rs" 23 4 23 43] [@cfg:stackify] [@cfg:subregion_analysis] (self : borrowed (Borrows_NonZero_Type.t_nonzero)) : borrowed int32
     requires {[#"../borrows.rs" 23 26 23 30] Inv0.inv self}
     ensures { [#"../borrows.rs" 21 14 21 38] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * self)) = Int32.to_int ( * result) }
@@ -171,7 +169,6 @@ module Borrows_Impl1_InnerMut
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : borrowed int32;
   var self : borrowed (Borrows_NonZero_Type.t_nonzero) = self;
-  var _2 : borrowed int32;
   var _5 : borrowed int32;
   {
     goto BB0
@@ -179,14 +176,10 @@ module Borrows_Impl1_InnerMut
   BB0 {
     _5 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * self));
     self <- { self with current = (let Borrows_NonZero_Type.C_NonZero a =  * self in Borrows_NonZero_Type.C_NonZero ( ^ _5)) };
-    _2 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _2) };
-    _0 <- Borrow.borrow_mut ( * _2);
-    _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve0.resolve _5 };
-    assume { Resolve0.resolve _2 };
+    _0 <- _5;
+    _5 <- any borrowed int32;
     assert { [@expl:type invariant] Inv0.inv self };
-    assume { Resolve1.resolve self };
+    assume { Resolve0.resolve self };
     return _0
   }
   
@@ -368,10 +361,8 @@ module Borrows_Simple
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
+    type t = Borrows_NonZero_Type.t_nonzero
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
@@ -384,7 +375,6 @@ module Borrows_Simple
   var _0 : ();
   var x : borrowed (Borrows_NonZero_Type.t_nonzero) = x;
   var _4 : ();
-  var _5 : borrowed int32;
   var _6 : borrowed int32;
   {
     goto BB0
@@ -392,16 +382,13 @@ module Borrows_Simple
   BB0 {
     _6 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
     x <- { x with current = (let Borrows_NonZero_Type.C_NonZero a =  * x in Borrows_NonZero_Type.C_NonZero ( ^ _6)) };
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    _4 <- ([#"../borrows.rs" 32 4 32 17] Inc0.inc _5);
-    _5 <- any borrowed int32;
+    _4 <- ([#"../borrows.rs" 32 4 32 17] Inc0.inc _6);
+    _6 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _6 };
     assert { [@expl:type invariant] Inv0.inv x };
-    assume { Resolve1.resolve x };
+    assume { Resolve0.resolve x };
     _0 <- ();
     return _0
   }
@@ -425,71 +412,57 @@ module Borrows_Hard
   use prelude.Borrow
   use prelude.Int
   use prelude.Int32
-  clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
   use Borrows_NonZero_Type as Borrows_NonZero_Type
   clone Borrows_Impl0_Invariant as Invariant0
-  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Borrows_NonZero_Type.t_nonzero
+  clone Borrows_NonZero_Type_Inv as Borrows_NonZero_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
+  clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = borrowed (Borrows_NonZero_Type.t_nonzero)
   clone TyInv_Borrow as TyInv_Borrow0 with
     type t = Borrows_NonZero_Type.t_nonzero,
-    predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
+    predicate Inv0.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   use prelude.Int
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = int32,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
-  clone Borrows_NonZero_Type_Inv as Borrows_NonZero_Type_Inv0 with
-    predicate Inv0.inv = Inv0.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
-    axiom .
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Borrows_NonZero_Type.t_nonzero
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
   clone Borrows_Impl1_InnerMut_Interface as InnerMut0 with
-    predicate Inv0.inv = Inv1.inv
+    predicate Inv0.inv = Inv0.inv
   let rec cfg hard [#"../borrows.rs" 38 0 38 28] [@cfg:stackify] [@cfg:subregion_analysis] (x : borrowed (Borrows_NonZero_Type.t_nonzero)) : ()
     requires {[#"../borrows.rs" 36 11 36 27] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * x)) < Int32.to_int Max0.mAX'}
     requires {[#"../borrows.rs" 37 11 37 21] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * x)) <> - 1}
-    requires {[#"../borrows.rs" 38 12 38 13] Inv1.inv x}
+    requires {[#"../borrows.rs" 38 12 38 13] Inv0.inv x}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var x : borrowed (Borrows_NonZero_Type.t_nonzero) = x;
   var _4 : ();
-  var _5 : borrowed int32;
   var _6 : borrowed int32;
-  var _7 : borrowed (Borrows_NonZero_Type.t_nonzero);
   {
     goto BB0
   }
   BB0 {
-    _7 <- Borrow.borrow_mut ( * x);
-    x <- { x with current = ( ^ _7) };
-    assume { Inv0.inv ( ^ _7) };
-    _6 <- ([#"../borrows.rs" 39 8 39 21] InnerMut0.inner_mut _7);
-    _7 <- any borrowed (Borrows_NonZero_Type.t_nonzero);
+    _6 <- ([#"../borrows.rs" 39 8 39 21] InnerMut0.inner_mut x);
+    x <- any borrowed (Borrows_NonZero_Type.t_nonzero);
     goto BB1
   }
   BB1 {
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    _4 <- ([#"../borrows.rs" 39 4 39 22] Inc0.inc _5);
-    _5 <- any borrowed int32;
+    _4 <- ([#"../borrows.rs" 39 4 39 22] Inc0.inc _6);
+    _6 <- any borrowed int32;
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve _6 };
-    assert { [@expl:type invariant] Inv1.inv x };
-    assume { Resolve1.resolve x };
     _0 <- ();
     return _0
   }
@@ -603,9 +576,9 @@ module Borrows_Tuple
     predicate Invariant0.invariant' = Invariant0.invariant',
     axiom .
   clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = Borrows_NonZero_Type.t_nonzero
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve1 with
     type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))
@@ -622,13 +595,11 @@ module Borrows_Tuple
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = Borrows_NonZero_Type.t_nonzero,
     type t2 = borrowed (Borrows_NonZero_Type.t_nonzero),
-    predicate Resolve0.resolve = Resolve2.resolve,
-    predicate Resolve1.resolve = Resolve3.resolve
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
+    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve1.resolve = Resolve2.resolve
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
@@ -641,7 +612,6 @@ module Borrows_Tuple
   var _0 : ();
   var x : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero)) = x;
   var _4 : ();
-  var _5 : borrowed int32;
   var _6 : borrowed int32;
   {
     goto BB0
@@ -650,16 +620,13 @@ module Borrows_Tuple
     x <- (let (a, b) = x in (let Borrows_NonZero_Type.C_NonZero a = let (a, _) = x in a in Borrows_NonZero_Type.C_NonZero ([#"../borrows.rs" 46 13 46 14] (0 : int32)), b));
     _6 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
     x <- (let (a, b) = x in (a, { (let (_, a) = x in a) with current = (let Borrows_NonZero_Type.C_NonZero a =  * (let (_, a) = x in a) in Borrows_NonZero_Type.C_NonZero ( ^ _6)) }));
-    _5 <- Borrow.borrow_mut ( * _6);
-    _6 <- { _6 with current = ( ^ _5) };
-    _4 <- ([#"../borrows.rs" 47 4 47 20] Inc0.inc _5);
-    _5 <- any borrowed int32;
+    _4 <- ([#"../borrows.rs" 47 4 47 20] Inc0.inc _6);
+    _6 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _6 };
     assert { [@expl:type invariant] Inv0.inv x };
-    assume { Resolve1.resolve x };
+    assume { Resolve0.resolve x };
     _0 <- ();
     return _0
   }
@@ -699,9 +666,9 @@ module Borrows_PartialMove
     predicate Invariant0.invariant' = Invariant0.invariant',
     axiom .
   clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
     type t = Borrows_NonZero_Type.t_nonzero
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve1 with
     type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))
@@ -718,13 +685,11 @@ module Borrows_PartialMove
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = Borrows_NonZero_Type.t_nonzero,
     type t2 = borrowed (Borrows_NonZero_Type.t_nonzero),
-    predicate Resolve0.resolve = Resolve2.resolve,
-    predicate Resolve1.resolve = Resolve3.resolve
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
+    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve1.resolve = Resolve2.resolve
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
@@ -738,7 +703,6 @@ module Borrows_PartialMove
   var x : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero)) = x;
   var a : Borrows_NonZero_Type.t_nonzero;
   var _5 : ();
-  var _6 : borrowed int32;
   var _7 : borrowed int32;
   {
     goto BB0
@@ -748,16 +712,13 @@ module Borrows_PartialMove
     x <- (let (a, b) = x in (any Borrows_NonZero_Type.t_nonzero, b));
     _7 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a)));
     x <- (let (a, b) = x in (a, { (let (_, a) = x in a) with current = (let Borrows_NonZero_Type.C_NonZero a =  * (let (_, a) = x in a) in Borrows_NonZero_Type.C_NonZero ( ^ _7)) }));
-    _6 <- Borrow.borrow_mut ( * _7);
-    _7 <- { _7 with current = ( ^ _6) };
-    _5 <- ([#"../borrows.rs" 55 4 55 20] Inc0.inc _6);
-    _6 <- any borrowed int32;
+    _5 <- ([#"../borrows.rs" 55 4 55 20] Inc0.inc _7);
+    _7 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _7 };
     assert { [@expl:type invariant] Inv0.inv x };
-    assume { Resolve1.resolve x };
+    assume { Resolve0.resolve x };
     a <- (let Borrows_NonZero_Type.C_NonZero a = a in Borrows_NonZero_Type.C_NonZero ([#"../borrows.rs" 56 10 56 11] (0 : int32)));
     _0 <- ();
     return _0
@@ -803,7 +764,7 @@ module Borrows_Destruct
     type t = int32,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
     type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))
@@ -815,18 +776,16 @@ module Borrows_Destruct
     predicate Inv2.inv = Inv1.inv,
     axiom .
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Borrows_NonZero_Type.t_nonzero
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = int32
+    type t = Borrows_NonZero_Type.t_nonzero
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
   clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = Borrows_NonZero_Type.t_nonzero,
     type t2 = borrowed (Borrows_NonZero_Type.t_nonzero),
-    predicate Resolve0.resolve = Resolve3.resolve,
-    predicate Resolve1.resolve = Resolve2.resolve
+    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve1.resolve = Resolve1.resolve
   let rec cfg destruct [#"../borrows.rs" 61 0 61 43] [@cfg:stackify] [@cfg:subregion_analysis] (x : (Borrows_NonZero_Type.t_nonzero, borrowed (Borrows_NonZero_Type.t_nonzero))) : ()
     requires {[#"../borrows.rs" 59 11 59 29] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a))) < Int32.to_int Max0.mAX'}
     requires {[#"../borrows.rs" 60 11 60 23] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * (let (_, a) = x in a))) <> - 1}
@@ -838,7 +797,6 @@ module Borrows_Destruct
   var a : Borrows_NonZero_Type.t_nonzero;
   var b : borrowed (Borrows_NonZero_Type.t_nonzero);
   var _6 : ();
-  var _7 : borrowed int32;
   var _8 : borrowed int32;
   {
     goto BB0
@@ -853,16 +811,13 @@ module Borrows_Destruct
     a <- (let Borrows_NonZero_Type.C_NonZero a = a in Borrows_NonZero_Type.C_NonZero ([#"../borrows.rs" 63 10 63 11] (0 : int32)));
     _8 <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * b));
     b <- { b with current = (let Borrows_NonZero_Type.C_NonZero a =  * b in Borrows_NonZero_Type.C_NonZero ( ^ _8)) };
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    _6 <- ([#"../borrows.rs" 64 4 64 17] Inc0.inc _7);
-    _7 <- any borrowed int32;
+    _6 <- ([#"../borrows.rs" 64 4 64 17] Inc0.inc _8);
+    _8 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve _8 };
     assert { [@expl:type invariant] Inv1.inv b };
-    assume { Resolve2.resolve b };
+    assume { Resolve1.resolve b };
     _0 <- ();
     return _0
   }
@@ -887,30 +842,28 @@ module Borrows_FrozenDead
   use prelude.Borrow
   use prelude.Int
   use prelude.Int32
-  clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
   use Borrows_NonZero_Type as Borrows_NonZero_Type
   clone Borrows_Impl0_Invariant as Invariant0
+  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
+    type t = Borrows_NonZero_Type.t_nonzero
+  clone Borrows_NonZero_Type_Inv as Borrows_NonZero_Type_Inv0 with
+    predicate Inv0.inv = Inv1.inv,
+    predicate Invariant0.invariant' = Invariant0.invariant',
+    axiom .
+  clone CreusotContracts_Std1_Num_Impl24_ShallowModel as ShallowModel1
   use prelude.Int
   clone CreusotContracts_Model_Impl7_ShallowModel as ShallowModel0 with
     type t = int32,
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Borrows_NonZero_Type.t_nonzero
-  clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = borrowed (Borrows_NonZero_Type.t_nonzero)
   clone TyInv_Borrow as TyInv_Borrow0 with
     type t = Borrows_NonZero_Type.t_nonzero,
-    predicate Inv0.inv = Inv1.inv,
-    predicate Inv1.inv = Inv0.inv,
-    axiom .
-  clone Borrows_NonZero_Type_Inv as Borrows_NonZero_Type_Inv0 with
     predicate Inv0.inv = Inv0.inv,
-    predicate Invariant0.invariant' = Invariant0.invariant',
+    predicate Inv1.inv = Inv1.inv,
     axiom .
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = int32
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
@@ -919,43 +872,33 @@ module Borrows_FrozenDead
   let rec cfg frozen_dead [#"../borrows.rs" 69 0 69 66] [@cfg:stackify] [@cfg:subregion_analysis] (x : borrowed (Borrows_NonZero_Type.t_nonzero)) (y : borrowed (Borrows_NonZero_Type.t_nonzero)) : ()
     requires {[#"../borrows.rs" 67 11 67 27] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * x)) < Int32.to_int Max0.mAX'}
     requires {[#"../borrows.rs" 68 11 68 21] Int32.to_int (Borrows_NonZero_Type.nonzero_0 ( * x)) <> - 1}
-    requires {[#"../borrows.rs" 69 27 69 28] Inv1.inv x}
-    requires {[#"../borrows.rs" 69 47 69 48] Inv1.inv y}
+    requires {[#"../borrows.rs" 69 27 69 28] Inv0.inv x}
+    requires {[#"../borrows.rs" 69 47 69 48] Inv0.inv y}
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var x : borrowed (Borrows_NonZero_Type.t_nonzero) = x;
   var y : borrowed (Borrows_NonZero_Type.t_nonzero) = y;
   var _a : borrowed int32;
-  var _6 : borrowed (Borrows_NonZero_Type.t_nonzero);
   var _7 : ();
-  var _8 : borrowed int32;
   {
     goto BB0
   }
   BB0 {
     _a <- Borrow.borrow_mut (Borrows_NonZero_Type.nonzero_0 ( * x));
     x <- { x with current = (let Borrows_NonZero_Type.C_NonZero a =  * x in Borrows_NonZero_Type.C_NonZero ( ^ _a)) };
-    _6 <- Borrow.borrow_mut ( * y);
-    y <- { y with current = ( ^ _6) };
-    assume { Inv0.inv ( ^ _6) };
-    assert { [@expl:type invariant] Inv1.inv x };
+    assert { [@expl:type invariant] Inv0.inv x };
     assume { Resolve0.resolve x };
-    x <- _6;
-    _6 <- any borrowed (Borrows_NonZero_Type.t_nonzero);
-    assert { [@expl:type invariant] Inv1.inv x };
+    x <- y;
+    y <- any borrowed (Borrows_NonZero_Type.t_nonzero);
+    assert { [@expl:type invariant] Inv0.inv x };
     assume { Resolve0.resolve x };
-    _8 <- Borrow.borrow_mut ( * _a);
-    _a <- { _a with current = ( ^ _8) };
-    _7 <- ([#"../borrows.rs" 75 4 75 11] Inc0.inc _8);
-    _8 <- any borrowed int32;
+    _7 <- ([#"../borrows.rs" 75 4 75 11] Inc0.inc _a);
+    _a <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve1.resolve _a };
     _0 <- ();
-    assert { [@expl:type invariant] Inv1.inv y };
-    assume { Resolve0.resolve y };
     return _0
   }
   
@@ -1099,13 +1042,11 @@ module Borrows_Impl3_Foo
     type ShallowModelTy0.shallowModelTy = int,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
   clone Core_Num_Impl2_Max as Max0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = Borrows_SumTo10_Type.t_sumto10
   clone Borrows_Dec_Interface as Dec0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Min0.mIN' = Min0.mIN'
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = int32
   clone Borrows_Inc_Interface as Inc0 with
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     val Max0.mAX' = Max0.mAX'
@@ -1117,10 +1058,8 @@ module Borrows_Impl3_Foo
   var _0 : ();
   var self : borrowed (Borrows_SumTo10_Type.t_sumto10) = self;
   var _3 : ();
-  var _4 : borrowed int32;
   var _5 : borrowed int32;
   var _6 : ();
-  var _7 : borrowed int32;
   var _8 : borrowed int32;
   {
     goto BB0
@@ -1128,26 +1067,20 @@ module Borrows_Impl3_Foo
   BB0 {
     _5 <- Borrow.borrow_mut (Borrows_SumTo10_Type.sumto10_a ( * self));
     self <- { self with current = (let Borrows_SumTo10_Type.C_SumTo10 a b =  * self in Borrows_SumTo10_Type.C_SumTo10 ( ^ _5) b) };
-    _4 <- Borrow.borrow_mut ( * _5);
-    _5 <- { _5 with current = ( ^ _4) };
-    _3 <- ([#"../borrows.rs" 94 8 94 24] Inc0.inc _4);
-    _4 <- any borrowed int32;
+    _3 <- ([#"../borrows.rs" 94 8 94 24] Inc0.inc _5);
+    _5 <- any borrowed int32;
     goto BB1
   }
   BB1 {
-    assume { Resolve0.resolve _5 };
     _8 <- Borrow.borrow_mut (Borrows_SumTo10_Type.sumto10_b ( * self));
     self <- { self with current = (let Borrows_SumTo10_Type.C_SumTo10 a b =  * self in Borrows_SumTo10_Type.C_SumTo10 a ( ^ _8)) };
-    _7 <- Borrow.borrow_mut ( * _8);
-    _8 <- { _8 with current = ( ^ _7) };
-    _6 <- ([#"../borrows.rs" 95 8 95 24] Dec0.dec _7);
-    _7 <- any borrowed int32;
+    _6 <- ([#"../borrows.rs" 95 8 95 24] Dec0.dec _8);
+    _8 <- any borrowed int32;
     goto BB2
   }
   BB2 {
-    assume { Resolve0.resolve _8 };
     assert { [@expl:type invariant] Inv0.inv self };
-    assume { Resolve1.resolve self };
+    assume { Resolve0.resolve self };
     _0 <- ();
     return _0
   }

--- a/creusot/tests/should_succeed/unnest.mlcfg
+++ b/creusot/tests/should_succeed/unnest.mlcfg
@@ -35,10 +35,8 @@ module Unnest_Unnest
   use prelude.Borrow
   use prelude.Int
   use prelude.UInt32
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = borrowed uint32
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = uint32
+    type t = borrowed uint32
   let rec cfg unnest [#"../unnest.rs" 8 0 8 64] [@cfg:stackify] [@cfg:subregion_analysis] (x : borrowed (borrowed uint32)) : borrowed uint32
     ensures { [#"../unnest.rs" 5 10 5 24]  * result =  *  * x }
     ensures { [#"../unnest.rs" 6 10 6 24]  ^ result =  *  ^ x }
@@ -54,10 +52,9 @@ module Unnest_Unnest
   BB0 {
     _2 <- Borrow.borrow_mut ( *  * x);
     x <- { x with current = { ( * x) with current = ( ^ _2) } };
-    _0 <- Borrow.borrow_mut ( * _2);
-    _2 <- { _2 with current = ( ^ _0) };
-    assume { Resolve0.resolve _2 };
-    assume { Resolve1.resolve x };
+    _0 <- _2;
+    _2 <- any borrowed uint32;
+    assume { Resolve0.resolve x };
     return _0
   }
   

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -365,6 +365,17 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     ensures { result = shallow_model self }
     
 end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_None -> any 't
+      | C_Some a -> a
+      end
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -386,17 +397,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
-end
-module Core_Option_Option_Type
-  type t_option 't =
-    | C_None
-    | C_Some 't
-    
-  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
-    match (self) with
-      | C_None -> any 't
-      | C_Some a -> a
-      end
 end
 module Alloc_Vec_Impl1_Len_Interface
   type t
@@ -1077,6 +1077,8 @@ module C01_AllZero
     predicate Inv0.inv = Inv5.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial4 with
@@ -1109,11 +1111,9 @@ module C01_AllZero
     type t = uint32
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel2 with
@@ -1159,9 +1159,9 @@ module C01_AllZero
     type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq uint32,
     function ShallowModel0.shallow_model = ShallowModel2.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
+    type t = Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = uint32
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut0 with
     type t = uint32,
@@ -1219,7 +1219,6 @@ module C01_AllZero
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _19 : Core_Option_Option_Type.t_option usize;
-  var _20 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _21 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _24 : Ghost.ghost_ty (Seq.seq usize);
@@ -1263,21 +1262,18 @@ module C01_AllZero
   BB7 {
     _21 <- Borrow.borrow_mut iter;
     iter <-  ^ _21;
-    _20 <- Borrow.borrow_mut ( * _21);
-    _21 <- { _21 with current = ( ^ _20) };
-    _19 <- ([#"../01.rs" 9 4 9 42] Next0.next _20);
-    _20 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _19 <- ([#"../01.rs" 9 4 9 42] Next0.next _21);
+    _21 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve0.resolve _21 };
     switch (_19)
       | Core_Option_Option_Type.C_None -> goto BB9
       | Core_Option_Option_Type.C_Some _ -> goto BB10
       end
   }
   BB9 {
-    assume { Resolve2.resolve v };
+    assume { Resolve1.resolve v };
     _0 <- ();
     return _0
   }
@@ -1285,7 +1281,7 @@ module C01_AllZero
     goto BB12
   }
   BB11 {
-    assume { Resolve2.resolve v };
+    assume { Resolve1.resolve v };
     absurd
   }
   BB12 {
@@ -1305,7 +1301,7 @@ module C01_AllZero
   }
   BB14 {
     _27 <- { _27 with current = ([#"../01.rs" 12 15 12 16] (0 : uint32)) };
-    assume { Resolve1.resolve _27 };
+    assume { Resolve0.resolve _27 };
     goto BB6
   }
   

--- a/creusot/tests/should_succeed/vector/02_gnome.mlcfg
+++ b/creusot/tests/should_succeed/vector/02_gnome.mlcfg
@@ -1561,18 +1561,30 @@ module C02Gnome_GnomeSort
     predicate Inv0.inv = Inv8.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = usize
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = usize,
+    type t = slice t,
     predicate Inv0.inv = Inv7.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+    type t = borrowed (slice t)
+  clone TyInv_Trivial as TyInv_Trivial6 with
+    type t = borrowed (slice t),
+    predicate Inv0.inv = Inv6.inv,
+    axiom .
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = usize
+  clone TyInv_Trivial as TyInv_Trivial5 with
+    type t = usize,
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial6 with
+  clone TyInv_Trivial as TyInv_Trivial4 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Logic_Ord_OrdLogic_EqCmp_Interface as EqCmp0 with
     type self = DeepModelTy0.deepModelTy,
@@ -1645,21 +1657,9 @@ module C02Gnome_GnomeSort
     predicate Inv0.inv = Inv3.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv8.inv
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (slice t)
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (slice t),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = slice t
-  clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = slice t,
-    predicate Inv0.inv = Inv4.inv,
-    axiom .
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel6 with
     type t = t,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv7.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv8.inv,
     axiom .
@@ -1728,14 +1728,12 @@ module C02Gnome_GnomeSort
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv8.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
-    type t = slice t
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv6.inv,
     function ShallowModel1.shallow_model = ShallowModel6.shallow_model,
-    predicate Inv1.inv = Inv4.inv,
+    predicate Inv1.inv = Inv7.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv8.inv
   clone Alloc_Vec_Impl9_DerefMut_Interface as DerefMut0 with
@@ -1746,8 +1744,8 @@ module C02Gnome_GnomeSort
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel2.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv1.inv = Inv5.inv,
-    predicate Inv2.inv = Inv4.inv,
+    predicate Inv1.inv = Inv6.inv,
+    predicate Inv2.inv = Inv7.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv3.inv = Inv8.inv,
     predicate Inv4.inv = Inv3.inv
@@ -1768,8 +1766,8 @@ module C02Gnome_GnomeSort
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model,
     predicate InBounds0.in_bounds = InBounds0.in_bounds,
-    predicate Inv0.inv = Inv6.inv,
-    predicate Inv1.inv = Inv7.inv,
+    predicate Inv0.inv = Inv4.inv,
+    predicate Inv1.inv = Inv5.inv,
     predicate HasValue0.has_value = HasValue0.has_value,
     predicate Inv2.inv = Inv2.inv,
     type Output0.output = t
@@ -1778,7 +1776,7 @@ module C02Gnome_GnomeSort
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
   clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with
     type t = t
@@ -1810,7 +1808,6 @@ module C02Gnome_GnomeSort
   var _24 : t;
   var _25 : t;
   var _28 : ();
-  var _29 : borrowed (slice t);
   var _30 : borrowed (slice t);
   var _31 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
@@ -1895,16 +1892,11 @@ module C02Gnome_GnomeSort
     goto BB14
   }
   BB14 {
-    _29 <- Borrow.borrow_mut ( * _30);
-    _30 <- { _30 with current = ( ^ _29) };
-    assume { Inv4.inv ( ^ _29) };
-    _28 <- ([#"../02_gnome.rs" 34 12 34 28] Swap0.swap _29 ([#"../02_gnome.rs" 34 19 34 24] i - ([#"../02_gnome.rs" 34 23 34 24] (1 : usize))) i);
-    _29 <- any borrowed (slice t);
+    _28 <- ([#"../02_gnome.rs" 34 12 34 28] Swap0.swap _30 ([#"../02_gnome.rs" 34 19 34 24] i - ([#"../02_gnome.rs" 34 23 34 24] (1 : usize))) i);
+    _30 <- any borrowed (slice t);
     goto BB15
   }
   BB15 {
-    assert { [@expl:type invariant] Inv5.inv _30 };
-    assume { Resolve3.resolve _30 };
     i <- ([#"../02_gnome.rs" 35 12 35 18] i - ([#"../02_gnome.rs" 35 17 35 18] (1 : usize)));
     _9 <- ();
     goto BB16

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -372,6 +372,17 @@ module CreusotContracts_Ghost_Impl1_ShallowModel
     ensures { result = shallow_model self }
     
 end
+module Core_Option_Option_Type
+  type t_option 't =
+    | C_None
+    | C_Some 't
+    
+  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
+    match (self) with
+      | C_None -> any 't
+      | C_Some a -> a
+      end
+end
 module CreusotContracts_Resolve_Impl1_Resolve_Stub
   type t
   use prelude.Borrow
@@ -393,17 +404,6 @@ module CreusotContracts_Resolve_Impl1_Resolve
   val resolve (self : borrowed t) : bool
     ensures { result = resolve self }
     
-end
-module Core_Option_Option_Type
-  type t_option 't =
-    | C_None
-    | C_Some 't
-    
-  let function some_0 (self : t_option 't) : 't = [@vc:do_not_keep_trace] [@vc:sp]
-    match (self) with
-      | C_None -> any 't
-      | C_Some a -> a
-      end
 end
 module TyInv_Trivial
   type t
@@ -959,50 +959,52 @@ module C03KnuthShuffle_KnuthShuffle
     type t = Seq.seq t,
     predicate Inv0.inv = Inv9.inv,
     axiom .
-  use Core_Option_Option_Type as Core_Option_Option_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv8 with
-    type t = Core_Option_Option_Type.t_option usize
+    type t = slice t
   clone TyInv_Trivial as TyInv_Trivial8 with
-    type t = Core_Option_Option_Type.t_option usize,
+    type t = slice t,
     predicate Inv0.inv = Inv8.inv,
     axiom .
-  use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv7 with
-    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
+    type t = borrowed (slice t)
   clone TyInv_Trivial as TyInv_Trivial7 with
-    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize),
+    type t = borrowed (slice t),
     predicate Inv0.inv = Inv7.inv,
+    axiom .
+  use Core_Option_Option_Type as Core_Option_Option_Type
+  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
+    type t = Core_Option_Option_Type.t_option usize
+  clone TyInv_Trivial as TyInv_Trivial6 with
+    type t = Core_Option_Option_Type.t_option usize,
+    predicate Inv0.inv = Inv6.inv,
+    axiom .
+  use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
+  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
+    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
+  clone TyInv_Trivial as TyInv_Trivial5 with
+    type t = borrowed (Core_Ops_Range_Range_Type.t_range usize),
+    predicate Inv0.inv = Inv5.inv,
     axiom .
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
-  clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone TyInv_Trivial as TyInv_Trivial6 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
-    predicate Inv0.inv = Inv6.inv,
-    axiom .
-  clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
-  clone TyInv_Trivial as TyInv_Trivial5 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
-    predicate Inv0.inv = Inv5.inv,
-    axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv4 with
-    type t = borrowed (slice t)
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone TyInv_Trivial as TyInv_Trivial4 with
-    type t = borrowed (slice t),
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv4.inv,
     axiom .
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
-    type t = slice t
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial3 with
-    type t = slice t,
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv3.inv,
     axiom .
   clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Slice_Impl0_ShallowModel_Interface as ShallowModel6 with
     type t = t,
-    predicate Inv0.inv = Inv3.inv,
+    predicate Inv0.inv = Inv8.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv9.inv,
     axiom .
@@ -1018,11 +1020,9 @@ module C03KnuthShuffle_KnuthShuffle
     axiom .
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve2.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = t,
@@ -1074,38 +1074,36 @@ module C03KnuthShuffle_KnuthShuffle
     type t = Ghost.ghost_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))),
     predicate Inv0.inv = Inv0.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = slice t
   clone Core_Slice_Impl0_Swap_Interface as Swap0 with
     type t = t,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
-    predicate Inv0.inv = Inv4.inv,
+    predicate Inv0.inv = Inv7.inv,
     function ShallowModel1.shallow_model = ShallowModel6.shallow_model,
-    predicate Inv1.inv = Inv3.inv,
+    predicate Inv1.inv = Inv8.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv9.inv
   clone Alloc_Vec_Impl9_DerefMut_Interface as DerefMut0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv5.inv,
+    predicate Inv0.inv = Inv3.inv,
     function ShallowModel0.shallow_model = ShallowModel5.shallow_model,
     function ShallowModel1.shallow_model = ShallowModel0.shallow_model,
     function ShallowModel2.shallow_model = ShallowModel6.shallow_model,
     function ShallowModel3.shallow_model = ShallowModel2.shallow_model,
-    predicate Inv1.inv = Inv4.inv,
-    predicate Inv2.inv = Inv3.inv,
+    predicate Inv1.inv = Inv7.inv,
+    predicate Inv2.inv = Inv8.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv3.inv = Inv9.inv,
     predicate Inv4.inv = Inv2.inv
   clone C03KnuthShuffle_RandInRange_Interface as RandInRange0
   clone Core_Iter_Range_Impl3_Next_Interface as Next0 with
     type a = usize,
-    predicate Inv0.inv = Inv7.inv,
+    predicate Inv0.inv = Inv5.inv,
     predicate Completed0.completed = Completed0.completed,
     predicate Produces0.produces = Produces0.produces,
-    predicate Inv1.inv = Inv8.inv
+    predicate Inv1.inv = Inv6.inv
   clone CreusotContracts_Logic_Seq_Impl0_PermutationOf as PermutationOf0 with
     type t = t
   clone CreusotContracts_Ghost_Impl1_ShallowModel as ShallowModel1 with
@@ -1120,12 +1118,12 @@ module C03KnuthShuffle_KnuthShuffle
   clone Alloc_Vec_Impl1_Len_Interface as Len0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv6.inv,
+    predicate Inv0.inv = Inv4.inv,
     function ShallowModel0.shallow_model = ShallowModel3.shallow_model
   clone CreusotContracts_Resolve_Resolve_Resolve_Interface as Resolve0 with
     type self = Ghost.ghost_ty (borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)))
   let rec cfg knuth_shuffle [#"../03_knuth_shuffle.rs" 13 0 13 39] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    requires {[#"../03_knuth_shuffle.rs" 13 24 13 25] Inv5.inv v}
+    requires {[#"../03_knuth_shuffle.rs" 13 24 13 25] Inv3.inv v}
     ensures { [#"../03_knuth_shuffle.rs" 12 0 12 36] PermutationOf0.permutation_of (ShallowModel2.shallow_model ( ^ v)) (ShallowModel0.shallow_model v) }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -1137,7 +1135,6 @@ module C03KnuthShuffle_KnuthShuffle
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _17 : Core_Option_Option_Type.t_option usize;
-  var _18 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _19 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _22 : Ghost.ghost_ty (Seq.seq usize);
@@ -1146,7 +1143,6 @@ module C03KnuthShuffle_KnuthShuffle
   var _26 : usize;
   var i : usize;
   var _31 : ();
-  var _32 : borrowed (slice t);
   var _33 : borrowed (slice t);
   var _34 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
@@ -1187,22 +1183,19 @@ module C03KnuthShuffle_KnuthShuffle
   BB7 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../03_knuth_shuffle.rs" 16 4 16 43] Next0.next _18);
-    _18 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _17 <- ([#"../03_knuth_shuffle.rs" 16 4 16 43] Next0.next _19);
+    _19 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB8
   }
   BB8 {
-    assume { Resolve1.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB9
       | Core_Option_Option_Type.C_Some _ -> goto BB10
       end
   }
   BB9 {
-    assert { [@expl:type invariant] Inv5.inv v };
-    assume { Resolve3.resolve v };
+    assert { [@expl:type invariant] Inv3.inv v };
+    assume { Resolve1.resolve v };
     _0 <- ();
     return _0
   }
@@ -1210,8 +1203,8 @@ module C03KnuthShuffle_KnuthShuffle
     goto BB12
   }
   BB11 {
-    assert { [@expl:type invariant] Inv5.inv v };
-    assume { Resolve3.resolve v };
+    assert { [@expl:type invariant] Inv3.inv v };
+    assume { Resolve1.resolve v };
     absurd
   }
   BB12 {
@@ -1241,16 +1234,11 @@ module C03KnuthShuffle_KnuthShuffle
     goto BB16
   }
   BB16 {
-    _32 <- Borrow.borrow_mut ( * _33);
-    _33 <- { _33 with current = ( ^ _32) };
-    assume { Inv3.inv ( ^ _32) };
-    _31 <- ([#"../03_knuth_shuffle.rs" 22 8 22 28] Swap0.swap _32 i ([#"../03_knuth_shuffle.rs" 22 18 22 27] upper - ([#"../03_knuth_shuffle.rs" 22 26 22 27] (1 : usize))));
-    _32 <- any borrowed (slice t);
+    _31 <- ([#"../03_knuth_shuffle.rs" 22 8 22 28] Swap0.swap _33 i ([#"../03_knuth_shuffle.rs" 22 18 22 27] upper - ([#"../03_knuth_shuffle.rs" 22 26 22 27] (1 : usize))));
+    _33 <- any borrowed (slice t);
     goto BB17
   }
   BB17 {
-    assert { [@expl:type invariant] Inv4.inv _33 };
-    assume { Resolve2.resolve _33 };
     goto BB6
   }
   

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -3050,6 +3050,8 @@ module C06KnightsTour_Impl1_CountDegree
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq (isize, isize),
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve3 with
+    type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Invariant_Inv_Interface as Inv3 with
     type t = borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial3 with
@@ -3090,14 +3092,12 @@ module C06KnightsTour_Impl1_CountDegree
     predicate Inv0.inv = Inv5.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv6.inv
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve2 with
     type t = isize
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Std1_Vec_Impl8_Completed as Completed0 with
     type t = (isize, isize),
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve3.resolve,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
@@ -3159,16 +3159,16 @@ module C06KnightsTour_Impl1_CountDegree
     predicate Inv1.inv = Inv6.inv,
     predicate Inv2.inv = Inv7.inv,
     predicate Inv3.inv = Inv8.inv
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve1 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = isize,
     type t2 = isize,
-    predicate Resolve0.resolve = Resolve3.resolve,
-    predicate Resolve1.resolve = Resolve3.resolve
-  clone CreusotContracts_Std1_Vec_Impl11_Resolve as Resolve2 with
+    predicate Resolve0.resolve = Resolve2.resolve,
+    predicate Resolve1.resolve = Resolve2.resolve
+  clone CreusotContracts_Std1_Vec_Impl11_Resolve as Resolve1 with
     type t = (isize, isize),
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model,
-    predicate Resolve0.resolve = Resolve1.resolve
+    predicate Resolve0.resolve = Resolve0.resolve
   clone C06KnightsTour_Impl1_Available_Interface as Available0 with
     predicate Wf0.wf = Wf0.wf,
     predicate InBounds0.in_bounds = InBounds0.in_bounds
@@ -3208,7 +3208,6 @@ module C06KnightsTour_Impl1_CountDegree
   var produced : Ghost.ghost_ty (Seq.seq (isize, isize));
   var _16 : ();
   var _17 : Core_Option_Option_Type.t_option (isize, isize);
-  var _18 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _19 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var __creusot_proc_iter_elem : (isize, isize);
   var _22 : Ghost.ghost_ty (Seq.seq (isize, isize));
@@ -3255,28 +3254,25 @@ module C06KnightsTour_Impl1_CountDegree
   BB8 {
     _19 <- Borrow.borrow_mut iter;
     iter <-  ^ _19;
-    _18 <- Borrow.borrow_mut ( * _19);
-    _19 <- { _19 with current = ( ^ _18) };
-    _17 <- ([#"../06_knights_tour.rs" 73 8 73 46] Next0.next _18);
-    _18 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
+    _17 <- ([#"../06_knights_tour.rs" 73 8 73 46] Next0.next _19);
+    _19 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
     goto BB9
   }
   BB9 {
-    assume { Resolve0.resolve _19 };
     switch (_17)
       | Core_Option_Option_Type.C_None -> goto BB10
       | Core_Option_Option_Type.C_Some _ -> goto BB11
       end
   }
   BB10 {
-    assume { Resolve2.resolve iter };
+    assume { Resolve1.resolve iter };
     goto BB20
   }
   BB11 {
     goto BB13
   }
   BB12 {
-    assume { Resolve2.resolve iter };
+    assume { Resolve1.resolve iter };
     absurd
   }
   BB13 {
@@ -3288,13 +3284,13 @@ module C06KnightsTour_Impl1_CountDegree
     produced <- _22;
     _22 <- any Ghost.ghost_ty (Seq.seq (isize, isize));
     m <- __creusot_proc_iter_elem;
-    assume { Resolve1.resolve __creusot_proc_iter_elem };
+    assume { Resolve0.resolve __creusot_proc_iter_elem };
     _28 <- m;
     next <- ([#"../06_knights_tour.rs" 75 23 75 32] Mov0.mov p _28);
     goto BB15
   }
   BB15 {
-    assume { Resolve1.resolve m };
+    assume { Resolve0.resolve m };
     _29 <- ([#"../06_knights_tour.rs" 76 15 76 35] Available0.available self next);
     goto BB16
   }
@@ -3563,10 +3559,8 @@ module C06KnightsTour_Impl1_Set
     predicate Inv1.inv = Inv4.inv,
     predicate Inv2.inv = Inv6.inv,
     predicate Inv3.inv = Inv7.inv
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve2 with
-    type t = C06KnightsTour_Board_Type.t_board
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
+    type t = C06KnightsTour_Board_Type.t_board
   clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
     type t = usize
   clone Alloc_Vec_Impl13_IndexMut_Interface as IndexMut1 with
@@ -3613,7 +3607,6 @@ module C06KnightsTour_Impl1_Set
   var p : C06KnightsTour_Point_Type.t_point = p;
   var v : usize = v;
   var _9 : borrowed usize;
-  var _10 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _11 : borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
   var _12 : borrowed (Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global));
   {
@@ -3627,18 +3620,15 @@ module C06KnightsTour_Impl1_Set
     goto BB1
   }
   BB1 {
-    _10 <- Borrow.borrow_mut ( * _11);
-    _11 <- { _11 with current = ( ^ _10) };
-    _9 <- ([#"../06_knights_tour.rs" 88 8 88 46] IndexMut1.index_mut _10 (UIntSize.of_int (IntSize.to_int (C06KnightsTour_Point_Type.point_y p))));
-    _10 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
+    _9 <- ([#"../06_knights_tour.rs" 88 8 88 46] IndexMut1.index_mut _11 (UIntSize.of_int (IntSize.to_int (C06KnightsTour_Point_Type.point_y p))));
+    _11 <- any borrowed (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global));
     goto BB2
   }
   BB2 {
     _9 <- { _9 with current = v };
     assume { Resolve0.resolve _9 };
     _0 <- ();
-    assume { Resolve1.resolve _11 };
-    assume { Resolve2.resolve self };
+    assume { Resolve1.resolve self };
     return _0
   }
   
@@ -4193,6 +4183,8 @@ module C06KnightsTour_Min
     type t = Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point),
     type ShallowModelTy0.shallowModelTy = slice (usize, C06KnightsTour_Point_Type.t_point),
     function ShallowModel0.shallow_model = ShallowModel1.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)
   use seq.Seq
   clone CreusotContracts_Invariant_Inv_Interface as Inv5 with
     type t = Seq.seq (usize, C06KnightsTour_Point_Type.t_point)
@@ -4233,8 +4225,6 @@ module C06KnightsTour_Min
     type t = Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv1.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)
   clone CreusotContracts_Std1_Slice_Impl14_Completed as Completed0 with
     type t = (usize, C06KnightsTour_Point_Type.t_point),
     predicate Resolve0.resolve = Resolve0.resolve,
@@ -4332,7 +4322,6 @@ module C06KnightsTour_Min
   var iter_old : Ghost.ghost_ty (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
   var produced : Ghost.ghost_ty (Seq.seq (usize, C06KnightsTour_Point_Type.t_point));
   var _15 : Core_Option_Option_Type.t_option (usize, C06KnightsTour_Point_Type.t_point);
-  var _16 : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
   var _17 : borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
   var __creusot_proc_iter_elem : (usize, C06KnightsTour_Point_Type.t_point);
   var _20 : Ghost.ghost_ty (Seq.seq (usize, C06KnightsTour_Point_Type.t_point));
@@ -4367,14 +4356,11 @@ module C06KnightsTour_Min
   BB5 {
     _17 <- Borrow.borrow_mut iter;
     iter <-  ^ _17;
-    _16 <- Borrow.borrow_mut ( * _17);
-    _17 <- { _17 with current = ( ^ _16) };
-    _15 <- ([#"../06_knights_tour.rs" 113 4 114 74] Next0.next _16);
-    _16 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
+    _15 <- ([#"../06_knights_tour.rs" 113 4 114 74] Next0.next _17);
+    _17 <- any borrowed (Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point));
     goto BB6
   }
   BB6 {
-    assume { Resolve0.resolve _17 };
     switch (_15)
       | Core_Option_Option_Type.C_None -> goto BB7
       | Core_Option_Option_Type.C_Some _ -> goto BB8
@@ -4758,6 +4744,8 @@ module C06KnightsTour_KnightsTour
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq (isize, isize),
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve6 with
+    type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Invariant_Inv_Interface as Inv12 with
     type t = borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial12 with
@@ -4795,6 +4783,8 @@ module C06KnightsTour_KnightsTour
     predicate Inv0.inv = Inv7.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve5 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial6 with
@@ -4825,7 +4815,7 @@ module C06KnightsTour_KnightsTour
     type t = Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv2.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve6 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve4 with
     type t1 = usize,
     type t2 = C06KnightsTour_Point_Type.t_point,
     predicate Resolve0.resolve = Resolve7.resolve,
@@ -4846,14 +4836,12 @@ module C06KnightsTour_KnightsTour
     type t = Alloc_Vec_Vec_Type.t_vec (usize, C06KnightsTour_Point_Type.t_point) (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq (usize, C06KnightsTour_Point_Type.t_point),
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve5 with
+  clone CreusotContracts_Resolve_Impl2_Resolve as Resolve3 with
     type t = isize
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
   clone CreusotContracts_Std1_Vec_Impl8_Completed as Completed1 with
     type t = (isize, isize),
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve6.resolve,
     function ShallowModel0.shallow_model = ShallowModel7.shallow_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)
@@ -4905,11 +4893,9 @@ module C06KnightsTour_KnightsTour
     predicate Inv1.inv = Inv11.inv
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed0 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve0.resolve,
+    predicate Resolve0.resolve = Resolve5.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel2 with
     type t = usize,
@@ -4964,27 +4950,27 @@ module C06KnightsTour_KnightsTour
     predicate Inv0.inv = Inv8.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv9.inv
-  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve4 with
+  clone CreusotContracts_Std1_Vec_Impl10_Resolve as Resolve2 with
     type t = (usize, C06KnightsTour_Point_Type.t_point),
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic,
-    predicate Resolve0.resolve = Resolve6.resolve,
+    predicate Resolve0.resolve = Resolve4.resolve,
     predicate Inv0.inv = Inv8.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv9.inv
   clone C06KnightsTour_Min_Interface as Min0 with
     function ShallowModel0.shallow_model = ShallowModel6.shallow_model,
     function IndexLogic0.index_logic = IndexLogic0.index_logic
-  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve2 with
+  clone CreusotContracts_Resolve_Impl0_Resolve as Resolve0 with
     type t1 = isize,
     type t2 = isize,
-    predicate Resolve0.resolve = Resolve5.resolve,
-    predicate Resolve1.resolve = Resolve5.resolve
-  clone CreusotContracts_Std1_Vec_Impl11_Resolve as Resolve3 with
+    predicate Resolve0.resolve = Resolve3.resolve,
+    predicate Resolve1.resolve = Resolve3.resolve
+  clone CreusotContracts_Std1_Vec_Impl11_Resolve as Resolve1 with
     type t = (isize, isize),
     type a = Alloc_Alloc_Global_Type.t_global,
     function ShallowModel0.shallow_model = ShallowModel4.shallow_model,
-    predicate Resolve0.resolve = Resolve2.resolve
+    predicate Resolve0.resolve = Resolve0.resolve
   clone Alloc_Vec_Impl1_Push_Interface as Push0 with
     type t = (usize, C06KnightsTour_Point_Type.t_point),
     type a = Alloc_Alloc_Global_Type.t_global,
@@ -5076,7 +5062,6 @@ module C06KnightsTour_KnightsTour
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _34 : ();
   var _35 : Core_Option_Option_Type.t_option usize;
-  var _36 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _37 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem : usize;
   var _40 : Ghost.ghost_ty (Seq.seq usize);
@@ -5087,7 +5072,6 @@ module C06KnightsTour_KnightsTour
   var iter_old1 : Ghost.ghost_ty (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var produced1 : Ghost.ghost_ty (Seq.seq (isize, isize));
   var _54 : Core_Option_Option_Type.t_option (isize, isize);
-  var _55 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var _56 : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
   var __creusot_proc_iter_elem1 : (isize, isize);
   var _59 : Ghost.ghost_ty (Seq.seq (isize, isize));
@@ -5154,14 +5138,11 @@ module C06KnightsTour_KnightsTour
   BB10 {
     _37 <- Borrow.borrow_mut iter;
     iter <-  ^ _37;
-    _36 <- Borrow.borrow_mut ( * _37);
-    _37 <- { _37 with current = ( ^ _36) };
-    _35 <- ([#"../06_knights_tour.rs" 142 4 142 36] Next0.next _36);
-    _36 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _35 <- ([#"../06_knights_tour.rs" 142 4 142 36] Next0.next _37);
+    _37 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB11
   }
   BB11 {
-    assume { Resolve0.resolve _37 };
     switch (_35)
       | Core_Option_Option_Type.C_None -> goto BB12
       | Core_Option_Option_Type.C_Some _ -> goto BB13
@@ -5228,21 +5209,18 @@ module C06KnightsTour_KnightsTour
   BB26 {
     _56 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _56;
-    _55 <- Borrow.borrow_mut ( * _56);
-    _56 <- { _56 with current = ( ^ _55) };
-    _54 <- ([#"../06_knights_tour.rs" 148 8 149 54] Next1.next _55);
-    _55 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
+    _54 <- ([#"../06_knights_tour.rs" 148 8 149 54] Next1.next _56);
+    _56 <- any borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global));
     goto BB27
   }
   BB27 {
-    assume { Resolve1.resolve _56 };
     switch (_54)
       | Core_Option_Option_Type.C_None -> goto BB28
       | Core_Option_Option_Type.C_Some _ -> goto BB29
       end
   }
   BB28 {
-    assume { Resolve3.resolve iter1 };
+    assume { Resolve1.resolve iter1 };
     goto BB39
   }
   BB29 {
@@ -5257,13 +5235,13 @@ module C06KnightsTour_KnightsTour
     produced1 <- _59;
     _59 <- any Ghost.ghost_ty (Seq.seq (isize, isize));
     m <- __creusot_proc_iter_elem1;
-    assume { Resolve2.resolve __creusot_proc_iter_elem1 };
+    assume { Resolve0.resolve __creusot_proc_iter_elem1 };
     _65 <- m;
     adj <- ([#"../06_knights_tour.rs" 151 22 151 31] Mov0.mov p _65);
     goto BB32
   }
   BB32 {
-    assume { Resolve2.resolve m };
+    assume { Resolve0.resolve m };
     _66 <- ([#"../06_knights_tour.rs" 152 15 152 35] Available0.available board adj);
     goto BB33
   }
@@ -5308,7 +5286,7 @@ module C06KnightsTour_KnightsTour
   }
   BB41 {
     _0 <- Core_Option_Option_Type.C_None;
-    assume { Resolve4.resolve candidates };
+    assume { Resolve2.resolve candidates };
     goto BB48
   }
   BB42 {
@@ -5316,7 +5294,7 @@ module C06KnightsTour_KnightsTour
   }
   BB43 {
     adj1 <- (let (_, a) = Core_Option_Option_Type.some_0 _79 in a);
-    assume { Resolve4.resolve candidates };
+    assume { Resolve2.resolve candidates };
     p <- adj1;
     _87 <- Borrow.borrow_mut board;
     board <-  ^ _87;
@@ -5350,12 +5328,12 @@ module C06KnightsTour_KnightsTour
     goto BB14
   }
   BB58 {
-    assume { Resolve3.resolve iter1 };
-    assume { Resolve4.resolve candidates };
+    assume { Resolve1.resolve iter1 };
+    assume { Resolve2.resolve candidates };
     goto BB14
   }
   BB59 {
-    assume { Resolve4.resolve candidates };
+    assume { Resolve2.resolve candidates };
     goto BB14
   }
   

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -636,28 +636,6 @@ module CreusotContracts_Std1_Iter_Range_Impl1_Produces
     ensures { result = produces self visited o }
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module Core_Option_Option_Type
   type t_option 't =
     | C_None
@@ -1374,6 +1352,28 @@ module CreusotContracts_Std1_Iter_Range_Impl0_ProducesTrans
     
   axiom produces_trans_spec : forall a : Core_Ops_Range_Range_Type.t_range idx, ab : Seq.seq idx, b : Core_Ops_Range_Range_Type.t_range idx, bc : Seq.seq idx, c : Core_Ops_Range_Range_Type.t_range idx . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] Produces0.produces a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] Produces0.produces b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] Inv0.inv a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] Inv1.inv ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] Inv0.inv b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] Inv1.inv bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] Inv0.inv c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] Produces0.produces a (Seq.(++) ab bc) c)
 end
+module CreusotContracts_Resolve_Impl1_Resolve_Stub
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+end
+module CreusotContracts_Resolve_Impl1_Resolve_Interface
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t)
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
+module CreusotContracts_Resolve_Impl1_Resolve
+  type t
+  use prelude.Borrow
+  predicate resolve (self : borrowed t) =
+    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
+  val resolve (self : borrowed t) : bool
+    ensures { result = resolve self }
+    
+end
 module CreusotContracts_Std1_Iter_Range_Impl0_Completed_Stub
   type idx
   use prelude.Borrow
@@ -1692,6 +1692,8 @@ module C08Haystack_Search
     predicate Inv0.inv = Inv7.inv,
     axiom .
   use Core_Ops_Range_Range_Type as Core_Ops_Range_Range_Type
+  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
+    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Invariant_Inv_Interface as Inv6 with
     type t = borrowed (Core_Ops_Range_Range_Type.t_range usize)
   clone TyInv_Trivial as TyInv_Trivial6 with
@@ -1740,11 +1742,9 @@ module C08Haystack_Search
     type t = uint8
   use prelude.Int
   clone CreusotContracts_Std1_Num_Impl16_DeepModel as DeepModel0
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve1 with
-    type t = Core_Ops_Range_Range_Type.t_range usize
   clone CreusotContracts_Std1_Iter_Range_Impl0_Completed as Completed1 with
     type idx = usize,
-    predicate Resolve0.resolve = Resolve1.resolve,
+    predicate Resolve0.resolve = Resolve0.resolve,
     function DeepModel0.deep_model = DeepModel0.deep_model
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
     type t = Core_Ops_Range_Range_Type.t_range usize
@@ -1871,8 +1871,6 @@ module C08Haystack_Search
     predicate IntoIterPre0.into_iter_pre = IntoIterPre1.into_iter_pre,
     predicate Inv0.inv = Inv1.inv,
     predicate IntoIterPost0.into_iter_post = IntoIterPost1.into_iter_post
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize
   clone Core_Iter_Range_Impl12_Next_Interface as Next0 with
     type a = usize,
     predicate Inv0.inv = Inv4.inv,
@@ -1919,7 +1917,6 @@ module C08Haystack_Search
   var iter_old : Ghost.ghost_ty (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var produced : Ghost.ghost_ty (Seq.seq usize);
   var _24 : Core_Option_Option_Type.t_option usize;
-  var _25 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var _26 : borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
   var __creusot_proc_iter_elem : usize;
   var _29 : Ghost.ghost_ty (Seq.seq usize);
@@ -1929,7 +1926,6 @@ module C08Haystack_Search
   var iter_old1 : Ghost.ghost_ty (Core_Ops_Range_Range_Type.t_range usize);
   var produced1 : Ghost.ghost_ty (Seq.seq usize);
   var _45 : Core_Option_Option_Type.t_option usize;
-  var _46 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var _47 : borrowed (Core_Ops_Range_Range_Type.t_range usize);
   var __creusot_proc_iter_elem1 : usize;
   var _50 : Ghost.ghost_ty (Seq.seq usize);
@@ -1978,14 +1974,11 @@ module C08Haystack_Search
   BB8 {
     _26 <- Borrow.borrow_mut iter;
     iter <-  ^ _26;
-    _25 <- Borrow.borrow_mut ( * _26);
-    _26 <- { _26 with current = ( ^ _25) };
-    _24 <- ([#"../08_haystack.rs" 22 4 22 112] Next0.next _25);
-    _25 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
+    _24 <- ([#"../08_haystack.rs" 22 4 22 112] Next0.next _26);
+    _26 <- any borrowed (Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize);
     goto BB9
   }
   BB9 {
-    assume { Resolve0.resolve _26 };
     switch (_24)
       | Core_Option_Option_Type.C_None -> goto BB10
       | Core_Option_Option_Type.C_Some _ -> goto BB11
@@ -2038,14 +2031,11 @@ module C08Haystack_Search
   BB20 {
     _47 <- Borrow.borrow_mut iter1;
     iter1 <-  ^ _47;
-    _46 <- Borrow.borrow_mut ( * _47);
-    _47 <- { _47 with current = ( ^ _46) };
-    _45 <- ([#"../08_haystack.rs" 24 8 24 68] Next1.next _46);
-    _46 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
+    _45 <- ([#"../08_haystack.rs" 24 8 24 68] Next1.next _47);
+    _47 <- any borrowed (Core_Ops_Range_Range_Type.t_range usize);
     goto BB21
   }
   BB21 {
-    assume { Resolve1.resolve _47 };
     switch (_45)
       | Core_Option_Option_Type.C_None -> goto BB22
       | Core_Option_Option_Type.C_Some _ -> goto BB23

--- a/creusot/tests/should_succeed/vector/09_capacity.mlcfg
+++ b/creusot/tests/should_succeed/vector/09_capacity.mlcfg
@@ -228,28 +228,6 @@ module Alloc_Alloc_Global_Type
     | C_Global
     
 end
-module CreusotContracts_Resolve_Impl1_Resolve_Stub
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-end
-module CreusotContracts_Resolve_Impl1_Resolve_Interface
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t)
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
-module CreusotContracts_Resolve_Impl1_Resolve
-  type t
-  use prelude.Borrow
-  predicate resolve (self : borrowed t) =
-    [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
-  val resolve (self : borrowed t) : bool
-    ensures { result = resolve self }
-    
-end
 module TyInv_Trivial
   type t
   clone CreusotContracts_Invariant_Inv_Stub as Inv0 with
@@ -458,8 +436,6 @@ module C09Capacity_ChangeCapacity
     type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     type ShallowModelTy0.shallowModelTy = Seq.seq t,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone Alloc_Vec_Impl1_ShrinkTo_Interface as ShrinkTo0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
@@ -511,7 +487,6 @@ module C09Capacity_ChangeCapacity
   var _8 : ();
   var _9 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   var _10 : ();
-  var _11 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
     goto BB0
   }
@@ -540,16 +515,11 @@ module C09Capacity_ChangeCapacity
     goto BB3
   }
   BB3 {
-    _11 <- Borrow.borrow_mut ( * v);
-    v <- { v with current = ( ^ _11) };
-    assume { Inv0.inv ( ^ _11) };
-    _10 <- ([#"../09_capacity.rs" 10 4 10 18] ShrinkTo0.shrink_to _11 ([#"../09_capacity.rs" 10 16 10 17] (1 : usize)));
-    _11 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
+    _10 <- ([#"../09_capacity.rs" 10 4 10 18] ShrinkTo0.shrink_to v ([#"../09_capacity.rs" 10 16 10 17] (1 : usize)));
+    v <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB4
   }
   BB4 {
-    assert { [@expl:type invariant] Inv1.inv v };
-    assume { Resolve0.resolve v };
     _0 <- ();
     return _0
   }
@@ -621,58 +591,50 @@ module C09Capacity_ClearVec
   use Alloc_Alloc_Global_Type as Alloc_Alloc_Global_Type
   use Alloc_Vec_Vec_Type as Alloc_Vec_Vec_Type
   clone CreusotContracts_Invariant_Inv_Interface as Inv1 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone TyInv_Trivial as TyInv_Trivial1 with
-    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
+    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
     predicate Inv0.inv = Inv1.inv,
     axiom .
-  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Invariant_Inv_Interface as Inv0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))
   clone TyInv_Trivial as TyInv_Trivial0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global),
+    type t = borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)),
     predicate Inv0.inv = Inv0.inv,
     axiom .
+  clone Core_Num_Impl11_Max as Max0
   clone CreusotContracts_Std1_Vec_Impl0_ShallowModel_Interface as ShallowModel0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv0.inv,
+    predicate Inv0.inv = Inv1.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv1.inv = Inv2.inv,
     axiom .
-  clone CreusotContracts_Resolve_Impl1_Resolve as Resolve0 with
-    type t = Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)
   clone Alloc_Vec_Impl1_Clear_Interface as Clear0 with
     type t = t,
     type a = Alloc_Alloc_Global_Type.t_global,
-    predicate Inv0.inv = Inv1.inv,
+    predicate Inv0.inv = Inv0.inv,
     function ShallowModel0.shallow_model = ShallowModel0.shallow_model,
-    predicate Inv1.inv = Inv0.inv,
+    predicate Inv1.inv = Inv1.inv,
     val Max0.mAX' = Max0.mAX',
     predicate Inv2.inv = Inv2.inv
   let rec cfg clear_vec [#"../09_capacity.rs" 14 0 14 35] [@cfg:stackify] [@cfg:subregion_analysis] (v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) : ()
-    requires {[#"../09_capacity.rs" 14 20 14 21] Inv1.inv v}
+    requires {[#"../09_capacity.rs" 14 20 14 21] Inv0.inv v}
     ensures { [#"../09_capacity.rs" 13 10 13 26] Seq.length (ShallowModel0.shallow_model ( ^ v)) = 0 }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
   var v : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global)) = v;
   var _3 : ();
-  var _4 : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
   {
     goto BB0
   }
   BB0 {
-    _4 <- Borrow.borrow_mut ( * v);
-    v <- { v with current = ( ^ _4) };
-    assume { Inv0.inv ( ^ _4) };
-    _3 <- ([#"../09_capacity.rs" 15 4 15 13] Clear0.clear _4);
-    _4 <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
+    _3 <- ([#"../09_capacity.rs" 15 4 15 13] Clear0.clear v);
+    v <- any borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global));
     goto BB1
   }
   BB1 {
-    assert { [@expl:type invariant] Inv1.inv v };
-    assume { Resolve0.resolve v };
     _0 <- ();
     return _0
   }


### PR DESCRIPTION
In trying to come up with a good way to handle #869 and #902, most of the trouble seems to come from unnecessary reborrowing in the MIR. If it wasn't for that adding a third field to mutable references might be enough to solve these issues while not breaking too many tests (`{ x with current = y }` would preserve the third field but `Borrow.borrow_mut y` would not).
Removing these reborrows also simplifies the Why3 a bit, it probably doesn't make a huge difference to provers, but it might be nice for people using the Why3IDE.

Since I didn't want to mess with the MIR to FMIR transformation I implemented this as a MIR optimization that runs before the analysis so the borrow-checker facts used to determine resolution are accurate. The "optimization" translates statements of the form `_x = &mut *_y` to `_x = move _y` when `_y: &mut _` and `_y` is dead after the statement. I think this should be sound but I'm just making this a draft to see what you think.