### PR TITLE
Prototype `HasDeps` trait

### DIFF
--- a/creusot/src/backend.rs
+++ b/creusot/src/backend.rs
@@ -310,6 +310,10 @@ impl<'tcx> Why3Generator<'tcx> {
 
         &self.projections_in_ty[&item]
     }
+
+    fn is_logical(&self, did: DefId) -> bool {
+       matches!(util::item_type(self.tcx, did), ItemType::Logic | ItemType::Ghost | ItemType::Predicate)
+    }
 }
 
 // Closures inherit the generic parameters of the original function they were defined in, but


### PR DESCRIPTION
I'm working on removing clones totally. The actual code to replace the current `CloneElaborator` is rather simple and small, however, there is a remaining issue where the `CloneMap` simultaneously gathers dependencies and provides names during translation. This means that a non-clone elaborator cannot change what the format or content of the provided names are since the elaborator is run *after* all dependencies are gathered. By moving dependency calculation to a standalone trait we can split this functionality out of the `CloneMap` making it solely responsible for providing names. 

My current approach aims for this trait to initially have 0 difference with the original code, we can refactor things like the handling of associated types in types later. 
