### PR TITLE
fix: why3 version check was only comparing the first 2 numbers

### DIFF
--- a/creusot-rustc/src/main.rs
+++ b/creusot-rustc/src/main.rs
@@ -87,7 +87,7 @@ fn setup_plugin() {
     if creusot.check_why3 {
         if let Some(why3_vers) = why3_version() {
             let parts: Vec<_> = why3_vers.split(|c| c == '.' || c == '+').collect();
-            if &parts[..2] < WHY3_VERSION {
+            if &parts[..3] < WHY3_VERSION {
                 emit_warning(format!(
                     "the recommended version of why3 is at least {} (installed: {why3_vers})",
                     WHY3_VERSION.join(".")


### PR DESCRIPTION
creusot was complaining about my version of why3, even though it is "1.7.1+git" (ie the recommended one).
It looks like the version check only compared the first two numbers (and indeed [1,7] < [1,7,1]).