### PR TITLE
Some stylistic changes in examples and creusot-contracts.

### DIFF
--- a/creusot-contracts/src/ghost_ptr.rs
+++ b/creusot-contracts/src/ghost_ptr.rs
@@ -70,9 +70,10 @@ impl<T: ?Sized> GhostPtrToken<T> {
 
     /// Shrinks the view of the `self` so that it's model is now new-model
     #[trusted]
-    #[requires(_new_model.subset(self@))]
-    #[ensures(result@ == *_new_model)]
-    pub fn shrink_token_ref(&self, _new_model: Ghost<FMap<*const T, T>>) -> &GhostPtrToken<T> {
+    #[requires(new_model.subset(self@))]
+    #[ensures(result@ == *new_model)]
+    #[allow(unused_variables)]
+    pub fn shrink_token_ref(&self, new_model: Ghost<FMap<*const T, T>>) -> &GhostPtrToken<T> {
         self
     }
 
@@ -110,11 +111,12 @@ impl<T: ?Sized> GhostPtrToken<T> {
     }
 
     #[trusted]
-    #[ensures((*self)@.disjoint(_other@))]
+    #[ensures((*self)@.disjoint(other@))]
     // Since we had full permission to and all of the entries in `self` and `other` simultaneously,
     // no pointer could have been in both
-    #[ensures((^self)@ == (*self)@.union(_other@))]
-    pub fn merge(&mut self, _other: GhostPtrToken<T>) {}
+    #[ensures((^self)@ == (*self)@.union(other@))]
+    #[allow(unused_variables)]
+    pub fn merge(&mut self, other: GhostPtrToken<T>) {}
 
     /// Leaks memory iff the precondition fails
     #[requires(self@.is_empty())]

--- a/creusot-contracts/src/logic/fmap.rs
+++ b/creusot-contracts/src/logic/fmap.rs
@@ -2,7 +2,7 @@ use crate::{logic::Mapping, util::*, *};
 
 type PMap<K, V> = Mapping<K, Option<SizedW<V>>>;
 
-#[trusted] //opauqe
+#[trusted] //opaque
 pub struct FMap<K, V: ?Sized>(PMap<K, V>);
 
 impl<K, V: ?Sized> FMap<K, V> {

--- a/creusot-contracts/src/std/deque.rs
+++ b/creusot-contracts/src/std/deque.rs
@@ -142,8 +142,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot-contracts/src/std/iter.rs
+++ b/creusot-contracts/src/std/iter.rs
@@ -25,14 +25,14 @@ pub use zip::ZipExt;
 
 pub trait Iterator: ::std::iter::Iterator {
     #[predicate]
-    fn produces(self, visited: Seq<Self::Item>, _o: Self) -> bool;
+    fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool;
 
     #[predicate]
     fn completed(&mut self) -> bool;
 
     #[law]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self);
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self);
 
     #[law]
     #[requires(a.produces(ab, b))]
@@ -127,8 +127,8 @@ extern_spec! {
                     where U::IntoIter: Iterator;
 
                 // TODO: Investigate why Self_ needed
-                #[ensures(exists<done_ : &mut Self_, prod: Seq<_>> (^done_).resolve() && done_.completed() &&
-                    self.produces(prod, *done_) && B::from_iter_post(prod, result))]
+                #[ensures(exists<done : &mut Self_, prod: Seq<_>> (^done).resolve() && done.completed() &&
+                    self.produces(prod, *done) && B::from_iter_post(prod, result))]
                 fn collect<B>(self) -> B
                     where B: FromIterator<Self::Item>;
             }
@@ -146,9 +146,9 @@ extern_spec! {
                 where Self: FromIterator<A> {
 
                 #[requires(iter.into_iter_pre())]
-                #[ensures(exists<into_iter: T::IntoIter, done_: &mut T::IntoIter, prod: Seq<A>>
+                #[ensures(exists<into_iter: T::IntoIter, done: &mut T::IntoIter, prod: Seq<A>>
                               iter.into_iter_post(into_iter) &&
-                              into_iter.produces(prod, *done_) && done_.completed() && (^done_).resolve() &&
+                              into_iter.produces(prod, *done) && done.completed() && (^done).resolve() &&
                               Self_::from_iter_post(prod, result))]
                 fn from_iter<T>(iter: T) -> Self
                     where T: IntoIterator<Item = A>, T::IntoIter: Iterator;

--- a/creusot-contracts/src/std/iter/cloned.rs
+++ b/creusot-contracts/src/std/iter/cloned.rs
@@ -48,8 +48,8 @@ where
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/copied.rs
+++ b/creusot-contracts/src/std/iter/copied.rs
@@ -48,8 +48,8 @@ where
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/empty.rs
+++ b/creusot-contracts/src/std/iter/empty.rs
@@ -15,8 +15,8 @@ impl<T> Iterator for Empty<T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/enumerate.rs
+++ b/creusot-contracts/src/std/iter/enumerate.rs
@@ -69,8 +69,8 @@ where
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/fuse.rs
+++ b/creusot-contracts/src/std/iter/fuse.rs
@@ -37,8 +37,8 @@ impl<I: Iterator> Iterator for Fuse<I> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot-contracts/src/std/iter/map_inv.rs
+++ b/creusot-contracts/src/std/iter/map_inv.rs
@@ -20,8 +20,8 @@ impl<I: Iterator, B, F: FnMut(I::Item, Ghost<Seq<I::Item>>) -> B> Iterator
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/once.rs
+++ b/creusot-contracts/src/std/iter/once.rs
@@ -29,8 +29,8 @@ impl<T> Iterator for Once<T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/range.rs
+++ b/creusot-contracts/src/std/iter/range.rs
@@ -29,8 +29,8 @@ impl<Idx: DeepModel<DeepModelTy = Int> + Step> Iterator for Range<Idx> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]
@@ -73,8 +73,8 @@ impl<Idx: DeepModel<DeepModelTy = Int> + Step> Iterator for RangeInclusive<Idx> 
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot-contracts/src/std/iter/repeat.rs
+++ b/creusot-contracts/src/std/iter/repeat.rs
@@ -29,8 +29,8 @@ impl<T: Clone> Iterator for Repeat<T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/skip.rs
+++ b/creusot-contracts/src/std/iter/skip.rs
@@ -66,8 +66,8 @@ impl<I: Iterator> Iterator for Skip<I> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/take.rs
+++ b/creusot-contracts/src/std/iter/take.rs
@@ -67,8 +67,8 @@ impl<I: Iterator> Iterator for Take<I> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/iter/zip.rs
+++ b/creusot-contracts/src/std/iter/zip.rs
@@ -52,8 +52,8 @@ impl<A: Iterator, B: Iterator> Iterator for Zip<A, B> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/ops.rs
+++ b/creusot-contracts/src/std/ops.rs
@@ -245,12 +245,12 @@ extern_spec! {
         mod ops {
             trait IndexMut<Idx>  where Idx : ?Sized, Self : ?Sized {
                 #[requires(false)]
-                fn index_mut(&mut self, _ix : Idx) -> &mut Self::Output;
+                fn index_mut(&mut self, ix : Idx) -> &mut Self::Output;
             }
 
             trait Index<Idx>  where Idx : ?Sized,  Self : ?Sized {
                 #[requires(false)]
-                fn index(&self, _ix : Idx) -> &Self::Output;
+                fn index(&self, ix : Idx) -> &Self::Output;
             }
         }
     }

--- a/creusot-contracts/src/std/option.rs
+++ b/creusot-contracts/src/std/option.rs
@@ -150,8 +150,8 @@ impl<T> Iterator for IntoIter<T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]
@@ -204,8 +204,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]
@@ -261,8 +261,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[law]
     #[open(self)]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open(self)]

--- a/creusot-contracts/src/std/slice.rs
+++ b/creusot-contracts/src/std/slice.rs
@@ -389,8 +389,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]
@@ -438,8 +438,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot-contracts/src/std/vec.rs
+++ b/creusot-contracts/src/std/vec.rs
@@ -119,9 +119,9 @@ extern_spec! {
 
             impl<T, A : Allocator> Extend<T> for Vec<T, A> {
                 #[requires(iter.into_iter_pre())]
-                #[ensures(exists<start_ : I::IntoIter, done_ : &mut I::IntoIter, prod: Seq<T>>
+                #[ensures(exists<start_ : I::IntoIter, done : &mut I::IntoIter, prod: Seq<T>>
                     iter.into_iter_post(start_) &&
-                    done_.completed() && start_.produces(prod, *done_) && (^self)@ == self@.concat(prod)
+                    done.completed() && start_.produces(prod, *done) && (^self)@ == self@.concat(prod)
                 )]
                 fn extend<I>(&mut self, iter: I)
                 where
@@ -240,8 +240,8 @@ impl<T, A: Allocator> Iterator for std::vec::IntoIter<T, A> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/100doors.mlcfg
+++ b/creusot/tests/should_succeed/100doors.mlcfg
@@ -225,12 +225,12 @@ module C100doors_F
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv11 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv11 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/bug/874.mlcfg
+++ b/creusot/tests/should_succeed/bug/874.mlcfg
@@ -113,15 +113,15 @@ module C874_CanExtend
     
   axiom produces_trans0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global), ab : Seq.seq int32, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global), bc : Seq.seq int32, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 248 15 248 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 249 15 249 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 22 251 23] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 31 251 33] inv3 ab) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 43 251 44] inv5 b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 52 251 54] inv3 bc) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 64 251 65] inv5 c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 250 14 250 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) : ()
+  function produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) : ()
     
    =
     [#"../../../../../creusot-contracts/src/std/vec.rs" 241 4 241 10] ()
-  val produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv5 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv5 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv5 self) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 45] produces0 self (Seq.empty ) self)
   predicate invariant5 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant5 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) : bool
@@ -253,7 +253,7 @@ module C874_CanExtend
     requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 121 27 121 47] into_iter_pre0 iter}
     requires {inv2 self}
     requires {inv1 iter}
-    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 16 125 18] exists prod : Seq.seq int32 . exists done_ : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) . exists start_ : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global) . inv3 prod /\ inv4 done_ /\ inv5 start_ /\ into_iter_post0 iter start_ /\ completed0 done_ /\ produces0 start_ prod ( * done_) /\ shallow_model0 ( ^ self) = Seq.(++) (shallow_model2 self) prod }
+    ensures { [#"../../../../../creusot-contracts/src/std/vec.rs" 122 16 125 18] exists prod : Seq.seq int32 . exists done' : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global)) . exists start_ : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter int32 (Alloc_Alloc_Global_Type.t_global) . inv3 prod /\ inv4 done' /\ inv5 start_ /\ into_iter_post0 iter start_ /\ completed0 done' /\ produces0 start_ prod ( * done') /\ shallow_model0 ( ^ self) = Seq.(++) (shallow_model2 self) prod }
     
   use prelude.Slice
   function shallow_model4 (self : slice int32) : Seq.seq int32

--- a/creusot/tests/should_succeed/hillel.mlcfg
+++ b/creusot/tests/should_succeed/hillel.mlcfg
@@ -717,12 +717,12 @@ module Hillel_InsertUnique
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv13 ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv13 bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : () =
     [#"../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant3 (self : Core_Slice_Iter_Iter_Type.t_iter t)
   val invariant3 (self : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = invariant3 self }
@@ -1299,12 +1299,12 @@ module Hillel_Unique
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv10 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv1 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv10 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv1 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool
@@ -1855,12 +1855,12 @@ module Hillel_Fulcrum
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces1 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces1 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv9 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv1 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv9 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv1 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool
@@ -1922,12 +1922,12 @@ module Hillel_Fulcrum
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32, ab : Seq.seq uint32, b : Core_Slice_Iter_Iter_Type.t_iter uint32, bc : Seq.seq uint32, c : Core_Slice_Iter_Iter_Type.t_iter uint32 . ([#"../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv6 ab) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv6 bc) -> ([#"../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : () =
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : () =
     [#"../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32 . [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter uint32 . [#"../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : bool

--- a/creusot/tests/should_succeed/iterators/01_range.mlcfg
+++ b/creusot/tests/should_succeed/iterators/01_range.mlcfg
@@ -30,8 +30,8 @@ module C01Range_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../01_range.rs" 44 4 44 29] (a : C01Range_Range_Type.t_range) : ()
-    ensures { [#"../01_range.rs" 43 14 43 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../01_range.rs" 44 4 44 26] (self : C01Range_Range_Type.t_range) : ()
+    ensures { [#"../01_range.rs" 43 14 43 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../01_range.rs" 41 4 41 10] ()
@@ -180,12 +180,12 @@ module C01Range_SumRange
     
   axiom produces_trans0_spec : forall a : C01Range_Range_Type.t_range, ab : Seq.seq isize, b : C01Range_Range_Type.t_range, bc : Seq.seq isize, c : C01Range_Range_Type.t_range . ([#"../01_range.rs" 48 15 48 32] produces0 a ab b) -> ([#"../01_range.rs" 49 15 49 32] produces0 b bc c) -> ([#"../01_range.rs" 50 14 50 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../01_range.rs" 44 4 44 29] (a : C01Range_Range_Type.t_range) : () =
+  function produces_refl0 [#"../01_range.rs" 44 4 44 26] (self : C01Range_Range_Type.t_range) : () =
     [#"../01_range.rs" 41 4 41 10] ()
-  val produces_refl0 [#"../01_range.rs" 44 4 44 29] (a : C01Range_Range_Type.t_range) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../01_range.rs" 44 4 44 26] (self : C01Range_Range_Type.t_range) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C01Range_Range_Type.t_range . [#"../01_range.rs" 43 14 43 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : C01Range_Range_Type.t_range . [#"../01_range.rs" 43 14 43 45] produces0 self (Seq.empty ) self
   predicate invariant0 (self : C01Range_Range_Type.t_range) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : C01Range_Range_Type.t_range) : bool
@@ -372,7 +372,7 @@ module C01Range_Impl0
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  goal produces_refl_refn : [#"../01_range.rs" 44 4 44 29] forall a : C01Range_Range_Type.t_range . inv0 a -> (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../01_range.rs" 44 4 44 26] forall self : C01Range_Range_Type.t_range . inv0 self -> (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal produces_trans_refn : [#"../01_range.rs" 51 4 51 90] forall a : C01Range_Range_Type.t_range . forall ab : Seq.seq isize . forall b : C01Range_Range_Type.t_range . forall bc : Seq.seq isize . forall c : C01Range_Range_Type.t_range . inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b -> produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
   goal next_refn : [#"../01_range.rs" 57 4 57 39] forall self : borrowed (C01Range_Range_Type.t_range) . inv2 self -> (forall result : Core_Option_Option_Type.t_option isize . match result with
     | Core_Option_Option_Type.C_None -> completed0 self

--- a/creusot/tests/should_succeed/iterators/01_range.rs
+++ b/creusot/tests/should_succeed/iterators/01_range.rs
@@ -40,8 +40,8 @@ impl Iterator for Range {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.mlcfg
@@ -105,9 +105,9 @@ module C02IterMut_Impl1_ProducesRefl_Impl
     ensures { result = produces0 self visited tl }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../02_iter_mut.rs" 50 4 50 29] (a : C02IterMut_IterMut_Type.t_itermut t) : ()
-    requires {[#"../02_iter_mut.rs" 50 21 50 22] inv0 a}
-    ensures { [#"../02_iter_mut.rs" 49 14 49 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../02_iter_mut.rs" 50 4 50 26] (self : C02IterMut_IterMut_Type.t_itermut t) : ()
+    requires {[#"../02_iter_mut.rs" 50 21 50 25] inv0 self}
+    ensures { [#"../02_iter_mut.rs" 49 14 49 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../02_iter_mut.rs" 47 4 47 10] ()
@@ -874,13 +874,13 @@ module C02IterMut_AllZero
     
   axiom produces_trans0_spec : forall a : C02IterMut_IterMut_Type.t_itermut usize, ab : Seq.seq (borrowed usize), b : C02IterMut_IterMut_Type.t_itermut usize, bc : Seq.seq (borrowed usize), c : C02IterMut_IterMut_Type.t_itermut usize . ([#"../02_iter_mut.rs" 54 15 54 32] produces0 a ab b) -> ([#"../02_iter_mut.rs" 55 15 55 32] produces0 b bc c) -> ([#"../02_iter_mut.rs" 57 22 57 23] inv0 a) -> ([#"../02_iter_mut.rs" 57 31 57 33] inv8 ab) -> ([#"../02_iter_mut.rs" 57 52 57 53] inv0 b) -> ([#"../02_iter_mut.rs" 57 61 57 63] inv8 bc) -> ([#"../02_iter_mut.rs" 57 82 57 83] inv0 c) -> ([#"../02_iter_mut.rs" 56 14 56 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../02_iter_mut.rs" 50 4 50 29] (a : C02IterMut_IterMut_Type.t_itermut usize) : () =
+  function produces_refl0 [#"../02_iter_mut.rs" 50 4 50 26] (self : C02IterMut_IterMut_Type.t_itermut usize) : () =
     [#"../02_iter_mut.rs" 47 4 47 10] ()
-  val produces_refl0 [#"../02_iter_mut.rs" 50 4 50 29] (a : C02IterMut_IterMut_Type.t_itermut usize) : ()
-    requires {[#"../02_iter_mut.rs" 50 21 50 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../02_iter_mut.rs" 50 4 50 26] (self : C02IterMut_IterMut_Type.t_itermut usize) : ()
+    requires {[#"../02_iter_mut.rs" 50 21 50 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C02IterMut_IterMut_Type.t_itermut usize . ([#"../02_iter_mut.rs" 50 21 50 22] inv0 a) -> ([#"../02_iter_mut.rs" 49 14 49 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : C02IterMut_IterMut_Type.t_itermut usize . ([#"../02_iter_mut.rs" 50 21 50 25] inv0 self) -> ([#"../02_iter_mut.rs" 49 14 49 45] produces0 self (Seq.empty ) self)
   predicate invariant0 [#"../02_iter_mut.rs" 20 4 20 30] (self : C02IterMut_IterMut_Type.t_itermut usize) =
     [#"../02_iter_mut.rs" 22 20 22 64] Seq.length (shallow_model4 ( ^ C02IterMut_IterMut_Type.itermut_inner self)) = Seq.length (shallow_model4 ( * C02IterMut_IterMut_Type.itermut_inner self))
   val invariant0 [#"../02_iter_mut.rs" 20 4 20 30] (self : C02IterMut_IterMut_Type.t_itermut usize) : bool
@@ -1179,7 +1179,7 @@ module C02IterMut_Impl1
     ensures { result = produces0 self visited tl }
     
   use seq.Seq
-  goal produces_refl_refn : [#"../02_iter_mut.rs" 50 4 50 29] forall a : C02IterMut_IterMut_Type.t_itermut t . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../02_iter_mut.rs" 50 4 50 26] forall self : C02IterMut_IterMut_Type.t_itermut t . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../02_iter_mut.rs" 63 4 63 44] forall self : borrowed (C02IterMut_IterMut_Type.t_itermut t) . inv1 self -> inv1 self /\ (forall result : Core_Option_Option_Type.t_option (borrowed t) . inv2 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)

--- a/creusot/tests/should_succeed/iterators/02_iter_mut.rs
+++ b/creusot/tests/should_succeed/iterators/02_iter_mut.rs
@@ -46,8 +46,8 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
+++ b/creusot/tests/should_succeed/iterators/03_std_iterators.mlcfg
@@ -143,12 +143,12 @@ module C03StdIterators_SliceIter
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv5 ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv5 bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : () =
     [#"../../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant2 (self : Core_Slice_Iter_Iter_Type.t_iter t)
   val invariant2 (self : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = invariant2 self }
@@ -515,12 +515,12 @@ module C03StdIterators_VecIter
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t, ab : Seq.seq t, b : Core_Slice_Iter_Iter_Type.t_iter t, bc : Seq.seq t, c : Core_Slice_Iter_Iter_Type.t_iter t . ([#"../../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv5 ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv5 bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : () =
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : () =
     [#"../../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter t) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter t) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter t . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant2 (self : Core_Slice_Iter_Iter_Type.t_iter t)
   val invariant2 (self : Core_Slice_Iter_Iter_Type.t_iter t) : bool
     ensures { result = invariant2 self }
@@ -874,12 +874,12 @@ module C03StdIterators_AllZero
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut usize, ab : Seq.seq (borrowed usize), b : Core_Slice_Iter_IterMut_Type.t_itermut usize, bc : Seq.seq (borrowed usize), c : Core_Slice_Iter_IterMut_Type.t_itermut usize . ([#"../../../../../creusot-contracts/src/std/slice.rs" 446 15 446 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 447 15 447 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 449 31 449 33] inv7 ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 449 61 449 63] inv7 bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 448 14 448 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_IterMut_Type.t_itermut usize) : () =
+  function produces_refl0 (self : Core_Slice_Iter_IterMut_Type.t_itermut usize) : () =
     [#"../../../../../creusot-contracts/src/std/slice.rs" 439 4 439 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_IterMut_Type.t_itermut usize) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_IterMut_Type.t_itermut usize) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_IterMut_Type.t_itermut usize . [#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_IterMut_Type.t_itermut usize . [#"../../../../../creusot-contracts/src/std/slice.rs" 441 14 441 45] produces0 self (Seq.empty ) self
   predicate invariant0 (self : Core_Slice_Iter_IterMut_Type.t_itermut usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Slice_Iter_IterMut_Type.t_itermut usize) : bool
@@ -1133,9 +1133,9 @@ module C03StdIterators_SkipTake
   val inv2 (_x : i) : bool
     ensures { result = inv2 _x }
     
-  predicate produces2 (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces2 (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces2 self visited _o }
+  predicate produces2 (self : i) (visited : Seq.seq item0) (o : i)
+  val produces2 (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces2 self visited o }
     
   function produces_trans2 (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
   val produces_trans2 (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
@@ -1150,12 +1150,12 @@ module C03StdIterators_SkipTake
     
   axiom produces_trans2_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces2 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces2 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv2 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv2 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces2 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl2 (a : i) : ()
-  val produces_refl2 (a : i) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a}
-    ensures { result = produces_refl2 a }
+  function produces_refl2 (self : i) : ()
+  val produces_refl2 (self : i) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self}
+    ensures { result = produces_refl2 self }
     
-  axiom produces_refl2_spec : forall a : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces2 a (Seq.empty ) a)
+  axiom produces_refl2_spec : forall self : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces2 self (Seq.empty ) self)
   use Core_Iter_Adapters_Take_Take_Type as Core_Iter_Adapters_Take_Take_Type
   predicate inv3 (_x : Core_Iter_Adapters_Take_Take_Type.t_take i)
   val inv3 (_x : Core_Iter_Adapters_Take_Take_Type.t_take i) : bool
@@ -1197,12 +1197,12 @@ module C03StdIterators_SkipTake
     ensures { result = produces_trans1 a ab b bc c }
     
   axiom produces_trans1_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i, ab : Seq.seq item0, b : Core_Iter_Adapters_Take_Take_Type.t_take i, bc : Seq.seq item0, c : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 75 15 75 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 76 15 76 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 78 22 78 23] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 78 31 78 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 78 52 78 53] inv3 b) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 78 61 78 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 78 82 78 83] inv3 c) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 77 14 77 42] produces1 a (Seq.(++) ab bc) c)
-  function produces_refl1 (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-  val produces_refl1 (a : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 22] inv3 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
+  val produces_refl1 (self : Core_Iter_Adapters_Take_Take_Type.t_take i) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 25] inv3 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 22] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Iter_Adapters_Take_Take_Type.t_take i . ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 71 21 71 25] inv3 self) -> ([#"../../../../../creusot-contracts/src/std/iter/take.rs" 70 14 70 45] produces1 self (Seq.empty ) self)
   predicate invariant6 (self : Seq.seq item0)
   val invariant6 (self : Seq.seq item0) : bool
     ensures { result = invariant6 self }
@@ -1258,13 +1258,13 @@ module C03StdIterators_SkipTake
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i), ab : Seq.seq item0, b : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i), bc : Seq.seq item0, c : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i) . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 74 15 74 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 75 15 75 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 22 77 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 31 77 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 52 77 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 61 77 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 77 82 77 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 76 14 76 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i)) : ()
+  function produces_refl0 (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i)) : ()
     
-  val produces_refl0 (a : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 21 70 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 21 70 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i) . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 21 70 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 69 14 69 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i) . ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 70 21 70 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/skip.rs" 69 14 69 45] produces0 self (Seq.empty ) self)
   predicate invariant4 (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i)))
     
   val invariant4 (self : borrowed (Core_Iter_Adapters_Skip_Skip_Type.t_skip (Core_Iter_Adapters_Take_Take_Type.t_take i))) : bool
@@ -1711,13 +1711,13 @@ module C03StdIterators_Counter
     
   axiom produces_trans2_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0, ab : Seq.seq uint32, b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0, bc : Seq.seq uint32, c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 28 15 28 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 29 15 29 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 22 31 23] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 31 31 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 52 31 53] inv5 b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 61 31 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 82 31 83] inv5 c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 30 14 30 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl2 (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : ()
+  function produces_refl2 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : ()
     
-  val produces_refl2 (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 22] inv5 a}
-    ensures { result = produces_refl2 a }
+  val produces_refl2 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 25] inv5 self}
+    ensures { result = produces_refl2 self }
     
-  axiom produces_refl2_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 22] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 23 14 23 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl2_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 25] inv5 self) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 23 14 23 45] produces1 self (Seq.empty ) self)
   predicate invariant7 (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0))
     
    =
@@ -1821,12 +1821,12 @@ module C03StdIterators_Counter
     ensures { result = produces_trans1 a ab b bc c }
     
   axiom produces_trans1_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32, ab : Seq.seq uint32, b : Core_Slice_Iter_Iter_Type.t_iter uint32, bc : Seq.seq uint32, c : Core_Slice_Iter_Iter_Type.t_iter uint32 . ([#"../../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv9 ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv9 bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl1 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : () =
+  function produces_refl1 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : () =
     [#"../../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl1 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
-    ensures { result = produces_refl1 a }
+  val produces_refl1 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32 . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl1_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter uint32 . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant3 (self : uint32) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant3 (self : uint32) : bool
@@ -1868,12 +1868,12 @@ module C03StdIterators_Counter
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32, ab : Seq.seq uint32, b : Core_Slice_Iter_Iter_Type.t_iter uint32, bc : Seq.seq uint32, c : Core_Slice_Iter_Iter_Type.t_iter uint32 . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv9 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv2 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv9 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv2 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter uint32 . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter uint32 . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   use seq.Seq
   predicate resolve2 (self : uint32) =
     [#"../../../../../creusot-contracts/src/resolve.rs" 45 8 45 12] true
@@ -1929,7 +1929,7 @@ module C03StdIterators_Counter
     
   val collect0 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
     requires {inv5 self}
-    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 130 16 131 84] exists prod : Seq.seq uint32 . exists done_ : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) . inv6 prod /\ inv7 done_ /\ resolve1 ( ^ done_) /\ completed0 done_ /\ produces1 self prod ( * done_) /\ from_iter_post0 prod result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 130 16 131 83] exists prod : Seq.seq uint32 . exists done' : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) . inv6 prod /\ inv7 done' /\ resolve1 ( ^ done') /\ completed0 done' /\ produces1 self prod ( * done') /\ from_iter_post0 prod result }
     ensures { inv8 result }
     
   val map_inv0 (self : Core_Slice_Iter_Iter_Type.t_iter uint32) (func : C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0) : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Slice_Iter_Iter_Type.t_iter uint32) uint32 C03StdIterators_Counter_Closure0.c03stditerators_counter_closure0
@@ -2102,12 +2102,12 @@ module C03StdIterators_SumRange
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range isize, ab : Seq.seq isize, b : Core_Ops_Range_Range_Type.t_range isize, bc : Seq.seq isize, c : Core_Ops_Range_Range_Type.t_range isize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv3 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv3 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range isize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range isize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range isize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range isize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range isize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range isize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range isize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range isize) : bool
@@ -2321,12 +2321,12 @@ module C03StdIterators_EnumerateRange
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv3 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv2 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv3 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv2 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv2 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv2 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv2 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces1 self (Seq.empty ) self)
   predicate invariant3 (self : Seq.seq usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant3 (self : Seq.seq usize) : bool
@@ -2392,13 +2392,13 @@ module C03StdIterators_EnumerateRange
     
   axiom produces_trans0_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize), ab : Seq.seq (usize, usize), b : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize), bc : Seq.seq (usize, usize), c : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 77 15 77 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 78 15 78 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 80 22 80 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 80 31 80 33] inv5 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 80 52 80 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 80 61 80 63] inv5 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 80 82 80 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 79 14 79 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)) : ()
+  function produces_refl0 (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)) : ()
     
-  val produces_refl0 (a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 21 73 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 21 73 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 21 73 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Iter_Adapters_Enumerate_Enumerate_Type.t_enumerate (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 73 21 73 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/enumerate.rs" 72 14 72 45] produces0 self (Seq.empty ) self)
   predicate resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) =
     [#"../../../../../creusot-contracts/src/resolve.rs" 25 20 25 34]  ^ self =  * self
   val resolve5 (self : borrowed (Core_Ops_Range_Range_Type.t_range usize)) : bool
@@ -2713,12 +2713,12 @@ module C03StdIterators_MyReverse
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv5 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv5 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv5 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv5 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv5 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv5 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces1 self (Seq.empty ) self)
   predicate invariant6 (self : Seq.seq usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant6 (self : Seq.seq usize) : bool
@@ -2798,13 +2798,13 @@ module C03StdIterators_MyReverse
     
   axiom produces_trans0_spec : forall a : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize), ab : Seq.seq (usize, usize), b : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize), bc : Seq.seq (usize, usize), c : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 60 15 60 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 61 15 61 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 63 22 63 23] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 63 31 63 33] inv10 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 63 52 63 53] inv1 b) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 63 61 63 63] inv10 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 63 82 63 83] inv1 c) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 62 14 62 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)) : ()
+  function produces_refl0 (self : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)) : ()
     
-  val produces_refl0 (a : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/zip.rs" 56 21 56 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/zip.rs" 56 21 56 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 56 21 56 22] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 55 14 55 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize) . ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 56 21 56 25] inv1 self) -> ([#"../../../../../creusot-contracts/src/std/iter/zip.rs" 55 14 55 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Iter_Adapters_Zip_Zip_Type.t_zip (Core_Ops_Range_Range_Type.t_range usize) (Core_Ops_Range_Range_Type.t_range usize))
     
    =

--- a/creusot/tests/should_succeed/iterators/04_skip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/04_skip.mlcfg
@@ -37,9 +37,9 @@ module C04Skip_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : Seq.seq item0 . inv1 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -55,12 +55,12 @@ module C04Skip_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C04Skip_Skip_Type as C04Skip_Skip_Type
   predicate invariant0 (self : C04Skip_Skip_Type.t_skip i)
   val invariant0 (self : C04Skip_Skip_Type.t_skip i) : bool
@@ -86,9 +86,9 @@ module C04Skip_Impl0_ProducesRefl_Impl
   val produces0 [#"../04_skip.rs" 36 4 36 64] (self : C04Skip_Skip_Type.t_skip i) (visited : Seq.seq item0) (o : C04Skip_Skip_Type.t_skip i) : bool
     ensures { result = produces0 self visited o }
     
-  let rec ghost function produces_refl [#"../04_skip.rs" 50 4 50 29] (a : C04Skip_Skip_Type.t_skip i) : ()
-    requires {[#"../04_skip.rs" 50 21 50 22] inv0 a}
-    ensures { [#"../04_skip.rs" 49 14 49 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../04_skip.rs" 50 4 50 26] (self : C04Skip_Skip_Type.t_skip i) : ()
+    requires {[#"../04_skip.rs" 50 21 50 25] inv0 self}
+    ensures { [#"../04_skip.rs" 49 14 49 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../04_skip.rs" 47 4 47 10] ()
@@ -111,9 +111,9 @@ module C04Skip_Impl0_ProducesTrans_Impl
   val inv1 (_x : Seq.seq item0) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -129,12 +129,12 @@ module C04Skip_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq item0)
   val invariant1 (self : Seq.seq item0) : bool
     ensures { result = invariant1 self }
@@ -272,9 +272,9 @@ module C04Skip_Impl0_Next
     
   axiom inv2 : forall x : borrowed (C04Skip_Skip_Type.t_skip i) . inv2 x = true
   use seq.Seq
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -290,12 +290,12 @@ module C04Skip_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv9 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv9 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   use prelude.Ghost
   predicate invariant1 (self : Ghost.ghost_ty (Seq.seq item0))
   val invariant1 (self : Ghost.ghost_ty (Seq.seq item0)) : bool
@@ -579,9 +579,9 @@ module C04Skip_Impl0
     ensures { result = resolve0 self }
     
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use prelude.Int
   use seq.Seq
@@ -600,7 +600,7 @@ module C04Skip_Impl0
   val produces0 [#"../04_skip.rs" 36 4 36 64] (self : C04Skip_Skip_Type.t_skip i) (visited : Seq.seq item0) (o : C04Skip_Skip_Type.t_skip i) : bool
     ensures { result = produces0 self visited o }
     
-  goal produces_refl_refn : [#"../04_skip.rs" 50 4 50 29] forall a : C04Skip_Skip_Type.t_skip i . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../04_skip.rs" 50 4 50 26] forall self : C04Skip_Skip_Type.t_skip i . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../04_skip.rs" 63 4 63 41] forall self : borrowed (C04Skip_Skip_Type.t_skip i) . inv1 self -> inv1 self /\ (forall result : Core_Option_Option_Type.t_option item0 . inv2 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)

--- a/creusot/tests/should_succeed/iterators/04_skip.rs
+++ b/creusot/tests/should_succeed/iterators/04_skip.rs
@@ -46,8 +46,8 @@ where
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/05_map.mlcfg
+++ b/creusot/tests/should_succeed/iterators/05_map.mlcfg
@@ -101,9 +101,9 @@ module C05Map_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : Seq.seq item0 . inv1 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -119,12 +119,12 @@ module C05Map_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate resolve0 (self : f)
   val resolve0 (self : f) : bool
     ensures { result = resolve0 self }
@@ -231,9 +231,9 @@ module C05Map_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited succ }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../05_map.rs" 29 4 29 29] (a : C05Map_Map_Type.t_map i b f) : ()
-    requires {[#"../05_map.rs" 29 21 29 22] inv0 a}
-    ensures { [#"../05_map.rs" 28 14 28 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../05_map.rs" 29 4 29 26] (self : C05Map_Map_Type.t_map i b f) : ()
+    requires {[#"../05_map.rs" 29 21 29 25] inv0 self}
+    ensures { [#"../05_map.rs" 28 14 28 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../05_map.rs" 26 4 26 10] ()
@@ -327,9 +327,9 @@ module C05Map_Impl0_ProducesTrans_Impl
     
   axiom inv2 : forall x : Seq.seq item0 . inv2 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -345,12 +345,12 @@ module C05Map_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate resolve0 (self : f)
   val resolve0 (self : f) : bool
     ensures { result = resolve0 self }
@@ -627,9 +627,9 @@ module C05Map_Impl1_ProducesOne_Impl
     
   axiom inv3 : forall x : item0 . inv3 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -645,12 +645,12 @@ module C05Map_Impl1_ProducesOne_Impl
     
   axiom produces_trans1_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv6 a) -> ([#"../common.rs" 21 31 21 33] inv4 ab) -> ([#"../common.rs" 21 52 21 53] inv6 b) -> ([#"../common.rs" 21 61 21 63] inv4 bc) -> ([#"../common.rs" 21 82 21 83] inv6 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv6 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv6 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv6 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv6 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant2 (self : borrowed f)
   val invariant2 (self : borrowed f) : bool
     ensures { result = invariant2 self }
@@ -700,13 +700,13 @@ module C05Map_Impl1_ProducesOne_Impl
     
   axiom produces_trans0_spec : forall a : C05Map_Map_Type.t_map i b f, ab : Seq.seq b, b : C05Map_Map_Type.t_map i b f, bc : Seq.seq b, c : C05Map_Map_Type.t_map i b f . ([#"../05_map.rs" 33 15 33 32] produces0 a ab b) -> ([#"../05_map.rs" 34 15 34 32] produces0 b bc c) -> ([#"../05_map.rs" 36 22 36 23] inv0 a) -> ([#"../05_map.rs" 36 31 36 33] inv8 ab) -> ([#"../05_map.rs" 36 52 36 53] inv0 b) -> ([#"../05_map.rs" 36 61 36 63] inv8 bc) -> ([#"../05_map.rs" 36 82 36 83] inv0 c) -> ([#"../05_map.rs" 35 14 35 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../05_map.rs" 29 4 29 29] (a : C05Map_Map_Type.t_map i b f) : () =
+  function produces_refl0 [#"../05_map.rs" 29 4 29 26] (self : C05Map_Map_Type.t_map i b f) : () =
     [#"../05_map.rs" 26 4 26 10] ()
-  val produces_refl0 [#"../05_map.rs" 29 4 29 29] (a : C05Map_Map_Type.t_map i b f) : ()
-    requires {[#"../05_map.rs" 29 21 29 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../05_map.rs" 29 4 29 26] (self : C05Map_Map_Type.t_map i b f) : ()
+    requires {[#"../05_map.rs" 29 21 29 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C05Map_Map_Type.t_map i b f . ([#"../05_map.rs" 29 21 29 22] inv0 a) -> ([#"../05_map.rs" 28 14 28 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : C05Map_Map_Type.t_map i b f . ([#"../05_map.rs" 29 21 29 25] inv0 self) -> ([#"../05_map.rs" 28 14 28 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : b)
   val invariant1 (self : b) : bool
     ensures { result = invariant1 self }
@@ -834,9 +834,9 @@ module C05Map_Impl1_ProducesOneInvariant_Impl
   val precondition0 (self : f) (_2 : item0) : bool
     ensures { result = precondition0 self _2 }
     
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../05_map.rs" 74 4 74 50] (iter : i) (func : f) =
@@ -936,12 +936,12 @@ module C05Map_Impl1_ProducesOneInvariant_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv5 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv5 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   let rec ghost function produces_one_invariant [#"../05_map.rs" 107 4 107 73] (self : C05Map_Map_Type.t_map i b f) (e : item0) (r : b) (f : borrowed f) (iter : i) : ()
     requires {[#"../05_map.rs" 102 4 102 60] produces0 (C05Map_Map_Type.map_iter self) (Seq.singleton e) iter}
     requires {[#"../05_map.rs" 103 15 103 30]  * f = C05Map_Map_Type.map_func self}
@@ -1030,9 +1030,9 @@ module C05Map_Impl0_Next
   val precondition0 (self : f) (_2 : item0) : bool
     ensures { result = precondition0 self _2 }
     
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../05_map.rs" 74 4 74 50] (iter : i) (func : f) =
@@ -1174,12 +1174,12 @@ module C05Map_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv10 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv10 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -1476,9 +1476,9 @@ module C05Map_Map
   val precondition0 (self : f) (_2 : item0) : bool
     ensures { result = precondition0 self _2 }
     
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate inv1 (_x : item0)
@@ -1548,12 +1548,12 @@ module C05Map_Map
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv7 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv7 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   let rec cfg map [#"../05_map.rs" 144 0 144 84] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) (func : f) : C05Map_Map_Type.t_map i b f
     requires {[#"../05_map.rs" 140 0 140 105] forall i2 : i . forall e : item0 . inv0 i2 -> inv1 e -> produces0 iter (Seq.singleton e) i2 -> precondition0 func (e)}
     requires {[#"../05_map.rs" 141 11 141 41] reinitialize0 ()}
@@ -1715,9 +1715,9 @@ module C05Map_Impl0
   val precondition0 (self : f) (_2 : item0) : bool
     ensures { result = precondition0 self _2 }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../05_map.rs" 74 4 74 50] (iter : i) (func : f) =
@@ -1802,7 +1802,7 @@ module C05Map_Impl0
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
     end)
-  goal produces_refl_refn : [#"../05_map.rs" 29 4 29 29] forall a : C05Map_Map_Type.t_map i b f . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../05_map.rs" 29 4 29 26] forall self : C05Map_Map_Type.t_map i b f . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
 end
 module C05Map_Impl2
   type i

--- a/creusot/tests/should_succeed/iterators/05_map.rs
+++ b/creusot/tests/should_succeed/iterators/05_map.rs
@@ -25,8 +25,8 @@ impl<I: Iterator, B, F: FnMut(I::Item) -> B> Iterator for Map<I, B, F> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.mlcfg
@@ -126,9 +126,9 @@ module C06MapPrecond_Impl1_PreservationInv_Impl
   val inv0 (_x : i) : bool
     ensures { result = inv0 _x }
     
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -144,12 +144,12 @@ module C06MapPrecond_Impl1_PreservationInv_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate invariant2 (self : Seq.seq item0)
   val invariant2 (self : Seq.seq item0) : bool
     ensures { result = invariant2 self }
@@ -333,9 +333,9 @@ module C06MapPrecond_Impl0_ProducesRefl_Impl
     
   axiom postcondition_mut_unnest0_spec : forall self : borrowed f, args : (item0, Ghost.ghost_ty (Seq.seq item0)), res : b . ([#"../../../../../creusot-contracts/src/std/ops.rs" 103 15 103 48] postcondition_mut0 self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 37 105 41] inv6 self) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 43 105 47] inv7 args) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 55 105 58] inv8 res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 104 14 104 35] unnest0 ( * self) ( ^ self))
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -351,12 +351,12 @@ module C06MapPrecond_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate precondition0 (self : f) (_2 : (item0, Ghost.ghost_ty (Seq.seq item0)))
   val precondition0 (self : f) (_2 : (item0, Ghost.ghost_ty (Seq.seq item0))) : bool
     ensures { result = precondition0 self _2 }
@@ -427,9 +427,9 @@ module C06MapPrecond_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited succ }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../06_map_precond.rs" 31 4 31 29] (a : C06MapPrecond_Map_Type.t_map i b f item0) : ()
-    requires {[#"../06_map_precond.rs" 31 21 31 22] inv0 a}
-    ensures { [#"../06_map_precond.rs" 30 14 30 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../06_map_precond.rs" 31 4 31 26] (self : C06MapPrecond_Map_Type.t_map i b f item0) : ()
+    requires {[#"../06_map_precond.rs" 31 21 31 25] inv0 self}
+    ensures { [#"../06_map_precond.rs" 30 14 30 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../06_map_precond.rs" 28 4 28 10] ()
@@ -582,9 +582,9 @@ module C06MapPrecond_Impl0_ProducesTrans_Impl
     
   axiom postcondition_mut_unnest0_spec : forall self : borrowed f, args : (item0, Ghost.ghost_ty (Seq.seq item0)), res : b . ([#"../../../../../creusot-contracts/src/std/ops.rs" 103 15 103 48] postcondition_mut0 self args res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 37 105 41] inv7 self) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 43 105 47] inv8 args) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 105 55 105 58] inv9 res) -> ([#"../../../../../creusot-contracts/src/std/ops.rs" 104 14 104 35] unnest0 ( * self) ( ^ self))
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -600,12 +600,12 @@ module C06MapPrecond_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq b)
   val invariant1 (self : Seq.seq b) : bool
     ensures { result = invariant1 self }
@@ -861,9 +861,9 @@ module C06MapPrecond_Impl1_ProducesOne_Impl
     
   axiom inv2 : forall x : borrowed f . inv2 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -879,12 +879,12 @@ module C06MapPrecond_Impl1_ProducesOne_Impl
     
   axiom produces_trans1_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv6 a) -> ([#"../common.rs" 21 31 21 33] inv4 ab) -> ([#"../common.rs" 21 52 21 53] inv6 b) -> ([#"../common.rs" 21 61 21 63] inv4 bc) -> ([#"../common.rs" 21 82 21 83] inv6 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv6 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv6 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv6 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv6 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C06MapPrecond_Map_Type as C06MapPrecond_Map_Type
   use seq.Seq
   predicate inv0 (_x : C06MapPrecond_Map_Type.t_map i b f item0)
@@ -933,13 +933,13 @@ module C06MapPrecond_Impl1_ProducesOne_Impl
     
   axiom produces_trans0_spec : forall a : C06MapPrecond_Map_Type.t_map i b f item0, ab : Seq.seq b, b : C06MapPrecond_Map_Type.t_map i b f item0, bc : Seq.seq b, c : C06MapPrecond_Map_Type.t_map i b f item0 . ([#"../06_map_precond.rs" 35 15 35 32] produces0 a ab b) -> ([#"../06_map_precond.rs" 36 15 36 32] produces0 b bc c) -> ([#"../06_map_precond.rs" 38 22 38 23] inv0 a) -> ([#"../06_map_precond.rs" 38 31 38 33] inv9 ab) -> ([#"../06_map_precond.rs" 38 52 38 53] inv0 b) -> ([#"../06_map_precond.rs" 38 61 38 63] inv9 bc) -> ([#"../06_map_precond.rs" 38 82 38 83] inv0 c) -> ([#"../06_map_precond.rs" 37 14 37 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../06_map_precond.rs" 31 4 31 29] (a : C06MapPrecond_Map_Type.t_map i b f item0) : () =
+  function produces_refl0 [#"../06_map_precond.rs" 31 4 31 26] (self : C06MapPrecond_Map_Type.t_map i b f item0) : () =
     [#"../06_map_precond.rs" 28 4 28 10] ()
-  val produces_refl0 [#"../06_map_precond.rs" 31 4 31 29] (a : C06MapPrecond_Map_Type.t_map i b f item0) : ()
-    requires {[#"../06_map_precond.rs" 31 21 31 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../06_map_precond.rs" 31 4 31 26] (self : C06MapPrecond_Map_Type.t_map i b f item0) : ()
+    requires {[#"../06_map_precond.rs" 31 21 31 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C06MapPrecond_Map_Type.t_map i b f item0 . ([#"../06_map_precond.rs" 31 21 31 22] inv0 a) -> ([#"../06_map_precond.rs" 30 14 30 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : C06MapPrecond_Map_Type.t_map i b f item0 . ([#"../06_map_precond.rs" 31 21 31 25] inv0 self) -> ([#"../06_map_precond.rs" 30 14 30 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : b)
   val invariant1 (self : b) : bool
     ensures { result = invariant1 self }
@@ -1087,9 +1087,9 @@ module C06MapPrecond_Impl1_ProducesOneInvariant_Impl
     ensures { result = precondition0 self _2 }
     
   use prelude.Ghost
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../06_map_precond.rs" 83 4 83 74] (iter : i) (func : f) (produced : Seq.seq item0) =
@@ -1199,12 +1199,12 @@ module C06MapPrecond_Impl1_ProducesOneInvariant_Impl
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv5 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv5 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   let rec ghost function produces_one_invariant [#"../06_map_precond.rs" 132 4 132 73] (self : C06MapPrecond_Map_Type.t_map i b f item0) (e : item0) (r : b) (f : borrowed f) (iter : i) : ()
     requires {[#"../06_map_precond.rs" 127 4 127 60] produces0 (C06MapPrecond_Map_Type.map_iter self) (Seq.singleton e) iter}
     requires {[#"../06_map_precond.rs" 128 15 128 30]  * f = C06MapPrecond_Map_Type.map_func self}
@@ -1272,9 +1272,9 @@ module C06MapPrecond_Impl0_Next
     ensures { result = precondition0 self _2 }
     
   use prelude.Ghost
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../06_map_precond.rs" 83 4 83 74] (iter : i) (func : f) (produced : Seq.seq item0) =
@@ -1458,12 +1458,12 @@ module C06MapPrecond_Impl0_Next
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv12 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv12 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -1799,9 +1799,9 @@ module C06MapPrecond_Map
     ensures { result = precondition0 self _2 }
     
   use prelude.Ghost
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   use seq.Seq
   predicate inv1 (_x : item0)
@@ -1881,12 +1881,12 @@ module C06MapPrecond_Map
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv7 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv7 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   let rec cfg map [#"../06_map_precond.rs" 170 0 173 17] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) (func : f) : C06MapPrecond_Map_Type.t_map i b f item0
     requires {[#"../06_map_precond.rs" 166 0 166 128] forall i2 : i . forall e : item0 . inv0 i2 -> inv1 e -> produces0 iter (Seq.singleton e) i2 -> precondition0 func (e, Ghost.new (Seq.empty ))}
     requires {[#"../06_map_precond.rs" 167 11 167 41] reinitialize0 ()}
@@ -1990,9 +1990,9 @@ module C06MapPrecond_Identity_Closure0
     
   axiom inv0 : forall x : Ghost.ghost_ty (Seq.seq item0) . inv0 x = true
   use seq.Seq
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -2008,12 +2008,12 @@ module C06MapPrecond_Identity_Closure0
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv3 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv3 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   use prelude.Int16
   use C06MapPrecond_Identity_Closure0_Type as C06MapPrecond_Identity_Closure0
   predicate unnest0 [#"../06_map_precond.rs" 178 14 178 20] (self : C06MapPrecond_Identity_Closure0.c06mapprecond_identity_closure0 i) (_2 : C06MapPrecond_Identity_Closure0.c06mapprecond_identity_closure0 i)
@@ -2129,9 +2129,9 @@ module C06MapPrecond_Identity
     
   axiom inv1 : forall x : i . inv1 x = true
   use seq.Seq
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -2147,12 +2147,12 @@ module C06MapPrecond_Identity
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv1 a) -> ([#"../common.rs" 21 31 21 33] inv6 ab) -> ([#"../common.rs" 21 52 21 53] inv1 b) -> ([#"../common.rs" 21 61 21 63] inv6 bc) -> ([#"../common.rs" 21 82 21 83] inv1 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv1 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv1 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate precondition0 [#"../06_map_precond.rs" 178 14 178 20] (self : C06MapPrecond_Identity_Closure0.c06mapprecond_identity_closure0 i) (args : (item0, Ghost.ghost_ty (Seq.seq item0)))
     
    =
@@ -2392,9 +2392,9 @@ module C06MapPrecond_Increment
     
   axiom inv2 : forall x : u . inv2 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : u) (visited : Seq.seq uint32) (_o : u)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : u) (visited : Seq.seq uint32) (_o : u) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : u) (visited : Seq.seq uint32) (o : u)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : u) (visited : Seq.seq uint32) (o : u) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : u) (ab : Seq.seq uint32) (b : u) (bc : Seq.seq uint32) (c : u) : ()
     
@@ -2410,12 +2410,12 @@ module C06MapPrecond_Increment
     
   axiom produces_trans1_spec : forall a : u, ab : Seq.seq uint32, b : u, bc : Seq.seq uint32, c : u . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv5 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv5 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : u) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : u) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : u) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : u) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : u . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : u . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : borrowed u)
   val invariant1 (self : borrowed u) : bool
     ensures { result = invariant1 self }
@@ -2479,15 +2479,15 @@ module C06MapPrecond_Increment
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32, ab : Seq.seq uint32, b : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32, bc : Seq.seq uint32, c : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32 . ([#"../06_map_precond.rs" 35 15 35 32] produces0 a ab b) -> ([#"../06_map_precond.rs" 36 15 36 32] produces0 b bc c) -> ([#"../06_map_precond.rs" 38 22 38 23] inv0 a) -> ([#"../06_map_precond.rs" 38 31 38 33] inv5 ab) -> ([#"../06_map_precond.rs" 38 52 38 53] inv0 b) -> ([#"../06_map_precond.rs" 38 61 38 63] inv5 bc) -> ([#"../06_map_precond.rs" 38 82 38 83] inv0 c) -> ([#"../06_map_precond.rs" 37 14 37 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../06_map_precond.rs" 31 4 31 29] (a : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32) : ()
+  function produces_refl0 [#"../06_map_precond.rs" 31 4 31 26] (self : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32) : ()
     
    =
     [#"../06_map_precond.rs" 28 4 28 10] ()
-  val produces_refl0 [#"../06_map_precond.rs" 31 4 31 29] (a : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32) : ()
-    requires {[#"../06_map_precond.rs" 31 21 31 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../06_map_precond.rs" 31 4 31 26] (self : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32) : ()
+    requires {[#"../06_map_precond.rs" 31 21 31 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32 . ([#"../06_map_precond.rs" 31 21 31 22] inv0 a) -> ([#"../06_map_precond.rs" 30 14 30 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : C06MapPrecond_Map_Type.t_map u uint32 (C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) uint32 . ([#"../06_map_precond.rs" 31 21 31 25] inv0 self) -> ([#"../06_map_precond.rs" 30 14 30 45] produces0 self (Seq.empty ) self)
   use seq.Seq
   predicate next_precondition0 [#"../06_map_precond.rs" 83 4 83 74] (iter : u) (func : C06MapPrecond_Increment_Closure2.c06mapprecond_increment_closure2 u) (produced : Seq.seq uint32)
     
@@ -2549,7 +2549,7 @@ module C06MapPrecond_Increment
     ensures { [#"../06_map_precond.rs" 173 5 173 17] inv0 result }
     
   let rec cfg increment [#"../06_map_precond.rs" 185 0 185 50] [@cfg:stackify] [@cfg:subregion_analysis] (iter : u) : ()
-    requires {[#"../06_map_precond.rs" 181 0 181 162] forall done_ : borrowed u . inv1 done_ -> completed0 done_ -> (forall steps : Seq.seq uint32 . forall next : u . inv2 next -> produces1 ( ^ done_) steps next -> steps = Seq.empty  /\  ^ done_ = next)}
+    requires {[#"../06_map_precond.rs" 181 0 181 158] forall done' : borrowed u . inv1 done' -> completed0 done' -> (forall steps : Seq.seq uint32 . forall next : u . inv2 next -> produces1 ( ^ done') steps next -> steps = Seq.empty  /\  ^ done' = next)}
     requires {[#"../06_map_precond.rs" 182 0 184 2] forall fin : u . forall prod : Seq.seq uint32 . inv2 fin -> produces1 iter prod fin -> (forall x : int . 0 <= x /\ x < Seq.length prod -> Seq.get prod x <= (10 : uint32))}
     requires {[#"../06_map_precond.rs" 185 42 185 46] inv2 iter}
     
@@ -2722,9 +2722,9 @@ module C06MapPrecond_Counter
     
   axiom inv2 : forall x : i . inv2 x = true
   use seq.Seq
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq uint32) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq uint32) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq uint32) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq uint32) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq uint32) (b : i) (bc : Seq.seq uint32) (c : i) : ()
     
@@ -2740,12 +2740,12 @@ module C06MapPrecond_Counter
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq uint32, b : i, bc : Seq.seq uint32, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv6 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv6 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : borrowed i)
   val invariant1 (self : borrowed i) : bool
     ensures { result = invariant1 self }
@@ -2848,7 +2848,7 @@ module C06MapPrecond_Counter
     ensures { [#"../06_map_precond.rs" 173 5 173 17] inv0 result }
     
   let rec cfg counter [#"../06_map_precond.rs" 201 0 201 48] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) : ()
-    requires {[#"../06_map_precond.rs" 199 0 199 162] forall done_ : borrowed i . inv1 done_ -> completed0 done_ -> (forall steps : Seq.seq uint32 . forall next : i . inv2 next -> produces0 ( ^ done_) steps next -> steps = Seq.empty  /\  ^ done_ = next)}
+    requires {[#"../06_map_precond.rs" 199 0 199 158] forall done' : borrowed i . inv1 done' -> completed0 done' -> (forall steps : Seq.seq uint32 . forall next : i . inv2 next -> produces0 ( ^ done') steps next -> steps = Seq.empty  /\  ^ done' = next)}
     requires {[#"../06_map_precond.rs" 200 0 200 92] forall fin : i . forall prod : Seq.seq uint32 . inv2 fin -> produces0 iter prod fin -> Seq.length prod <= UIntSize.to_int max0}
     requires {[#"../06_map_precond.rs" 201 40 201 44] inv2 iter}
     
@@ -3014,9 +3014,9 @@ module C06MapPrecond_Impl0
     ensures { result = precondition0 self _2 }
     
   use prelude.Ghost
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use seq.Seq
   predicate next_precondition0 [#"../06_map_precond.rs" 83 4 83 74] (iter : i) (func : f) (produced : Seq.seq item0) =
@@ -3108,7 +3108,7 @@ module C06MapPrecond_Impl0
     
   use seq.Seq
   use seq.Seq
-  goal produces_refl_refn : [#"../06_map_precond.rs" 31 4 31 29] forall a : C06MapPrecond_Map_Type.t_map i b f item0 . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../06_map_precond.rs" 31 4 31 26] forall self : C06MapPrecond_Map_Type.t_map i b f item0 . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../06_map_precond.rs" 63 4 63 44] forall self : borrowed (C06MapPrecond_Map_Type.t_map i b f item0) . inv1 self -> inv1 self /\ (forall result : Core_Option_Option_Type.t_option b . inv2 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces_one0 ( * self) v ( ^ self)

--- a/creusot/tests/should_succeed/iterators/06_map_precond.rs
+++ b/creusot/tests/should_succeed/iterators/06_map_precond.rs
@@ -27,8 +27,8 @@ impl<I: Iterator, B, F: FnMut(I::Item, Ghost<Seq<I::Item>>) -> B> Iterator for M
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]
@@ -178,7 +178,7 @@ pub fn identity<I: Iterator>(iter: I) {
     map(iter, |x, _| x);
 }
 
-#[requires(forall<done_ : &mut U> done_.completed() ==> forall<next : U, steps: Seq<_>> (^done_).produces(steps, next) ==> steps == Seq::EMPTY && ^done_ == next)]
+#[requires(forall<done : &mut U> done.completed() ==> forall<next : U, steps: Seq<_>> (^done).produces(steps, next) ==> steps == Seq::EMPTY && ^done == next)]
 #[requires(forall<prod : _, fin: U> iter.produces(prod, fin) ==>
     forall<x : _> 0 <= x && x < prod.len() ==> prod[x] <= 10u32
 )]
@@ -196,7 +196,7 @@ pub fn increment<U: Iterator<Item = u32>>(iter: U) {
     };
 }
 
-#[requires(forall<done_ : &mut I> done_.completed() ==> forall<next : I, steps: Seq<_>> (^done_).produces(steps, next) ==> steps == Seq::EMPTY && ^done_ == next)]
+#[requires(forall<done : &mut I> done.completed() ==> forall<next : I, steps: Seq<_>> (^done).produces(steps, next) ==> steps == Seq::EMPTY && ^done == next)]
 #[requires(forall<prod : _, fin: I> iter.produces(prod, fin) ==> prod.len() <= usize::MAX@)]
 pub fn counter<I: Iterator<Item = u32>>(iter: I) {
     let mut cnt = 0;

--- a/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
+++ b/creusot/tests/should_succeed/iterators/07_fuse.mlcfg
@@ -58,9 +58,9 @@ module C07Fuse_Impl0_Next
   val inv3 (_x : i) : bool
     ensures { result = inv3 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -76,12 +76,12 @@ module C07Fuse_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv6 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv6 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant3 (self : i)
   val invariant3 (self : i) : bool
     ensures { result = invariant3 self }
@@ -303,9 +303,9 @@ module C07Fuse_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : i . inv1 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -321,12 +321,12 @@ module C07Fuse_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv1 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv1 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv1 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv1 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv1 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C07Fuse_Fuse_Type as C07Fuse_Fuse_Type
   predicate invariant0 (self : C07Fuse_Fuse_Type.t_fuse i)
   val invariant0 (self : C07Fuse_Fuse_Type.t_fuse i) : bool
@@ -351,9 +351,9 @@ module C07Fuse_Impl0_ProducesRefl_Impl
   val produces0 [#"../07_fuse.rs" 25 4 25 65] (self : C07Fuse_Fuse_Type.t_fuse i) (prod : Seq.seq item0) (other : C07Fuse_Fuse_Type.t_fuse i) : bool
     ensures { result = produces0 self prod other }
     
-  let rec ghost function produces_refl [#"../07_fuse.rs" 55 4 55 29] (a : C07Fuse_Fuse_Type.t_fuse i) : ()
-    requires {[#"../07_fuse.rs" 55 21 55 22] inv0 a}
-    ensures { [#"../07_fuse.rs" 54 14 54 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../07_fuse.rs" 55 4 55 26] (self : C07Fuse_Fuse_Type.t_fuse i) : ()
+    requires {[#"../07_fuse.rs" 55 21 55 25] inv0 self}
+    ensures { [#"../07_fuse.rs" 54 14 54 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../07_fuse.rs" 52 4 52 10] ()
@@ -376,9 +376,9 @@ module C07Fuse_Impl0_ProducesTrans_Impl
   val inv1 (_x : Seq.seq item0) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -394,12 +394,12 @@ module C07Fuse_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq item0)
   val invariant1 (self : Seq.seq item0) : bool
     ensures { result = invariant1 self }
@@ -470,9 +470,9 @@ module C07Fuse_Impl1_IsFused_Impl
   val inv1 (_x : Seq.seq item0) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -488,12 +488,12 @@ module C07Fuse_Impl1_IsFused_Impl
     
   axiom produces_trans1_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C07Fuse_Fuse_Type as C07Fuse_Fuse_Type
   predicate invariant2 (self : C07Fuse_Fuse_Type.t_fuse i)
   val invariant2 (self : C07Fuse_Fuse_Type.t_fuse i) : bool
@@ -547,13 +547,13 @@ module C07Fuse_Impl1_IsFused_Impl
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : C07Fuse_Fuse_Type.t_fuse i, ab : Seq.seq item0, b : C07Fuse_Fuse_Type.t_fuse i, bc : Seq.seq item0, c : C07Fuse_Fuse_Type.t_fuse i . ([#"../07_fuse.rs" 59 15 59 32] produces0 a ab b) -> ([#"../07_fuse.rs" 60 15 60 32] produces0 b bc c) -> ([#"../07_fuse.rs" 62 22 62 23] inv2 a) -> ([#"../07_fuse.rs" 62 31 62 33] inv1 ab) -> ([#"../07_fuse.rs" 62 52 62 53] inv2 b) -> ([#"../07_fuse.rs" 62 61 62 63] inv1 bc) -> ([#"../07_fuse.rs" 62 82 62 83] inv2 c) -> ([#"../07_fuse.rs" 61 14 61 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../07_fuse.rs" 55 4 55 29] (a : C07Fuse_Fuse_Type.t_fuse i) : () =
+  function produces_refl0 [#"../07_fuse.rs" 55 4 55 26] (self : C07Fuse_Fuse_Type.t_fuse i) : () =
     [#"../07_fuse.rs" 52 4 52 10] ()
-  val produces_refl0 [#"../07_fuse.rs" 55 4 55 29] (a : C07Fuse_Fuse_Type.t_fuse i) : ()
-    requires {[#"../07_fuse.rs" 55 21 55 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 [#"../07_fuse.rs" 55 4 55 26] (self : C07Fuse_Fuse_Type.t_fuse i) : ()
+    requires {[#"../07_fuse.rs" 55 21 55 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : C07Fuse_Fuse_Type.t_fuse i . ([#"../07_fuse.rs" 55 21 55 22] inv2 a) -> ([#"../07_fuse.rs" 54 14 54 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : C07Fuse_Fuse_Type.t_fuse i . ([#"../07_fuse.rs" 55 21 55 25] inv2 self) -> ([#"../07_fuse.rs" 54 14 54 45] produces0 self (Seq.empty ) self)
   predicate completed1 [#"../common.rs" 11 4 11 36] (self : borrowed i)
   val completed1 [#"../common.rs" 11 4 11 36] (self : borrowed i) : bool
     ensures { result = completed1 self }
@@ -638,9 +638,9 @@ module C07Fuse_Impl0
     ensures { result = completed0 self }
     
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use seq.Seq
   predicate produces0 [#"../07_fuse.rs" 25 4 25 65] (self : C07Fuse_Fuse_Type.t_fuse i) (prod : Seq.seq item0) (other : C07Fuse_Fuse_Type.t_fuse i)
@@ -656,7 +656,7 @@ module C07Fuse_Impl0
   val produces0 [#"../07_fuse.rs" 25 4 25 65] (self : C07Fuse_Fuse_Type.t_fuse i) (prod : Seq.seq item0) (other : C07Fuse_Fuse_Type.t_fuse i) : bool
     ensures { result = produces0 self prod other }
     
-  goal produces_refl_refn : [#"../07_fuse.rs" 55 4 55 29] forall a : C07Fuse_Fuse_Type.t_fuse i . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../07_fuse.rs" 55 4 55 26] forall self : C07Fuse_Fuse_Type.t_fuse i . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../07_fuse.rs" 39 4 39 44] forall self : borrowed (C07Fuse_Fuse_Type.t_fuse i) . inv1 self -> inv1 self /\ (forall result : Core_Option_Option_Type.t_option item0 . inv2 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
@@ -720,9 +720,9 @@ module C07Fuse_Impl1
   val completed0 [#"../07_fuse.rs" 16 4 16 35] (self : borrowed (C07Fuse_Fuse_Type.t_fuse i)) : bool
     ensures { result = completed0 self }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   predicate produces0 [#"../07_fuse.rs" 25 4 25 65] (self : C07Fuse_Fuse_Type.t_fuse i) (prod : Seq.seq item0) (other : C07Fuse_Fuse_Type.t_fuse i)
     

--- a/creusot/tests/should_succeed/iterators/07_fuse.rs
+++ b/creusot/tests/should_succeed/iterators/07_fuse.rs
@@ -51,8 +51,8 @@ impl<I: Iterator> Iterator for Fuse<I> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.mlcfg
@@ -129,9 +129,9 @@ module C08CollectExtend_Extend
   val inv3 (_x : i) : bool
     ensures { result = inv3 _x }
     
-  predicate produces0 (self : i) (visited : Seq.seq t) (_o : i)
-  val produces0 (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 (self : i) (visited : Seq.seq t) (o : i)
+  val produces0 (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -146,12 +146,12 @@ module C08CollectExtend_Extend
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv8 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv3 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv8 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv3 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : i) : ()
-  val produces_refl0 (a : i) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : i) : ()
+  val produces_refl0 (self : i) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv3 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   predicate invariant3 (self : i)
   val invariant3 (self : i) : bool
     ensures { result = invariant3 self }
@@ -281,7 +281,7 @@ module C08CollectExtend_Extend
   let rec cfg extend [#"../08_collect_extend.rs" 25 0 25 66] [@cfg:stackify] [@cfg:subregion_analysis] (vec : borrowed (Alloc_Vec_Vec_Type.t_vec t (Alloc_Alloc_Global_Type.t_global))) (iter : i) : ()
     requires {[#"../08_collect_extend.rs" 25 40 25 43] inv7 vec}
     requires {[#"../08_collect_extend.rs" 25 58 25 62] inv3 iter}
-    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq t . exists done_ : borrowed i . inv8 prod /\ inv4 done_ /\ completed0 done_ /\ produces0 iter prod ( * done_) /\ shallow_model2 ( ^ vec) = Seq.(++) (shallow_model0 vec) prod }
+    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq t . exists done' : borrowed i . inv8 prod /\ inv4 done' /\ completed0 done' /\ produces0 iter prod ( * done') /\ shallow_model2 ( ^ vec) = Seq.(++) (shallow_model0 vec) prod }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
   var _0 : ();
@@ -512,9 +512,9 @@ module C08CollectExtend_Collect
   val inv2 (_x : i) : bool
     ensures { result = inv2 _x }
     
-  predicate produces0 (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
   val produces_trans0 (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
@@ -529,12 +529,12 @@ module C08CollectExtend_Collect
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv6 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv2 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv6 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv2 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : i) : ()
-  val produces_refl0 (a : i) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : i) : ()
+  val produces_refl0 (self : i) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv2 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv2 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   predicate invariant2 (self : i)
   val invariant2 (self : i) : bool
     ensures { result = invariant2 self }
@@ -651,7 +651,7 @@ module C08CollectExtend_Collect
     
   let rec cfg collect [#"../08_collect_extend.rs" 42 0 42 52] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) : Alloc_Vec_Vec_Type.t_vec item0 (Alloc_Alloc_Global_Type.t_global)
     requires {[#"../08_collect_extend.rs" 42 28 42 32] inv2 iter}
-    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq item0 . exists done_ : borrowed i . inv6 prod /\ inv3 done_ /\ completed0 done_ /\ produces0 iter prod ( * done_) /\ shallow_model0 result = prod }
+    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq item0 . exists done' : borrowed i . inv6 prod /\ inv3 done' /\ completed0 done' /\ produces0 iter prod ( * done') /\ shallow_model0 result = prod }
     ensures { [#"../08_collect_extend.rs" 42 40 42 52] inv5 result }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
@@ -873,15 +873,15 @@ module C08CollectExtend_ExtendIndex
     
   axiom produces_trans0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global), ab : Seq.seq uint32, b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global), bc : Seq.seq uint32, c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 248 15 248 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 249 15 249 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 22 251 23] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 31 251 33] inv5 ab) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 43 251 44] inv3 b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 52 251 54] inv5 bc) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 64 251 65] inv3 c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 250 14 250 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) : ()
+  function produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) : ()
     
    =
     [#"../../../../../creusot-contracts/src/std/vec.rs" 241 4 241 10] ()
-  val produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv3 self) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 45] produces0 self (Seq.empty ) self)
   use prelude.Borrow
   predicate invariant6 (self : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)))
     
@@ -1034,7 +1034,7 @@ module C08CollectExtend_ExtendIndex
   val extend0 [#"../08_collect_extend.rs" 25 0 25 66] (vec : borrowed (Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global))) (iter : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) : ()
     requires {[#"../08_collect_extend.rs" 25 40 25 43] inv4 vec}
     requires {[#"../08_collect_extend.rs" 25 58 25 62] inv3 iter}
-    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq uint32 . exists done_ : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) . inv5 prod /\ inv6 done_ /\ completed0 done_ /\ produces0 iter prod ( * done_) /\ shallow_model0 ( ^ vec) = Seq.(++) (shallow_model4 vec) prod }
+    ensures { [#"../08_collect_extend.rs" 21 0 24 2] exists prod : Seq.seq uint32 . exists done' : borrowed (Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global)) . inv5 prod /\ inv6 done' /\ completed0 done' /\ produces0 iter prod ( * done') /\ shallow_model0 ( ^ vec) = Seq.(++) (shallow_model4 vec) prod }
     
   predicate into_iter_post0 (self : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)) (res : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter uint32 (Alloc_Alloc_Global_Type.t_global))
     
@@ -1174,9 +1174,9 @@ module C08CollectExtend_CollectExample
   val inv0 (_x : i) : bool
     ensures { result = inv0 _x }
     
-  predicate produces0 (self : i) (visited : Seq.seq uint32) (_o : i)
-  val produces0 (self : i) (visited : Seq.seq uint32) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 (self : i) (visited : Seq.seq uint32) (o : i)
+  val produces0 (self : i) (visited : Seq.seq uint32) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   function produces_trans0 (a : i) (ab : Seq.seq uint32) (b : i) (bc : Seq.seq uint32) (c : i) : ()
   val produces_trans0 (a : i) (ab : Seq.seq uint32) (b : i) (bc : Seq.seq uint32) (c : i) : ()
@@ -1191,12 +1191,12 @@ module C08CollectExtend_CollectExample
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq uint32, b : i, bc : Seq.seq uint32, c : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv1 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv1 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : i) : ()
-  val produces_refl0 (a : i) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : i) : ()
+  val produces_refl0 (self : i) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -1227,7 +1227,7 @@ module C08CollectExtend_CollectExample
     
   val collect0 [#"../08_collect_extend.rs" 42 0 42 52] (iter : i) : Alloc_Vec_Vec_Type.t_vec uint32 (Alloc_Alloc_Global_Type.t_global)
     requires {[#"../08_collect_extend.rs" 42 28 42 32] inv0 iter}
-    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq uint32 . exists done_ : borrowed i . inv1 prod /\ inv2 done_ /\ completed0 done_ /\ produces0 iter prod ( * done_) /\ shallow_model0 result = prod }
+    ensures { [#"../08_collect_extend.rs" 38 0 41 2] exists prod : Seq.seq uint32 . exists done' : borrowed i . inv1 prod /\ inv2 done' /\ completed0 done' /\ produces0 iter prod ( * done') /\ shallow_model0 result = prod }
     ensures { [#"../08_collect_extend.rs" 42 40 42 52] inv3 result }
     
   let rec cfg collect_example [#"../08_collect_extend.rs" 61 0 61 56] [@cfg:stackify] [@cfg:subregion_analysis] (iter : i) : ()

--- a/creusot/tests/should_succeed/iterators/08_collect_extend.rs
+++ b/creusot/tests/should_succeed/iterators/08_collect_extend.rs
@@ -19,8 +19,8 @@ use creusot_contracts::{
 //
 // Here we prove the specific instance of `extend` for `Vec<T>`.
 #[ensures(
-  exists<done_ : &mut I, prod: Seq<_>>
-    done_.completed() && iter.produces(prod, *done_) && (^vec)@ == vec@.concat(prod)
+  exists<done : &mut I, prod: Seq<_>>
+    done.completed() && iter.produces(prod, *done) && (^vec)@ == vec@.concat(prod)
 )]
 pub fn extend<T, I: Iterator<Item = T>>(vec: &mut Vec<T>, iter: I) {
     let old_vec = gh! { vec };
@@ -36,8 +36,8 @@ pub fn extend<T, I: Iterator<Item = T>>(vec: &mut Vec<T>, iter: I) {
 //
 //  We prove the specific instance for vector
 #[ensures(
-  exists<done_ : &mut I, prod: Seq<_>>
-    done_.completed() && iter.produces(prod, *done_) && result@ == prod
+  exists<done : &mut I, prod: Seq<_>>
+    done.completed() && iter.produces(prod, *done) && result@ == prod
 )]
 pub fn collect<I: Iterator>(iter: I) -> Vec<I::Item> {
     let mut res = Vec::new();

--- a/creusot/tests/should_succeed/iterators/09_empty.mlcfg
+++ b/creusot/tests/should_succeed/iterators/09_empty.mlcfg
@@ -22,8 +22,8 @@ module C09Empty_Impl0_ProducesRefl_Impl
   val produces0 [#"../09_empty.rs" 21 4 21 64] (self : C09Empty_Empty_Type.t_empty t) (visited : Seq.seq t) (o : C09Empty_Empty_Type.t_empty t) : bool
     ensures { result = produces0 self visited o }
     
-  let rec ghost function produces_refl [#"../09_empty.rs" 28 4 28 29] (a : C09Empty_Empty_Type.t_empty t) : ()
-    ensures { [#"../09_empty.rs" 27 14 27 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../09_empty.rs" 28 4 28 26] (self : C09Empty_Empty_Type.t_empty t) : ()
+    ensures { [#"../09_empty.rs" 27 14 27 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../09_empty.rs" 25 4 25 10] ()
@@ -184,7 +184,7 @@ module C09Empty_Impl0
     ensures { result = produces0 self visited o }
     
   goal produces_trans_refn : [#"../09_empty.rs" 35 4 35 90] forall a : C09Empty_Empty_Type.t_empty t . forall ab : Seq.seq t . forall b : C09Empty_Empty_Type.t_empty t . forall bc : Seq.seq t . forall c : C09Empty_Empty_Type.t_empty t . inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b -> inv1 bc /\ inv1 ab /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
-  goal produces_refl_refn : [#"../09_empty.rs" 28 4 28 29] forall a : C09Empty_Empty_Type.t_empty t . inv0 a -> (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../09_empty.rs" 28 4 28 26] forall self : C09Empty_Empty_Type.t_empty t . inv0 self -> (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../09_empty.rs" 41 4 41 35] forall self : borrowed (C09Empty_Empty_Type.t_empty t) . inv2 self -> (forall result : Core_Option_Option_Type.t_option t . inv3 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)

--- a/creusot/tests/should_succeed/iterators/09_empty.rs
+++ b/creusot/tests/should_succeed/iterators/09_empty.rs
@@ -24,8 +24,8 @@ impl<T> Iterator for Empty<T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/10_once.mlcfg
+++ b/creusot/tests/should_succeed/iterators/10_once.mlcfg
@@ -47,9 +47,9 @@ module C10Once_Impl0_ProducesRefl_Impl
   val produces0 [#"../10_once.rs" 21 4 21 64] (self : C10Once_Once_Type.t_once t) (visited : Seq.seq t) (o : C10Once_Once_Type.t_once t) : bool
     ensures { result = produces0 self visited o }
     
-  let rec ghost function produces_refl [#"../10_once.rs" 31 4 31 29] (a : C10Once_Once_Type.t_once t) : ()
-    requires {[#"../10_once.rs" 31 21 31 22] inv0 a}
-    ensures { [#"../10_once.rs" 30 14 30 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../10_once.rs" 31 4 31 26] (self : C10Once_Once_Type.t_once t) : ()
+    requires {[#"../10_once.rs" 31 21 31 25] inv0 self}
+    ensures { [#"../10_once.rs" 30 14 30 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../10_once.rs" 28 4 28 10] ()
@@ -277,7 +277,7 @@ module C10Once_Impl0
   val produces0 [#"../10_once.rs" 21 4 21 64] (self : C10Once_Once_Type.t_once t) (visited : Seq.seq t) (o : C10Once_Once_Type.t_once t) : bool
     ensures { result = produces0 self visited o }
     
-  goal produces_refl_refn : [#"../10_once.rs" 31 4 31 29] forall a : C10Once_Once_Type.t_once t . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../10_once.rs" 31 4 31 26] forall self : C10Once_Once_Type.t_once t . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../10_once.rs" 44 4 44 35] forall self : borrowed (C10Once_Once_Type.t_once t) . inv1 self -> inv1 self /\ (forall result : Core_Option_Option_Type.t_option t . inv2 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)

--- a/creusot/tests/should_succeed/iterators/10_once.rs
+++ b/creusot/tests/should_succeed/iterators/10_once.rs
@@ -27,8 +27,8 @@ impl<T> Iterator for Once<T> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
+++ b/creusot/tests/should_succeed/iterators/11_repeat.mlcfg
@@ -32,9 +32,9 @@ module C11Repeat_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../11_repeat.rs" 33 4 33 29] (a : C11Repeat_Repeat_Type.t_repeat a) : ()
-    requires {[#"../11_repeat.rs" 33 21 33 22] inv0 a}
-    ensures { [#"../11_repeat.rs" 32 14 32 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../11_repeat.rs" 33 4 33 26] (self : C11Repeat_Repeat_Type.t_repeat a) : ()
+    requires {[#"../11_repeat.rs" 33 21 33 25] inv0 self}
+    ensures { [#"../11_repeat.rs" 32 14 32 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../11_repeat.rs" 30 4 30 10] ()
@@ -252,7 +252,7 @@ module C11Repeat_Impl0
     ensures { result = produces0 self visited o }
     
   goal produces_trans_refn : [#"../11_repeat.rs" 40 4 40 90] forall a : C11Repeat_Repeat_Type.t_repeat a . forall ab : Seq.seq a . forall b : C11Repeat_Repeat_Type.t_repeat a . forall bc : Seq.seq a . forall c : C11Repeat_Repeat_Type.t_repeat a . inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b -> inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
-  goal produces_refl_refn : [#"../11_repeat.rs" 33 4 33 29] forall a : C11Repeat_Repeat_Type.t_repeat a . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../11_repeat.rs" 33 4 33 26] forall self : C11Repeat_Repeat_Type.t_repeat a . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal next_refn : [#"../11_repeat.rs" 46 4 46 35] forall self : borrowed (C11Repeat_Repeat_Type.t_repeat a) . inv2 self -> inv2 self /\ (forall result : Core_Option_Option_Type.t_option a . inv3 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)

--- a/creusot/tests/should_succeed/iterators/11_repeat.rs
+++ b/creusot/tests/should_succeed/iterators/11_repeat.rs
@@ -29,8 +29,8 @@ impl<A: Clone> Iterator for Repeat<A> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/12_zip.mlcfg
+++ b/creusot/tests/should_succeed/iterators/12_zip.mlcfg
@@ -55,9 +55,9 @@ module C12Zip_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : Seq.seq item1 . inv1 x = true
   use seq.Seq
-  predicate produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b)
-  val produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b) : bool
-    ensures { result = produces2 self visited _o }
+  predicate produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b)
+  val produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b) : bool
+    ensures { result = produces2 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : b) (ab : Seq.seq item1) (b : b) (bc : Seq.seq item1) (c : b) : ()
     
@@ -73,16 +73,16 @@ module C12Zip_Impl0_ProducesRefl_Impl
     
   axiom produces_trans1_spec : forall a : b, ab : Seq.seq item1, b : b, bc : Seq.seq item1, c : b . ([#"../common.rs" 18 15 18 32] produces2 a ab b) -> ([#"../common.rs" 19 15 19 32] produces2 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces2 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : b . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces2 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : b . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces2 self (Seq.empty ) self)
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : a) (ab : Seq.seq item0) (b : a) (bc : Seq.seq item0) (c : a) : ()
     
@@ -98,12 +98,12 @@ module C12Zip_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : a, ab : Seq.seq item0, b : a, bc : Seq.seq item0, c : a . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : a . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : a . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C12Zip_Zip_Type as C12Zip_Zip_Type
   predicate invariant0 (self : C12Zip_Zip_Type.t_zip a b)
   val invariant0 (self : C12Zip_Zip_Type.t_zip a b) : bool
@@ -129,9 +129,9 @@ module C12Zip_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited tl }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../12_zip.rs" 41 4 41 29] (a : C12Zip_Zip_Type.t_zip a b) : ()
-    requires {[#"../12_zip.rs" 41 21 41 22] inv0 a}
-    ensures { [#"../12_zip.rs" 40 14 40 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../12_zip.rs" 41 4 41 26] (self : C12Zip_Zip_Type.t_zip a b) : ()
+    requires {[#"../12_zip.rs" 41 21 41 25] inv0 self}
+    ensures { [#"../12_zip.rs" 40 14 40 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../12_zip.rs" 38 4 38 10] ()
@@ -179,9 +179,9 @@ module C12Zip_Impl0_ProducesTrans_Impl
     
   axiom inv2 : forall x : Seq.seq item1 . inv2 x = true
   use seq.Seq
-  predicate produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b)
-  val produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b) : bool
-    ensures { result = produces2 self visited _o }
+  predicate produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b)
+  val produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b) : bool
+    ensures { result = produces2 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : b) (ab : Seq.seq item1) (b : b) (bc : Seq.seq item1) (c : b) : ()
     
@@ -197,16 +197,16 @@ module C12Zip_Impl0_ProducesTrans_Impl
     
   axiom produces_trans1_spec : forall a : b, ab : Seq.seq item1, b : b, bc : Seq.seq item1, c : b . ([#"../common.rs" 18 15 18 32] produces2 a ab b) -> ([#"../common.rs" 19 15 19 32] produces2 b bc c) -> ([#"../common.rs" 21 22 21 23] inv5 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv5 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv5 c) -> ([#"../common.rs" 20 14 20 42] produces2 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv5 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv5 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : b . ([#"../common.rs" 15 21 15 22] inv5 a) -> ([#"../common.rs" 14 14 14 39] produces2 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : b . ([#"../common.rs" 15 21 15 25] inv5 self) -> ([#"../common.rs" 14 14 14 45] produces2 self (Seq.empty ) self)
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : a) (ab : Seq.seq item0) (b : a) (bc : Seq.seq item0) (c : a) : ()
     
@@ -222,12 +222,12 @@ module C12Zip_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : a, ab : Seq.seq item0, b : a, bc : Seq.seq item0, c : a . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv4 a) -> ([#"../common.rs" 21 31 21 33] inv3 ab) -> ([#"../common.rs" 21 52 21 53] inv4 b) -> ([#"../common.rs" 21 61 21 63] inv3 bc) -> ([#"../common.rs" 21 82 21 83] inv4 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv4 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv4 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : a . ([#"../common.rs" 15 21 15 22] inv4 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : a . ([#"../common.rs" 15 21 15 25] inv4 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq (item0, item1))
   val invariant1 (self : Seq.seq (item0, item1)) : bool
     ensures { result = invariant1 self }
@@ -362,9 +362,9 @@ module C12Zip_Impl0_Next
   val inv3 (_x : b) : bool
     ensures { result = inv3 _x }
     
-  predicate produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b)
-  val produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b) : bool
-    ensures { result = produces2 self visited _o }
+  predicate produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b)
+  val produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b) : bool
+    ensures { result = produces2 self visited o }
     
   function produces_trans1 [#"../common.rs" 21 4 21 91] (a : b) (ab : Seq.seq item1) (b : b) (bc : Seq.seq item1) (c : b) : ()
     
@@ -380,12 +380,12 @@ module C12Zip_Impl0_Next
     
   axiom produces_trans1_spec : forall a : b, ab : Seq.seq item1, b : b, bc : Seq.seq item1, c : b . ([#"../common.rs" 18 15 18 32] produces2 a ab b) -> ([#"../common.rs" 19 15 19 32] produces2 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv9 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv9 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces2 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-  val produces_refl1 [#"../common.rs" 15 4 15 30] (a : b) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+  val produces_refl1 [#"../common.rs" 15 4 15 27] (self : b) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : b . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces2 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : b . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces2 self (Seq.empty ) self)
   predicate invariant3 (self : b)
   val invariant3 (self : b) : bool
     ensures { result = invariant3 self }
@@ -415,9 +415,9 @@ module C12Zip_Impl0_Next
   val inv0 (_x : a) : bool
     ensures { result = inv0 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : a) (ab : Seq.seq item0) (b : a) (bc : Seq.seq item0) (c : a) : ()
     
@@ -433,12 +433,12 @@ module C12Zip_Impl0_Next
     
   axiom produces_trans0_spec : forall a : a, ab : Seq.seq item0, b : a, bc : Seq.seq item0, c : a . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv10 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv10 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : a) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : a) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : a . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : a . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant0 (self : a)
   val invariant0 (self : a) : bool
     ensures { result = invariant0 self }
@@ -739,9 +739,9 @@ module C12Zip_Impl0
   val resolve0 (self : item0) : bool
     ensures { result = resolve0 self }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : a) (visited : Seq.seq item0) (_o : a) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : a) (visited : Seq.seq item0) (o : a) : bool
+    ensures { result = produces1 self visited o }
     
   use seq.Seq
   predicate completed1 [#"../common.rs" 11 4 11 36] (self : borrowed a)
@@ -755,9 +755,9 @@ module C12Zip_Impl0
     
   use seq.Seq
   use seq.Seq
-  predicate produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b)
-  val produces2 [#"../common.rs" 8 4 8 66] (self : b) (visited : Seq.seq item1) (_o : b) : bool
-    ensures { result = produces2 self visited _o }
+  predicate produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b)
+  val produces2 [#"../common.rs" 8 4 8 65] (self : b) (visited : Seq.seq item1) (o : b) : bool
+    ensures { result = produces2 self visited o }
     
   use seq.Seq
   use seq.Seq
@@ -774,7 +774,7 @@ module C12Zip_Impl0
     ensures { result = produces0 self visited tl }
     
   use seq.Seq
-  goal produces_refl_refn : [#"../12_zip.rs" 41 4 41 29] forall a : C12Zip_Zip_Type.t_zip a b . inv0 a -> inv0 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../12_zip.rs" 41 4 41 26] forall self : C12Zip_Zip_Type.t_zip a b . inv0 self -> inv0 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal produces_trans_refn : [#"../12_zip.rs" 48 4 48 90] forall a : C12Zip_Zip_Type.t_zip a b . forall ab : Seq.seq (item0, item1) . forall b : C12Zip_Zip_Type.t_zip a b . forall bc : Seq.seq (item0, item1) . forall c : C12Zip_Zip_Type.t_zip a b . inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b -> inv0 c /\ inv1 bc /\ inv0 b /\ inv1 ab /\ inv0 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
   goal next_refn : [#"../12_zip.rs" 54 4 54 44] forall self : borrowed (C12Zip_Zip_Type.t_zip a b) . inv2 self -> inv2 self /\ (forall result : Core_Option_Option_Type.t_option (item0, item1) . inv3 result /\ match result with
     | Core_Option_Option_Type.C_None -> completed0 self

--- a/creusot/tests/should_succeed/iterators/12_zip.rs
+++ b/creusot/tests/should_succeed/iterators/12_zip.rs
@@ -37,8 +37,8 @@ impl<A: Iterator, B: Iterator> Iterator for Zip<A, B> {
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
+++ b/creusot/tests/should_succeed/iterators/13_cloned.mlcfg
@@ -26,9 +26,9 @@ module C13Cloned_Impl0_ProducesRefl_Impl
   val inv1 (_x : Seq.seq t) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -43,12 +43,12 @@ module C13Cloned_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq t)
   val invariant1 (self : Seq.seq t) : bool
     ensures { result = invariant1 self }
@@ -78,9 +78,9 @@ module C13Cloned_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../13_cloned.rs" 39 4 39 29] (a : C13Cloned_Cloned_Type.t_cloned i) : ()
-    requires {[#"../13_cloned.rs" 39 21 39 22] inv0 a}
-    ensures { [#"../13_cloned.rs" 38 14 38 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../13_cloned.rs" 39 4 39 26] (self : C13Cloned_Cloned_Type.t_cloned i) : ()
+    requires {[#"../13_cloned.rs" 39 21 39 25] inv0 self}
+    ensures { [#"../13_cloned.rs" 38 14 38 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../13_cloned.rs" 36 4 36 10] ()
@@ -103,9 +103,9 @@ module C13Cloned_Impl0_ProducesTrans_Impl
   val inv2 (_x : Seq.seq t) : bool
     ensures { result = inv2 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -120,12 +120,12 @@ module C13Cloned_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant2 (self : Seq.seq t)
   val invariant2 (self : Seq.seq t) : bool
     ensures { result = invariant2 self }
@@ -249,9 +249,9 @@ module C13Cloned_Impl0_Next
   val inv0 (_x : i) : bool
     ensures { result = inv0 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -266,12 +266,12 @@ module C13Cloned_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv6 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv6 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -415,9 +415,9 @@ module C13Cloned_Impl0
   use prelude.Int
   use seq.Seq
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   predicate produces0 [#"../13_cloned.rs" 28 4 28 64] (self : C13Cloned_Cloned_Type.t_cloned i) (visited : Seq.seq t) (o : C13Cloned_Cloned_Type.t_cloned i)
     
@@ -443,6 +443,6 @@ module C13Cloned_Impl0
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
     end)
-  goal produces_refl_refn : [#"../13_cloned.rs" 39 4 39 29] forall a : C13Cloned_Cloned_Type.t_cloned i . inv2 a -> inv2 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../13_cloned.rs" 39 4 39 26] forall self : C13Cloned_Cloned_Type.t_cloned i . inv2 self -> inv2 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal produces_trans_refn : [#"../13_cloned.rs" 46 4 46 90] forall a : C13Cloned_Cloned_Type.t_cloned i . forall ab : Seq.seq t . forall b : C13Cloned_Cloned_Type.t_cloned i . forall bc : Seq.seq t . forall c : C13Cloned_Cloned_Type.t_cloned i . inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b -> inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
 end

--- a/creusot/tests/should_succeed/iterators/13_cloned.rs
+++ b/creusot/tests/should_succeed/iterators/13_cloned.rs
@@ -35,8 +35,8 @@ where
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/14_copied.mlcfg
+++ b/creusot/tests/should_succeed/iterators/14_copied.mlcfg
@@ -26,9 +26,9 @@ module C14Copied_Impl0_ProducesRefl_Impl
   val inv1 (_x : Seq.seq t) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -43,12 +43,12 @@ module C14Copied_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq t)
   val invariant1 (self : Seq.seq t) : bool
     ensures { result = invariant1 self }
@@ -78,9 +78,9 @@ module C14Copied_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../14_copied.rs" 39 4 39 29] (a : C14Copied_Copied_Type.t_copied i) : ()
-    requires {[#"../14_copied.rs" 39 21 39 22] inv0 a}
-    ensures { [#"../14_copied.rs" 38 14 38 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../14_copied.rs" 39 4 39 26] (self : C14Copied_Copied_Type.t_copied i) : ()
+    requires {[#"../14_copied.rs" 39 21 39 25] inv0 self}
+    ensures { [#"../14_copied.rs" 38 14 38 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../14_copied.rs" 36 4 36 10] ()
@@ -103,9 +103,9 @@ module C14Copied_Impl0_ProducesTrans_Impl
   val inv2 (_x : Seq.seq t) : bool
     ensures { result = inv2 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -120,12 +120,12 @@ module C14Copied_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant2 (self : Seq.seq t)
   val invariant2 (self : Seq.seq t) : bool
     ensures { result = invariant2 self }
@@ -249,9 +249,9 @@ module C14Copied_Impl0_Next
   val inv0 (_x : i) : bool
     ensures { result = inv0 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
   val produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq t) (b : i) (bc : Seq.seq t) (c : i) : ()
@@ -266,12 +266,12 @@ module C14Copied_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq t, b : i, bc : Seq.seq t, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv6 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv6 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -415,9 +415,9 @@ module C14Copied_Impl0
   use prelude.Int
   use seq.Seq
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq t) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq t) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   predicate produces0 [#"../14_copied.rs" 28 4 28 64] (self : C14Copied_Copied_Type.t_copied i) (visited : Seq.seq t) (o : C14Copied_Copied_Type.t_copied i)
     
@@ -444,5 +444,5 @@ module C14Copied_Impl0
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
     end)
   goal produces_trans_refn : [#"../14_copied.rs" 46 4 46 90] forall a : C14Copied_Copied_Type.t_copied i . forall ab : Seq.seq t . forall b : C14Copied_Copied_Type.t_copied i . forall bc : Seq.seq t . forall c : C14Copied_Copied_Type.t_copied i . inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b -> inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
-  goal produces_refl_refn : [#"../14_copied.rs" 39 4 39 29] forall a : C14Copied_Copied_Type.t_copied i . inv2 a -> inv2 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../14_copied.rs" 39 4 39 26] forall self : C14Copied_Copied_Type.t_copied i . inv2 self -> inv2 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
 end

--- a/creusot/tests/should_succeed/iterators/14_copied.rs
+++ b/creusot/tests/should_succeed/iterators/14_copied.rs
@@ -35,8 +35,8 @@ where
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.mlcfg
@@ -47,9 +47,9 @@ module C15Enumerate_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : Seq.seq item0 . inv1 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -65,12 +65,12 @@ module C15Enumerate_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use prelude.UIntSize
   predicate completed0 [#"../common.rs" 11 4 11 36] (self : borrowed i)
   val completed0 [#"../common.rs" 11 4 11 36] (self : borrowed i) : bool
@@ -105,9 +105,9 @@ module C15Enumerate_Impl0_ProducesRefl_Impl
     ensures { result = produces0 self visited o }
     
   use seq.Seq
-  let rec ghost function produces_refl [#"../15_enumerate.rs" 40 4 40 29] (a : C15Enumerate_Enumerate_Type.t_enumerate i) : ()
-    requires {[#"../15_enumerate.rs" 40 21 40 22] inv0 a}
-    ensures { [#"../15_enumerate.rs" 39 14 39 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../15_enumerate.rs" 40 4 40 26] (self : C15Enumerate_Enumerate_Type.t_enumerate i) : ()
+    requires {[#"../15_enumerate.rs" 40 21 40 25] inv0 self}
+    ensures { [#"../15_enumerate.rs" 39 14 39 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../15_enumerate.rs" 37 4 37 10] ()
@@ -145,9 +145,9 @@ module C15Enumerate_Impl0_ProducesTrans_Impl
     
   axiom inv2 : forall x : Seq.seq item0 . inv2 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -163,12 +163,12 @@ module C15Enumerate_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv3 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv3 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv3 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv3 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv3 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv3 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv3 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use prelude.UIntSize
   predicate invariant1 (self : Seq.seq (usize, item0))
   val invariant1 (self : Seq.seq (usize, item0)) : bool
@@ -260,9 +260,9 @@ module C15Enumerate_Impl0_Next
   use prelude.UIntSize
   type item0
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   predicate inv5 (_x : Seq.seq item0)
   val inv5 (_x : Seq.seq item0) : bool
@@ -333,12 +333,12 @@ module C15Enumerate_Impl0_Next
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv0 a) -> ([#"../common.rs" 21 31 21 33] inv5 ab) -> ([#"../common.rs" 21 52 21 53] inv0 b) -> ([#"../common.rs" 21 61 21 63] inv5 bc) -> ([#"../common.rs" 21 82 21 83] inv0 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv0 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv0 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant0 (self : i)
   val invariant0 (self : i) : bool
     ensures { result = invariant0 self }
@@ -484,9 +484,9 @@ module C15Enumerate_Enumerate
   use prelude.UIntSize
   type item0
   use seq.Seq
-  predicate produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces0 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces0 self visited _o }
+  predicate produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces0 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces0 self visited o }
     
   predicate inv2 (_x : Seq.seq item0)
   val inv2 (_x : Seq.seq item0) : bool
@@ -529,12 +529,12 @@ module C15Enumerate_Enumerate
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces0 a ab b) -> ([#"../common.rs" 19 15 19 32] produces0 b bc c) -> ([#"../common.rs" 21 22 21 23] inv1 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv1 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv1 c) -> ([#"../common.rs" 20 14 20 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv1 a) -> ([#"../common.rs" 14 14 14 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv1 self) -> ([#"../common.rs" 14 14 14 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : borrowed i)
   val invariant0 (self : borrowed i) : bool
     ensures { result = invariant0 self }
@@ -620,9 +620,9 @@ module C15Enumerate_Impl0
     (18446744073709551615 : usize)
   use seq.Seq
   use prelude.UIntSize
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use C15Enumerate_Enumerate_Type as C15Enumerate_Enumerate_Type
   predicate invariant2 [#"../15_enumerate.rs" 71 4 71 30] (self : C15Enumerate_Enumerate_Type.t_enumerate i) =
@@ -683,7 +683,7 @@ module C15Enumerate_Impl0
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
     end)
-  goal produces_refl_refn : [#"../15_enumerate.rs" 40 4 40 29] forall a : C15Enumerate_Enumerate_Type.t_enumerate i . inv2 a -> inv2 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../15_enumerate.rs" 40 4 40 26] forall self : C15Enumerate_Enumerate_Type.t_enumerate i . inv2 self -> inv2 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal produces_trans_refn : [#"../15_enumerate.rs" 47 4 47 90] forall a : C15Enumerate_Enumerate_Type.t_enumerate i . forall ab : Seq.seq (usize, item0) . forall b : C15Enumerate_Enumerate_Type.t_enumerate i . forall bc : Seq.seq (usize, item0) . forall c : C15Enumerate_Enumerate_Type.t_enumerate i . inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b -> inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
 end
 module C15Enumerate_Impl1

--- a/creusot/tests/should_succeed/iterators/15_enumerate.rs
+++ b/creusot/tests/should_succeed/iterators/15_enumerate.rs
@@ -36,8 +36,8 @@ where
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/16_take.mlcfg
+++ b/creusot/tests/should_succeed/iterators/16_take.mlcfg
@@ -37,9 +37,9 @@ module C16Take_Impl0_ProducesRefl_Impl
     
   axiom inv1 : forall x : i . inv1 x = true
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -55,12 +55,12 @@ module C16Take_Impl0_ProducesRefl_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv1 a) -> ([#"../common.rs" 21 31 21 33] inv2 ab) -> ([#"../common.rs" 21 52 21 53] inv1 b) -> ([#"../common.rs" 21 61 21 63] inv2 bc) -> ([#"../common.rs" 21 82 21 83] inv1 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv1 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv1 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   use C16Take_Take_Type as C16Take_Take_Type
   predicate invariant0 (self : C16Take_Take_Type.t_take i)
   val invariant0 (self : C16Take_Take_Type.t_take i) : bool
@@ -81,9 +81,9 @@ module C16Take_Impl0_ProducesRefl_Impl
   val produces0 [#"../16_take.rs" 31 4 31 64] (self : C16Take_Take_Type.t_take i) (visited : Seq.seq item0) (o : C16Take_Take_Type.t_take i) : bool
     ensures { result = produces0 self visited o }
     
-  let rec ghost function produces_refl [#"../16_take.rs" 40 4 40 29] (a : C16Take_Take_Type.t_take i) : ()
-    requires {[#"../16_take.rs" 40 21 40 22] inv0 a}
-    ensures { [#"../16_take.rs" 39 14 39 39] produces0 a (Seq.empty ) a }
+  let rec ghost function produces_refl [#"../16_take.rs" 40 4 40 26] (self : C16Take_Take_Type.t_take i) : ()
+    requires {[#"../16_take.rs" 40 21 40 25] inv0 self}
+    ensures { [#"../16_take.rs" 39 14 39 45] produces0 self (Seq.empty ) self }
     
    = [@vc:do_not_keep_trace] [@vc:sp]
     [#"../16_take.rs" 37 4 37 10] ()
@@ -106,9 +106,9 @@ module C16Take_Impl0_ProducesTrans_Impl
   val inv1 (_x : Seq.seq item0) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -124,12 +124,12 @@ module C16Take_Impl0_ProducesTrans_Impl
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv2 a) -> ([#"../common.rs" 21 31 21 33] inv1 ab) -> ([#"../common.rs" 21 52 21 53] inv2 b) -> ([#"../common.rs" 21 61 21 63] inv1 bc) -> ([#"../common.rs" 21 82 21 83] inv2 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv2 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv2 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv2 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv2 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Seq.seq item0)
   val invariant1 (self : Seq.seq item0) : bool
     ensures { result = invariant1 self }
@@ -212,9 +212,9 @@ module C16Take_Impl0_Next
   val inv1 (_x : i) : bool
     ensures { result = inv1 _x }
     
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   function produces_trans0 [#"../common.rs" 21 4 21 91] (a : i) (ab : Seq.seq item0) (b : i) (bc : Seq.seq item0) (c : i) : ()
     
@@ -230,12 +230,12 @@ module C16Take_Impl0_Next
     
   axiom produces_trans0_spec : forall a : i, ab : Seq.seq item0, b : i, bc : Seq.seq item0, c : i . ([#"../common.rs" 18 15 18 32] produces1 a ab b) -> ([#"../common.rs" 19 15 19 32] produces1 b bc c) -> ([#"../common.rs" 21 22 21 23] inv1 a) -> ([#"../common.rs" 21 31 21 33] inv4 ab) -> ([#"../common.rs" 21 52 21 53] inv1 b) -> ([#"../common.rs" 21 61 21 63] inv4 bc) -> ([#"../common.rs" 21 82 21 83] inv1 c) -> ([#"../common.rs" 20 14 20 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-  val produces_refl0 [#"../common.rs" 15 4 15 30] (a : i) : ()
-    requires {[#"../common.rs" 15 21 15 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+  val produces_refl0 [#"../common.rs" 15 4 15 27] (self : i) : ()
+    requires {[#"../common.rs" 15 21 15 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : i . ([#"../common.rs" 15 21 15 22] inv1 a) -> ([#"../common.rs" 14 14 14 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : i . ([#"../common.rs" 15 21 15 25] inv1 self) -> ([#"../common.rs" 14 14 14 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : i)
   val invariant1 (self : i) : bool
     ensures { result = invariant1 self }
@@ -377,9 +377,9 @@ module C16Take_Impl0
   use seq.Seq
   use seq.Seq
   use seq.Seq
-  predicate produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i)
-  val produces1 [#"../common.rs" 8 4 8 66] (self : i) (visited : Seq.seq item0) (_o : i) : bool
-    ensures { result = produces1 self visited _o }
+  predicate produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i)
+  val produces1 [#"../common.rs" 8 4 8 65] (self : i) (visited : Seq.seq item0) (o : i) : bool
+    ensures { result = produces1 self visited o }
     
   use prelude.Int
   use seq.Seq
@@ -413,6 +413,6 @@ module C16Take_Impl0
     | Core_Option_Option_Type.C_None -> completed0 self
     | Core_Option_Option_Type.C_Some v -> produces0 ( * self) (Seq.singleton v) ( ^ self)
     end)
-  goal produces_refl_refn : [#"../16_take.rs" 40 4 40 29] forall a : C16Take_Take_Type.t_take i . inv2 a -> inv2 a /\ (forall result : () . produces0 a (Seq.empty ) a -> produces0 a (Seq.empty ) a)
+  goal produces_refl_refn : [#"../16_take.rs" 40 4 40 26] forall self : C16Take_Take_Type.t_take i . inv2 self -> inv2 self /\ (forall result : () . produces0 self (Seq.empty ) self -> produces0 self (Seq.empty ) self)
   goal produces_trans_refn : [#"../16_take.rs" 47 4 47 90] forall a : C16Take_Take_Type.t_take i . forall ab : Seq.seq item0 . forall b : C16Take_Take_Type.t_take i . forall bc : Seq.seq item0 . forall c : C16Take_Take_Type.t_take i . inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b -> inv2 c /\ inv3 bc /\ inv2 b /\ inv3 ab /\ inv2 a /\ produces0 b bc c /\ produces0 a ab b /\ (forall result : () . produces0 a (Seq.(++) ab bc) c -> produces0 a (Seq.(++) ab bc) c)
 end

--- a/creusot/tests/should_succeed/iterators/16_take.rs
+++ b/creusot/tests/should_succeed/iterators/16_take.rs
@@ -36,8 +36,8 @@ where
 
     #[law]
     #[open]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self) {}
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self) {}
 
     #[law]
     #[open]

--- a/creusot/tests/should_succeed/iterators/common.rs
+++ b/creusot/tests/should_succeed/iterators/common.rs
@@ -5,14 +5,14 @@ pub trait Iterator {
     type Item;
 
     #[predicate]
-    fn produces(self, visited: Seq<Self::Item>, _o: Self) -> bool;
+    fn produces(self, visited: Seq<Self::Item>, o: Self) -> bool;
 
     #[predicate]
     fn completed(&mut self) -> bool;
 
     #[law]
-    #[ensures(a.produces(Seq::EMPTY, a))]
-    fn produces_refl(a: Self);
+    #[ensures(self.produces(Seq::EMPTY, self))]
+    fn produces_refl(self);
 
     #[law]
     #[requires(a.produces(ab, b))]

--- a/creusot/tests/should_succeed/knapsack_full.mlcfg
+++ b/creusot/tests/should_succeed/knapsack_full.mlcfg
@@ -600,13 +600,13 @@ module KnapsackFull_Knapsack01Dyn
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize, ab : Seq.seq usize, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize, bc : Seq.seq usize, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 81 15 81 32] produces1 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 82 15 82 32] produces1 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 22 84 23] inv2 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 31 84 33] inv10 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 52 84 53] inv2 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 61 84 63] inv10 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 82 84 83] inv2 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 83 14 83 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : () =
+  function produces_refl1 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : () =
     [#"../../../../creusot-contracts/src/std/iter/range.rs" 74 4 74 10] ()
-  val produces_refl1 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv2 a}
-    ensures { result = produces_refl1 a }
+  val produces_refl1 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv2 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv2 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv2 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 45] produces1 self (Seq.empty ) self)
   predicate invariant2 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant2 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : bool
@@ -646,12 +646,12 @@ module KnapsackFull_Knapsack01Dyn
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv10 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv10 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
+++ b/creusot/tests/should_succeed/rusthorn/inc_max_repeat.mlcfg
@@ -155,12 +155,12 @@ module IncMaxRepeat_IncMaxRepeat
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range uint32, ab : Seq.seq uint32, b : Core_Ops_Range_Range_Type.t_range uint32, bc : Seq.seq uint32, c : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv3 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv3 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range uint32) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range uint32) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range uint32) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range uint32) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range uint32) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range uint32) : bool

--- a/creusot/tests/should_succeed/selection_sort_generic.mlcfg
+++ b/creusot/tests/should_succeed/selection_sort_generic.mlcfg
@@ -336,12 +336,12 @@ module SelectionSortGeneric_SelectionSort
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv13 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv1 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv13 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv1 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/sum.mlcfg
+++ b/creusot/tests/should_succeed/sum.mlcfg
@@ -132,13 +132,13 @@ module Sum_SumFirstN
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32, ab : Seq.seq uint32, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32, bc : Seq.seq uint32, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 81 15 81 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 82 15 82 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 22 84 23] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 31 84 33] inv4 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 52 84 53] inv0 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 61 84 63] inv4 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 84 82 84 83] inv0 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 83 14 83 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) : () =
+  function produces_refl0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) : () =
     [#"../../../../creusot-contracts/src/std/iter/range.rs" 74 4 74 10] ()
-  val produces_refl0 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv0 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive uint32) : bool

--- a/creusot/tests/should_succeed/sum_of_odds.mlcfg
+++ b/creusot/tests/should_succeed/sum_of_odds.mlcfg
@@ -127,12 +127,12 @@ module SumOfOdds_ComputeSumOfOdd
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range uint32, ab : Seq.seq uint32, b : Core_Ops_Range_Range_Type.t_range uint32, bc : Seq.seq uint32, c : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv3 ab) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv3 bc) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range uint32) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range uint32) : ()
-    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range uint32) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range uint32) : ()
+    requires {[#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range uint32 . ([#"../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range uint32) =
     [#"../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range uint32) : bool

--- a/creusot/tests/should_succeed/vector/01.mlcfg
+++ b/creusot/tests/should_succeed/vector/01.mlcfg
@@ -206,12 +206,12 @@ module C01_AllZero
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv9 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv9 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
+++ b/creusot/tests/should_succeed/vector/03_knuth_shuffle.mlcfg
@@ -202,12 +202,12 @@ module C03KnuthShuffle_KnuthShuffle
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv10 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv1 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv10 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv1 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
+++ b/creusot/tests/should_succeed/vector/06_knights_tour.mlcfg
@@ -473,13 +473,13 @@ module C06KnightsTour_Impl1_New
     
   axiom produces_trans2_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3, ab : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)), b : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3, bc : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)), c : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 28 15 28 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 29 15 29 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 22 31 23] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 31 31 33] inv4 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 52 31 53] inv3 b) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 61 31 63] inv4 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 31 82 31 83] inv3 c) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 30 14 30 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl2 (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : ()
+  function produces_refl2 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : ()
     
-  val produces_refl2 (a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 22] inv3 a}
-    ensures { result = produces_refl2 a }
+  val produces_refl2 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 25] inv3 self}
+    ensures { result = produces_refl2 self }
     
-  axiom produces_refl2_spec : forall a : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 22] inv3 a) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 23 14 23 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl2_spec : forall self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3 . ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 24 21 24 25] inv3 self) -> ([#"../../../../../creusot-contracts/src/std/iter/map_inv.rs" 23 14 23 45] produces1 self (Seq.empty ) self)
   predicate invariant5 (self : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3))
     
    =
@@ -579,12 +579,12 @@ module C06KnightsTour_Impl1_New
     ensures { result = produces_trans1 a ab b bc c }
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv7 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv7 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant1 (self : usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : usize) : bool
@@ -610,12 +610,12 @@ module C06KnightsTour_Impl1_New
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter.rs" 38 15 38 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 39 15 39 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 22 41 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 31 41 33] inv7 ab) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 52 41 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 61 41 63] inv7 bc) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 41 82 41 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 40 14 40 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter.rs" 35 21 35 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter.rs" 34 14 34 45] produces0 self (Seq.empty ) self)
   function index_logic0 [@inline:trivial] (self : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)) (ix : int) : Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)
     
    =
@@ -661,7 +661,7 @@ module C06KnightsTour_Impl1_New
     
   val collect0 (self : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : Alloc_Vec_Vec_Type.t_vec (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) (Alloc_Alloc_Global_Type.t_global)
     requires {inv3 self}
-    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 130 16 131 84] exists prod : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) . exists done_ : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) . inv4 prod /\ inv5 done_ /\ resolve0 ( ^ done_) /\ completed0 done_ /\ produces1 self prod ( * done_) /\ from_iter_post0 prod result }
+    ensures { [#"../../../../../creusot-contracts/src/std/iter.rs" 130 16 131 83] exists prod : Seq.seq (Alloc_Vec_Vec_Type.t_vec usize (Alloc_Alloc_Global_Type.t_global)) . exists done' : borrowed (CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) . inv4 prod /\ inv5 done' /\ resolve0 ( ^ done') /\ completed0 done' /\ produces1 self prod ( * done') /\ from_iter_post0 prod result }
     ensures { inv6 result }
     
   val map_inv0 (self : Core_Ops_Range_Range_Type.t_range usize) (func : C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3) : CreusotContracts_Std1_Iter_MapInv_MapInv_Type.t_mapinv (Core_Ops_Range_Range_Type.t_range usize) usize C06KnightsTour_Impl1_New_Closure3.c06knightstour_impl1_new_closure3
@@ -1162,15 +1162,15 @@ module C06KnightsTour_Impl1_CountDegree
     
   axiom produces_trans0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global), ab : Seq.seq (isize, isize), b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global), bc : Seq.seq (isize, isize), c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 248 15 248 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 249 15 249 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 22 251 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 31 251 33] inv4 ab) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 43 251 44] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 52 251 54] inv4 bc) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 64 251 65] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 250 14 250 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
+  function produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
     
    =
     [#"../../../../../creusot-contracts/src/std/vec.rs" 241 4 241 10] ()
-  val produces_refl0 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))
     
    =
@@ -1856,12 +1856,12 @@ module C06KnightsTour_Min
     
   axiom produces_trans0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point), ab : Seq.seq (usize, C06KnightsTour_Point_Type.t_point), b : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point), bc : Seq.seq (usize, C06KnightsTour_Point_Type.t_point), c : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point) . ([#"../../../../../creusot-contracts/src/std/slice.rs" 397 15 397 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 398 15 398 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 31 400 33] inv3 ab) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 400 61 400 63] inv3 bc) -> ([#"../../../../../creusot-contracts/src/std/slice.rs" 399 14 399 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) : () =
+  function produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) : () =
     [#"../../../../../creusot-contracts/src/std/slice.rs" 390 4 390 10] ()
-  val produces_refl0 (a : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) : ()
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) : ()
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point) . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 39] produces0 a (Seq.empty ) a
+  axiom produces_refl0_spec : forall self : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point) . [#"../../../../../creusot-contracts/src/std/slice.rs" 392 14 392 45] produces0 self (Seq.empty ) self
   predicate invariant0 (self : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Slice_Iter_Iter_Type.t_iter (usize, C06KnightsTour_Point_Type.t_point)) : bool
@@ -2300,15 +2300,15 @@ module C06KnightsTour_KnightsTour
     
   axiom produces_trans1_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global), ab : Seq.seq (isize, isize), b : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global), bc : Seq.seq (isize, isize), c : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 248 15 248 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 249 15 249 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 22 251 23] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 31 251 33] inv15 ab) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 43 251 44] inv1 b) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 52 251 54] inv15 bc) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 251 64 251 65] inv1 c) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 250 14 250 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
+  function produces_refl1 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
     
    =
     [#"../../../../../creusot-contracts/src/std/vec.rs" 241 4 241 10] ()
-  val produces_refl1 (a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv1 a}
-    ensures { result = produces_refl1 a }
+  val produces_refl1 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global)) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv1 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 22] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global) . ([#"../../../../../creusot-contracts/src/std/vec.rs" 244 21 244 25] inv1 self) -> ([#"../../../../../creusot-contracts/src/std/vec.rs" 243 14 243 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Alloc_Vec_IntoIter_IntoIter_Type.t_intoiter (isize, isize) (Alloc_Alloc_Global_Type.t_global))
     
    =
@@ -2350,12 +2350,12 @@ module C06KnightsTour_KnightsTour
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv11 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv11 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces0 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl0 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  function produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl0 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_Range_Type.t_range usize) : bool

--- a/creusot/tests/should_succeed/vector/08_haystack.mlcfg
+++ b/creusot/tests/should_succeed/vector/08_haystack.mlcfg
@@ -219,12 +219,12 @@ module C08Haystack_Search
     
   axiom produces_trans1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize, ab : Seq.seq usize, b : Core_Ops_Range_Range_Type.t_range usize, bc : Seq.seq usize, c : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 37 15 37 32] produces1 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 38 15 38 32] produces1 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 22 40 23] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 31 40 33] inv8 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 52 40 53] inv1 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 61 40 63] inv8 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 40 82 40 83] inv1 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 39 14 39 42] produces1 a (Seq.(++) ab bc) c)
   use seq.Seq
-  function produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-  val produces_refl1 (a : Core_Ops_Range_Range_Type.t_range usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a}
-    ensures { result = produces_refl1 a }
+  function produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+  val produces_refl1 (self : Core_Ops_Range_Range_Type.t_range usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self}
+    ensures { result = produces_refl1 self }
     
-  axiom produces_refl1_spec : forall a : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 22] inv1 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 39] produces1 a (Seq.empty ) a)
+  axiom produces_refl1_spec : forall self : Core_Ops_Range_Range_Type.t_range usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 33 21 33 25] inv1 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 32 14 32 45] produces1 self (Seq.empty ) self)
   predicate invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant1 (self : Core_Ops_Range_Range_Type.t_range usize) : bool
@@ -283,13 +283,13 @@ module C08Haystack_Search
     ensures { result = produces_trans0 a ab b bc c }
     
   axiom produces_trans0_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize, ab : Seq.seq usize, b : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize, bc : Seq.seq usize, c : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 81 15 81 32] produces0 a ab b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 82 15 82 32] produces0 b bc c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 84 22 84 23] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 84 31 84 33] inv8 ab) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 84 52 84 53] inv0 b) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 84 61 84 63] inv8 bc) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 84 82 84 83] inv0 c) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 83 14 83 42] produces0 a (Seq.(++) ab bc) c)
-  function produces_refl0 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : () =
+  function produces_refl0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : () =
     [#"../../../../../creusot-contracts/src/std/iter/range.rs" 74 4 74 10] ()
-  val produces_refl0 (a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : ()
-    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv0 a}
-    ensures { result = produces_refl0 a }
+  val produces_refl0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : ()
+    requires {[#"../../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv0 self}
+    ensures { result = produces_refl0 self }
     
-  axiom produces_refl0_spec : forall a : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 22] inv0 a) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 39] produces0 a (Seq.empty ) a)
+  axiom produces_refl0_spec : forall self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize . ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 77 21 77 25] inv0 self) -> ([#"../../../../../creusot-contracts/src/std/iter/range.rs" 76 14 76 45] produces0 self (Seq.empty ) self)
   predicate invariant0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) =
     [#"../../../../../creusot-contracts/src/invariant.rs" 8 8 8 12] true
   val invariant0 (self : Core_Ops_Range_RangeInclusive_Type.t_rangeinclusive usize) : bool

--- a/why3/src/name.rs
+++ b/why3/src/name.rs
@@ -162,6 +162,7 @@ const RESERVED: &[&str] = &[
     "continue",
     "diverges",
     "do",
+    "done",
     "else",
     "end",
     "ensures",


### PR DESCRIPTION
- Use done instead of _done, and make sure done is detected as a keyword.
- Use self as the unique parameter of produces_refl